### PR TITLE
[tests] Be more flexible when parsing build-tools versions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -407,7 +407,8 @@ namespace Xamarin.Android.Build.Tests
 		protected string GetPathToLatestBuildTools (string exe)
 		{
 			var path = Path.Combine (AndroidSdkPath, "build-tools");
-			foreach (var dir in Directory.GetDirectories (path, "*", SearchOption.TopDirectoryOnly).OrderByDescending (x => new Version (Path.GetFileName (x)))) {
+			foreach (var dir in Directory.GetDirectories (path, "*", SearchOption.TopDirectoryOnly).OrderByDescending (x => Path.GetFileName (x))) {
+				TestContext.Out.WriteLine ($"Found build tools version: {dir}.");
 				var aapt2 = Path.Combine (dir, exe);
 				if (File.Exists (aapt2))
 					return dir;


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3520928&view=ms.vss-test-web.build-test-results-tab&runId=11613622&resultId=100500&paneView=debug

Xamarin.Android.Build.Task tests which attempt to look up the path to
aapt/aapt2 recently started failing on the Azure Pipelines hosted macOS
machine pool [0]. I suspect this is caused by a preview version of tools
ending up on the machine. I think we can be a bit more lenient when
locating the latest version of build-tools by instead using a string
comparison. This will also allow the relevant tests to use a preview
version of build-tools if they exist. Additional logging has also been
added to confirm this hypothesis.

[0]:

    System.FormatException : Input string was not in a correct format.
        at System.Number.ThrowOverflowOrFormatException (System.Boolean overflow, System.String overflowResourceKey) [0x0001a] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Number.ParseInt32 (System.ReadOnlySpan`1[T] value, System.Globalization.NumberStyles styles, System.Globalization.NumberFormatInfo info) [0x00016] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Int32.Parse (System.ReadOnlySpan`1[T] s, System.Globalization.NumberStyles style, System.IFormatProvider provider) [0x0000e] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Version.TryParseComponent (System.ReadOnlySpan`1[T] component, System.String componentName, System.Boolean throwOnFailure, System.Int32& parsedComponent) [0x0000b] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Version.ParseVersion (System.ReadOnlySpan`1[T] input, System.Boolean throwOnFailure) [0x0011a] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Version.Parse (System.String input) [0x00014] in <8855e4c75b1445438dde4104dd4134bb>:0
        at System.Version..ctor (System.String version) [0x00014] in <8855e4c75b1445438dde4104dd4134bb>:0
        at Xamarin.Android.Build.Tests.BaseTest+<>c.<GetPathToLatestBuildTools>b__48_0 (System.String x) [0x00006] in <e6ad3936767d47cea783c180acfe7cf6>:0
        at System.Linq.EnumerableSorter`2[TElement,TKey].ComputeKeys (TElement[] elements, System.Int32 count) [0x00010] in <89222f8e94f04b5cb12f2328985a10a8>:0
        at System.Linq.EnumerableSorter`1[TElement].ComputeMap (TElement[] elements, System.Int32 count) [0x00000] in <89222f8e94f04b5cb12f2328985a10a8>:0
        at System.Linq.EnumerableSorter`1[TElement].Sort (TElement[] elements, System.Int32 count) [0x00000] in <89222f8e94f04b5cb12f2328985a10a8>:0
        at System.Linq.OrderedEnumerable`1[TElement].SortedMap (System.Linq.Buffer`1[TElement] buffer) [0x00006] in <89222f8e94f04b5cb12f2328985a10a8>:0
        at System.Linq.OrderedEnumerable`1+<GetEnumerator>d__3[TElement].MoveNext () [0x0003d] in <89222f8e94f04b5cb12f2328985a10a8>:0
        at Xamarin.Android.Build.Tests.BaseTest.GetPathToLatestBuildTools (System.String exe) [0x00061] in <e6ad3936767d47cea783c180acfe7cf6>:0
        at Xamarin.Android.Build.Tests.BaseTest.GetPathToAapt () [0x00015] in <e6ad3936767d47cea783c180acfe7cf6>:0
        at Xamarin.Android.Build.Tests.ManagedResourceParserTests.CompareAaptAndManagedParserOutputWithCustomIds () [0x000d2] in <e6ad3936767d47cea783c180acfe7cf6>:0