### PR TITLE
[Mono.Android] Enable constants on interfaces.

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -108,7 +108,7 @@
       <_Api>$(IntermediateOutputPath)mcw\api.xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>
       <_FullIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
-      <_LangFeatures Condition="$(AndroidApiLevel) &gt;= 30">--lang-features=default-interface-methods,nested-interface-types</_LangFeatures>
+      <_LangFeatures Condition="$(AndroidApiLevel) &gt;= 30">--lang-features=default-interface-methods,nested-interface-types,interface-constants</_LangFeatures>
     </PropertyGroup>
     <Exec
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(Generator) $(_GenFlags) $(_ApiLevel) $(_Out) $(_Codegen) $(_Fixup) $(_Enums1) $(_Enums2) $(_Versions) $(_Annotations) $(_Assembly) $(_TypeMap) $(_LangFeatures) $(_Dirs) $(_Api)"


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/509

Beginning with C#8, interfaces may now contain constants.  This allows us to better match the `android.jar` we are binding. 

This PR:
- Enables the `generator` flag: `--lang-features=interface-constants`, which will generates constants on interfaces using C#8.
- This does not remove any previously created constants.  We will need to `[Obsolete]` them in a future PR.

API diff between `master` `API-30` and this PR: https://gist.github.com/jpobst/31c692a67a7f0389895b59cca92480ff