### PR TITLE
[Xamarin.Android.Build.Tasks] Add Support fo Comma delimited Aliases

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -137,8 +137,10 @@ namespace Xamarin.Android.Tasks
 					assembly.CopyMetadataTo (item);
 					assemblies.Add (item);
 					string alias = assembly.GetMetadata ("Aliases");
-					if (!string.IsNullOrEmpty (alias))
-						aliases.Add (alias);
+					if (!string.IsNullOrEmpty (alias)) {
+						foreach (var a in alias.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries))
+							aliases.Add (a.Trim ());
+					}
 					Log.LogDebugMessage ("Scan assembly {0} for resource generator", fileName);
 				}
 				new ResourceDesignerImportGenerator (Namespace, resources, Log)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				References = {
 					new BuildItem.ProjectReference (Path.Combine("..", library.ProjectName, Path.GetFileName (library.ProjectFilePath)), "Library1") {
-						Metadata = { { "Aliases", "Lib1" } },
+						Metadata = { { "Aliases", "Lib1, LibA1,LibB1" } },
 					},
 				},
 			};

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
@@ -59,7 +59,8 @@ namespace Xamarin.Android.Tasks
 						var declaringTypeName = $"{reader.GetString (declaringType.Namespace)}.{reader.GetString (declaringType.Name)}";
 						if (declaringTypeName == resourceDesignerName) {
 							if (hasAlias) {
-								declaringTypeName = $"{alias}::{declaringTypeName}";
+								string [] aliases = alias.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
+								declaringTypeName = $"{aliases[0].Trim ()}::{declaringTypeName}";
 							}
 							CreateImportFor (declaringTypeName, typeDefinition, method, reader, hasAlias);
 						}


### PR DESCRIPTION
Fixes #4409

Our inital commit (d18c824c) to support Aliases did not take
into account the fact your can add more than one.

This commit handles the comma delimited `Aliases` metadata
so that the generated Resource.designer.cs file compiles.