### PR TITLE
[build] Don't build "real" debug DSOs

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -49,9 +49,9 @@ macro(xa_common_prepare)
     fstrict-return
     Wa,-noexecstack
     fPIC
-	g
-	fomit-frame-pointer
-	O2
+    g
+    fomit-frame-pointer
+    O2
     )
 
   if(CMAKE_BUILD_TYPE STREQUAL Release)

--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -49,12 +49,12 @@ macro(xa_common_prepare)
     fstrict-return
     Wa,-noexecstack
     fPIC
+	g
+	fomit-frame-pointer
+	O2
     )
 
-  if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(XA_COMPILER_FLAGS ${XA_COMPILER_FLAGS} ggdb3 fno-omit-frame-pointer O0)
-  else()
-    set(XA_COMPILER_FLAGS ${XA_COMPILER_FLAGS} g fomit-frame-pointer O2)
+  if(CMAKE_BUILD_TYPE STREQUAL Release)
     add_definitions("-DRELEASE")
   endif()
 

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -229,8 +229,8 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
   # will force a -O0 on us and our "debug" build is not really for debugging of our native code but
   # rather for "debug" builds of user apps - it has extra code but it has to be as fast as possible.
   if(ENABLE_NDK)
-	# This is specific to clang, enable only for Android builds
-	set(XA_COMPILER_FLAGS_DEBUG -fno-limit-debug-info)
+    # This is specific to clang, enable only for Android builds
+    set(XA_COMPILER_FLAGS_DEBUG -fno-limit-debug-info)
   endif()
   set(CMAKE_C_FLAGS_DEBUG "${XA_COMPILER_FLAGS_DEBUG}")
   set(CMAKE_CXX_FLAGS_DEBUG "${XA_COMPILER_FLAGS_DEBUG}")

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -224,6 +224,18 @@ add_definitions("-DMONO_DLL_EXPORT")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_CXX_FLAGS}")
 
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  # Convince NDK to really optimize our Debug builds. Without this, NDK's cmake toolchain definition
+  # will force a -O0 on us and our "debug" build is not really for debugging of our native code but
+  # rather for "debug" builds of user apps - it has extra code but it has to be as fast as possible.
+  if(ENABLE_NDK)
+	# This is specific to clang, enable only for Android builds
+	set(XA_COMPILER_FLAGS_DEBUG -fno-limit-debug-info)
+  endif()
+  set(CMAKE_C_FLAGS_DEBUG "${XA_COMPILER_FLAGS_DEBUG}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${XA_COMPILER_FLAGS_DEBUG}")
+endif()
+
 include_directories("${DEFAULT_BIN_DIR}/include/mono-2.0")
 include_directories("jni")
 include_directories("${DEFAULT_BIN_DIR}/include")


### PR DESCRIPTION
We always build both release and debug binaries but the purpose of the
Debug build is not to be debuggable/unoptimized/etc in the native sense
but rather to contain code specific to and required by the managed Debug
builds.

So far, the Debug native builds have been built without any
optimizations thus making our Debug apps slower than they really need to
be. This commit changes the compiler optimization to `-O2` for the Debug
build, putting it on par with the Release builds, as far as optimization
is concerned.

This should make our Debug apps a bit faster.

The changes aren't dramatic, but there's a slight improvement:

= Before

Date (UTC): **3/25/2020 8:23:52 AM**
App configuration: **Debug**

Xamarin.Android
  - Version: **10.3.99-129**
  - Branch: **master**
  - Commit: **5099550c47d1ec39179a8cb7b05ca37fa3e61b74**

Device
  - Model: **Pixel 3 XL**
  - Native architecture: **arm64-v8a**
  - SDK version: **29**

= After

Date (UTC): **3/25/2020 9:48:59 AM**
App configuration: **Debug**

Xamarin.Android
  - Version: **10.3.99-130**
  - Branch: **always-optimize-native-code**
  - Commit: **00ac073bb855e2e88ed1b383745b3aa89b7a39cd**

Device
  - Model: **Pixel 3 XL**
  - Native architecture: **arm64-v8a**
  - SDK version: **29**

= Comparison

== Displayed time

| Before  | After   | Change    |
| ------- | ------- | --------- |
| 995.500 | 988.200 | -0.73% 🠅  |

== Native to managed transition time

| Before | After  | Change    |
| ------ | ------ | --------- |
| 50.187 | 50.164 | -0.04% 🠅  |

== Total native init time

| Before | After  | Change    |
| ------ | ------ | --------- |
| 89.513 | 87.692 | -2.03% 🠅  |