### PR TITLE
[api-merge] Generate all api's in single pass.

### DIFF
--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -202,9 +202,11 @@ namespace Xamarin.Android.ApiMerge {
 		public void Save (string filename)
 		{
 			FixupOverrides ();
-			if (filename != null)
+			if (filename != null) {
+				filename = filename.Replace ('\\', Path.DirectorySeparatorChar);
+				Directory.CreateDirectory (Path.GetDirectoryName (filename));
 				Contents.Save (filename);
-			else
+			} else
 				Contents.Save (Console.Out);
 		}
 

--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -203,10 +203,9 @@ namespace Xamarin.Android.ApiMerge {
 		{
 			FixupOverrides ();
 			if (filename != null) {
-				filename = filename.Replace ('\\', Path.DirectorySeparatorChar);
 				Directory.CreateDirectory (Path.GetDirectoryName (filename));
 				Contents.Save (filename);
-			} else
+			}  else
 				Contents.Save (Console.Out);
 		}
 

--- a/build-tools/api-merge/api-merge.cs
+++ b/build-tools/api-merge/api-merge.cs
@@ -100,11 +100,11 @@ namespace Xamarin.Android.ApiMerge {
 			}
 
 			var doc = XDocument.Load (config);
-			var inputs = doc.Root.Element ("Inputs").Elements ("File").Select (elem => Tuple.Create (Path.Combine (inputDir, elem.Attribute ("Path").Value), elem.Attribute ("Level").Value)).ToList ();
+			var inputs = doc.Root.Element ("Inputs").Elements ("File").Select (elem => (Path: Path.Combine (inputDir, elem.Attribute ("Path").Value), Level: elem.Attribute ("Level").Value)).ToList ();
 
 			// Remove any missing inputs
-			foreach (var missing in inputs.Where (i => !File.Exists (i.Item1)).ToList ()) {
-				Console.WriteLine ($"warning: skipping missing file {missing.Item1}...");
+			foreach (var missing in inputs.Where (i => !File.Exists (i.Path)).ToList ()) {
+				Console.WriteLine ($"warning: skipping missing file {missing.Path}...");
 				inputs.Remove (missing);
 			}
 
@@ -114,26 +114,26 @@ namespace Xamarin.Android.ApiMerge {
 			}
 
 			// Create the initial context
-			var context = new ApiDescription (inputs [0].Item1);
+			var context = new ApiDescription (inputs [0].Path);
 
-			var outputs = doc.Root.Element ("Outputs").Elements ("File").Select (elem => Tuple.Create (Path.Combine (outputDir, elem.Attribute ("Path").Value), elem.Attribute ("LastLevel").Value)).ToList ();
+			var outputs = doc.Root.Element ("Outputs").Elements ("File").Select (elem => (Path: Path.Combine (outputDir, elem.Attribute ("Path").Value), LastLevel: elem.Attribute ("LastLevel").Value)).ToList ();
 			var current_input = 0;
 			var current_output = 0;
 
 			// Handle the initial case if needed
-			if (inputs[current_input].Item2 == outputs[current_output].Item2) {
-				Console.WriteLine ($"api-merge: writing output {outputs [current_output].Item1}...");
-				context.Save (outputs [current_output].Item1);
+			if (inputs[current_input].Level == outputs[current_output].LastLevel) {
+				Console.WriteLine ($"api-merge: writing output {outputs [current_output].Path}...");
+				context.Save (outputs [current_output].Path);
 				current_output++;
 			}
 
 			// Write each output
 			while (current_output < outputs.Count) {
-				context.Merge (inputs [++current_input].Item1);
+				context.Merge (inputs [++current_input].Path);
 
-				if (inputs [current_input].Item2 == outputs [current_output].Item2) {
-					Console.WriteLine ($"api-merge: writing output {outputs [current_output].Item1}...");
-					context.Save (outputs [current_output].Item1);
+				if (inputs [current_input].Level == outputs [current_output].LastLevel) {
+					Console.WriteLine ($"api-merge: writing output {outputs [current_output].Path}...");
+					context.Save (outputs [current_output].Path);
 					current_output++;
 				}
 			}

--- a/build-tools/api-merge/api-merge.cs
+++ b/build-tools/api-merge/api-merge.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.ApiMerge {
 			}
 
 			var doc = XDocument.Load (config);
-			var inputs = doc.Root.Element ("Inputs").Elements ("File").Select (elem => (Path: Path.Combine (inputDir, elem.Attribute ("Path").Value), Level: elem.Attribute ("Level").Value)).ToList ();
+			var inputs = doc.Root.Element ("Inputs").Elements ("File").Select (elem => (Path: FixPath (Path.Combine (inputDir, elem.Attribute ("Path").Value)), Level: elem.Attribute ("Level").Value)).ToList ();
 
 			// Remove any missing inputs
 			foreach (var missing in inputs.Where (i => !File.Exists (i.Path)).ToList ()) {
@@ -116,7 +116,7 @@ namespace Xamarin.Android.ApiMerge {
 			// Create the initial context
 			var context = new ApiDescription (inputs [0].Path);
 
-			var outputs = doc.Root.Element ("Outputs").Elements ("File").Select (elem => (Path: Path.Combine (outputDir, elem.Attribute ("Path").Value), LastLevel: elem.Attribute ("LastLevel").Value)).ToList ();
+			var outputs = doc.Root.Element ("Outputs").Elements ("File").Select (elem => (Path: FixPath (Path.Combine (outputDir, elem.Attribute ("Path").Value)), LastLevel: elem.Attribute ("LastLevel").Value)).ToList ();
 			var current_input = 0;
 			var current_output = 0;
 
@@ -140,6 +140,8 @@ namespace Xamarin.Android.ApiMerge {
 
 			return 0;
 		}
+
+		static string FixPath (string path) => path?.Replace ('\\', Path.DirectorySeparatorChar);
 
 		static string NormalizePath (string path)
 		{

--- a/build-tools/api-merge/api-merge.csproj
+++ b/build-tools/api-merge/api-merge.csproj
@@ -41,5 +41,10 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="merge-configuration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/build-tools/api-merge/merge-configuration.xml
+++ b/build-tools/api-merge/merge-configuration.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+  <!-- Both lists should be sorted in chronological order -->
+  <Inputs>
+    <File Path="api-10.xml.in" Level="10" />
+    <File Path="api-15.xml.in" Level="15" />
+    <File Path="api-16.xml.in" Level="16" />
+    <File Path="api-17.xml.in" Level="17" />
+    <File Path="api-18.xml.in" Level="18" />
+    <File Path="api-19.xml.in" Level="19" />
+    <File Path="api-20.xml.in" Level="20" />
+    <File Path="api-21.xml.in" Level="21" />
+    <File Path="api-22.xml.in" Level="22" />
+    <File Path="api-23.xml.in" Level="23" />
+    <File Path="api-24.xml.in" Level="24" />
+    <File Path="api-25.xml.in" Level="25" />
+    <File Path="api-26.xml.in" Level="26" />
+    <File Path="api-27.xml.in" Level="27" />
+    <File Path="api-28.xml.in" Level="28" />
+    <File Path="api-29.xml.in" Level="29" />
+    <File Path="api-R.xml.in" Level="R" />
+  </Inputs>
+  <Outputs>
+    <File Path="android-19\mcw\api.xml" LastLevel="19" />
+    <File Path="android-20\mcw\api.xml" LastLevel="20" />
+    <File Path="android-21\mcw\api.xml" LastLevel="21" />
+    <File Path="android-22\mcw\api.xml" LastLevel="22" />
+    <File Path="android-23\mcw\api.xml" LastLevel="23" />
+    <File Path="android-24\mcw\api.xml" LastLevel="24" />
+    <File Path="android-25\mcw\api.xml" LastLevel="25" />
+    <File Path="android-26\mcw\api.xml" LastLevel="26" />
+    <File Path="android-27\mcw\api.xml" LastLevel="27" />
+    <File Path="android-28\mcw\api.xml" LastLevel="28" />
+    <File Path="android-29\mcw\api.xml" LastLevel="29" />
+    <File Path="android-R\mcw\api.xml" LastLevel="R" />
+  </Outputs>
+</Configuration>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -67,7 +67,7 @@
       <ApiMerge>..\..\bin\Build$(Configuration)\api-merge.exe</ApiMerge>
       <_ConfigurationFile>..\..\bin\Build$(Configuration)\merge-configuration.xml</_ConfigurationFile>
       <_ConfigurationInputBaseDirectory>..\..\bin\Build$(Configuration)\api\</_ConfigurationInputBaseDirectory>
-      <_ConfigurationOutputBaseDirectory>obj\$(Configuration)\</_ConfigurationOutputBaseDirectory>
+      <_ConfigurationOutputBaseDirectory>$(IntermediateOutputPath)\..\</_ConfigurationOutputBaseDirectory>
     </PropertyGroup>
     <Exec
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)"

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -65,13 +65,12 @@
     </ItemGroup>
     <PropertyGroup>
       <ApiMerge>..\..\bin\Build$(Configuration)\api-merge.exe</ApiMerge>
-      <_Profiles>@(_AndroidProfile->'%(Identity)', ' ')</_Profiles>
-      <_Glob>-s '..\..\bin\Build$(Configuration)\api\api-*.xml.in'</_Glob>
-      <_LastProfile>--last-description=..\..\bin\Build$(Configuration)\api\api-$(AndroidPlatformId).xml.in</_LastProfile>
-      <_Out>-o "$(IntermediateOutputPath)mcw\api.xml"</_Out>
+      <_ConfigurationFile>..\..\bin\Build$(Configuration)\merge-configuration.xml</_ConfigurationFile>
+      <_ConfigurationInputBaseDirectory>..\..\bin\Build$(Configuration)\api\</_ConfigurationInputBaseDirectory>
+      <_ConfigurationOutputBaseDirectory>obj\$(Configuration)\</_ConfigurationOutputBaseDirectory>
     </PropertyGroup>
     <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) $(_Out) $(_Glob) $(_Profiles) $(_LastProfile)"
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)"
     />
   </Target>
   <Target Name="_GenerateBinding"


### PR DESCRIPTION
When we run `make jenkins`, we run `api-merge.exe` N times, where N is the number of Android Platform Levels (currently 12).  Each successive run has to merge all previous levels and then the new level.  

That is, our runs look like this:
- 10 + 15 + 16 + 17 +18 + 19 -> 19
- 10 + 15 + 16 + 17 +18 + 19 + 20 -> 20
- 10 + 15 + 16 + 17 +18 + 19 + 20 + 21 -> 21
- etc.

Instead, we can do a single pass where we do all the merging once, outputting the `api.xml` files in between the merges as needed.

- Merge 10 + 15 + 16 + 17 + 18 + 19
- Write 19
- Merge 20
- Write 20
- etc.

This shaves about 4 minutes off of `make jenkins`:

```
Before: 25:35
After: 21:44
```

Note:
This may not be the best place to insert this process. Should we instead do it somewhere earlier in the `make jenkins` chain, and then the existing targets will skip running because of inputs/outputs?  If so, where should we add it?