### PR TITLE
[build] Add BCL doc redirects to OSS installers

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -32,6 +32,9 @@
     <_MonoDocAssembly Include="@(_MsxDocAssembly);OpenTK-1.0;Xamarin.Android.NUnitLite">
       <SourceDir>$(_AndroidApiDocsPath)docs\%(Identity)\en\</SourceDir>
     </_MonoDocAssembly>
+    <_BclDocsAssembly Include="mscorlib;System.Core;System.ComponentModel.Composition;System.ComponentModel.DataAnnotations;System.Data;System" />
+    <_BclDocsAssembly Include="System.EnterpriseServices;System.Json;System.Numerics;System.Runtime.Serialization;System.ServiceModel" />
+    <_BclDocsAssembly Include="System.ServiceModel.Web;System.Transactions;System.Web.Services;System.Xml;System.Xml.Linq" />
   </ItemGroup>
   <Target Name="_FindFrameworkDirs">
     <ItemGroup>
@@ -68,6 +71,14 @@
     <MakeDir Directories="$(_MonoDocOutputPath)"/>
     <Exec Command="$(ManagedRuntime) &quot;$(MSBuildSrcDir)mdoc.exe&quot; --debug assemble -o &quot;$(_MonoDocOutputPath)MonoAndroid-lib&quot; @(_MonoDocAssembly->'&quot;%(SourceDir)\&quot;', ' ')" />
   </Target>
+  <Target Name="_GenerateBclAssemblyDocXmlRedirects"
+      Inputs="$(XamarinAndroidSourcePath)build-tools\scripts\redirect-BCL.xml.in"
+      Outputs="@(_BclDocsAssembly->'$(FrameworkSrcDir)$(BclFrameworkVersion)\%(Identity).xml')">
+    <ReplaceFileContents
+        SourceFile="$(XamarinAndroidSourcePath)build-tools\scripts\redirect-BCL.xml.in"
+        DestinationFile="$(FrameworkSrcDir)$(BclFrameworkVersion)\%(_BclDocsAssembly.Identity).xml"
+        Replacements="@ASSEMBLY@=%(_BclDocsAssembly.Identity)" />
+  </Target>
   <Target Name="_CopyMonoAndroidDocsSource"
       Inputs="$(_AndroidApiDocsPath)MonoAndroid-docs.source"
       Outputs="$(_MonodocOutputPath)MonoAndroid-docs.source">
@@ -77,7 +88,7 @@
   </Target>
   <Target
       Name="AssembleApiDocs"
-      DependsOnTargets="_GenerateMsxDocXmls;_GenerateMsxDocXmlRedirects;_GenerateMonoAndroidLibArchive;_CopyMonoAndroidDocsSource" />
+      DependsOnTargets="_GenerateMsxDocXmls;_GenerateMsxDocXmlRedirects;_GenerateMonoAndroidLibArchive;_GenerateBclAssemblyDocXmlRedirects;_CopyMonoAndroidDocsSource" />
   <ItemGroup>
     <_DesignerFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\bcl\**\*" />
     <_DesignerFilesWin Include="$(MSBuildSrcDir)\bcl\**\* "/>
@@ -99,6 +110,8 @@
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.dll" />
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.pdb" />
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK-1.0.xml" />
+    <_FrameworkFilesWin Include="@(_BclDocsAssembly->'$(FrameworkSrcDir)$(BclFrameworkVersion)\%(Identity).xml')" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.xml" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
@@ -384,27 +397,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.Common.targets" />
     <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.Bindings.targets" />
     <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.VisualBasic.targets" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.CompilerServices.SymbolWriter.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Sqlite.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Tds.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Security.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\mscorlib.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Core.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.ComponentModel.Composition.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.ComponentModel.DataAnnotations.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Data.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.EnterpriseServices.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Json.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Numerics.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Runtime.Serialization.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.ServiceModel.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.ServiceModel.Web.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Transactions.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Web.Services.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Xml.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.Xml.Linq.xml" />
-    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.xml" />
   </ItemGroup>
   <Target Name="ConstructInstallerItems"
       DependsOnTargets="_FindFrameworkDirs;AssembleApiDocs"

--- a/build-tools/scripts/redirect-BCL.xml.in
+++ b/build-tools/scripts/redirect-BCL.xml.in
@@ -1,0 +1,1 @@
+<doc redirect="%PROGRAMFILESDIR%Reference Assemblies\Microsoft\Framework\.NETFramework\v4.X\@ASSEMBLY@.xml" />


### PR DESCRIPTION
Context: 1d053ec45b416c2ad1d8e2b702ab201b595f7975

Commit 1d053ec4 added the classlib docs and doc redirect files for
`Mono.Android.dll` and `OpenTK-1.0.dll` to the OSS installers, but it
unintentionally overlooked the doc redirect files for the BCL
assemblies.

Those redirect files don't require anything from monodroid, so it makes
sense to generate them as part of the xamarin-android build and include
them into the Windows OSS installers.

Other changes:

Remove the unneeded doc redirect files for the `Mono.*` assemblies.
.NET Framework does not have documentation for those assemblies, so the
redirect files aren't useful.

Include `Xamarin.Android.NUnitLite.xml` into the Windows OSS installers.
`Xamarin.Android.NUnitLite.csproj` already generated that file during
OSS builds, but the file was not yet included in the installers.