### PR TITLE
[Xamarin.Android.Build.Tasks] ResolveAssemblies l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -51,7 +51,7 @@ ms.date: 01/24/2020
 + [XA0102](xa0102.md): Generic `lint` Warning.
 + [XA0103](xa0103.md): Generic `lint` Error.
 + XA0104: Invalid value for \`$(AndroidSequencePointsMode)\`
-+ [XA0105](xa0105.md): The $(TargetFrameworkVersion) for a dll is greater than the $(TargetFrameworkVersion) for your project.
++ [XA0105](xa0105.md): The $(TargetFrameworkVersion) for a library is greater than the $(TargetFrameworkVersion) for the application project.
 + [XA0107](xa0107.md): `{Assmebly}` is a Reference Assembly.
 + [XA0108](xa0108.md): Could not get version from `lint`.
 + [XA0109](xa0109.md): Unsupported or invalid `$(TargetFrameworkVersion)` value of 'v4.5'.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project..
+        /// </summary>
+        internal static string XA0105 {
+            get {
+                return ResourceManager.GetString("XA0105", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} is a Reference Assembly..
         /// </summary>
         internal static string XA0107 {
@@ -210,6 +219,24 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA0117 {
             get {
                 return ResourceManager.GetString("XA0117", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not parse &apos;{0}&apos;.
+        /// </summary>
+        internal static string XA0118_Parse {
+            get {
+                return ResourceManager.GetString("XA0118_Parse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not resolve `target` in lock file for &apos;{0}&apos;.
+        /// </summary>
+        internal static string XA0118_Target {
+            get {
+                return ResourceManager.GetString("XA0118_Target", resourceCulture);
             }
         }
         
@@ -300,6 +327,24 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA2001 {
             get {
                 return ResourceManager.GetString("XA2001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn&apos;t exist in the Mono for Android profile?.
+        /// </summary>
+        internal static string XA2002_Framework {
+            get {
+                return ResourceManager.GetString("XA2002_Framework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`..
+        /// </summary>
+        internal static string XA2002_NuGet {
+            get {
+                return ResourceManager.GetString("XA2002_NuGet", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -157,6 +157,13 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Invalid value for `$(AndroidSequencePointsMode)`: {0}</value>
     <comment>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</comment>
   </data>
+  <data name="XA0105" xml:space="preserve">
+    <value>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</value>
+    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</comment>
+  </data>
   <data name="XA0107" xml:space="preserve">
     <value>{0} is a Reference Assembly.</value>
   </data>
@@ -191,6 +198,18 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</value>
     <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</comment>
+  </data>
+  <data name="XA0118_Parse" xml:space="preserve">
+    <value>Could not parse '{0}'</value>
+    <comment>{0} - A NuGet target framework moniker string</comment>
+  </data>
+  <data name="XA0118_Target" xml:space="preserve">
+    <value>Could not resolve `target` in lock file for '{0}'</value>
+    <comment>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</comment>
   </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
@@ -241,6 +260,12 @@ In this message, the phrase "should not be reached" means that this error messag
   </data>
   <data name="XA2001" xml:space="preserve">
     <value>Source file '{0}' could not be found.</value>
+  </data>
+  <data name="XA2002_Framework" xml:space="preserve">
+    <value>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</value>
+  </data>
+  <data name="XA2002_NuGet" xml:space="preserve">
+    <value>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</value>
   </data>
   <data name="XA2006" xml:space="preserve">
     <value>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -51,6 +51,14 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
+      <trans-unit id="XA0105">
+        <source>The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</source>
+        <target state="new">The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for the application project ({2}). Please increase the $(TargetFrameworkVersion) for the application project.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The file name of the library referenced by the application
+{1} - The target framework version number for the library
+{2} - The target framework version number for the application project</note>
+      </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
         <target state="new">{0} is a Reference Assembly.</target>
@@ -94,6 +102,20 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
         <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
 {0} - The current value of TargetFrameworkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Parse">
+        <source>Could not parse '{0}'</source>
+        <target state="new">Could not parse '{0}'</target>
+        <note>{0} - A NuGet target framework moniker string</note>
+      </trans-unit>
+      <trans-unit id="XA0118_Target">
+        <source>Could not resolve `target` in lock file for '{0}'</source>
+        <target state="new">Could not resolve `target` in lock file for '{0}'</target>
+        <note>The following are literal names and should not be translated: `target`
+
+The term "lock file" comes from NuGet. For example, search for "UnauthorizedLockFail" in https://github.com/NuGet/NuGet.Build.Localization to see some example localizations of "lock file."
+
+{0} - A NuGet target framework moniker string</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
@@ -154,6 +176,16 @@ In this message, the phrase "should not be reached" means that this error messag
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_Framework">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA2002_NuGet">
+        <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
+        <target state="new">Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA2006">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -117,9 +117,8 @@ namespace Xamarin.Android.Tasks
 			var mainapiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 			foreach (var item in api_levels.Where (x => mainapiLevel < x.Value)) {
 				var itemOSVersion = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (item.Value);
-				LogCodedWarning ("XA0105", ProjectFile, 0,
-					"The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for your project ({2}). " +
-					"You need to increase the $(TargetFrameworkVersion) for your project.", Path.GetFileName (item.Key), itemOSVersion, TargetFrameworkVersion);
+				LogCodedWarning ("XA0105", ProjectFile, 0, Properties.Resources.XA0105,
+					Path.GetFileName (item.Key), itemOSVersion, TargetFrameworkVersion);
 			}
 
 			var resolvedAssemblies          = new List<ITaskItem> (assemblies.Count);
@@ -176,12 +175,12 @@ namespace Xamarin.Android.Tasks
 
 			var framework = NuGetFramework.Parse (TargetMoniker);
 			if (framework == null) {
-				LogCodedWarning ("XA0118", $"Could not parse '{TargetMoniker}'");
+				LogCodedWarning ("XA0118", Properties.Resources.XA0118_Parse, TargetMoniker);
 				return null;
 			}
 			var target = lockFile.GetTarget (framework, string.Empty);
 			if (target == null) {
-				LogCodedWarning ("XA0118", $"Could not resolve target for '{TargetMoniker}'");
+				LogCodedWarning ("XA0118", Properties.Resources.XA0118_Target, TargetMoniker);
 				return null;
 			}
 			foreach (var folder in lockFile.PackageFolders) {
@@ -266,11 +265,10 @@ namespace Xamarin.Android.Tasks
 					if (missingAssembly.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)) {
 						missingAssembly = Path.GetFileNameWithoutExtension (missingAssembly);
 					}
-					string message = $"Can not resolve reference: `{missingAssembly}`, referenced by {references}.";
 					if (MonoAndroidHelper.IsFrameworkAssembly (ex.FileName)) {
-						LogCodedError ("XA2002", $"{message} Perhaps it doesn't exist in the Mono for Android profile?");
+						LogCodedError ("XA2002", Properties.Resources.XA2002_Framework, missingAssembly, references);
 					} else {
-						LogCodedError ("XA2002", $"{message} Please add a NuGet package or assembly reference for `{missingAssembly}`, or remove the reference to `{resolutionPath [0]}`.");
+						LogCodedError ("XA2002", Properties.Resources.XA2002_NuGet, missingAssembly, references, resolutionPath [0]);
 					}
 					return;
 				}


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA0105, XA0118, & XA2002 into the `.resx`
file so that they are localizable.

Other changes:

Reword the XA0105 message to avoid "you" and "your".

Replace "target" with "`target` in lock file" so that "`target`" can be
left unlocalized.