### PR TITLE
[ci] Don't build XA.sln in parallel on Windows, as it sometimes fails.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -262,7 +262,6 @@ stages:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
         msbuildArguments: /t:Build /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog
-        maximumCpuCount: true
 
     - task: MSBuild@1
       displayName: msbuild create-vsix


### PR DESCRIPTION
The [2020-02 Mono bump](https://github.com/xamarin/xamarin-android/pull/4219) enabled `msbuild /m` for parallel builds in our CI for Windows.  However we have not audited our `Xamarin.Android.sln` to ensure build dependencies are correctly set.  Something(s) in there are not correct and this causes a race condition where builds sometimes fail because expected files do no exist yet.

Often this looks like this:
```
Error MSB3644: The reference assemblies for MonoAndroid,Version=v10.0 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks
```

This disables parallel builds until a future audit is completed.