### PR TITLE
[Xamarin.Android.Build.Tasks] ValidateJavaVersion l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -41,10 +41,10 @@ ms.date: 01/24/2020
 + [XA0002](xa0002.md): Could not find mono.android.jar
 + [XA0003](xa0003.md): Invalid `android:versionCode` value. It must be an integer value.
 + [XA0004](xa0004.md): VersionCode {code} is outside 0, {maxVersionCode} interval.
-+ [XA0030](xa0030.md): Building with JDK Version `{versionNumber}` is not supported.
-+ [XA0031](xa0031.md): Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVersion {targetFrameworkVersion}.
-+ [XA0032](xa0032.md): Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.
-+ [XA0033](xa0033.md): Failed to get the Java SDK version as it does not appear to contain a valid version number.
++ [XA0030](xa0030.md): Building with JDK version `{versionNumber}` is not supported.
++ [XA0031](xa0031.md): Java SDK {requiredJavaForFrameworkVersion} or above is required when when using $(TargetFrameworkVersion) {targetFrameworkVersion}.
++ [XA0032](xa0032.md): Java SDK {requiredJavaForBuildTools} or above is required when using Android SDK Build-Tools {buildToolsVersion}.
++ [XA0033](xa0033.md): Failed to get the Java SDK version because the returned value does not appear to contain a valid version number.
 + [XA0034](xa0034.md): Failed to get the Java SDK version.
 + XA0100: EmbeddedNativeLibrary is invalid in Android Application projects. Please use AndroidNativeLibrary instead.
 + [XA0101](xa0101.md): warning XA0101: @(Content) build action is not supported.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -124,6 +124,51 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors.
+        /// </summary>
+        internal static string XA0030 {
+            get {
+                return ResourceManager.GetString("XA0030", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}..
+        /// </summary>
+        internal static string XA0031 {
+            get {
+                return ResourceManager.GetString("XA0031", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Java SDK {0} or above is required when using Android SDK Build-Tools {1}..
+        /// </summary>
+        internal static string XA0032 {
+            get {
+                return ResourceManager.GetString("XA0032", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```.
+        /// </summary>
+        internal static string XA0033 {
+            get {
+                return ResourceManager.GetString("XA0033", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get the Java SDK version. Please ensure you have Java {0} or above installed..
+        /// </summary>
+        internal static string XA0034 {
+            get {
+                return ResourceManager.GetString("XA0034", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EmbeddedNativeLibrary &apos;{0}&apos; is invalid in Android Application projects. Please use AndroidNativeLibrary instead..
         /// </summary>
         internal static string XA0100 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -148,6 +148,32 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</value>
     <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)</comment>
   </data>
+  <data name="XA0030" xml:space="preserve">
+    <value>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</value>
+    <comment>The abbreviation "JDK" should not be translated.</comment>
+  </data>
+  <data name="XA0031" xml:space="preserve">
+    <value>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</value>
+    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</comment>
+  </data>
+  <data name="XA0032" xml:space="preserve">
+    <value>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</value>
+    <comment>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</comment>
+  </data>
+  <data name="XA0033" xml:space="preserve">
+    <value>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</value>
+    <comment>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</comment>
+  </data>
+  <data name="XA0034" xml:space="preserve">
+    <value>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</value>
+    <comment>{0} - The Java version number</comment>
+  </data>
   <data name="XA0100" xml:space="preserve">
     <value>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</value>
     <comment>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -40,6 +40,37 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0030">
+        <source>Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</source>
+        <target state="new">Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors</target>
+        <note>The abbreviation "JDK" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA0031">
+        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The Java SDK version number
+{1} - The target framework version number</note>
+      </trans-unit>
+      <trans-unit id="XA0032">
+        <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>
+        <target state="new">Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools
+{0} - The Java SDK version number
+{1} - The Android SDK Build-Tools version number</note>
+      </trans-unit>
+      <trans-unit id="XA0033">
+        <source>Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</source>
+        <target state="new">Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `{0} -version` returned: ```{1}```</target>
+        <note>The following are literal names and should not be translated: `{0} -version`, ```{1}```
+{0} - The name of the Java command
+{1} - The output of the command</note>
+      </trans-unit>
+      <trans-unit id="XA0034">
+        <source>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</source>
+        <target state="new">Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</target>
+        <note>{0} - The Java version number</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -80,18 +80,18 @@ namespace Xamarin.Android.Tasks
 				if (versionNumber != null) {
 					Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
 					if (versionNumber < requiredJavaForFrameworkVersion) {
-						Log.LogCodedError ("XA0031", $"Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVersion {targetFrameworkVersion}.");
+						Log.LogCodedError ("XA0031", Properties.Resources.XA0031, requiredJavaForFrameworkVersion, targetFrameworkVersion);
 					}
 					if (versionNumber < requiredJavaForBuildTools) {
-						Log.LogCodedError ("XA0032", $"Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.");
+						Log.LogCodedError ("XA0032", Properties.Resources.XA0032, requiredJavaForBuildTools, buildToolsVersion);
 					}
 					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-						Log.LogCodedError ("XA0030", $"Building with JDK Version `{versionNumber}` is not supported. Please install JDK version `{LatestSupportedJavaVersion}`. See https://aka.ms/xamarin/jdk9-errors");
+						Log.LogCodedError ("XA0030",Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
 					}
 				}
 			} catch (Exception ex) {
 				Log.LogWarningFromException (ex);
-				Log.LogCodedWarning ("XA0034", $"Failed to get the Java SDK version. Please ensure you have Java {required} or above installed.");
+				Log.LogCodedWarning ("XA0034", Properties.Resources.XA0034, required);
 				return false;
 			}
 
@@ -125,7 +125,7 @@ namespace Xamarin.Android.Tasks
 				JdkVersion = versionNumberMatch.Groups ["version"].Value;
 				return versionNumber;
 			} else {
-				Log.LogCodedWarning ("XA0033", $"Failed to get the Java SDK version as it does not appear to contain a valid version number. `{javaExe} -version` returned: ```{versionInfo}```");
+				Log.LogCodedWarning ("XA0033", Properties.Resources.XA0033, javaExe, versionInfo);
 				return null;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Build.Tests
 				MinimumSupportedJavaVersion = "1.7.0",
 			};
 			Assert.False (validateJavaVersion.Execute (), "Execute should *not* succeed!");
-			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when targeting FrameworkVersion {validateJavaVersion.TargetFrameworkVersion}."), "Should get error about TargetFrameworkVersion=v8.1");
+			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when using $(TargetFrameworkVersion) {validateJavaVersion.TargetFrameworkVersion}."), "Should get error about TargetFrameworkVersion=v8.1");
 		}
 
 		[Test]
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Build.Tests
 				MinimumSupportedJavaVersion = "1.7.0",
 			};
 			Assert.False (validateJavaVersion.Execute (), "Execute should *not* succeed!");
-			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when using build-tools {validateJavaVersion.AndroidSdkBuildToolsVersion}."), "Should get error about build-tools=27.0.0");
+			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when using Android SDK Build-Tools {validateJavaVersion.AndroidSdkBuildToolsVersion}."), "Should get error about build-tools=27.0.0");
 		}
 
 		[Test]


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA0030, XA0031, XA0032, XA0033, & XA0034
into the `.resx` file so that they are localizable.

Other changes:

Use the literal name `$(TargetFrameworkVersion)` so that it doesn't need
to be localized.

Standardize the name "Android SDK Build-Tools" to match XA5205.

Replace a usage of "it" in the message for XA0033 to reduce potential
ambiguity for the l10n team.