### PR TITLE
[xaprepare] Do less when updating Mono

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -765,16 +765,21 @@ namespace Xamarin.Android.Prepare
 
 			Tools.Init (this);
 
-			Banner ("Updating Git submodules");
+			if (SelectedScenario.NeedsGitSubmodules) {
+				Banner ("Updating Git submodules");
 
-			var git = new GitRunner (this);
-			if (!await git.SubmoduleUpdate ()) {
-				Log.ErrorLine ("Failed to update Git submodules");
-				return false;
+				var git = new GitRunner (this);
+				if (!await git.SubmoduleUpdate ()) {
+					Log.ErrorLine ("Failed to update Git submodules");
+					return false;
+				}
 			}
 
 			BuildInfo = new BuildInfo ();
-			await BuildInfo.GatherGitInfo (this);
+			if (SelectedScenario.NeedsGitBuildInfo) {
+				await BuildInfo.GatherGitInfo (this);
+			}
+
 			AbiNames.LogAllNames (this);
 
 			if (MakeConcurrency == 0)

--- a/build-tools/xaprepare/xaprepare/Application/Scenario.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Scenario.cs
@@ -10,6 +10,9 @@ namespace Xamarin.Android.Prepare
 		public string Description { get; }
 		public string LogFilePath { get; protected set; }
 		public List<Step> Steps   { get; } = new List<Step> ();
+		public bool NeedsGitSubmodules { get; protected set; }
+		public bool NeedsGitBuildInfo { get; protected set; }
+		public bool NeedsCompilers { get; protected set; }
 
 		protected Scenario (string name, string description, Context context)
 		{

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -368,7 +368,8 @@ namespace Xamarin.Android.Prepare
 				Environment.SetEnvironmentVariable (name, value);
 			}
 
-			DetectCompilers ();
+			if (Context.SelectedScenario.NeedsCompilers)
+				DetectCompilers ();
 		}
 
 		/// <summary>

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternal.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternal.cs
@@ -7,7 +7,9 @@ namespace Xamarin.Android.Prepare
 	{
 		public Scenario_PrepareExternal ()
 			: base ("PrepareExternal", "Prepare external submodules", Context.Instance)
-		{}
+		{
+			NeedsGitSubmodules = true;
+		}
 
 		protected override void AddSteps (Context context)
 		{

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
@@ -7,7 +7,11 @@ namespace Xamarin.Android.Prepare
 	class Scenario_Required : Scenario
 	{
 		public Scenario_Required () : base ("Required", "Just the basic steps to quickly install required tools and generate build files.", Context.Instance)
-		{}
+		{
+			NeedsGitSubmodules = true;
+			NeedsCompilers = true;
+			NeedsGitBuildInfo = true;
+		}
 
 		protected override void AddSteps (Context context)
 		{

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -7,7 +7,11 @@ namespace Xamarin.Android.Prepare
 	{
 		public Scenario_Standard ()
 			: base ("Standard", "Standard init", Context.Instance)
-		{}
+		{
+			NeedsGitSubmodules = true;
+			NeedsCompilers = true;
+			NeedsGitBuildInfo = true;
+		}
 
 		protected override void AddSteps (Context context)
 		{

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
@@ -8,7 +8,9 @@ namespace Xamarin.Android.Prepare
 	{
 		public Scenario_ThirdPartyNotices ()
 			: base ("ThirdPartyNotices", "Generate the `ThirdPartyNotices.txt` files.", Context.Instance)
-		{}
+		{
+			NeedsGitSubmodules = true;
+		}
 
 		protected override void AddSteps (Context context)
 		{

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_UpdateMono.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_UpdateMono.Unix.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Prepare
 			// ...and disable installation of other programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);
 
-			// ...but do not signal an error when any are missing
+			// ...but do not signal an error when any are missing...
 			context.SetCondition (KnownConditions.IgnoreMissingPrograms, true);
 		}
 	}


### PR DESCRIPTION
When updating Mono from an older version (e.g. 6.6) `xaprepare` can
crash as soon as the Mono package is installed with exceptions similar
to the ones below:

    System.InvalidOperationException: Failed to obtain version information from the cc compiler
      at Xamarin.Android.Prepare.Unix.DetectCompilers () [0x00344] in build-tools/xaprepare/xaprepare/OperatingSystems/Unix.cs:102
      at Xamarin.Android.Prepare.OS.ConfigureEnvironment () [0x00096] in build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs:371
      at Xamarin.Android.Prepare.OS.Init () [0x000e6] in build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs:254
      at Xamarin.Android.Prepare.Context.Init (System.String scenarioName) [0x0026c] in build-tools/xaprepare/xaprepare/Application/Context.cs:761
      at Xamarin.Android.Prepare.App.Run (System.String[] args) [0x0078a] in build-tools/xaprepare/xaprepare/Main.cs:153

    System.InvalidOperationException: Unable to determine the last version change commit
      at Xamarin.Android.Prepare.BuildInfo.DetermineLastVersionChangeCommit (Xamarin.Android.Prepare.Context context) [0x000fa] in build-tools/xaprepare/xaprepare/Application/BuildInfo.cs:130
      at Xamarin.Android.Prepare.BuildInfo.GatherGitInfo (Xamarin.Android.Prepare.Context context) [0x0006d] in build-tools/xaprepare/xaprepare/Application/BuildInfo.cs:36
      at Xamarin.Android.Prepare.Context.Init (System.String scenarioName) [0x00430] in build-tools/xaprepare/xaprepare/Application/Context.cs:780
      at Xamarin.Android.Prepare.App.Run (System.String[] args) [0x0078a] in build-tools/xaprepare/xaprepare/Main.cs:153

This is most probably caused by the new Mono changing assemblies/shared libraries
underneath the older Mono which is currently executing `xaprepare`.

In order to avoid the crash, do as little as possible to update Mono and quit as
quickly as possible.