### PR TITLE
[Xamarin.Android.Build.Tasks] don't use temp files in <ConvertResourcesCases/>

### DIFF
--- a/Documentation/release-notes/4395.md
+++ b/Documentation/release-notes/4395.md
@@ -1,0 +1,7 @@
+### Build and deployment performance
+
+  * [GitHub PR 4395](https://github.com/xamarin/xamarin-android/pull/4395):
+    Remove temporary file usage in the `<ConvertResourcesCases/>` MSBuild
+    task. This reduced the time for this MSBuild task from 613ms to 508ms
+    in a real-world project in an initial clean build or incremental builds
+    with Android resource changes.

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -120,10 +120,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <ConvertResourcesCases
       ContinueOnError="$(DesignTimeBuild)"
       AcwMapFile="$(_AcwMapFile)"
-      AdditionalResourceDirectories="@(_LibraryResourceDirectories)"
       AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
       CustomViewMapFile="$(_CustomViewMapFile)"
-      ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+      ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceDirectories)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
   />
   <Touch Files="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp" AlwaysCreate="True" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] ResourceDirectories { get; set; }
 
-		public ITaskItem[] AdditionalResourceDirectories { get; set; }
-
 		[Required]
 		public string AcwMapFile { get; set; }
 
@@ -93,17 +91,11 @@ namespace Xamarin.Android.Tasks
 					continue;
 				resourcedirectories.Add (dir.ItemSpec);
 			}
-			foreach (var dir in AdditionalResourceDirectories ?? new ITaskItem[0]) {
-				if (dir == item)
-					continue;
-				resourcedirectories.Add (dir.ItemSpec);
-			}
 
 			// Fix up each file
 			foreach (string file in xmls) {
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (file);
 				if (srcmodifiedDate <= lastUpdate) {
-					Log.LogDebugMessage ("  Skipping: {0}  {1} <= {2}", file, srcmodifiedDate, lastUpdate);
 					continue;
 				}
 				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);


### PR DESCRIPTION
I noticed that we were still using temporary files for
`AndroidResource.UpdateXmlResource`. I reworked this to use
`MemoryStreamPool.CreateStreamWriter` and generate the file in-memory.

We also had the code:

    if (srcmodifiedDate <= lastUpdate) {
        Log.LogDebugMessage ("  Skipping: {0}  {1} <= {2}", file, srcmodifiedDate, lastUpdate);
        continue;
    }
    Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);

I removed the "Skipping" log message, because we have found that
MSBuild log messages can hurt performance. In this case, it could
potentially log a lot of files, and it will help incremental builds to
only log files that changed.

Building the Toggl app on Windows:

https://github.com/jonathanpeppers/mobileapp/tree/peppers-fixes

Originally from:

https://github.com/toggl/mobileapp

    Before:
    613 ms  ConvertResourcesCases                      2 calls
    After:
    508 ms  ConvertResourcesCases                      2 calls

For this app, this will save ~100ms on an initial build, or builds
where Android resources change.

I also cleaned up a few things:

* Removed an unused `logMessage` parameter.

* Removed `ConvertResourcesCases.AdditionalResourceDirectories` so
  that both aapt & aapt2 will invoke `<ConvertResourcesCases/>` the
  same way.

    ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceDirectories)"