### PR TITLE
[Xamarin.Android.Build.Tasks] Add XA4310 for keystore not found

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -114,6 +114,7 @@ ms.date: 01/24/2020
 + [XA4307](xa4307.md): Invalid ProGuard configuration file.
 + [XA4308](xa4308.md): Failed to generate type maps
 + [XA4309](xa4309.md): 'MultiDexMainDexList' file '{file}' does not exist.
++ [XA4310](xa4310.md): \`$(AndroidSigningKeyStore)\` file \`{keystore}\` could not be found.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/guides/messages/xa4310.md
+++ b/Documentation/guides/messages/xa4310.md
@@ -1,0 +1,24 @@
+---
+title: Xamarin.Android error XA4310
+description: XA4310 error code
+ms.date: 03/09/2020
+---
+# Xamarin.Android warning XA4310
+
+## Example messages
+
+```
+error XA4310: `$(AndroidSigningKeyStore)` file `filename.keystore` could not be found.
+```
+
+## Issue
+
+The specified `$(AndroidSigningKeyStore)` file could not be located on disk.
+
+## Solution
+
+Check that the `$(AndroidSigningKeyStore)` MSBuild property is set to a valid
+path of an existing keystore.
+
+This property corresponds to the **Keystore** field in the **Android Package
+Signing** section of the Visual Studio project property pages.

--- a/Documentation/release-notes/xa4310.md
+++ b/Documentation/release-notes/xa4310.md
@@ -1,0 +1,5 @@
+#### Application and library build and deployment
+
+- Imprecise error *error MSB6006: "jarsigner.exe" exited with code 1* or *error
+  MSB6006: "java.exe" exited with code 2* was shown if `$(AndroidKeyStore)` was
+  `true` and `$(AndroidSigningKeyStore)` was set to a file that did not exist.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -709,6 +709,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to `$(AndroidSigningKeyStore)` file `{0}` could not be found..
+        /// </summary>
+        internal static string XA4310 {
+            get {
+                return ResourceManager.GetString("XA4310", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing Android NDK toolchains directory &apos;{0}&apos;. Please install the Android NDK..
         /// </summary>
         internal static string XA5101 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -456,6 +456,10 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <value>'MultiDexMainDexList' file '{0}' does not exist.</value>
     <comment>The following are literal names and should not be translated: MultiDexMainDexList</comment>
   </data>
+  <data name="XA4310" xml:space="preserve">
+    <value>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</value>
+    <comment>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</comment>
+  </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>
     <comment>{0} - The path of the missing directory</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -420,6 +420,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
+      <trans-unit id="XA4310">
+        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
+        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -90,6 +90,10 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitchIfNotNull ("-jar ", ApkSignerJar);
 			cmd.AppendSwitch ("sign");
+			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
+				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
+				return string.Empty;
+			}
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
 			AddStorePass (cmd, "--ks-pass", StorePass);
 			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -89,6 +89,10 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitchIfNotNull ("-tsa ", TimestampAuthorityUrl);
 			cmd.AppendSwitchIfNotNull ("-tsacert ", TimestampAuthorityCertificateAlias);
+			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
+				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
+				return string.Empty;
+			}
 			cmd.AppendSwitchIfNotNull ("-keystore ", KeyStore);
 			AddStorePass (cmd, "-storepass", StorePass);
 			AddStorePass (cmd, "-keypass", KeyPass);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4150,5 +4150,24 @@ namespace UnnamedProject
 				}
 			}
 		}
+
+		[Test]
+		public void XA4310 ([Values ("apk", "aab")] string packageFormat)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidKeyStore", "true");
+			proj.SetProperty ("AndroidSigningKeyStore", "DoesNotExist");
+			proj.SetProperty ("AndroidSigningStorePass", "android");
+			proj.SetProperty ("AndroidSigningKeyAlias", "mykey");
+			proj.SetProperty ("AndroidSigningKeyPass", "android");
+			proj.SetProperty ("AndroidPackageFormat", packageFormat);
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "SignAndroidPackage";
+				Assert.IsFalse (builder.Build (proj), "Build should have failed with XA4310.");
+				StringAssertEx.Contains ($"error XA4310", builder.LastBuildOutput, "Error should be XA4310");
+				StringAssertEx.Contains ($"`DoesNotExist`", builder.LastBuildOutput, "Error should include the name of the nonexistent file");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context: User comments on https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1073446

A user noticed that the error messages from `<AndroidSignPackage/>` and
`<AndroidApkSigner/>` did not provide much information when
`$(AndroidKeyStore)` was `true` and `$(AndroidSigningKeyStore)` was set
to a file that did not exist.

For `$(AndroidPackageFormat)`=`aab`, `<AndroidSignPackage/>` produced
the error:

	error MSB6006: "jarsigner.exe" exited with code 1

For `$(AndroidPackageFormat)`=`apk`, `<AndroidApkSigner/>` produced
the error:

	error MSB6006: "java.exe" exited with code 2

To improve this, add a new XA4310 error with a more descriptive message.