### PR TITLE
[ci] Fix path to designer checkout

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -899,12 +899,8 @@ stages:
     - template: yaml-templates/run-installer.yaml
 
     - template: designer/android-designer-build-mac.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)
 
     - template: designer/android-designer-tests.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)
 
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
@@ -950,12 +946,8 @@ stages:
     - template: yaml-templates\run-installer.yaml
 
     - template: designer\android-designer-build-win.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)
 
     - template: designer\android-designer-tests.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)
 
 - stage: integrated_regression_test
   displayName: Regression Tests

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -884,7 +884,7 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Set-Location -Path $(System.DefaultWorkingDirectory)/designer
+        Set-Location -Path $(System.DefaultWorkingDirectory)
         git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
@@ -893,18 +893,18 @@ stages:
       displayName: provision designer dependencies
       inputs:
         github_token: $(GitHub.Token)
-        provisioning_script: $(System.DefaultWorkingDirectory)/designer/bot-provisioning/dependencies.csx
+        provisioning_script: $(System.DefaultWorkingDirectory)/bot-provisioning/dependencies.csx
         provisioning_extra_args: -remove Xamarin.Android -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
 
     - template: yaml-templates/run-installer.yaml
 
     - template: designer/android-designer-build-mac.yaml@yaml
       parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)/designer
+        designerSourcePath: $(System.DefaultWorkingDirectory)
 
     - template: designer/android-designer-tests.yaml@yaml
       parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)/designer
+        designerSourcePath: $(System.DefaultWorkingDirectory)
 
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
@@ -935,7 +935,7 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Set-Location -Path $(System.DefaultWorkingDirectory)\designer
+        Set-Location -Path $(System.DefaultWorkingDirectory)
         git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
@@ -944,18 +944,18 @@ stages:
       displayName: provision designer dependencies
       inputs:
         github_token: $(GitHub.Token)
-        provisioning_script: $(System.DefaultWorkingDirectory)\designer\bot-provisioning\dependencies.csx
+        provisioning_script: $(System.DefaultWorkingDirectory)\bot-provisioning\dependencies.csx
         provisioning_extra_args: -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
 
     - template: yaml-templates\run-installer.yaml
 
     - template: designer\android-designer-build-win.yaml@yaml
       parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)\designer
+        designerSourcePath: $(System.DefaultWorkingDirectory)
 
     - template: designer\android-designer-tests.yaml@yaml
       parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)\designer
+        designerSourcePath: $(System.DefaultWorkingDirectory)
 
 - stage: integrated_regression_test
   displayName: Regression Tests


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3531536&view=logs&jobId=bfe1c8f0-0562-5169-4501-8cf84831035d&j=bfe1c8f0-0562-5169-4501-8cf84831035d&t=8d0f59aa-88c2-53a6-661f-85ce58936952
Context: https://github.com/xamarin/xamarin-android/commit/ed29bf1d47661e9df8458b5be074ed0369752b0b

Designer test jobs have been failing when attempting to checkout a
different source branch after cloning the repo. It seems that the value
of `$(System.DefaultWorkingDirectory)` has changed recently. The value
of this this variable will apparently change depending on the number of
checkout steps in a given job, and whether or not those checkout steps
use a custom path.