### PR TITLE
[Xamarin.Android.Build.Tasks] move DX into its own MSBuild targets file

### DIFF
--- a/Documentation/release-notes/4414.md
+++ b/Documentation/release-notes/4414.md
@@ -1,0 +1,5 @@
+### For D8 DEX compiler, R8 now used automatically instead of ProGuard
+
+Xamarin.Android now selects the R8 code shrinker automatically for projects that
+have the **Dex compiler** (`$(AndroidDexTool)`) set to **d8** and **Code
+shrinker** (`$(AndroidLinkTool)`) set to **ProGuard**.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -229,6 +229,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.CSharp.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.D8.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Designer.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DX.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.FSharp.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.props" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3460,25 +3460,23 @@ namespace UnnamedProject {
 		}
 
 		[Test]
-		public void ProguardBOMError ([Values ("dx", "d8")] string dexTool, [Values ("proguard")] string linkTool)
+		public void ProguardBOMError ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				DexTool = dexTool,
-				LinkTool = linkTool,
+				DexTool = "dx",
+				LinkTool = "proguard",
 			};
-			if (!string.IsNullOrEmpty (linkTool)) {
-				var rules = new List<string> {
-					"-dontwarn com.google.devtools.build.android.desugar.**",
-					"-dontwarn javax.annotation.**",
-					"-dontwarn org.codehaus.mojo.animal_sniffer.*",
-				};
-				var encoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: true);
-				proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
-					TextContent = () => string.Join (Environment.NewLine, rules),
-					Encoding = encoding,
-				});
-			}
+			var rules = new List<string> {
+				"-dontwarn com.google.devtools.build.android.desugar.**",
+				"-dontwarn javax.annotation.**",
+				"-dontwarn org.codehaus.mojo.animal_sniffer.*",
+			};
+			var encoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: true);
+			proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
+				TextContent = () => string.Join (Environment.NewLine, rules),
+				Encoding = encoding,
+			});
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (proj), "Build should have failed.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -190,7 +190,7 @@ namespace UnnamedProject
 
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 
-				var targets = new [] { "_CompileJava", "_CompileToDalvikWithDx" };
+				var targets = new [] { "_CompileJava", "_CompileToDalvik" };
 				foreach (var t in targets) {
 					Assert.IsTrue (b.Output.IsTargetSkipped (t), $"`{t}` should be skipped!");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1073,7 +1073,7 @@ namespace Lib2
 					"_ResolveLibraryProjectImports",
 					"_GenerateJavaStubs",
 					"_CompileJava",
-					"_CompileToDalvikWithD8",
+					"_CompileToDalvik",
 				};
 				foreach (var target in targets) {
 					Assert.IsTrue (builder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -111,6 +111,9 @@
     <None Include="Xamarin.Android.D8.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Android.DX.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Android.FSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -304,6 +304,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- NOTE: $(AndroidLinkTool) would be blank if code shrinking is not used at all -->
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == '' And '$(AndroidEnableProguard)' == 'True' ">proguard</AndroidLinkTool>
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidEnableDesugar)' == 'True' ">r8</AndroidLinkTool>
+	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' ">r8</AndroidLinkTool>
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
@@ -401,6 +402,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 -->
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
@@ -2372,93 +2374,6 @@ because xbuild doesn't support framework reference assemblies.
 		;$(_AndroidBuildPropertiesCache)
 	</_CompileToDalvikInputs>
 </PropertyGroup>
-
-<Target Name="_CompileToDalvikWithDx"
-  DependsOnTargets="$(_BeforeCompileToDalvikWithDx);$(_CompileToDalvikDependsOnTargets)"
-  Condition=" '$(AndroidDexTool)' == 'dx' "
-  Inputs="$(_CompileToDalvikInputs)"
-  Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
-
-  <ItemGroup>
-    <_JarsToProguard Include="@(_JavaLibrariesToCompile)" />
-  </ItemGroup>
-  
-  <MakeDir Directories="$(IntermediateOutputPath)proguard" />
-
-  <Proguard
-    Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' "
-    ProguardJarPath="$(ProguardJarPath)"
-    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
-    JavaToolPath="$(JavaToolPath)"
-    ProguardToolPath="$(ProguardToolPath)"
-    ToolExe="$(ProguardToolExe)"
-    UseProguard="$(UseProguard)"
-    JavaPlatformJarPath="$(JavaPlatformJarPath)"
-    ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-    AcwMapFile="$(_AcwMapFile)"
-    ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
-    ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
-    ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
-    ProguardConfigurationFiles="$(ProguardConfigFiles)"
-    JavaLibrariesToEmbed="@(_JarsToProguard);@(_InstantRunJavaReference)"
-    JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
-    ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
-    EnableLogging="$(ProguardEnableLogging)"
-    DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"
-    PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
-    PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
-    PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
-    ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
-     />
-
-  <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
-    <_AlternativeJarForAppDx Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar" />
-  </ItemGroup>
-
-  <CreateMultiDexMainDexClassList
-    Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
-    ToolPath="$(JavaToolPath)"
-    ToolExe="$(JavaToolExe)"
-    ProguardJarPath="$(ProguardJarPath)"
-    AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
-    ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-    JavaLibraries="@(_JarsToProguard)"
-    MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-    CustomMainDexListFiles="@(MultiDexMainDexList)"
-    ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
-    ExtraArgs="$(AndroidMultiDexClassListExtraArgs)"
-    >
-  </CreateMultiDexMainDexClassList>
-
-  <!-- remove existing dex files that may be previous multidex outputs. -->
-  <ItemGroup>
-    <_DexesToDelete Include="$(IntermediateOutputPath)android\bin\*.dex" />
-  </ItemGroup>
-  <Delete Files="@(_DexesToDelete)" />
-
-  <!-- Compile java code to dalvik -->
-  <CompileToDalvik 
-    DxJarPath="$(DxJarPath)"
-    DxExtraArguments="$(DxExtraArguments)"
-    JavaToolPath="$(JavaToolPath)"
-    JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
-    JavaOptions="$(JavaOptions)"
-    ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory.TrimEnd('\'))"
-    ClassesZip="$(_AndroidIntermediateClassesZip)"
-    ToolPath="$(DxToolPath)"
-    ToolExe="$(DxToolExe)"
-    UseDx="$(UseDx)"
-    MultiDexEnabled="$(AndroidEnableMultiDex)"
-    MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-    JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp)"
-    AlternativeJarFiles="@(_AlternativeJarForAppDx)"
-  />
-  <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />
-  <ItemGroup>
-    <FileWrites Include="$(IntermediateOutputPath)android\bin\*.dex" />
-  </ItemGroup>
-
-</Target>
 
 <PropertyGroup>
 	<_CompileDexDependsOn>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -401,8 +401,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 <!-- As we split up/refactor this file, put new imports here -->
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" />
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" Condition=" '$(AndroidDexTool)' == 'dx' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
@@ -2377,8 +2377,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <PropertyGroup>
 	<_CompileDexDependsOn>
-		_CompileToDalvikWithDx;
-		_CompileToDalvikWithD8;
+		_CompileToDalvik;
 	</_CompileDexDependsOn>
 </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -14,9 +14,8 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="_CompileToDalvikWithD8"
-      Condition=" '$(AndroidDexTool)' == 'd8' "
-      DependsOnTargets="$(_CompileToDalvikDependsOnTargets)"
+  <Target Name="_CompileToDalvik"
+      DependsOnTargets="$(_BeforeCompileToDalvik);$(_CompileToDalvikDependsOnTargets)"
       Inputs="$(_CompileToDalvikInputs)"
       Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -23,11 +23,11 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <!-- Target-level properties to simplify conditions-->
     <PropertyGroup>
       <!--Flag indicating if using d8 or r8-->
-      <_UseR8>False</_UseR8>
       <_UseR8 Condition=" ('$(AndroidLinkTool)' == 'r8' And '$(_ProguardProjectConfiguration)' != '') Or '$(AndroidEnableMultiDex)' == 'True' ">True</_UseR8>
+      <_UseR8 Condition=" '$(_UseR8)' == '' ">False</_UseR8>
       <!--Flag indicating if r8 should have EnableShrinking-->
-      <_R8EnableShrinking>False</_R8EnableShrinking>
       <_R8EnableShrinking Condition=" '$(AndroidLinkTool)' == 'r8' ">True</_R8EnableShrinking>
+      <_R8EnableShrinking Condition=" '$(_R8EnableShrinking)' == '' ">False</_R8EnableShrinking>
     </PropertyGroup>
 
     <Error
@@ -45,36 +45,6 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         Directories="$(IntermediateOutputPath)proguard"
         Condition=" '$(AndroidLinkTool)' != '' "
     />
-
-    <Proguard
-        Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' "
-        ProguardJarPath="$(ProguardJarPath)"
-        AndroidSdkDirectory="$(_AndroidSdkDirectory)"
-        JavaToolPath="$(JavaToolPath)"
-        ProguardToolPath="$(ProguardToolPath)"
-        ToolExe="$(ProguardToolExe)"
-        UseProguard="$(UseProguard)"
-        JavaPlatformJarPath="$(JavaPlatformJarPath)"
-        ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-        AcwMapFile="$(_AcwMapFile)"
-        ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
-        ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
-        ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
-        ProguardConfigurationFiles="$(ProguardConfigFiles)"
-        JavaLibrariesToEmbed="@(_JavaLibrariesToCompileForApp);@(_InstantRunJavaReference)"
-        JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
-        ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
-        EnableLogging="$(ProguardEnableLogging)"
-        DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"
-        PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
-        PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
-        PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
-        ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
-    />
-
-    <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
-      <_AlternativeJarForAppD8 Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar" />
-    </ItemGroup>
 
     <R8
         Condition=" '$(_UseR8)' == 'True' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -15,10 +15,10 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="_CompileToDalvikWithDx"
-    DependsOnTargets="$(_BeforeCompileToDalvikWithDx);$(_CompileToDalvikDependsOnTargets)"
-    Condition=" '$(AndroidDexTool)' == 'dx' "
-    Inputs="$(_CompileToDalvikInputs)"
-    Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
+      DependsOnTargets="$(_BeforeCompileToDalvikWithDx);$(_CompileToDalvikDependsOnTargets)"
+      Condition=" '$(AndroidDexTool)' == 'dx' "
+      Inputs="$(_CompileToDalvikInputs)"
+      Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
 
     <ItemGroup>
       <_JarsToProguard Include="@(_JavaLibrariesToCompile)" />
@@ -27,29 +27,29 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <MakeDir Directories="$(IntermediateOutputPath)proguard" />
 
     <Proguard
-      Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' "
-      ProguardJarPath="$(ProguardJarPath)"
-      AndroidSdkDirectory="$(_AndroidSdkDirectory)"
-      JavaToolPath="$(JavaToolPath)"
-      ProguardToolPath="$(ProguardToolPath)"
-      ToolExe="$(ProguardToolExe)"
-      UseProguard="$(UseProguard)"
-      JavaPlatformJarPath="$(JavaPlatformJarPath)"
-      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-      AcwMapFile="$(_AcwMapFile)"
-      ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
-      ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
-      ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
-      ProguardConfigurationFiles="$(ProguardConfigFiles)"
-      JavaLibrariesToEmbed="@(_JarsToProguard);@(_InstantRunJavaReference)"
-      JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
-      ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
-      EnableLogging="$(ProguardEnableLogging)"
-      DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"
-      PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
-      PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
-      PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
-      ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
+        Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' "
+        ProguardJarPath="$(ProguardJarPath)"
+        AndroidSdkDirectory="$(_AndroidSdkDirectory)"
+        JavaToolPath="$(JavaToolPath)"
+        ProguardToolPath="$(ProguardToolPath)"
+        ToolExe="$(ProguardToolExe)"
+        UseProguard="$(UseProguard)"
+        JavaPlatformJarPath="$(JavaPlatformJarPath)"
+        ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
+        AcwMapFile="$(_AcwMapFile)"
+        ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
+        ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
+        ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
+        ProguardConfigurationFiles="$(ProguardConfigFiles)"
+        JavaLibrariesToEmbed="@(_JarsToProguard);@(_InstantRunJavaReference)"
+        JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
+        ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
+        EnableLogging="$(ProguardEnableLogging)"
+        DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"
+        PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
+        PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
+        PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
+        ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
     />
 
     <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
@@ -57,17 +57,17 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     </ItemGroup>
 
     <CreateMultiDexMainDexClassList
-      Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
-      ToolPath="$(JavaToolPath)"
-      ToolExe="$(JavaToolExe)"
-      ProguardJarPath="$(ProguardJarPath)"
-      AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
-      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-      JavaLibraries="@(_JarsToProguard)"
-      MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-      CustomMainDexListFiles="@(MultiDexMainDexList)"
-      ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
-      ExtraArgs="$(AndroidMultiDexClassListExtraArgs)"
+        Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
+        ToolPath="$(JavaToolPath)"
+        ToolExe="$(JavaToolExe)"
+        ProguardJarPath="$(ProguardJarPath)"
+        AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
+        ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
+        JavaLibraries="@(_JarsToProguard)"
+        MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
+        CustomMainDexListFiles="@(MultiDexMainDexList)"
+        ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
+        ExtraArgs="$(AndroidMultiDexClassListExtraArgs)"
     />
 
     <!-- remove existing dex files that may be previous multidex outputs. -->
@@ -78,20 +78,20 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 
     <!-- Compile java code to dalvik -->
     <CompileToDalvik 
-      DxJarPath="$(DxJarPath)"
-      DxExtraArguments="$(DxExtraArguments)"
-      JavaToolPath="$(JavaToolPath)"
-      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
-      JavaOptions="$(JavaOptions)"
-      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory.TrimEnd('\'))"
-      ClassesZip="$(_AndroidIntermediateClassesZip)"
-      ToolPath="$(DxToolPath)"
-      ToolExe="$(DxToolExe)"
-      UseDx="$(UseDx)"
-      MultiDexEnabled="$(AndroidEnableMultiDex)"
-      MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-      JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp)"
-      AlternativeJarFiles="@(_AlternativeJarForAppDx)"
+        DxJarPath="$(DxJarPath)"
+        DxExtraArguments="$(DxExtraArguments)"
+        JavaToolPath="$(JavaToolPath)"
+        JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+        JavaOptions="$(JavaOptions)"
+        ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory.TrimEnd('\'))"
+        ClassesZip="$(_AndroidIntermediateClassesZip)"
+        ToolPath="$(DxToolPath)"
+        ToolExe="$(DxToolExe)"
+        UseDx="$(UseDx)"
+        MultiDexEnabled="$(AndroidEnableMultiDex)"
+        MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
+        JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp)"
+        AlternativeJarFiles="@(_AlternativeJarForAppDx)"
     />
     <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -1,0 +1,103 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.DX.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file contains targets specific to DX and ProGuard integration.
+
+Copyright (C) 2018 Xamarin. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="_CompileToDalvikWithDx"
+    DependsOnTargets="$(_BeforeCompileToDalvikWithDx);$(_CompileToDalvikDependsOnTargets)"
+    Condition=" '$(AndroidDexTool)' == 'dx' "
+    Inputs="$(_CompileToDalvikInputs)"
+    Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
+
+    <ItemGroup>
+      <_JarsToProguard Include="@(_JavaLibrariesToCompile)" />
+    </ItemGroup>
+    
+    <MakeDir Directories="$(IntermediateOutputPath)proguard" />
+
+    <Proguard
+      Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' "
+      ProguardJarPath="$(ProguardJarPath)"
+      AndroidSdkDirectory="$(_AndroidSdkDirectory)"
+      JavaToolPath="$(JavaToolPath)"
+      ProguardToolPath="$(ProguardToolPath)"
+      ToolExe="$(ProguardToolExe)"
+      UseProguard="$(UseProguard)"
+      JavaPlatformJarPath="$(JavaPlatformJarPath)"
+      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
+      AcwMapFile="$(_AcwMapFile)"
+      ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
+      ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
+      ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
+      ProguardConfigurationFiles="$(ProguardConfigFiles)"
+      JavaLibrariesToEmbed="@(_JarsToProguard);@(_InstantRunJavaReference)"
+      JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
+      ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
+      EnableLogging="$(ProguardEnableLogging)"
+      DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"
+      PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
+      PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
+      PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
+      ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
+    />
+
+    <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
+      <_AlternativeJarForAppDx Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar" />
+    </ItemGroup>
+
+    <CreateMultiDexMainDexClassList
+      Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
+      ToolPath="$(JavaToolPath)"
+      ToolExe="$(JavaToolExe)"
+      ProguardJarPath="$(ProguardJarPath)"
+      AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
+      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
+      JavaLibraries="@(_JarsToProguard)"
+      MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
+      CustomMainDexListFiles="@(MultiDexMainDexList)"
+      ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
+      ExtraArgs="$(AndroidMultiDexClassListExtraArgs)"
+    />
+
+    <!-- remove existing dex files that may be previous multidex outputs. -->
+    <ItemGroup>
+      <_DexesToDelete Include="$(IntermediateOutputPath)android\bin\*.dex" />
+    </ItemGroup>
+    <Delete Files="@(_DexesToDelete)" />
+
+    <!-- Compile java code to dalvik -->
+    <CompileToDalvik 
+      DxJarPath="$(DxJarPath)"
+      DxExtraArguments="$(DxExtraArguments)"
+      JavaToolPath="$(JavaToolPath)"
+      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+      JavaOptions="$(JavaOptions)"
+      ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory.TrimEnd('\'))"
+      ClassesZip="$(_AndroidIntermediateClassesZip)"
+      ToolPath="$(DxToolPath)"
+      ToolExe="$(DxToolExe)"
+      UseDx="$(UseDx)"
+      MultiDexEnabled="$(AndroidEnableMultiDex)"
+      MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
+      JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp)"
+      AlternativeJarFiles="@(_AlternativeJarForAppDx)"
+    />
+    <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)android\bin\*.dex" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -14,9 +14,8 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="_CompileToDalvikWithDx"
-      DependsOnTargets="$(_BeforeCompileToDalvikWithDx);$(_CompileToDalvikDependsOnTargets)"
-      Condition=" '$(AndroidDexTool)' == 'dx' "
+  <Target Name="_CompileToDalvik"
+      DependsOnTargets="$(_BeforeCompileToDalvik);$(_CompileToDalvikDependsOnTargets)"
       Inputs="$(_CompileToDalvikInputs)"
       Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -74,8 +74,8 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "2 _UpdateAndroidResgen was not skipped");
 			// CoreCompile should not be built.
 			Assert.IsTrue (b.Output.IsTargetSkipped ("CoreCompile"), "2 CoreCompile was not skipped");
-			// _CompileToDalvikWithDx should not be built either.
-			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvikWithDx"), "2 _CompileToDalvikWithDx was not skipped");
+			// _CompileToDalvik should not be built either.
+			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvik"), "2 _CompileToDalvik was not skipped");
 
 			// make insignificant changes in C# code and build
 			proj.MainActivity = proj.DefaultMainActivity + "// extra";
@@ -85,8 +85,8 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "3 _UpdateAndroidResgen was not skipped");
 			// CoreCompile should be built.
 			Assert.IsTrue (!b.Output.IsTargetSkipped ("CoreCompile"), "3 CoreCompile was skipped");
-			// _CompileToDalvikWithDx should not be built either.
-			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvikWithDx"), "3 _CompileToDalvikWithDx was not skipped");
+			// _CompileToDalvik should not be built either.
+			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvik"), "3 _CompileToDalvik was not skipped");
 
 			// make significant changes (but doesn't impact Resource.Designer.cs) in layout XML resource and build
 			proj.LayoutMain = proj.LayoutMain.Replace ("LinearLayout", "RelativeLayout"); // without this, resource designer .cs will be identical and further tasks will be skipped.
@@ -96,8 +96,8 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (!b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "4 _UpdateAndroidResgen was skipped");
 			// CoreCompile should not be built.
 			Assert.IsTrue (b.Output.IsTargetSkipped ("CoreCompile"), "4 CoreCompile was not skipped");
-			// _CompileToDalvikWithDx should not be built either.
-			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvikWithDx"), "4 _CompileToDalvikWithDx was not skipped");
+			// _CompileToDalvik should not be built either.
+			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvik"), "4 _CompileToDalvik was not skipped");
 
 			// make significant changes (but doesn't impact Resource.Designer.cs) in layout XML resource,
 			// then call AndroidUpdateResource, then build (which is what our IDEs do).
@@ -124,8 +124,8 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Output.IsTargetSkipped ("CoreCompile"), "5 CoreCompile was not skipped");
 			}
 
-			// _CompileToDalvikWithDx should not be built either.
-			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvikWithDx"), "5 _CompileToDalvikWithDx should be skipped");
+			// _CompileToDalvik should not be built either.
+			Assert.IsTrue (b.Output.IsTargetSkipped ("_CompileToDalvik"), "5 _CompileToDalvik should be skipped");
 
 			b.Dispose ();
 		}


### PR DESCRIPTION
Context: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

As part of consolidation, cleanup, and the fact DX is about to be
unsupported:

* Move calls to DX and the `<CompileToDalvik/>` MSBuild task to a new
  `Xamarin.Android.DX.targets` file.

* This includes usage of ProGuard.

* Remove support for using ProGuard in combination with d8. r8 should
  just be used in this case.

Additionally, I cleaned up some logic in `Xamarin.Android.D8.targets`.
Resetting properties causes some unnecessary logging in MSBuild.