### PR TITLE
[Mono.Android] Add logging around RegisterNativeMembers()

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1648,11 +1648,21 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 {
 	timing_period total_time;
 
+	char *type = nullptr;
+
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
 
 	int managedType_len = env->GetStringLength (managedType);
 	const jchar *managedType_ptr = env->GetStringChars (managedType, nullptr);
+
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
+		type = utils.strdup_new (mt_ptr);
+		env->ReleaseStringUTFChars (managedType, mt_ptr);
+
+		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type);
+	}
 
 	int methods_len = env->GetStringLength (methods);
 	const jchar *methods_ptr = env->GetStringChars (methods, nullptr);
@@ -1683,11 +1693,6 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
 
-		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
-		char *type = utils.strdup_new (mt_ptr);
-		env->ReleaseStringUTFChars (managedType, mt_ptr);
-
-		log_info_nocheck (LOG_TIMING, "Runtime.register: registered type '%s'", type);
 		Timing::info (total_time, "Runtime.register: end time");
 
 		dump_counters ("## Runtime.register: type=%s\n", type);


### PR DESCRIPTION
Context: https://xamarinhq.slack.com/archives/CFB4MC864/p1584020384371400

Logging of which Java types we're registering native methods for was
removed in af02a65a.

Reintroduce a similar form of logging so that we can determine which
type is causing `Delegate.CreateDelegate()` to throw from
`AndroidTypeManager.RegisterNativeMembers()`.

The new log messages will only be printed when `timing` logging is
enabled:

	$ adb shell setprop debug.mono.log timing

For example:

	Registering native methods for managed type `Xamarin.Forms.Platform.Android.PlatformRenderer, Xamarin.Forms.Platform.Android, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null`
	Finished registering native methods for managed type `Xamarin.Forms.Platform.Android.PlatformRenderer, Xamarin.Forms.Platform.Android, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null` on Java type `crc643f46942d9dd1fff9/PlatformRenderer`; elapsed: 0s:2::587500