### PR TITLE
[build] Run class-parse and api-xml-adjuster in parallel

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -71,7 +71,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						LogError ($"Unable to run command: {cmd.GetMetadata ("Command")}\nException:\n{e}");
 						success = false;
 					}
+
+					Complete ();
 				});
+
+			WaitForCompletion ();
 
 			if (!success)
 				return false;

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -24,6 +24,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		{
 			bool success = true;
 
+			LogMessage ($"RunParallelCmds max parallelism: {Environment.ProcessorCount}");
+
 			Tasks.Parallel.ForEach (Commands, new Tasks.ParallelOptions () { MaxDegreeOfParallelism = Environment.ProcessorCount },
 				cmd => {
 					var command = cmd.GetMetadata ("Command");

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -5,11 +5,13 @@ using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+using Xamarin.Build;
+
 using Tasks = System.Threading.Tasks;
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
-	public class RunParallelCmds : Task
+	public class RunParallelCmds : AsyncTask
 	{
 		[Required]
 		public ITaskItem[] Commands { get; set; }
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					var useManagedRuntime = !string.IsNullOrEmpty (ManagedRuntime);
 					var argumentsBeginning = useManagedRuntime ? ManagedRuntimeArguments + " " : "";
 
-					Log.LogMessage (MessageImportance.Normal, $"Starting Command: {cmd.GetMetadata ("Command")} Arguments: {cmd.GetMetadata ("Arguments")}");
+					LogMessage ($"Starting Command: {cmd.GetMetadata ("Command")} Arguments: {cmd.GetMetadata ("Arguments")}");
 
 					try {
 						using (var proc = new Process ()) {
@@ -58,15 +60,15 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 							var errOutput = errorOutput.ToString ();
 
 							if (proc.ExitCode != 0) {
-								Log.LogMessage (MessageImportance.High, $"Non-zero exit code: {proc.ExitCode}  Error output: {errOutput}");
+								LogMessage ($"Non-zero exit code: {proc.ExitCode}  Error output: {errOutput}", MessageImportance.High);
 								success = false;
 							}
 
 							if (!string.IsNullOrEmpty (output))
-								Log.LogMessage (MessageImportance.Normal, $"Output: {output}");
+								LogMessage ($"Output: {output}");
 						}
 					} catch (Exception e) {
-						Log.LogError ($"Unable to run command: {cmd.GetMetadata ("Command")}\nException:\n{e}");
+						LogError ($"Unable to run command: {cmd.GetMetadata ("Command")}\nException:\n{e}");
 						success = false;
 					}
 				});

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Tasks = System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class RunParallelCmds : Task
+	{
+		[Required]
+		public ITaskItem[] Commands { get; set; }
+
+		public string ManagedRuntime { get; set; }
+
+		public string ManagedRuntimeArguments { get; set; }
+
+		public override bool Execute ()
+		{
+			bool success = true;
+
+			Tasks.Parallel.ForEach (Commands, new Tasks.ParallelOptions () { MaxDegreeOfParallelism = Environment.ProcessorCount },
+				cmd => {
+					var useManagedRuntime = !string.IsNullOrEmpty (ManagedRuntime);
+					var argumentsBeginning = useManagedRuntime ? ManagedRuntimeArguments + " " : "";
+					var procStartInfo = new ProcessStartInfo () {
+						FileName =  useManagedRuntime ? ManagedRuntime : cmd.GetMetadata ("Command"),
+						Arguments = $"{argumentsBeginning}{cmd.GetMetadata ("Arguments")}",
+						CreateNoWindow = true,
+						UseShellExecute = false,
+						RedirectStandardOutput = true,
+						RedirectStandardError = true,
+					};
+
+					Log.LogMessage (MessageImportance.Normal, $"Starting Command: {cmd.GetMetadata ("Command")} Arguments: {cmd.GetMetadata ("Arguments")}");
+
+					try {
+						using (var proc = Process.Start (procStartInfo)) {
+							proc.WaitForExit ();
+
+							if (proc.ExitCode != 0) {
+								Log.LogMessage (MessageImportance.High, $"Non-zero exit code: {proc.ExitCode}  Error output: {proc.StandardError.ReadToEnd ()}");
+								success = false;
+							}
+
+							var output = proc.StandardOutput.ReadToEnd ();
+
+							if (!string.IsNullOrEmpty (output))
+								Log.LogMessage (MessageImportance.Normal, $"Output: {output}");
+						}
+					} catch (Exception e) {
+						Log.LogError ($"Unable to run command: {cmd.GetMetadata ("Command")}\nException:\n{e}");
+						success = false;
+					}
+				});
+
+			if (!success)
+				return false;
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -26,16 +26,17 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 			Tasks.Parallel.ForEach (Commands, new Tasks.ParallelOptions () { MaxDegreeOfParallelism = Environment.ProcessorCount },
 				cmd => {
+					var command = cmd.GetMetadata ("Command");
 					var useManagedRuntime = !string.IsNullOrEmpty (ManagedRuntime);
-					var argumentsBeginning = useManagedRuntime ? ManagedRuntimeArguments + " " : "";
+					var argumentsBeginning = useManagedRuntime ? $"{ManagedRuntimeArguments} {command} " : "";
 
-					LogMessage ($"Starting Command: {cmd.GetMetadata ("Command")} Arguments: {cmd.GetMetadata ("Arguments")}");
+					LogMessage ($"Starting Command: {command} Arguments: {cmd.GetMetadata ("Arguments")}");
 
 					try {
 						using (var proc = new Process ()) {
 							StringBuilder standardOutput = new StringBuilder (), errorOutput = new StringBuilder ();
 
-							proc.StartInfo.FileName = useManagedRuntime ? ManagedRuntime : cmd.GetMetadata ("Command");
+							proc.StartInfo.FileName = useManagedRuntime ? ManagedRuntime : command;
 							proc.StartInfo.Arguments = $"{argumentsBeginning}{cmd.GetMetadata ("Arguments")}";
 							proc.StartInfo.CreateNoWindow = true;
 							proc.StartInfo.UseShellExecute = false;
@@ -68,7 +69,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 								LogMessage ($"Output: {output}");
 						}
 					} catch (Exception e) {
-						LogError ($"Unable to run command: {cmd.GetMetadata ("Command")}\nException:\n{e}");
+						LogError ($"Unable to run command: {command}\nException:\n{e}");
 						success = false;
 					}
 

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -40,12 +40,13 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						using (var proc = Process.Start (procStartInfo)) {
 							proc.WaitForExit ();
 
+							var output = proc.StandardOutput.ReadToEnd ();
+							var errOutput = proc.StandardError.ReadToEnd ();
+
 							if (proc.ExitCode != 0) {
-								Log.LogMessage (MessageImportance.High, $"Non-zero exit code: {proc.ExitCode}  Error output: {proc.StandardError.ReadToEnd ()}");
+								Log.LogMessage (MessageImportance.High, $"Non-zero exit code: {proc.ExitCode}  Error output: {errOutput}");
 								success = false;
 							}
-
-							var output = proc.StandardOutput.ReadToEnd ();
 
 							if (!string.IsNullOrEmpty (output))
 								Log.LogMessage (MessageImportance.Normal, $"Output: {output}");

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -1,5 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunParallelCmds" />
   <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')" />
 
   <PropertyGroup>
@@ -20,19 +21,28 @@
     </CreateItem>
   </Target>
 
-  <Target Name="_ClassParse"
-      BeforeTargets="_AdjustApiXml"
-      DependsOnTargets="_DefineApiFiles"
-      Inputs="%(ApiFileDefinition.ParameterDescription)"
-      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
+  <Target Name="_ClassParsePrepare"
+      DependsOnTargets="_DefineApiFiles">
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
     <MakeDir Directories="$(_OutputPath)api" />
-    <Exec
-        Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ClassParse) $(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;"
-    />
+    <CreateItem
+        Include="@(ApiFileDefinition)"
+        AdditionalMetadata='Command=$(ClassParse);Arguments=$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;'>
+      <Output TaskParameter="Include" ItemName="ClassParseCommands"/>
+    </CreateItem>
+  </Target>
+  <Target Name="_ClassParse"
+      BeforeTargets="_AdjustApiXml"
+      DependsOnTargets="_ClassParsePrepare"
+      Inputs="@(ApiFileDefinition.ParameterDescription)"
+      Outputs="@(ApiFileDefinition.ApiAdjustedXml)">
+    <RunParallelCmds
+        Commands="@(ClassParseCommands)"
+        ManagedRuntime="$(ManagedRuntime)"
+        ManagedRuntimeArguments="$(ManagedRuntimeArgs)"
+      />
   </Target>
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -28,9 +28,10 @@
     </PropertyGroup>
     <MakeDir Directories="$(_OutputPath)api" />
     <CreateItem
+        Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
         Include="@(ApiFileDefinition)"
         AdditionalMetadata='Command=$(ClassParse);Arguments=$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;'>
-      <Output TaskParameter="Include" ItemName="ClassParseCommands"/>
+      <Output TaskParameter="Include" ItemName="_ClassParseCommands"/>
     </CreateItem>
   </Target>
   <Target Name="_ClassParse"
@@ -39,23 +40,33 @@
       Inputs="@(ApiFileDefinition.ParameterDescription)"
       Outputs="@(ApiFileDefinition.ApiAdjustedXml)">
     <RunParallelCmds
-        Commands="@(ClassParseCommands)"
+        Commands="@(_ClassParseCommands)"
         ManagedRuntime="$(ManagedRuntime)"
         ManagedRuntimeArguments="$(ManagedRuntimeArgs)"
       />
   </Target>
-  <Target Name="_AdjustApiXml"
-      AfterTargets="Build"
-      DependsOnTargets="_DefineApiFiles"
-      Inputs="%(ApiFileDefinition.ClassParseXml)"
-      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
+  <Target Name="_AdjustApiXmlPrepare"
+      DependsOnTargets="_DefineApiFiles">
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>
-    <Exec
+    <CreateItem
         Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiXmlAdjuster) %(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)"
-    />
+        Include="@(ApiFileDefinition)"
+        AdditionalMetadata='Command=$(ApiXmlAdjuster);Arguments=%(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)'>
+      <Output TaskParameter="Include" ItemName="_AdjustApiXmlPrepareCommands"/>
+    </CreateItem>
+  </Target>
+  <Target Name="_AdjustApiXml"
+      AfterTargets="Build"
+      DependsOnTargets="_AdjustApiXmlPrepare"
+      Inputs="@(ApiFileDefinition.ClassParseXml)"
+      Outputs="@(ApiFileDefinition.ApiAdjustedXml);abc">
+    <RunParallelCmds
+        Commands="@(_AdjustApiXmlPrepareCommands)"
+        ManagedRuntime="$(ManagedRuntime)"
+        ManagedRuntimeArguments="$(ManagedRuntimeArgs)"
+      />
   </Target>
 
   <Target Name="_CleanApiXml"

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -61,7 +61,7 @@
       AfterTargets="Build"
       DependsOnTargets="_AdjustApiXmlPrepare"
       Inputs="@(ApiFileDefinition.ClassParseXml)"
-      Outputs="@(ApiFileDefinition.ApiAdjustedXml);abc">
+      Outputs="@(ApiFileDefinition.ApiAdjustedXml)">
     <RunParallelCmds
         Commands="@(_AdjustApiXmlPrepareCommands)"
         ManagedRuntime="$(ManagedRuntime)"

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -27,12 +27,14 @@
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
     <MakeDir Directories="$(_OutputPath)api" />
-    <CreateItem
-        Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
-        Include="@(ApiFileDefinition)"
-        AdditionalMetadata='Command=$(ClassParse);Arguments=$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;'>
-      <Output TaskParameter="Include" ItemName="_ClassParseCommands"/>
-    </CreateItem>
+    <ItemGroup>
+      <_ClassParseCommands
+          Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
+          Include="@(ApiFileDefinition)">
+        <Command>$(ClassParse)</Command>
+        <Arguments>$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;</Arguments>
+      </_ClassParseCommands>
+    </ItemGroup>
   </Target>
   <Target Name="_ClassParse"
       BeforeTargets="_AdjustApiXml"
@@ -50,12 +52,14 @@
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>
-    <CreateItem
-        Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
-        Include="@(ApiFileDefinition)"
-        AdditionalMetadata='Command=$(ApiXmlAdjuster);Arguments=%(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)'>
-      <Output TaskParameter="Include" ItemName="_AdjustApiXmlPrepareCommands"/>
-    </CreateItem>
+    <ItemGroup>
+      <_AdjustApiXmlPrepareCommands
+          Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
+          Include="@(ApiFileDefinition)">
+        <Command>$(ApiXmlAdjuster)</Command>
+        <Arguments>%(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)</Arguments>
+      </_AdjustApiXmlPrepareCommands>
+    </ItemGroup>
   </Target>
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -39,8 +39,8 @@
   <Target Name="_ClassParse"
       BeforeTargets="_AdjustApiXml"
       DependsOnTargets="_ClassParsePrepare"
-      Inputs="@(ApiFileDefinition.ParameterDescription)"
-      Outputs="@(ApiFileDefinition.ApiAdjustedXml)">
+      Inputs="@(ApiFileDefinition->'%(ParameterDescription)')"
+      Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
     <RunParallelCmds
         Commands="@(_ClassParseCommands)"
         ManagedRuntime="$(ManagedRuntime)"
@@ -64,8 +64,8 @@
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"
       DependsOnTargets="_AdjustApiXmlPrepare"
-      Inputs="@(ApiFileDefinition.ClassParseXml)"
-      Outputs="@(ApiFileDefinition.ApiAdjustedXml)">
+      Inputs="@(ApiFileDefinition->'%(ClassParseXml)')"
+      Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
     <RunParallelCmds
         Commands="@(_AdjustApiXmlPrepareCommands)"
         ManagedRuntime="$(ManagedRuntime)"


### PR DESCRIPTION
Improve the build speed by running the class-parse and api-xml-adjuster tools in parallel.

Measured times:

Original:

    Project Performance Summary:
        60265 ms  C:\Users\rodo\git\xamarin-android\build-tools\api-xml-adjuster\api-xml-adjuster.csproj   1 calls
                  60265 ms  _AdjustApiXml                              1 calls
    
    Target Performance Summary:
           20 ms  _DefineApiFiles                            1 calls
        26117 ms  _AdjustApiXml                             16 calls
        34116 ms  _ClassParse                               16 calls
    
    Task Performance Summary:
            3 ms  MakeDir                                   16 calls
            5 ms  CreateItem                                16 calls
        60221 ms  Exec                                      32 calls

New:

    Project Performance Summary:
         5673 ms  C:\Users\rodo\git\xamarin-android\build-tools\api-xml-adjuster\api-xml-adjuster.csproj   1 calls
                   5673 ms  _AdjustApiXml                              1 calls
    
    Target Performance Summary:
            3 ms  _AdjustApiXmlPrepare                       1 calls
            4 ms  _ClassParsePrepare                         1 calls
           14 ms  _DefineApiFiles                            1 calls
         2437 ms  _AdjustApiXml                              1 calls
         3200 ms  _ClassParse                                1 calls
    
    Task Performance Summary:
            1 ms  MakeDir                                    1 calls
            7 ms  CreateItem                                48 calls
         5633 ms  RunParallelCmds                            2 calls

CI builds:

mac before: `make jenkins ... 31m 41s` (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3538996) 
mac after: `make jenkins ... 29m 51s` (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3539034)

windows before: `msbuild Xamarin.Android /t:Build ... 11m 18s` (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3538996)
windows after: `msbuild Xamarin.Android /t:Build ... 11m 59s` (https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3539034 slower, hopefully it is build bot variance?)