### PR TITLE
[Xamarin.Android.Build.Tests] Move debug.keystore into Project Tree

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			// Ensure the path where are going to write the key exists
 			var store_dir = Path.GetDirectoryName (KeyStore);
 
-			if (!Directory.Exists (store_dir))
+			if (!string.IsNullOrEmpty (store_dir) && !Directory.Exists (store_dir))
 				Directory.CreateDirectory (store_dir);
 
 			return base.RunTask ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -33,6 +33,7 @@ namespace Xamarin.ProjectTools
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
 			ExtraNuGetConfigSources = new List<string> { XABuildPaths.BuildOutputDirectory };
 			GlobalPackagesFolder = Path.Combine (XABuildPaths.TopDirectory, "packages");
+			SetProperty ("_ApkDebugKeyStore", "debug.keystore");
 
 			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.AndroidManifest.xml")))
 				default_android_manifest = sr.ReadToEnd ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -24,6 +24,7 @@ namespace Xamarin.ProjectTools
 			SetProperty ("OutputType", "Library");
 			SetProperty ("MonoAndroidAssetsPrefix", "Assets");
 			SetProperty ("MonoAndroidResourcePrefix", "Resources");
+			SetProperty ("_ApkDebugKeyStore", "debug.keystore");
 
 			SetProperty (KnownProperties.AndroidUseLatestPlatformSdk, () => UseLatestPlatformSdk ? "True" : "False");
 			SetProperty (KnownProperties.TargetFrameworkVersion, () => TargetFrameworkVersion);

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
@@ -18,6 +18,7 @@
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AndroidGenerateLayoutBindings>True</AndroidGenerateLayoutBindings>
     <DebugType>portable</DebugType>
+    <_ApkDebugKeyStore>debug.keystore</_ApkDebugKeyStore>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
When running unit tests we occasionally see a random
`ANDKT0000` build error. We suspect this happens when
two tests try to create the same `debug.keystore` in
the same locaiton.

To work around this issue all projects should use override
the `_ApkDebugKeyStore` property to make sure the file
is created in the project directory. This should stop
parallel tests creating the same file at the same time.