### PR TITLE
[docs] Add Commercial Xamarin.Android 10.3 Windows download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 | **Commercial Xamarin.Android 10.0 (d16-3)** for macOS                                       | [Download][commercial-d16-3-macOS-x86_64]   |
 | **Commercial Xamarin.Android 10.1 (d16-4)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-4-Windows-x86_64] |
 | **Commercial Xamarin.Android 10.1 (d16-4)** for macOS                                       | [Download][commercial-d16-4-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.2 (d16-5) Preview** for Windows+Visual Studio 2019 Preview  | [Download][commercial-d16-5-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.2 (d16-5)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-5-Windows-x86_64] |
 | **Commercial Xamarin.Android 10.2 (d16-5) Preview** for macOS                               | [Download][commercial-d16-5-macOS-x86_64]   |
-| **OSS Xamarin.Android 10.2.99 (master)** for macOS &amp; Windows+Visual Studio 2019\*       | [![Open Source Xamarin.Android 10.2.99, macOS+VS2019][oss-master-macOS-x86_64-icon]][oss-master-macOS-x86_64-artifacts] |
+| **Commercial Xamarin.Android 10.3 (d16-6) Preview** for Windows+Visual Studio 2019 Preview  | [Download][commercial-d16-6-Windows-x86_64] |
+| **OSS Xamarin.Android 10.3.99 (master)** for macOS &amp; Windows+Visual Studio 2019\*       | [![Open Source Xamarin.Android 10.3.99, macOS+VS2019][oss-master-macOS-x86_64-icon]][oss-master-macOS-x86_64-artifacts] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
 
@@ -59,6 +60,7 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d16-4-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-4-macos
 [commercial-d16-5-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-5-windows
 [commercial-d16-5-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-5-macos
+[commercial-d16-6-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-6-windows
 [oss-master-macOS-x86_64-icon]:           https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/badge/icon
 [oss-master-macOS-x86_64-artifacts]:      https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure
 


### PR DESCRIPTION
Add Commercial Xamarin.Android 10.3 Windows download location to the
README.

Update OSS master version number to 10.3.99.