### PR TITLE
[build] Do not generate and use source.proitems file

### DIFF
--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -97,18 +97,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LOCAL_C_FLAGS}")
 
 file(TO_CMAKE_PATH "${SQLITE_SOURCE_DIR}/dist/sqlite3.c" SQLITE_XAMARIN_SOURCES)
 
-set(SOURCES_FRAGMENT_FILE "sources.projitems")
-file(WRITE ${SOURCES_FRAGMENT_FILE} "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
-<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n\
-  <ItemGroup>\n")
-
-foreach(file ${SQLITE_XAMARIN_SOURCES})
-  file(APPEND ${SOURCES_FRAGMENT_FILE} "    <_SqliteSource Include=\"${file}\" />\n")
-endforeach(file)
-
-file(APPEND ${SOURCES_FRAGMENT_FILE} "  </ItemGroup>\n\
-</Project>\n")
-
 add_library(${SQLITE_LIBRARY_NAME} SHARED ${SQLITE_XAMARIN_SOURCES})
 
 set(LINK_LIBS "-ldl -llog")

--- a/src/sqlite-xamarin/sqlite-xamarin.csproj
+++ b/src/sqlite-xamarin/sqlite-xamarin.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <OutputPath>\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <OutputPath>\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -1,6 +1,5 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="sqlite-xamarin.props" />
-  <Import Project="sources.projitems" Condition="Exists ('sources.projitems')" />
 
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunParallelCmds" />
 
@@ -44,7 +43,7 @@
 
   <Target Name="_BuildAndroidSqlite"
 	  DependsOnTargets="_PrepareBuildAndroidSqlite"
-	  Inputs="@(_SqliteSource);@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-$(Configure)\build.ninja');;..\..\build-tools\scripts\Ndk.targets"
+	  Inputs="$(SqliteSourceFullPath)\dist\sqlite3.c;@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-$(Configuration)\build.ninja');;..\..\build-tools\scripts\Ndk.targets"
 	  Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\$(_SqliteLibName)')">
     <RunParallelCmds Commands="@(_BuildSqliteCommands)" />
     <Copy SourceFiles="Mono.Data.Sqlite.dll.config" DestinationFolder="$(_BclFrameworkDir)" SkipUnchangedFiles="True" />


### PR DESCRIPTION
Similar reasons as https://github.com/xamarin/xamarin-android/pull/4417

Also fix `OutputPath` and typo in dependencies to avoid unnecessary
rebuilds