### PR TITLE
[Mono.Android] Allow interfaces to contain nested types starting with API-30

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -98,7 +98,7 @@
       <_Api>$(IntermediateOutputPath)mcw\api.xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>
       <_FullIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
-      <_LangFeatures Condition="$(AndroidApiLevel) &gt;= 30">--lang-features=default-interface-methods</_LangFeatures>
+      <_LangFeatures Condition="$(AndroidApiLevel) &gt;= 30">--lang-features=default-interface-methods,nested-interface-types</_LangFeatures>
     </PropertyGroup>
     <Exec
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(Generator) $(_GenFlags) $(_ApiLevel) $(_Out) $(_Codegen) $(_Fixup) $(_Enums1) $(_Enums2) $(_Versions) $(_Annotations) $(_Assembly) $(_TypeMap) $(_LangFeatures) $(_Dirs) $(_Api)"

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1560,4 +1560,44 @@
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationStart' and count(parameter)=2]" />
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationEnd' and count(parameter)=2]" />
 
+  <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.
+       To preserve backwards compatibility, we need to "un-nest" anything added before API-30 -->
+  
+  <!-- Handle everything that has always existed (no @merge.SourceFile) -->
+  <attr api-since="30" path="/api/package/interface[not(@merge.SourceFile)]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[not(@merge.SourceFile)]" name="unnest">true</attr>
+
+  <!-- Need these for each platform prior to 30 -->
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-10.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-10.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-15.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-15.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-16.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-16.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-17.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-17.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-18.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-18.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-19.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-19.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-20.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-20.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-21.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-21.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-22.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-22.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-23.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-23.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-24.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-24.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-25.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-25.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-26.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-26.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-27.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-27.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-28.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-28.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-29.xml.in')]" name="unnest">true</attr>
+  <attr api-since="30" path="/api/package/class[contains(@merge.SourceFile,'api-29.xml.in')]" name="unnest">true</attr>
 </metadata>


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/509

Beginning with C#8, interfaces may now contain nested types.  This allows us to better match the `android.jar` we are binding.  However, we cannot nest any types prior to API-30, as that would result in a breaking API change.

This PR:
- Enables the `generator` flag: `--lang-features=nested-interface-types`, which will nest all types on interfaces using C#8.
- Adds `metadata` that looks for all `@merge.SourceFile` prior to API-30 and adds the `unnest=true` attribute to those types.  This attribute tells `generator` to treat them as legacy "unnested" types for backwards compatibility.

API diff between `master` `API-30` and this PR: https://gist.github.com/jpobst/a23ecebbed0837a1abfe7c6cbd7ecf1e