### PR TITLE
[build] Preserve CONFIGURATION for subsequent make invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+-include bin/configuration.mk
+
 V             ?= 0
 prefix         = /usr/local
-CONFIGURATION  = Debug
+CONFIGURATION ?= Debug
 RUNTIME       := $(shell which mono64 2> /dev/null && echo mono64 || echo mono) --debug=casts
 SOLUTION       = Xamarin.Android.sln
 TEST_TARGETS   = build-tools/scripts/RunTests.targets

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Unix.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-        partial void AddUnixPostBuildSteps (Context context, List<GeneratedFile> steps)
+		partial void AddUnixPostBuildSteps (Context context, List<GeneratedFile> steps)
 		{
 			steps.Add (new GeneratedMakeRulesFile (Path.Combine (Configurables.Paths.BuildBinDir, "rules.mk")));
 			steps.Add (new GeneratedConfigurationFile (Path.Combine (Configurables.Paths.BinDirRoot, "configuration.mk")));

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Unix.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -5,9 +6,28 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Step_GenerateFiles
 	{
-		partial void AddUnixPostBuildSteps (Context context, List<GeneratedFile> steps)
+		sealed class GeneratedConfigurationFile : GeneratedFile
+		{
+			public GeneratedConfigurationFile (string outputPath) :
+				base(outputPath)
+			{}
+
+			public override void Generate (Context context)
+			{
+				if (context == null)
+					throw new ArgumentNullException (nameof (context));
+
+				using (StreamWriter sw = Utilities.OpenStreamWriter (OutputPath)) {
+					sw.WriteLine ($"CONFIGURATION = {context.Configuration}");
+					sw.Flush ();
+				}
+			}
+		}
+
+        partial void AddUnixPostBuildSteps (Context context, List<GeneratedFile> steps)
 		{
 			steps.Add (new GeneratedMakeRulesFile (Path.Combine (Configurables.Paths.BuildBinDir, "rules.mk")));
+			steps.Add (new GeneratedConfigurationFile (Path.Combine (Configurables.Paths.BinDirRoot, "configuration.mk")));
 		}
 	}
 }


### PR DESCRIPTION
When the tree is configured with `make CONFIGURATION=Release`, every
subsequent `make` invocation will require `CONFIGURATION=Release` to be
present on the command line or otherwise the build tree will be messed
up and will require a re-run of `make prepare`.
Prevent the above from happening by storing the configuration in a
`bin/configuration.mk` file which is included by the `Makefile` as the
very first thing.