### PR TITLE
[build] include designer binlog files from tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -902,6 +902,22 @@ stages:
 
     - template: designer/android-designer-tests.yaml@yaml
 
+    - task: CopyFiles@2
+      displayName: 'Copy binlogs'
+      inputs:
+        sourceFolder: Xamarin.Designer.Android
+        contents: '**/*.binlog'
+        targetFolder: $(Build.ArtifactStagingDirectory)/designer-binlogs
+        overWrite: true
+        flattenFolders: true
+      condition: always()
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload designer binlogs
+      inputs:
+        artifactName: Test Results - Designer - macOS
+        targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
+
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
     displayName: Designer - Windows
@@ -948,6 +964,22 @@ stages:
     - template: designer\android-designer-build-win.yaml@yaml
 
     - template: designer\android-designer-tests.yaml@yaml
+
+    - task: CopyFiles@2
+      displayName: 'Copy binlogs'
+      inputs:
+        sourceFolder: Xamarin.Designer.Android
+        contents: '**/*.binlog'
+        targetFolder: $(Build.ArtifactStagingDirectory)/designer-binlogs
+        overWrite: true
+        flattenFolders: true
+      condition: always()
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload designer binlogs
+      inputs:
+        artifactName: Test Results - Designer - Windows
+        targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
 
 - stage: integrated_regression_test
   displayName: Regression Tests


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4360

I fear that #4360 is causing a real problem from the designer unit
tests. However, I need the `.binlog` files to understand what is
happening.

We currently do not have these as artifacts, so this will add them.