### PR TITLE
[Xamarin.Android.Build.Tasks] improvements to Set*Writeable

### DIFF
--- a/Documentation/release-notes/4407.md
+++ b/Documentation/release-notes/4407.md
@@ -1,0 +1,5 @@
+### Build and deployment performance
+
+  * [GitHub PR 4407](https://github.com/xamarin/xamarin-android/pull/4407):
+    Improved code for removing "readonly" attributes from files and directories.
+    This saved ~90ms to an initial build of a Xamarin.Forms template project.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 
 				try {
-					MonoAndroidHelper.SetWriteable (pdb);
+					Tools.Files.SetWriteableUnchecked (pdb);
 					Converter.Convert (Path.ChangeExtension (pdb, ".dll"));
 					convertedFiles.Add (new TaskItem (Path.ChangeExtension (pdb, ".dll")));
 				} catch (Exception ex) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -4,10 +4,10 @@ using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Monodroid;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);
-				MonoAndroidHelper.SetWriteable (file);
+				Files.SetWriteableUnchecked (file);
 				bool success = AndroidResource.UpdateXmlResource (resdir, file, acwMap,
 					resourcedirectories, (level, message) => {
 						switch (level) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System.Security.Cryptography;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
@@ -45,9 +45,9 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ($"  Skipping {src} it is up to date");
 					continue;
 				}
-				if (!MonoAndroidHelper.CopyIfChanged (src.FullName, dest.FullName)) {
+				if (!Files.CopyIfChanged (src.FullName, dest.FullName)) {
 					Log.LogDebugMessage ($"  Skipping {src} it was not changed.");
-					MonoAndroidHelper.SetWriteable (dest.FullName);
+					Files.SetWriteableUnchecked (dest.FullName);
 					continue;
 				}
 				modifiedFiles.Add (new TaskItem (dest.FullName));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 					// if that fails we probably have readonly files (or locked files)
 					// so try to make them writable and try again.
 					try {
-						MonoAndroidHelper.SetDirectoryWriteable (fullPath);
+						Files.SetDirectoryWriteable (fullPath);
 						Directory.Delete (fullPath, true);
 						temporaryRemovedDirectories.Add (directory);
 					} catch (Exception inner) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ("Deleting File {0}", f);
 					var item = new TaskItem (f.Replace (absDir, "res" + Path.DirectorySeparatorChar));
 					removedFiles.Add (item);
-					MonoAndroidHelper.SetWriteable (f);
+					Tools.Files.SetWriteableUnchecked (f);
 					File.Delete (f);
 				}
 			
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Tasks
 					if (!knownDirs.Contains (d) && IsDirectoryEmpty (d)) {
 						Log.LogDebugMessage ("Deleting Directory {0}", d);
 						removedDirectories.Add (new TaskItem(d));
-						MonoAndroidHelper.SetDirectoryWriteable (d);
+						Tools.Files.SetDirectoryWriteable (d);
 						System.IO.Directory.Delete (d);
 					}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -101,11 +101,11 @@ namespace Xamarin.Android.Tasks
 				.ToArray ();
 
 			foreach (var directory in ResolvedResourceDirectories) {
-				MonoAndroidHelper.SetDirectoryWriteable (directory.ItemSpec);
+				Files.SetDirectoryWriteable (directory.ItemSpec);
 			}
 
 			foreach (var directory in ResolvedAssetDirectories) {
-				MonoAndroidHelper.SetDirectoryWriteable (directory.ItemSpec);
+				Files.SetDirectoryWriteable (directory.ItemSpec);
 			}
 
 			if (!string.IsNullOrEmpty (CacheFile)) {
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Tasks
 			// lets "upgrade" the old directory.
 			string oldPath = Path.GetFullPath (Path.Combine (OutputImportDirectory, "..", "__library_projects__"));
 			if (!OutputImportDirectory.Contains ("__library_projects__") && Directory.Exists (oldPath)) {
-				MonoAndroidHelper.SetDirectoryWriteable (Path.Combine (oldPath, ".."));
+				Files.SetDirectoryWriteable (Path.Combine (oldPath, ".."));
 				Directory.Delete (oldPath, recursive: true);
 			}
 			var outdir = Path.GetFullPath (OutputImportDirectory);
@@ -186,7 +186,7 @@ namespace Xamarin.Android.Tasks
 
 				// Skip already-extracted resources.
 				bool updated = false;
-				string assemblyHash = MonoAndroidHelper.HashFile (assemblyPath);
+				string assemblyHash = Files.HashFile (assemblyPath);
 				string stamp = Path.Combine (outdir, assemblyIdentName + ".stamp");
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				if (assemblyHash == stampHash) {
@@ -228,7 +228,7 @@ namespace Xamarin.Android.Tasks
 						if (name.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase)) {
 							var outFile = Path.Combine (outDirForDll, name);
 							using (var stream = pe.GetEmbeddedResourceStream (resource)) {
-								updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, outFile);
+								updated |= Files.CopyIfStreamChanged (stream, outFile);
 							}
 							resolvedEnvironments.Add (new TaskItem (Path.GetFullPath (outFile), new Dictionary<string, string> {
 								{ OriginalFile, assemblyPath }
@@ -238,7 +238,7 @@ namespace Xamarin.Android.Tasks
 						else if (name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase)) {
 							using (var stream = pe.GetEmbeddedResourceStream (resource)) {
 								AddJar (jars, importsDir, name, assemblyPath);
-								updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, Path.Combine (importsDir, name));
+								updated |= Files.CopyIfStreamChanged (stream, Path.Combine (importsDir, name));
 							}
 						}
 						// embedded native libraries
@@ -345,7 +345,7 @@ namespace Xamarin.Android.Tasks
 				string assetsDir = Path.Combine (importsDir, "assets");
 
 				bool updated = false;
-				string aarHash = MonoAndroidHelper.HashFile (aarFile.ItemSpec);
+				string aarHash = Files.HashFile (aarFile.ItemSpec);
 				string stamp = Path.Combine (outdir, aarIdentityName + ".stamp");
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				var aarFullPath = Path.GetFullPath (aarFile.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -361,36 +361,6 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public static void SetWriteable (string source)
-		{
-			if (!File.Exists (source))
-				return;
-
-			var fileInfo = new FileInfo (source);
-			if (fileInfo.IsReadOnly)
-				fileInfo.IsReadOnly = false;
-		}
-
-		public static void SetDirectoryWriteable (string directory)
-		{
-			if (!Directory.Exists (directory))
-				return;
-
-			var dirInfo = new DirectoryInfo (directory);
-			if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-				dirInfo.Attributes &= ~FileAttributes.ReadOnly;
-
-			foreach (var dir in Directory.EnumerateDirectories (directory, "*", SearchOption.AllDirectories)) {
-				dirInfo = new DirectoryInfo (dir);
-				if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-					dirInfo.Attributes &= ~FileAttributes.ReadOnly;
-			}
-
-			foreach (var file in Directory.EnumerateFiles (directory, "*", SearchOption.AllDirectories)) {
-				SetWriteable (Path.GetFullPath (file));
-			}
-		}
-
 		public static bool CopyAssemblyAndSymbols (string source, string destination)
 		{
 			bool changed = CopyIfChanged (source, destination);
@@ -477,11 +447,6 @@ namespace Xamarin.Android.Tasks
 			return Files.HashBytes (bytes);
 		}
 
-		public static bool HasFileChanged (string source, string destination)
-		{
-			return Files.HasFileChanged (source, destination);
-		}
-
 		/// <summary>
 		/// Open a file given its path and remove the 3 bytes UTF-8 BOM if there is one
 		/// </summary>
@@ -507,7 +472,7 @@ namespace Xamarin.Android.Tasks
 						input.CopyTo (stream);
 				}
 
-				SetWriteable (filePath);
+				Files.SetWriteableUnchecked (filePath);
 				File.Delete (filePath);
 				File.Copy (temp, filePath);
 			} finally {


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/Benchmarks/tree/setwriteable

`MonoAndroidHelper` has a couple methods that are called a lot during
a build:

1. `public static void SetDirectoryWriteable (string directory)`
2. `public static void SetWriteable (string source)`

Both have some room for performance improvements.

## SetWriteable ##

I changed usage of `FileInfo` to just use the static `File` methods.
We can do this for files, but not directories. There is no
`Directory.GetAttributes` method in the BCL.

We had a `File.Exists` check, which all callers were already doing. I
changed this to use `try-catch` around `File.GetAttributes`.

Benchmarking the difference:

    BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
    Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
    [Host]     : .NET Framework 4.8 (4.8.4121.0), X86 LegacyJIT

    |     Method |      Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
    |----------- |----------:|---------:|---------:|------:|------:|------:|----------:|
    | Writeable2 |  36.20 us | 0.531 us | 0.443 us |     - |     - |     - |         - |
    | Writeable1 |  61.27 us | 0.826 us | 0.732 us |     - |     - |     - |         - |
    |  Readonly2 | 100.97 us | 1.274 us | 1.129 us |     - |     - |     - |         - |
    |  Readonly1 | 126.21 us | 1.441 us | 1.348 us |     - |     - |     - |         - |

## SetDirectoryWriteable ##

The main improvement is to *not* call `Directory.EnumerateDirectories`
and `Directory.EnumerateFiles` independently. Use
`DirectoryInfo.EnumerateFileSystemInfos` instead. This way we aren't
enumerating the file system twice.

It also doesn't need to call `SetWriteable` for files.

Benchmarking the difference, it is an order of magnitude better now:

    BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
    Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
    [Host]     : .NET Framework 4.8 (4.8.4121.0), X86 LegacyJIT

    |     Method |      Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
    |----------- |----------:|---------:|---------:|------:|------:|------:|----------:|
    | Writeable2 | 158.51 us | 1.870 us | 1.749 us |     - |     - |     - |         - |
    |  Readonly2 | 159.54 us | 2.172 us | 2.032 us |     - |     - |     - |         - |
    | Writeable1 | 758.41 us | 5.558 us | 5.199 us |     - |     - |     - |   16384 B |
    |  Readonly1 | 763.97 us | 8.778 us | 8.211 us |     - |     - |     - |   16384 B |

## Overall results ##

On an initial build of the Xamarin.Forms integration project in this
repo:

    Before:
     461 ms  GenerateJavaStubs                          1 calls
    1061 ms  ResolveLibraryProjectImports               1 call
    After:
     448 ms  GenerateJavaStubs                          1 calls
     993 ms  ResolveLibraryProjectImports               1 calls

These two targets would call into `Set*Writeable` a lot because they
write lots of files.

This saves ~90ms on an initial build. Incremental builds will have a
smaller improvement.