### PR TITLE
[Xamarin.Andrdoid.Build.Tasks] Add XA1010 code for invalid placeholders

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -685,6 +685,21 @@ when packaging Release applications.
 
   [manifest-merger]: https://developer.android.com/studio/build/manifest-merge
 
+- **AndroidManifestPlaceholders** &ndash; A semicolon-separated list of
+  key-value replacement pairs for *AndroidManifest.xml*, where each pair
+  has the format `key=value`.
+
+  For example, a property value of `assemblyName=$(AssemblyName)`
+  defines an `${assemblyName}` placeholder that can then appear in
+  *AndroidManifest.xml*:
+
+  ```xml
+  <application android:label="${assemblyName}"
+  ```
+
+  This provides a way to insert variables from the build process into
+  the *AndroidManifest.xml* file.
+
 - **AndroidMultiDexClassListExtraArgs** &ndash; A string property
   which allows developers to pass additional arguments to the
   `com.android.multidex.MainDexListBuilder` when generating the

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -79,6 +79,7 @@ ms.date: 01/24/2020
 + [XA1007](xa1007.md): The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).
 + [XA1008](xa1008.md): The TargetFrameworkVersion (Android API level {compileSdk}) is lower than the targetSdkVersion ({targetSdk}).
 + [XA1009](xa1009.md): The {assembly} is Obsolete. Please upgrade to {assembly} {version}
++ [XA1010](xa1010.md): Invalid \`$(AndroidManifestPlaceholders)\` value for Android manifest placeholders. Please use \`key1=value1;key2=value2\` format. The specified value was: `{placeholders}`
 
 ## XA2xxx: Linker
 

--- a/Documentation/guides/messages/xa1010.md
+++ b/Documentation/guides/messages/xa1010.md
@@ -1,0 +1,23 @@
+---
+title: Xamarin.Android warning XA1010
+description: XA1010 warning code
+ms.date: 03/11/2020
+---
+# Xamarin.Android warning XA1010
+
+## Example messages
+
+```
+warning XA1010: Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `assemblyName=App1;projectName`
+```
+
+## Issue
+
+One of the key-value pairs provided in the `$(AndroidManifestPlaceholders)`
+MSBuild property was invalid.  The invalid key-value pair will be ignored.
+
+## Solution
+
+Check that the `$(AndroidManifestPlaceholders)` MSBuild property contains a
+semicolon-separated list of key-value pairs where each pair has the format
+`key=value`.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`.
+        /// </summary>
+        internal static string XA1010 {
+            get {
+                return ResourceManager.GetString("XA1010", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Source file &apos;{0}&apos; could not be found..
         /// </summary>
         internal static string XA2001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -299,6 +299,10 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</comment>
   </data>
+  <data name="XA1010" xml:space="preserve">
+    <value>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</value>
+    <comment>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</comment>
+  </data>
   <data name="XA2001" xml:space="preserve">
     <value>Source file '{0}' could not be found.</value>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -222,6 +222,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {0} - The target framework version number
 {1} - The target SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA1010">
+        <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
+        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -283,7 +283,7 @@ namespace Xamarin.Android.Tasks
 				return string.Empty;
 			}
 			manifest.ApplicationName = ApplicationName;
-			manifest.Save (LogWarning, manifestFile);
+			manifest.Save (LogCodedWarning, manifestFile);
 
 			cmd.AppendSwitchIfNotNull ("-M ", manifestFile);
 			var designerDirectory = Path.IsPathRooted (JavaDesignerOutputDirectory) ? JavaDesignerOutputDirectory : Path.Combine (WorkingDirectory, JavaDesignerOutputDirectory);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Android.Tasks {
 				return string.Empty;
 			}
 			manifest.ApplicationName = ApplicationName;
-			manifest.Save (LogWarning, manifestFile);
+			manifest.Save (LogCodedWarning, manifestFile);
 
 			cmd.AppendSwitchIfNotNull ("--manifest ", manifestFile);
 			if (!string.IsNullOrEmpty (JavaDesignerOutputDirectory)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 						sb.AppendLine ("--placeholder");
 						sb.AppendLine ($"{entry [0]}={entry [1]}");
 					} else
-						Log.LogWarning ("Invalid application placeholders (AndroidApplicationPlaceholders) value. Use 'key1=value1;key2=value2, ...' format. The specified value was: " + ManifestPlaceholders);
+						Log.LogCodedWarning ("XA1010", string.Format (Properties.Resources.XA1010, string.Join (";", ManifestPlaceholders)));
 				}
 			}
 			sb.AppendLine ("--out");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -893,24 +893,24 @@ namespace Xamarin.Android.Tasks {
 		}
 
 		public void Save (TaskLoggingHelper log, string filename) =>
-			Save (m => log.LogWarning (m), filename);
+			Save ((c, m) => log.LogCodedWarning (c, m), filename);
 
-		public void Save (Action<string> logWarning, string filename)
+		public void Save (Action<string, string> logCodedWarning, string filename)
 		{
 			using (var file = new StreamWriter (filename, append: false, encoding: MonoAndroidHelper.UTF8withoutBOM))
-				Save (logWarning, file);
+				Save (logCodedWarning, file);
 		}
 
 		public void Save (TaskLoggingHelper log, Stream stream) =>
-			Save (m => log.LogWarning (m), stream);
+			Save ((c, m) => log.LogCodedWarning (c, m), stream);
 
-		public void Save (Action<string> logWarning, Stream stream)
+		public void Save (Action<string, string> logCodedWarning, Stream stream)
 		{
 			using (var file = new StreamWriter (stream, MonoAndroidHelper.UTF8withoutBOM, bufferSize: 1024, leaveOpen: true))
-				Save (logWarning, file);
+				Save (logCodedWarning, file);
 		}
 
-		public void Save (Action<string> logWarning, TextWriter stream)
+		public void Save (Action<string, string> logCodedWarning, TextWriter stream)
 		{
 			RemoveDuplicateElements ();
 			string s;
@@ -930,7 +930,7 @@ namespace Xamarin.Android.Tasks {
 					if (entry.Length == 2)
 						s = s.Replace ("${" + entry [0] + "}", entry [1]);
 					else
-						logWarning ("Invalid application placeholders (AndroidApplicationPlaceholders) value. Use 'key1=value1;key2=value2, ...' format. The specified value was: " + Placeholders);
+						logCodedWarning ("XA1010", string.Format (Properties.Resources.XA1010, string.Join (";", Placeholders)));
 				}
 			stream.Write (s);
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1560
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Add a warning code XA1010 to the existing warning about invalid values
of `$(AndroidManifestPlaceholders)`, and move the message string into
the `.resx` file so that it is localizable.

Other changes:

Correct the warning to say `AndroidManifestPlaceholders` instead of
`AndroidApplicationPlaceholders`.

Correct the warning to show the list of key-value pairs from the
property instead of `System.String[]`.

Add an entry for `$(AndroidManifestPlaceholders)` in `BuildProcess.md`.