### PR TITLE
[xaprepare] Update dependencies on Ubuntu 20.04

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
@@ -31,7 +31,8 @@ namespace Xamarin.Android.Prepare
 			if (UbuntuRelease.Major < 18 || (UbuntuRelease.Major == 18 && UbuntuRelease.Minor < 10))
 				Dependencies.AddRange (preCosmicPackages);
 			else {
-				Dependencies.AddRange (cosmicPackages);
+				if (UbuntuRelease.Major < 20)
+					Dependencies.AddRange (cosmicPackages);
 				if (UbuntuRelease.Major < 19)
 					Dependencies.AddRange (preDiscoPackages);
 			}


### PR DESCRIPTION
Ubuntu 20.04 (focal fossa) no longer includes the `libx32ncurses6-dev`
package. Don't try to install when running on Ubuntu version 20 or
higher.