### PR TITLE
[Mono.Android] Dont include Test code in Mono.Android.dll

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -319,7 +319,12 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
     <Compile Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Test\**" />
+    <None Remove="Test\**" />
+    <EmbeddedResource Remove="Test\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -319,6 +319,7 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
     <Compile Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
+    <Compile Remove="Test\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I recently hit the following test failure

	CheckTimestamps:
	obj/Release/android/assets/it-IT/Mono.Android.resources.dll` is older than `20/03/2020 11:43:38`, with a timestamp of `20/03/2020 11:04:48`!

Which was completely weird. Partly because the project was not
building any localised assets. But mostly because it was
for `Mono.Android`.

It turns out the move to SDK style projects was accidently
including ALL the `.cs` files from the `Test` folder as
well as the normal code.

This exaplins why we are now generating this file and including
it in our build system.

So lets Remove all the `Test` files from the project.