### PR TITLE
[CI] Add job attempt to artifact name to prevent duplicates.

### DIFF
--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -12,9 +12,15 @@ steps:
     msbuildArguments: /restore /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
   condition: always()
 
+# Add the "(Attempt X)" for retries, but leave the initial run blank
+- powershell: |
+    $UploadAttemptSuffix = If ($(System.JobAttempt) -gt 1) {"(Attempt $(System.JobAttempt))"} Else {""}
+    Write-Host "##vso[task.setvariable variable=UploadAttemptSuffix;]$UploadAttemptSuffix"
+  displayName: Set upload artifact name
+
 - task: PublishPipelineArtifact@1
   displayName: upload build and test results
   inputs:
-    artifactName: ${{ parameters.artifactName }}
+    artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)
     targetPath: $(Build.ArtifactStagingDirectory)
   condition: always()


### PR DESCRIPTION
Today we cannot successfully rerun failed jobs on our CI because the new runs fail with "duplicate artifact name" when uploading the logs, even if everything else was successful.

This PR uses the AzDO variable `System.JobAttempt` to append a unique run number to the artifact name, allowing the upload to succeed.  Note that the run number is only added for retries, the original run does not change.

Example:
* First run: `Build Results - Windows`
* Second run: `Build Results - Windows (Attempt 2)`
* Third run: `Build Results - Windows (Attempt 3)`