### PR TITLE
Bump to libZipSharp 1.0.10

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -111,7 +111,7 @@
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>
     <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
-    <LibZipSharpVersion>1.0.8</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.10</LibZipSharpVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/Documentation/release-notes/4320.md
+++ b/Documentation/release-notes/4320.md
@@ -1,0 +1,8 @@
+### Build and deployment performance
+
+  * [GitHub PR 4320](https://github.com/xamarin/xamarin-android/pull/4320):
+    Update to LibZipSharp 1.0.10 which uses `System.Buffers.ArrayPool`
+    instead of `byte[]` to save on allocations.  This reduced the combined time
+    for the `ResolveLibraryProjectImports` and `BuildApk` tasks from about 5.3
+    seconds to about 5.0 seconds for a small test Xamarin.Forms app on an
+    initial clean build.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -202,6 +202,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\manifestmerger.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\protobuf-net.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\SgmlReaderDll.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\System.Buffers.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Aapt.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Aapt2.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Analysis.targets" />

--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -36,6 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
@@ -43,7 +44,9 @@
     <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll" Condition=" '$(OS)' == 'Windows_NT' " >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(MSBuildToolsPath)\System.*.dll" Condition=" '$(OS)' == 'Windows_NT' " >
+    <None Include="$(MSBuildToolsPath)\System.*.dll"
+        Exclude="$(MSBuildToolsPath)\System.Buffers.dll"
+        Condition=" '$(OS)' == 'Windows_NT' " >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Backport of: #4320

Changes: https://github.com/xamarin/libZipSharp/compare/1.0.8...1.0.10

Context: https://github.com/xamarin/LibZipSharp/pull/50

When profiling xamarin-android builds with the Mono profiler, I
noticed `libZipSharp` is one of the biggest allocators of `byte[]`:

	Allocation summary
	    Bytes      Count  Average Type name
	251089192      57759     4347 System.Byte[]
	    94852584 bytes from:
	        Xamarin.Tools.Zip.ZipArchive:Close ()
	        (wrapper managed-to-native) Xamarin.Tools.Zip.Native:zip_close (intptr)
	        (wrapper native-to-managed) Xamarin.Tools.Zip.ZipArchive:stream_callback (intptr,intptr,ulong,Xamarin.Tools.Zip.SourceCommand)
	        Xamarin.Tools.Zip.ZipArchive:stream_callback (intptr,intptr,ulong,Xamarin.Tools.Zip.SourceCommand)
	        (wrapper alloc) object:ProfilerAllocVector (intptr,intptr)
	        (wrapper managed-to-native) object:__icall_wrapper_mono_gc_alloc_vector (intptr,intptr,intptr)
	    25673176 bytes from:
	        Xamarin.Android.Tasks.ResolveLibraryProjectImports:Extract (System.Collections.Generic.IDictionary`2<string, Microsoft.Build.Framework.ITaskItem>,System.Collections.Generic.ICollection`1<Microsoft.Build.Framework.ITaskItem>,System.Collections.Generic.ICollection`1<Microsoft.Build.Framework.ITaskItem>,System.Collections.Generic.ICollection`1<Microsoft.Build.Framework.ITaskItem>)
	        Xamarin.Android.Tools.Files:ExtractAll (Xamarin.Tools.Zip.ZipArchive,string,System.Action`2<int, int>,System.Func`2<string, string>,System.Func`2<string, bool>)
	        Xamarin.Tools.Zip.ZipEntry:Extract (System.IO.Stream)
	        Xamarin.Tools.Zip.ZipEntry:DoExtract (intptr,System.IO.Stream,Xamarin.Tools.Zip.EntryExtractEventArgs)
	        (wrapper alloc) object:ProfilerAllocVector (intptr,intptr)
	        (wrapper managed-to-native) object:__icall_wrapper_mono_gc_alloc_vector (intptr,intptr,intptr)
	    3780312 bytes from:
	        Xamarin.Tools.Zip.ZipEntry:DoExtract (intptr,System.IO.Stream,Xamarin.Tools.Zip.EntryExtractEventArgs)
	        (wrapper managed-to-native) Xamarin.Tools.Zip.Native:zip_fread (intptr,byte[],ulong)
	        (wrapper native-to-managed) Xamarin.Tools.Zip.ZipArchive:stream_callback (intptr,intptr,ulong,Xamarin.Tools.Zip.SourceCommand)
	        Xamarin.Tools.Zip.ZipArchive:stream_callback (intptr,intptr,ulong,Xamarin.Tools.Zip.SourceCommand)
	        (wrapper alloc) object:ProfilerAllocVector (intptr,intptr)
	        (wrapper managed-to-native) object:__icall_wrapper_mono_gc_alloc_vector (intptr,intptr,intptr)

This seems like *a lot* of `byte[]` allocations.

To improve this, I added a `@(PackageReference)` to `System.Buffers`
to make use of `ArrayPool`.

`libZipSharp` will likely still allocate some large `byte[]`, but
things should improve because many arrays will be reused.

The changes appear to have saved ~122,523,744 bytes of allocations:

  * Before:

        Allocation summary
            Bytes      Count  Average Type name
        251089192      57759     4347 System.Byte[]

  * After:

        Allocation summary
            Bytes      Count  Average Type name
        128565448      31764     4047 System.Byte[]

I saw build performance improvements for the Xamarin.Forms integration
project, the two tasks heavily using `libZipSharp`:

  * Before:

        1881 ms  ResolveLibraryProjectImports               1 calls
        3406 ms  BuildApk                                   1 calls

  * After:

        1795 ms  ResolveLibraryProjectImports               1 calls
        3150 ms  BuildApk                                   1 calls

I would guess this saves ~350ms on an initial build.  Incremental
builds won't be allocating `byte[]` as heavily, but should see some
improvement.

I also need to make sure our installers include `System.Buffers.dll`
alongside everywhere we have a copy of `libZipSharp.dll`.