### PR TITLE
[ci] Always set artifact run number, even if previous steps failed.

### DIFF
--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -17,6 +17,7 @@ steps:
     $UploadAttemptSuffix = If ($(System.JobAttempt) -gt 1) {"(Attempt $(System.JobAttempt))"} Else {""}
     Write-Host "##vso[task.setvariable variable=UploadAttemptSuffix;]$UploadAttemptSuffix"
   displayName: Set upload artifact name
+  condition: always()
 
 - task: PublishPipelineArtifact@1
   displayName: upload build and test results


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android/pull/4373 we append the job run number to the log artifact's name to create a unique name so the upload succeeds.  However the script does not have `condition: always()` set so it isn't being run if a previous step failed.