### PR TITLE
[macos] Bump MinGW version

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Prepare
 
 			new HomebrewProgram ("make"),
 
-			new HomebrewProgram ("mingw-w64", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/c6829c44d27f756b302c8ca76b75edf231d076ee/Formula/mingw-w64.rb")) {
-				MinimumVersion = "7.0.0_1",
-				MaximumVersion = "7.0.0_2",
+			new HomebrewProgram ("mingw-w64", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/196509755a5afc1115bf39e02314b99d7ed22eb0/Formula/mingw-w64.rb")) {
+				MinimumVersion = "7.0.0_2",
+				MaximumVersion = "7.0.0_3",
 				Pin = true,
 			},
 


### PR DESCRIPTION
New MinGW version is out (7.0.0_2) and it appears that some bots are sad
they don't have it:

    Full Homebrew executable path value: /usr/local/bin/brew
    Running: /usr/local/bin/brew "tap" "xamarin/xamarin-android-windeps"
    Running: /usr/local/bin/brew "install" "xamarin/xamarin-android-windeps/mingw-zlib"
    stderr | Error: You must `brew unpin mingw-w64` as installing xamarin/xamarin-android-windeps/mingw-zlib requires the latest version of pinned dependencies
     | ==> Installing mingw-zlib from xamarin/xamarin-android-windeps
      Error: Installation of xamarin/xamarin-android-windeps/mingw-zlib failed

Please them by updating to the latest version.