### PR TITLE
[ci] Use a nicer error message when test failures occur.

### DIFF
--- a/build-tools/automation/yaml-templates/fail-on-issue.yaml
+++ b/build-tools/automation/yaml-templates/fail-on-issue.yaml
@@ -5,7 +5,6 @@ steps:
 - powershell: |
     Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
     if ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
-        Write-Host "Marking this job as failed because one (or more) steps exited with a 'SuccessWithIssues' status."
-        exit 1
+        Write-Host "##vso[task.complete result=Failed;]DONE"
     }
   displayName: fail if any issues occurred

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -14,6 +14,11 @@ steps:
     } else {
         ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }}  ${{ parameters.nunitConsoleExtraArgs }}
     }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "##vso[task.logissue type=error]Test suite had $LASTEXITCODE failure(s)."
+        Write-Host "##vso[task.complete result=Failed;]"
+        exit 0
+    }
   displayName: run ${{ parameters.testRunTitle }}
   condition: ${{ parameters.condition }}
   continueOnError: true


### PR DESCRIPTION
Because we use PowerShell to run our tests instead of the VSTask AzDO task each failed test suite generates 2 unhelpful error messages in the UI:

![before](https://user-images.githubusercontent.com/179295/77172240-a6396880-6a8b-11ea-8fde-3ae9695c5e8d.png)

This PR changes the test suite failure message to be `Test suite had X failure(s)` and removes any message from the `fail if any issues occurred` step while still marking the build as Failed.

After:
![after](https://user-images.githubusercontent.com/179295/77172444-f1537b80-6a8b-11ea-8a11-7f023ffadcea.png)
