### PR TITLE
[Mono.Android] Delegate.CreateDelegate & generic type definitions

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -364,9 +364,6 @@ namespace Android.Runtime {
 
 		public override void RegisterNativeMembers (JniType nativeClass, Type type, string methods)
 		{
-			if (type.IsGenericTypeDefinition) {
-				return;
-			}
 			if (FastRegisterNativeMembers (nativeClass, type, methods))
 				return;
 

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/ExceptionTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/ExceptionTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.JcwGenTests {
 		public void ManagedJavaManaged_FinallyExecuted ()
 		{
 			using (var t = new Bxc7634 ()) {
-				using (var r = new Java.Lang.Runnable (() => {throw new InvalidOperationException ();})) {
+				using (var r = new MyGenericRunnable<int> ()) {
 					Assert.IsFalse (t.FinallyBlockRun);
 					bool ioeThrown = false;
 					try {
@@ -39,6 +39,14 @@ namespace Xamarin.Android.JcwGenTests {
 				}
 				Assert.IsNotNull (t.ThrowableCaught);
 				Assert.AreEqual ("Android.Runtime.JavaProxyThrowable", t.ThrowableCaught.GetType ().FullName);
+			}
+		}
+
+		class MyGenericRunnable<T> : Java.Lang.Object, Java.Lang.IRunnable {
+
+			public void Run ()
+			{
+				throw new InvalidOperationException ();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4394

When using a preview drop of the .NET 5 BCL with a Xamarin.Forms app,
app startup crashes within
`AndroidTypeManager.RegisterNativeMembers()` becuase we attempt to use
`Delegate.CreateDelegate()` on a generic type definition, a
`typeof(VisualElementRenderer<>)`.

.NET Core and .NET Framework doesn't like this; mono does, which is
why it hasn't been a problem before.

We attempt to register the generic type definition for
`VisualElementRenderer<T>` because that's what the Java Callable
Wrapper does!  Given C#:

	// C#
	partial class FormsViewGroup : Android.Views.ViewGroup {
	}
	partial class VisualElementRenderer<T> : FormsViewGroup {
	}
	partial class PageRenderer : VisualElementRenderer<Page> {
	}

the Java Callable Wrappers will "mirror" that hierarchy, with
`Runtime.register()` calls in the class constructors:

	// Java Callable Wrappers
	public class FormsViewGroup extends android.view.ViewGroup {}
	public class VisualElementRenderer_1 extends FormsViewGroup {
	  static {
	    mono.android.Runtime.register ("VisualElementRenderer`1, …");
	  }
	}
	public class PageRenderer extends VisualElementRenderer_1 {
	  static {
	    mono.android.Runtime.register ("VisualElementRenderer`1, …");
	  }
	}

When a `PageRenderer` instance is created from C#, an instance of the
Java Callable Wrapper `PageRenderer` will also be created, but before
the instance an be constructed the static initializer of
`PageRenderer` and all base classes must be executed *first*, and
because there's a `Runtime.register()` for
``VisualElementRenderer`1``,
`AndroidTypeManager.RegisterNativeMembers()` will thus attempt to
register the generic type definition.

How should this be fixed?

Assuming that updating .NET Core to behave like Mono isn't an option,
there are three other solutions:

 1. Don't emit `Runtime.register()` in the Java Callable Wrappers for
    C# types which are generic.

 2. Within `AndroidRuntime.RegisterNativeMembers()`, skip generic type
    definitions entirely.

 3. Improve the semantics of connector method lookups.

@jonpryor is reticent to do something as significant as (1) or (2)
without significant testing, as the side effects may be non-obvious.
For example, could this break [`GenericHolder<T>`][0] or some
unknown variation thereof?

Instead, let's go with (3).

The whole reason that we can lookup connector methods on a generic
type definition in the first place is because the connector methods
are in fact present in a *non*-generic base class, and Mono looks at
all base classes to resolve a method before deciding to throw.
Instead of relying on Mono, we can do this ourselves.

[0]: https://github.com/xamarin/xamarin-android/blob/8599d63d28922a580c75aeb015554ae9d5034bf3/src/Mono.Android/Test/Java.Interop/JnienvTest.cs#L468-L472