### PR TITLE
[Xamarin.Android.Build.Tasks] XA0002 & XA5211 l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -126,6 +126,7 @@ ms.date: 01/24/2020
 + XA5201: NDK linker exited with an error. Exit code {0}
 + [XA5205](xa5205.md): Cannot find `{ToolName}` in the Android SDK.
 + [XA5207](xa5207.md): Could not find android.jar for API level `{compileSdk}`.
++ XA5211: Embedded Wear app package name differs from handheld app package name ({wearPackageName} != {handheldPackageName}).
 + XA5213: java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{tool} {arguments}'
 + [XA5300](xa5300.md): The Android/Java SDK Directory could not be found.
 + [XA5301](xa5301.md): Failed to generate Java type for class: {managedType} due to MAX_PATH: {exception}

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find mono.android.jar.
+        /// </summary>
+        internal static string XA0002 {
+            get {
+                return ResourceManager.GetString("XA0002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value..
         /// </summary>
         internal static string XA0003 {
@@ -831,6 +840,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA5207_SDK_Manager_Windows {
             get {
                 return ResourceManager.GetString("XA5207_SDK_Manager_Windows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Wear app package name differs from handheld app package name ({0} != {1})..
+        /// </summary>
+        internal static string XA5211 {
+            get {
+                return ResourceManager.GetString("XA5211", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -148,6 +148,10 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</value>
     <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)</comment>
   </data>
+  <data name="XA0002" xml:space="preserve">
+    <value>Could not find mono.android.jar</value>
+    <comment>The following are literal names and should not be translated: mono.android.jar</comment>
+  </data>
   <data name="XA0003" xml:space="preserve">
     <value>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</value>
     <comment>The following are literal names and should not be translated: `android:versionCode`, `AndroidManifest.xml`</comment>
@@ -526,6 +530,14 @@ In this message, the term "bundled" is a short way of saying "included into the 
   <data name="XA5207_SDK_Manager_Windows" xml:space="preserve">
     <value>Tools &gt; Android &gt; Android SDK Manager...</value>
     <comment>This string is the location of a menu command in Visual Studio.</comment>
+  </data>
+  <data name="XA5211" xml:space="preserve">
+    <value>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</value>
+    <comment>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</comment>
   </data>
   <data name="XA5213" xml:space="preserve">
     <value>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -40,6 +40,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
         <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
       </trans-unit>
+      <trans-unit id="XA0002">
+        <source>Could not find mono.android.jar</source>
+        <target state="new">Could not find mono.android.jar</target>
+        <note>The following are literal names and should not be translated: mono.android.jar</note>
+      </trans-unit>
       <trans-unit id="XA0003">
         <source>Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</source>
         <target state="new">Invalid `android:versionCode` value `{0}` in `AndroidManifest.xml`. It must be an integer value.</target>
@@ -504,6 +509,15 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>Tools &gt; Open Android SDK Manager...</source>
         <target state="new">Tools &gt; Open Android SDK Manager...</target>
         <note>This string is the location of a menu command in Visual Studio for Mac.</note>
+      </trans-unit>
+      <trans-unit id="XA5211">
+        <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
+        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <note>The following are literal names and should not be translated: Wear
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+In this message, the term "handheld app" means "app for handheld devices."
+{0} - The Wear app package name
+{1} - The handheld app package name</note>
       </trans-unit>
       <trans-unit id="XA5213">
         <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tasks
 					return true;
 				}
 
-			Log.LogError ("Could not find mono.android.jar");
+			Log.LogCodedError ("XA0002", "Could not find mono.android.jar");
 
 			return false;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Tasks
 			var modified = new List<string> ();
 
 			if (PackageName != wearPackageName)
-				Log.LogCodedError ("XA5211", "Embedded wear app package name differs from handheld app package name ({0} != {1}).", wearPackageName, PackageName);
+				Log.LogCodedError ("XA5211", Properties.Resources.XA5211, wearPackageName, PackageName);
 
 			if (!File.Exists (WearApplicationApkPath)) {
 				Log.LogWarning ("This application won't contain the paired Wear package because the Wear application package .apk is not created yet. If you are using MSBuild or XBuild, you have to invoke \"SignAndroidPackage\" target.");


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA0002 & XA5211 into the `.resx` file so
that they are localizable.

Other changes:

Update `<GetMonoPlatformJar/>` to call `LogCodedError()` with the XA0002
code number.  XA0002 was already listed in
`Documentation/guides/messages/README.md`, but it wasn't yet used in
`<GetMonoPlatformJar/>` itself.