### PR TITLE
[build] Remove doc generation duplication

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@01a4e0a0c436bf1b0b62acf870cc06e67e62034c
+xamarin/monodroid:master@34f5275d1db891e25af17d743b425cc318e6e7df
 mono/mono:2019-12@2ff898859b8b75f123a5c895959a7e82dc829ea5

--- a/Documentation/release-notes/4351.md
+++ b/Documentation/release-notes/4351.md
@@ -1,4 +1,0 @@
-#### Xamarin.Android SDK installation
-
-  * [GitHub 4344](https://github.com/xamarin/xamarin-android/issues/4344):
-    Fixes an IntelliSense issue introduced in Xamarin.Android 10.1 caused by generating documentation from an out of date submodule that was accidentally referenced twice.

--- a/Documentation/release-notes/4351.md
+++ b/Documentation/release-notes/4351.md
@@ -1,0 +1,4 @@
+#### Xamarin.Android SDK installation
+
+  * [GitHub 4344](https://github.com/xamarin/xamarin-android/issues/4344):
+    Fixes an IntelliSense issue introduced in Xamarin.Android 10.1 caused by generating documentation from an out of date submodule that was accidentally referenced twice.


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/1076

Removes the duplicate docs reference and doc generation
from the inverted build system.