### PR TITLE
[Xamarin.Android.Build.Tasks] clean $(IntermediateOutputPath) if build.props changes

### DIFF
--- a/Documentation/release-notes/4360.md
+++ b/Documentation/release-notes/4360.md
@@ -1,0 +1,43 @@
+### More aggressive incremental clean of `obj` directory for certain scenarios
+
+In previous versions, Xamarin.Android reserved a costlier, more complete
+incremental clean of the intermediate output directory for special scenarios
+where a NuGet package changed or where the `$(AndroidPackageNamingPolicy)`
+MSBuild property changed.  Xamarin.Android 10.3 expands this behavior to
+cover several other MSBuild properties:
+
+  *`$(AndroidAotMode)`
+  *`$(AndroidCreatePackagePerAbi)`
+  *`$(AndroidDexTool)`
+  *`$(AndroidEmbedProfilers)`
+  *`$(AndroidEnableProfiledAot)`
+  *`$(AndroidExplicitCrunch)`
+  *`$(AndroidGenerateJniMarshalMethods)`
+  *`$(AndroidIncludeDebugSymbols)`
+  *`$(AndroidLinkMode)`
+  *`$(AndroidLinkSkip)`
+  *`$(AndroidLinkTool)`
+  *`$(AndroidNdkDirectory)`
+  *`$(AndroidPackageFormat)`
+  *`$(AndroidSdkBuildToolsVersion)`
+  *`$(AndroidSdkDirectory)`
+  *`$(AndroidSequencePointsMode)`
+  *`$(AndroidUseLatestPlatformSdk)`
+  *`$(AndroidUseSharedRuntime)`
+  *`$(AotAssemblies)`
+  *`$(BundleAssemblies)`
+  *`$(EmbedAssembliesIntoApk)`
+  *`$(JavaSdkDirectory)`
+  *`$(MonoSymbolArchive)`
+  *`$(OS)`
+  *`$(TargetFrameworkVersion)`
+  *`$(XamarinAndroidVersion)`
+
+This should reduce the number of cases where project authors need to run a full
+clean by hand after changing one of these properties, such as after updating to
+a new Xamarin.Android version.
+
+Changes to these particular properties already triggered additional build
+steps, so this new behavior should not noticeably increase incremental build
+times. As in the past, to get the best incremental build times, avoid changing
+these properties back and forth too much between builds.

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -936,6 +936,7 @@ stages:
       inputs:
         artifactName: Test Results - Designer - macOS
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
+      condition: always()
 
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
@@ -999,6 +1000,7 @@ stages:
       inputs:
         artifactName: Test Results - Designer - Windows
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
+      condition: always()
 
 - stage: integrated_regression_test
   displayName: Regression Tests

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -109,9 +109,9 @@ namespace UnnamedProject
 				Assert.IsNotNull (doc.Element ("LinearLayout").Element ("unnamedproject.CustomTextView"),
 					"unnamedproject.CustomTextView should have not been replaced with a $(Hash).CustomTextView");
 				// Build the library project now
-				Assert.IsTrue (libb.Build (lib), "library build should have succeeded.");
+				Assert.IsTrue (libb.Build (lib, doNotCleanupOnUpdate: true), "library build should have succeeded.");
 				appb.Target = "Build";
-				Assert.IsTrue (appb.Build (proj), "app build should have succeeded.");
+				Assert.IsTrue (appb.Build (proj, doNotCleanupOnUpdate: true), "app build should have succeeded.");
 				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_UpdateAndroidResgen"), "_UpdateAndroidResgen should have run completely.");
 				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_Foo"), "_Foo should have run completely");
 				doc = XDocument.Load (customViewPath);
@@ -120,7 +120,7 @@ namespace UnnamedProject
 				Assert.IsNull (doc.Element ("LinearLayout").Element ("unnamedproject.CustomTextView"),
 					"unnamedproject.CustomTextView should have been replaced with a $(Hash).CustomTextView");
 				appb.Target = target;
-				Assert.IsTrue (appb.Build (proj, parameters: DesignerParameters), $"build should have succeeded for target `{target}`");
+				Assert.IsTrue (appb.Build (proj, parameters: DesignerParameters, doNotCleanupOnUpdate: true), $"build should have succeeded for target `{target}`");
 				Assert.IsTrue (appb.Output.AreTargetsAllSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen should have been skipped.");
 				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_Foo"), "_Foo should have run completely");
 				doc = XDocument.Load (customViewPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -349,7 +349,7 @@ namespace Lib2
 			var targets = new List<string> {
 				"_GeneratePackageManagerJava",
 				"_ResolveLibraryProjectImports",
-				"_CleanIntermediateIfNuGetsChange",
+				"_CleanIntermediateIfNeeded",
 				"_CopyConfigFiles",
 			};
 			var proj = new XamarinFormsAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -572,9 +572,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _ValidateLinkMode;
     _CheckNonIdealConfigurations;
     _SetupDesignTimeBuildForBuild;
-    _CleanIntermediateIfNuGetsChange;
-    _CleanIntermediateIfPackageNamingPolicyChanges;
     _CreatePropertiesCache;
+    _CleanIntermediateIfNeeded;
     _CheckProjectItems;
     _CheckForContent;
     _CheckTargetFramework;
@@ -592,9 +591,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _ValidateLinkMode;
     _CheckNonIdealConfigurations;
      _SetupDesignTimeBuildForBuild;
-    _CleanIntermediateIfNuGetsChange;
-    _CleanIntermediateIfPackageNamingPolicyChanges;
-     _CreatePropertiesCache;
+    _CreatePropertiesCache;
+    _CleanIntermediateIfNeeded;
     _AddAndroidDefines;
     _CreateNativeLibraryArchive;
     _AddAndroidEnvironmentToCompile;
@@ -668,6 +666,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CleanDependsOn>
 		$(CleanDependsOn);
 		_CleanMonoAndroidIntermediateDir;
+		_CleanAndroidBuildPropertiesCache;
 	</CleanDependsOn>
 </PropertyGroup>
 
@@ -721,37 +720,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</PropertyGroup>
 </Target>
 
-<Target Name="_BeforeCleanIntermediateIfNuGetsChange">
-  <PropertyGroup>
-    <_NuGetAssetsFile Condition="Exists('$(ProjectLockFile)')">$(ProjectLockFile)</_NuGetAssetsFile>
-    <_NuGetAssetsFile Condition="'$(_NuGetAssetsFile)' == '' and Exists('packages.config')">packages.config</_NuGetAssetsFile>
-  </PropertyGroup>
-</Target>
-
-<Target Name="_CleanIntermediateIfNuGetsChange" DependsOnTargets="_BeforeCleanIntermediateIfNuGetsChange"
-    Inputs="$(_NuGetAssetsFile)"
-    Outputs="$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp">
-  <!--NOTE: only want to clean if the stamp exists, *after* an initial build-->
-  <CallTarget Targets="_CleanMonoAndroidIntermediateDir" Condition=" Exists ('$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp') " />
+<Target Name="_CleanIntermediateIfNeeded"
+    Condition=" '$(DesignTimeBuild)' != 'True' "
+    DependsOnTargets="_CreatePropertiesCache"
+    Inputs="$(_AndroidBuildPropertiesCache)"
+    Outputs="$(_AndroidStampDirectory)_CleanIntermediateIfNeeded.stamp">
+  <!--NOTE: only want to clean if build.props existed at the beginning of the build -->
+  <CallTarget Targets="_CleanMonoAndroidIntermediateDir" Condition=" '$(_AndroidBuildPropertiesCacheExists)' == 'True' " />
   <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
-  <Touch Files="$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp" AlwaysCreate="true" />
-</Target>
-
-<Target Name="_CleanIntermediateIfPackageNamingPolicyChanges">
-  <ReadLinesFromFile File="$(IntermediateOutputPath)packagenamingpolicy.props">
-    <Output TaskParameter="Lines" PropertyName="_PackageNamingPolicy" />
-  </ReadLinesFromFile>
-  <CallTarget
-      Targets="_CleanMonoAndroidIntermediateDir"
-      Condition=" '$(AndroidPackageNamingPolicy)' != '$(_PackageNamingPolicy)' And Exists ('$(IntermediateOutputPath)packagenamingpolicy.props') "
-  />
-  <WriteLinesToFile
-      Condition=" '$(AndroidPackageNamingPolicy)' != '$(_PackageNamingPolicy)' "
-      File="$(IntermediateOutputPath)packagenamingpolicy.props"
-      Lines="$(AndroidPackageNamingPolicy)"
-      Overwrite="True"
-  />
-  <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
+  <Touch Files="$(_AndroidStampDirectory)_CleanIntermediateIfNeeded.stamp" AlwaysCreate="true" />
 </Target>
 
 <Target Name="_AddAndroidDefines"
@@ -1177,8 +1154,14 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion;_ResolveMonoAndroidSdks">
+	<PropertyGroup>
+		<_AndroidBuildPropertiesCacheExists Condition=" Exists('$(_AndroidBuildPropertiesCache)') ">True</_AndroidBuildPropertiesCacheExists>
+		<_NuGetAssetsFile      Condition=" Exists('$(ProjectLockFile)') ">$(ProjectLockFile)</_NuGetAssetsFile>
+		<_NuGetAssetsFile      Condition=" '$(_NuGetAssetsFile)' == '' and Exists('packages.config') ">packages.config</_NuGetAssetsFile>
+		<_NuGetAssetsTimestamp Condition=" '$(_NuGetAssetsFile)' != '' ">$([System.IO.File]::GetLastWriteTime('$(_NuGetAssetsFile)').Ticks)</_NuGetAssetsTimestamp>
+	</PropertyGroup>
 	<ItemGroup>
-		<!--- List of items we want to trigger a build if changed -->
+		<!-- List of items we want to trigger a build if changed -->
 		<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
 		<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
 		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
@@ -1203,9 +1186,9 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 		<_PropertyCacheItems Include="AndroidGenerateJniMarshalMethods=$(AndroidGenerateJniMarshalMethods)" />
 		<_PropertyCacheItems Include="OS=$(OS)" />
-		<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
+		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
 	</ItemGroup>
 	<MakeDir Directories="$(_AndroidStampDirectory)" Condition="!Exists('$(_AndroidStampDirectory)')" />
 	<WriteLinesToFile
@@ -1739,32 +1722,6 @@ because xbuild doesn't support framework reference assemblies.
   </PropertyGroup>
 </Target>
 
-<Target Name="_CleanupOldStaticResources"
-    Condition=" Exists ('$(_AndroidIntermediateJavaSourceDirectory)mono\android\app\NotifyTimeZoneChanges.java') ">
-  <ItemGroup>
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\incrementaldeployment\MultiDexLoader.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\ResourcePatcher.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\Seppuku.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\MonoPackageManager.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\incrementaldeployment\IncrementalClassLoader.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\incrementaldeployment\Placeholder.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\app\NotifyTimeZoneChanges.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaSourceDirectory)mono\android\incrementaldeployment\MonkeyPatcher.java" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\incrementaldeployment\MultiDexLoader.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\ResourcePatcher.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\Seppuku.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\MonoPackageManager.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\MonoPackageManager_Resources.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\incrementaldeployment\IncrementalClassLoader*.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\incrementaldeployment\Placeholder.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\app\NotifyTimeZoneChanges.class" />
-    <_OldStaticResources Include="$(_AndroidIntermediateJavaClassDirectory)mono\android\MonkeyPatcher.class" />
-    <_OldStaticResources Include="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" />
-    <_OldStaticResources Include="$(IntermediateOutputPath)_javac.stamp" />
-  </ItemGroup>
-  <Delete Files="@(_OldStaticResources)" />
-</Target>
-
 <Target Name="_GetMonoPlatformJarPath">
   <GetMonoPlatformJar TargetFrameworkDirectory="$(TargetFrameworkDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
@@ -1775,7 +1732,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_AddStaticResources"
 		Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStaticResourcesFlag)"
-		DependsOnTargets="_CollectRuntimeJarFilenames;$(_BeforeAddStaticResources);_CleanupOldStaticResources;_GetMonoPlatformJarPath">
+		DependsOnTargets="_CollectRuntimeJarFilenames;$(_BeforeAddStaticResources);_GetMonoPlatformJarPath">
 	<CopyResource ResourceName="machine.config" OutputPath="$(MonoAndroidIntermediateAssemblyDir)machine.config" />
   <CopyResource
       Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &gt;= '21' "
@@ -3081,11 +3038,11 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(IntermediateOutputPath)stub_application_data.txt" />
 	<Delete Files="$(IntermediateOutputPath)_javac.stamp" />
 	<Delete Files="$(_AndroidResFlagFile)" />
+	<Delete Files="$(_AndroidResgenFlagFile)" />
 	<Delete Files="$(_AndroidLinkFlag)" />
 	<Delete Files="$(_AndroidDebugKeyStoreFlag)" />
 	<Delete Files="$(_AndroidLintConfigFile)" />
 	<Delete Files="$(_AndroidResourceDesignerFile)" Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'True' " />
-	<Delete Files="$(_AndroidBuildPropertiesCache)" />
 	<Delete Files="$(_AdbPropertiesCache)" />
 	<Delete Files="$(_AndroidLibraryImportsCache)" />
 	<Delete Files="$(_AndroidStaticResourcesFlag)" />
@@ -3096,6 +3053,10 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidMainDexListFile)" />
 	<Delete Files="$(_AndroidBuildIdFile)" />
 	<Delete Files="$(_ResolvedUserAssembliesHashFile)" />
+</Target>
+
+<Target Name="_CleanAndroidBuildPropertiesCache">
+	<Delete Files="$(_AndroidBuildPropertiesCache)" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -49,9 +49,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				b.Save (proj, saveProject: true);
-				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
-				Assert.True (b.Build (proj), "Project should have built.");
 				Assert.True (b.Install (proj), "Project should have installed.");
 				ClearAdbLogcat ();
 				if (CommercialBuildAvailable)
@@ -208,9 +205,6 @@ namespace ${ROOT_NAMESPACE} {
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				b.Save (proj, saveProject: true);
-				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
-				Assert.True (b.Build (proj), "Project should have built.");
 				Assert.True (b.Install (proj), "Project should have installed.");
 
 				int breakcountHitCount = 0;
@@ -335,9 +329,6 @@ namespace ${ROOT_NAMESPACE} {
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				b.Save (proj, saveProject: true);
-				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
-				Assert.True (b.Build (proj), "Project should have built.");
 				Assert.True (b.Install (proj), "Project should have installed.");
 
 				int breakcountHitCount = 0;


### PR DESCRIPTION
I found a crash at runtime, if you:

1. Build / Run a project with 16.4

2. Build / Run the same project with 16.6

The stack trace is:

    java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "jm_typemap" referenced by "/data/app/com.companyname.app59-bgIEcmaPpoMxpR948Wo8ZA==/lib/x86/libmonodroid.so"...
        at java.lang.Runtime.loadLibrary0(Runtime.java:1071)
        at java.lang.Runtime.loadLibrary0(Runtime.java:1007)
        at java.lang.System.loadLibrary(System.java:1667)
        at mono.MonoPackageManager.LoadApplication(MonoPackageManager.java:80)
        at mono.MonoRuntimeProvider.attachInfo(MonoRuntimeProvider.java:48)
        at android.app.ActivityThread.installProvider(ActivityThread.java:6983)
        at android.app.ActivityThread.installContentProviders(ActivityThread.java:6528)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6445)
        at android.app.ActivityThread.access$1300(ActivityThread.java:219)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)

What happened is in ce2bc689, the `jm_typemap` and `mj_typemap`
symbols were removed. But we don't actually have anything that cleans
the generated assembly files when `$(XamarinAndroidVersion)` changes.

We have a `DeleteBinObjTest` test, why didn't that catch this?

Apparently the test was triggering:

    Building target "_CleanIntermediateIfNuGetsChange" completely.
    Input file "HelloForms.Android\obj\project.assets.json" is newer than output file "obj\Debug\90\stamp\_CleanIntermediateIfNuGetsChange.stamp".

And so the test wasn't actually *testing* much of anything!

As part of that test, we have to run a NuGet restore. The zip file
contains a project that was restored on another machine. We *have* to
run `/t:Restore` for things to build. The changes in this PR remove
`_CleanIntermediateIfNuGetsChange`, so we should be OK going forward.

I also updated the test to include projects built with 16.4 and verify
the app launches.

## Actual Changes ##

To fix the real problem here, I think we need to fundamentally change
what happens when values in `build.props` /
`$(_AndroidBuildPropertiesCache)` changes. Currently we are using it
to trigger several MSBuild targets, but I believe we should also use
it to trigger the `_CleanMonoAndroidIntermediateDir` target if the
file changes.

1. Repurpose `_CleanIntermediateIfNuGetsChange` to instead be a
   `_CleanIntermediateIfNeeded` target that does not run on
   design-time builds.

2. Include the `GetLastWriteTime` value of `$(_NuGetAssetsFile)` in
   `build.props`.

3. Remove `DesignTimeBuild=$(DesignTimeBuild)` from `build.props`. We
   use a different path for DTBs at `obj\Debug\designtime\build.props`
   anyway.

4. `_CleanMonoAndroidIntermediateDir` can't delete `build.props`
   anymore. I moved this so it will still happen during a full
   `Clean`.

5. Remove the `_CleanIntermediateIfPackageNamingPolicyChanges` and
   `_CleanupOldStaticResources` MSBuild targets. They are no longer
   needed at all.

6. Remove `Xamarin.Android.DefaultOutputPaths.targets`.