### PR TITLE
[Xamarin.Android.Build.Tasks] only extract specific .jar files from .aar

### DIFF
--- a/Documentation/release-notes/4385.md
+++ b/Documentation/release-notes/4385.md
@@ -1,0 +1,7 @@
+#### Bindings projects
+
+  * [GitHub PR 4385](https://github.com/xamarin/xamarin-android/pull/4385):
+    *You have Jar libraries, lint.jar, lint.jar, ... that have the identical
+    name with inconsistent file contents* build error could prevent apps from
+    consuming custom bindings libraries for certain Java libraries.  This was
+    discovered while binding new versions of the AndroidX libraries.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -390,6 +390,17 @@ namespace Xamarin.Android.Tasks
 							return entryFullName;
 						}, deleteCallback: (fileToDelete) => {
 							return !jars.ContainsKey (fileToDelete);
+						}, skipCallback: (entryFullName) => {
+							// AAR files may contain other jars not needed for compilation
+							// See: https://developer.android.com/studio/projects/android-library.html#aar-contents
+							if (!entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase))
+								return false;
+							if (entryFullName == "classes.jar" ||
+									entryFullName.StartsWith ("libs/", StringComparison.OrdinalIgnoreCase) ||
+									entryFullName.StartsWith ("libs\\", StringComparison.OrdinalIgnoreCase))
+								return false;
+							// This could be `lint.jar` or `api.jar`, etc.
+							return true;
 						});
 
 						if (Directory.Exists (importsDir) && aarHash != stampHash) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2331,6 +2331,9 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			var proj = new XamarinAndroidApplicationProject () {
 				OtherBuildItems = {
 					aar,
+					new AndroidItem.AndroidAarLibrary ("fragment-1.2.2.aar") {
+						WebContent = "https://maven.google.com/androidx/fragment/fragment/1.2.2/fragment-1.2.2.aar"
+					}
 				},
 			};
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
@@ -2344,8 +2347,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				foreach (var s in File.ReadLines (assemblyMap)) {
 					assemblyIdentityMap.Add (s);
 				}
-				FileAssert.Exists (Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "lp",
-					assemblyIdentityMap.IndexOf ("android-crop-1.0.1").ToString (), "jl", "classes.jar"),
+				var libraryProjects = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "lp");
+				FileAssert.Exists (Path.Combine (libraryProjects, assemblyIdentityMap.IndexOf ("android-crop-1.0.1").ToString (), "jl", "classes.jar"),
 					"classes.jar was not extracted from the aar.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
@@ -2365,13 +2368,15 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 
 				//NOTE: the designer requires the paths to be full paths
 				foreach (var paths in doc.Elements ("Paths")) {
-					foreach (var element in paths.Elements ()) {
+					foreach (var element in paths.Elements ("Path")) {
 						var path = element.Value;
 						if (!string.IsNullOrEmpty (path)) {
 							Assert.IsTrue (path == Path.GetFullPath (path), $"`{path}` is not a full path!");
 						}
 					}
 				}
+				Assert.IsFalse (Directory.EnumerateFiles (libraryProjects, "lint.jar", SearchOption.AllDirectories).Any (),
+					"`lint.jar` should not be extracted!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
@@ -38,6 +38,11 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (contents, File.ReadAllText (fullPath), $"Contents did not match at path: {path}");
 		}
 
+		void AssertFileDoesNotExist (string path)
+		{
+			FileAssert.DoesNotExist (Path.Combine (tempDir, path));
+		}
+
 		bool ExtractAll (MemoryStream stream)
 		{
 			using (var zip = ZipArchive.Open (stream)) {
@@ -370,6 +375,24 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			AssertFile ("a.txt", "a");
+			AssertFile (Path.Combine ("b", "b.txt"), "b");
+		}
+
+		[Test]
+		public void ExtractAll_SkipCallback ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				bool changes = Files.ExtractAll (zip, tempDir, skipCallback: e => e == "a.txt");
+				Assert.IsTrue (changes, "ExtractAll should report changes.");
+			}
+
+			AssertFileDoesNotExist ("a.txt");
 			AssertFile (Path.Combine ("b", "b.txt"), "b");
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -315,7 +315,7 @@ namespace Xamarin.Android.Tools
 		}
 
 		public static bool ExtractAll (ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null,
-			Func<string, bool> deleteCallback = null)
+			Func<string, bool> deleteCallback = null, Func<string, bool> skipCallback = null)
 		{
 			int i = 0;
 			int total = (int)zip.EntryCount;
@@ -330,6 +330,8 @@ namespace Xamarin.Android.Tools
 					if (entry.FullName.Contains ("/__MACOSX/") ||
 							entry.FullName.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
 							entry.FullName.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))
+						continue;
+					if (skipCallback != null && skipCallback (entry.FullName))
 						continue;
 					var fullName = modifyCallback?.Invoke (entry.FullName) ?? entry.FullName;
 					var outfile = Path.GetFullPath (Path.Combine (destination, fullName));


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/73
Context: https://developer.android.com/studio/projects/android-library.html#aar-contents
Context: https://groups.google.com/forum/#!topic/lint-dev/BM8q5EQ3POE

With the latest AndroidX bindings, we were encountering a build error
from r8 such as:

    You have Jar libraries, 
        lint.jar, 
        lint.jar, 
        lint.jar, 
    that have the identical name with inconsistent file contents. 
    Please make sure to remove any conflicting libraries in EmbeddedJar, InputJar and AndroidJavaLibrary. 

The following `.aar` contains a  `lint.jar`:

https://maven.google.com/androidx/fragment/fragment/1.2.2/fragment-1.2.2.aar

Apparently there is a feature for implementing your own custom `lint`
rules. These are placed in `lint.jar` and Android Studio runs them as
needed.

Reading the spec for `.aar` files, it looks like there are different
`.jar` files that may exist within:

* `/classes.jar`
* `/libs/*.jar`
* `/lint.jar`
* `/api.jar`

However, we currently just unzip *everything* inside `.aar` files. Any
`.jar` file extracted is passed to javac, r8, etc.

To fix this issue, I think we should only extract `classes.jar` or
`libs/*.jar`. This should prevent us from unzipping unnecessary files
and solve this particular issue.

I added/updated some tests around this scenario.