### PR TITLE
[.NET 5] Start adding some project capabilities

### DIFF
--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Common.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Common.targets
@@ -386,6 +386,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <!-- Automatically supply project capabilities for IDE use -->
 <ItemGroup>
+  <ProjectCapability Include="Mobile" />
   <ProjectCapability Include="Android" />
   <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
 </ItemGroup>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Common.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Common.targets
@@ -384,6 +384,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</AllowedReferenceRelatedFileExtensions>
 </PropertyGroup>
 
+<!-- Automatically supply project capabilities for IDE use -->
+<ItemGroup>
+  <ProjectCapability Include="Android" />
+  <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
+</ItemGroup>
+
 <!--
 *******************************************
           Imports


### PR DESCRIPTION
Visual Studio uses CPS to load SDK-style projects. In CPS, most things are keyed-off so-called capabilities[0] which replace other methods that were used previously like project type GUIDs.

While capabilities can be defined in the IDE, they make most sense to be directly expressed in the targets themselves where CPS will pick them up automatically.

[0]  https://github.com/microsoft/VSProjectSystem/blob/master/doc/overview/about_project_capabilities.md