### PR TITLE
[tests] fix deletion of debug.keystore

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -313,6 +313,9 @@ namespace Xamarin.ProjectTools
 			if (!doNotCleanup) {
 				var dirFullPath = Path.GetFullPath (directory) + '/';
 				foreach (var fi in new DirectoryInfo (directory).GetFiles ("*", SearchOption.AllDirectories)) {
+					// Don't delete our debug.keystore file
+					if (fi.Name == "debug.keystore")
+						continue;
 					var subname = fi.FullName.Substring (dirFullPath.Length).Replace ('\\', '/');
 					if (subname.StartsWith ("bin", StringComparison.OrdinalIgnoreCase) || subname.StartsWith ("obj", StringComparison.OrdinalIgnoreCase))
 						continue;

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -11,5 +11,5 @@ Build_JLO_Change,8700
 Build_CSProj_Change,9500
 Build_XAML_Change,9400
 Build_XAML_Change_RefAssembly,6000
-Install_CSharp_Change,5500
-Install_XAML_Change,7000
+Install_CSharp_Change,5000
+Install_XAML_Change,6500


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4381

In 18957918, we made the `debug.keystore` reside in each test app
instead of system-wide. This was to improve random parallel build
failures.

Unfortunately, this file is getting cleaned in various incremental
build tests.

One such is a performance test where this target runs:

    _CreateAndroidDebugSigningKey (1.102s)

This appears to be happening on any incremental `SignAndroidPackage`
call in our tests.

I'm updating the file cleaning logic in Xamarin.ProjectTools to skip
over `debug.keystore` files.

After fixing this, I found we can lower the times by ~500ms for the
performance tests that install APKs. There is still a buffer:

    => Xamarin.Android.Build.Tests.PerformanceTest.Install_CSharp_Change
    [TESTLOG] Test InstallCSharpChange Starting
    ...
    Found Time Elapsed 00:00:04.7500000
    [TESTLOG] Test InstallCSharpChange Complete