### PR TITLE
[api-merge] Preload XDocuments in parallel

### DIFF
--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -18,9 +18,9 @@ namespace Xamarin.Android.ApiMerge {
 		XAttribute contentsPlatform;
 		Dictionary<string, XElement> Types = new Dictionary<string, XElement>();
 
-		public ApiDescription (string source)
+		public ApiDescription (XDocument contents, string source)
 		{
-			Contents = XDocument.Load (source);
+			Contents = contents;
 
 			string platform;
 			XElement api = GetRoot (Contents, source, out platform);
@@ -29,6 +29,11 @@ namespace Xamarin.Android.ApiMerge {
 			}
 
 			contentsPlatform = api.Attributes ("platform").LastOrDefault ();
+		}
+
+		public static ApiDescription LoadFrom (string source)
+		{
+			return new ApiDescription (XDocument.Load (source), source);
 		}
 
 		XElement GetRoot (XDocument doc, string sourcePath, out string platform)
@@ -46,13 +51,12 @@ namespace Xamarin.Android.ApiMerge {
 			return api;
 		}
 
-		public void Merge (string apiLocation)
+		public void Merge (XDocument n, string apiLocation)
 		{
 #if ADD_OBSOLETE_ON_DISAPPEARANCE
 			var filename = Path.GetFileName (apiLocation);
 			int apiLevel = int.Parse (filename.Substring (4, filename.IndexOf ('.', 4) - 4));
 #endif
-			var n = XDocument.Load (apiLocation);
 			string platform = null;
 			XElement api = GetRoot (n, apiLocation, out platform);
 			if (!String.IsNullOrEmpty (platform) && contentsPlatform != null) {


### PR DESCRIPTION
I was curious whether loading all the XML docs in parallel could
exercise a SSD a bit and gain some time.

    MSBuild.exe /t:_GenerateApiDescription .\Mono.Android.csproj
    Before: Time Elapsed 00:00:20.47
    After:  Time Elapsed 00:00:17.67

Let see whether CI bots will like that.

CI mac:

    Before:     45084 ms  _GenerateApiDescription                    1 calls
    After:      40289 ms  _GenerateApiDescription                    1 calls

CI win:

    Before:     32441 ms  _GenerateApiDescription                    1 calls
    After:      26871 ms  _GenerateApiDescription                    1 calls

So even CI builds benefit from this change :-)
