### PR TITLE
[MSBuildDeviceIntegration] Fix AotProfileTest

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Android.Build.Tests
 				RunAdbCommand ($"shell rm {remote}");
 				RunAdbCommand ($"logcat > {deviceLog}", timeout: 5);
 				TestContext.AddTestAttachment (local);
+				TestContext.AddTestAttachment (deviceLog);
 			}
 
 			base.CleanupTest ();

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -8,6 +8,14 @@ namespace Xamarin.Android.Build.Tests
 	public class AotProfileTests : DeviceTest
 	{
 
+		readonly string PermissionManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{0}"">
+	<uses-sdk />
+	<application android:label=""{0}"">
+	</application>
+	<uses-permission android:name=""android.permission.INTERNET"" />
+</manifest>";
+
 		[Test]
 		public void BuildBasicApplicationAndAotProfileIt ()
 		{
@@ -18,6 +26,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
 			var port = 9000 + new Random ().Next (1000);
 			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());
+			proj.AndroidManifest = string.Format (PermissionManifest, proj.PackageName);
 			var projDirectory = Path.Combine ("temp", TestName);
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");


### PR DESCRIPTION
The app for the AotProfileTest was crashing on
startup with

	Could not create log profiler server socket: Operation not permitted

This was because the `INTERNET` permission was not being
included in the manifst. This PR adds that permission.

Why this was working in the first place is a question that
is still unanswered.