### PR TITLE
[Xamarin.Android.Build.Tasks] XA1000, XA4303, XA5207, & XA5302 l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -69,7 +69,7 @@ ms.date: 01/24/2020
 
 ## XA1xxx: Project related
 
-+ [XA1000](xa1000.md): There was an problem parsing {file}. This is likely due to incomplete or invalid xml.
++ [XA1000](xa1000.md): There was a problem parsing {file}. This is likely due to incomplete or invalid XML.
 + [XA1001](xa1001.md): AndroidResgen: Warning while updating Resource XML '{filename}': {Message}
 + [XA1002](xa1002.md): The closest match found for '{customViewName}' is '{customViewLookupName}', but the capitalization does not match. Please correct the capitalization.
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
@@ -123,7 +123,7 @@ ms.date: 01/24/2020
 + XA5105: Toolchain utility '{utility}' for target {arch} was not found. Tried in path: "{path}"
 + XA5201: NDK linker exited with an error. Exit code {0}
 + [XA5205](xa5205.md): Cannot find `{ToolName}` in the Android SDK.
-+ [XA5207](xa5207.md): Could not find android.jar for API Level `{compileSdk}`.
++ [XA5207](xa5207.md): Could not find android.jar for API level `{compileSdk}`.
 + XA5213: java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{tool} {arguments}'
 + [XA5300](xa5300.md): The Android/Java SDK Directory could not be found.
 + [XA5301](xa5301.md): Failed to generate Java type for class: {managedType} due to MAX_PATH: {exception}

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -259,6 +259,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}.
+        /// </summary>
+        internal static string XA1000 {
+            get {
+                return ResourceManager.GetString("XA1000", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to AndroidResgen: Warning while updating resource XML &apos;{0}&apos;: {1}.
         /// </summary>
         internal static string XA1001 {
@@ -547,6 +556,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error extracting resources from &quot;{0}&quot;: {1}.
+        /// </summary>
+        internal static string XA4303 {
+            get {
+                return ResourceManager.GetString("XA4303", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ProGuard configuration file &apos;{0}&apos; was not found..
         /// </summary>
         internal static string XA4304 {
@@ -700,6 +718,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.).
+        /// </summary>
+        internal static string XA5207 {
+            get {
+                return ResourceManager.GetString("XA5207", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tools &gt; Open Android SDK Manager....
+        /// </summary>
+        internal static string XA5207_SDK_Manager_macOS {
+            get {
+                return ResourceManager.GetString("XA5207_SDK_Manager_macOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tools &gt; Android &gt; Android SDK Manager....
+        /// </summary>
+        internal static string XA5207_SDK_Manager_Windows {
+            get {
+                return ResourceManager.GetString("XA5207_SDK_Manager_Windows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing &apos;{0} {1}&apos;.
         /// </summary>
         internal static string XA5213 {
@@ -741,6 +786,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA5301 {
             get {
                 return ResourceManager.GetString("XA5301", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Two processes may be building this project at once. Lock file exists at path: {0}.
+        /// </summary>
+        internal static string XA5302 {
+            get {
+                return ResourceManager.GetString("XA5302", resourceCulture);
             }
         }
     }

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -221,6 +221,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet</comment>
   </data>
+  <data name="XA1000" xml:space="preserve">
+    <value>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</value>
+    <comment>{0} - The file name
+{1} - The exception message of the associated exception</comment>
+  </data>
   <data name="XA1001" xml:space="preserve">
     <value>AndroidResgen: Warning while updating resource XML '{0}': {1}</value>
     <comment>The following are literal names and should not be translated: AndroidResgen
@@ -374,6 +379,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</comment>
   </data>
+  <data name="XA4303" xml:space="preserve">
+    <value>Error extracting resources from "{0}": {1}</value>
+    <comment>{0} - The file name
+{1} - The exception message of the associated exception</comment>
+  </data>
   <data name="XA4304" xml:space="preserve">
     <value>ProGuard configuration file '{0}' was not found.</value>
     <comment>The following are literal names and should not be translated: ProGuard</comment>
@@ -454,6 +464,21 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</comment>
   </data>
+  <data name="XA5207" xml:space="preserve">
+    <value>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</value>
+    <comment>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</comment>
+  </data>
+  <data name="XA5207_SDK_Manager_macOS" xml:space="preserve">
+    <value>Tools &gt; Open Android SDK Manager...</value>
+    <comment>This string is the location of a menu command in Visual Studio for Mac.</comment>
+  </data>
+  <data name="XA5207_SDK_Manager_Windows" xml:space="preserve">
+    <value>Tools &gt; Android &gt; Android SDK Manager...</value>
+    <comment>This string is the location of a menu command in Visual Studio.</comment>
+  </data>
   <data name="XA5213" xml:space="preserve">
     <value>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</value>
     <comment>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
@@ -481,5 +506,8 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</comment>
+  </data>
+  <data name="XA5302" xml:space="preserve">
+    <value>Two processes may be building this project at once. Lock file exists at path: {0}</value>
   </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -129,6 +129,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA1000">
+        <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
+        <target state="new">There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
@@ -318,6 +324,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4303">
+        <source>Error extracting resources from "{0}": {1}</source>
+        <target state="new">Error extracting resources from "{0}": {1}</target>
+        <note>{0} - The file name
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
       <trans-unit id="XA4304">
         <source>ProGuard configuration file '{0}' was not found.</source>
         <target state="new">ProGuard configuration file '{0}' was not found.</target>
@@ -416,6 +428,24 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
+      <trans-unit id="XA5207">
+        <source>Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</source>
+        <target state="new">Could not find android.jar for API level {0}. This means the Android SDK platform for API level {0} is not installed. Either install it in the Android SDK Manager ({2}), or change the Xamarin.Android project to target an API version that is installed. ({1} missing.)</target>
+        <note>The following are literal names and should not be translated: android.jar
+{0} - The API level name
+{1} - The expected path of the android.jar file
+{2} - The menu location in Visual Studio that can be used to launch the Android SDK Manager</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_Windows">
+        <source>Tools &gt; Android &gt; Android SDK Manager...</source>
+        <target state="new">Tools &gt; Android &gt; Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio.</note>
+      </trans-unit>
+      <trans-unit id="XA5207_SDK_Manager_macOS">
+        <source>Tools &gt; Open Android SDK Manager...</source>
+        <target state="new">Tools &gt; Open Android SDK Manager...</target>
+        <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
         <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
@@ -448,6 +478,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: MAX_PATH.
 {0} - The managed type name
 {1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA5302">
+        <source>Two processes may be building this project at once. Lock file exists at path: {0}</source>
+        <target state="new">Two processes may be building this project at once. Lock file exists at path: {0}</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -256,10 +256,10 @@ namespace Xamarin.Android.Tasks
 										return !files.Contains (fileToDelete);
 									});
 								} catch (PathTooLongException ex) {
-									Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+									Log.LogCodedError ("XA4303", Properties.Resources.XA4303, assemblyPath, ex);
 									return;
 								} catch (NotSupportedException ex) {
-									Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+									Log.LogCodedError ("XA4303", Properties.Resources.XA4303, assemblyPath, ex);
 									return;
 								}
 							}
@@ -283,10 +283,10 @@ namespace Xamarin.Android.Tasks
 										return !jars.ContainsKey (fileToDelete);
 									});
 								} catch (PathTooLongException ex) {
-									Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+									Log.LogCodedError ("XA4303", Properties.Resources.XA4303, assemblyPath, ex);
 									return;
 								} catch (NotSupportedException ex) {
-									Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+									Log.LogCodedError ("XA4303", Properties.Resources.XA4303, assemblyPath, ex);
 									return;
 								}
 							}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Tasks
 				var existing = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build) as DeleteFileAfterBuild;
 				if (existing == null) {
 					if (File.Exists (path)) {
-						Log.LogCodedWarning ("XA5302", "Two processes may be building this project at once. Lock file exists at path: {0}", path);
+						Log.LogCodedWarning ("XA5302", Properties.Resources.XA5302, path);
 					} else {
 						Directory.CreateDirectory (Path.GetDirectoryName (path));
 						File.WriteAllText (path, "");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3161,7 +3161,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					$"_AndroidApiLevel=27",
 				}), "Build should have failed");
 				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("error XA5207:"), "XA5207 should have been raised.");
-				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("Could not find android.jar for API Level 27"), "XA5207 should have had a good error message.");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("Could not find android.jar for API level 27"), "XA5207 should have had a good error message.");
 			}
 			Directory.Delete (AndroidSdkDirectory, recursive: true);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -404,7 +404,7 @@ namespace Xamarin.Android.Tasks
 				try {
 					ProcessXmlFile (file);
 				} catch (XmlException ex) {
-					Log.LogCodedWarning ("XA1000", $"There was an problem parsing {file}. This is likely due to incomplete or invalid xml. Exception: {ex}");
+					Log.LogCodedWarning ("XA1000", Properties.Resources.XA1000, file, ex);
 				}
 				break;
 			default:

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -639,13 +639,8 @@ namespace Xamarin.Android.Tasks
 			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
 			if (platformPath == null) {
 				var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
-				var sdkManagerMenuPath = OS.IsWindows ? "Tools > Android > Android SDK Manager..." : "Tools > Open Android SDK Manager...";
-				log.LogCodedError ("XA5207", "Could not find android.jar for API Level {0}. " +
-						"This means the Android SDK platform for API Level {0} is not installed. " +
-						"Either install it in the Android SDK Manager ({2}), " +
-						"or change your Xamarin.Android project to target an API version that is installed. " +
-						"({1} missing.)",
-						platform, Path.Combine (expectedPath, "android.jar"), sdkManagerMenuPath);
+				var sdkManagerMenuPath = OS.IsWindows ? Properties.Resources.XA5207_SDK_Manager_Windows : Properties.Resources.XA5207_SDK_Manager_macOS;
+				log.LogCodedError ("XA5207", Properties.Resources.XA5207, platform, Path.Combine (expectedPath, "android.jar"), sdkManagerMenuPath);
 				return null;
 			}
 			return Path.Combine (platformPath, "android.jar");


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA1000, XA4303, XA5207, & XA5302 into the
`.resx` file so that they are localizable.