### PR TITLE
[Xamarin.Android.Build.Tasks] Avoid running tool after XA4310

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -90,10 +90,6 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitchIfNotNull ("-jar ", ApkSignerJar);
 			cmd.AppendSwitch ("sign");
-			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
-				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
-				return string.Empty;
-			}
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
 			AddStorePass (cmd, "--ks-pass", StorePass);
 			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
@@ -125,6 +121,15 @@ namespace Xamarin.Android.Tasks
 
 		protected override string ToolName {
 			get { return OS.IsWindows ? "java.exe" : "java"; }
+		}
+
+		protected override bool ValidateParameters ()
+		{
+			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
+				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
+				return false;
+			}
+			return base.ValidateParameters ();
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -89,10 +89,6 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitchIfNotNull ("-tsa ", TimestampAuthorityUrl);
 			cmd.AppendSwitchIfNotNull ("-tsacert ", TimestampAuthorityCertificateAlias);
-			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
-				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
-				return string.Empty;
-			}
 			cmd.AppendSwitchIfNotNull ("-keystore ", KeyStore);
 			AddStorePass (cmd, "-storepass", StorePass);
 			AddStorePass (cmd, "-keypass", KeyPass);
@@ -149,6 +145,15 @@ namespace Xamarin.Android.Tasks
 		protected override string ToolName
 		{
 			get { return IsWindows ? "jarsigner.exe" : "jarsigner"; }
+		}
+
+		protected override bool ValidateParameters ()
+		{
+			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
+				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
+				return false;
+			}
+			return base.ValidateParameters ();
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4165,8 +4165,11 @@ namespace UnnamedProject
 				builder.ThrowOnBuildFailure = false;
 				builder.Target = "SignAndroidPackage";
 				Assert.IsFalse (builder.Build (proj), "Build should have failed with XA4310.");
-				StringAssertEx.Contains ($"error XA4310", builder.LastBuildOutput, "Error should be XA4310");
-				StringAssertEx.Contains ($"`DoesNotExist`", builder.LastBuildOutput, "Error should include the name of the nonexistent file");
+
+				StringAssertEx.Contains ("error XA4310", builder.LastBuildOutput, "Error should be XA4310");
+				StringAssertEx.Contains ("`DoesNotExist`", builder.LastBuildOutput, "Error should include the name of the nonexistent file");
+				StringAssertEx.Contains ("0 Warning(s)", builder.LastBuildOutput, "Should have no MSBuild warnings.");
+
 			}
 		}
 	}


### PR DESCRIPTION
In 160f1c6c, I overlooked the fact that `<ToolTask/>` doesn't
automatically skip running the tool if `GenerateCommandLineCommands()`
returns `string.Empty`.  This meant that `jarsigner.exe` and
`apksigner.jar` were still running when the keystore was not found,
resulting noisy additional build output lines and warnings.

To solve this, move the XA4310 `KeyStore` validation check to the
`ValidateParameters()` override that runs before
`GenerateCommandLineCommands()`.

Other changes:

Remove unused string interpolation in the test.