### PR TITLE
[Bindings.targets] Ensure we create our JavaDoc stamp file. [#2745]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -346,7 +346,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		
     <Unzip Sources="@(JavaDocJar)" DestinationDirectories="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')" />
 		
-    <Touch Files="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName).stamp')" />
+    <Touch Files="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName).stamp')" AlwaysCreate="True" />
 		
     <ItemGroup>
       <JavaDocIndex Include="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')" />


### PR DESCRIPTION
Fixes #2745.

Whenever we use `<Touch>` to create a `.stamp` file we need to specify `AlwaysCreate="true"` or else the file will not get created.