### PR TITLE
[Xamarin.Android.Build.Tasks] only warn about failed deletion of temp dirs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1563,8 +1563,11 @@ because xbuild doesn't support framework reference assemblies.
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 	/>
 
-	<!-- Delete our temporary directory -->
-	<RemoveDirFixed Directories="$(ResgenTemporaryDirectory)" />
+  <!-- Delete our temporary directory -->
+  <RemoveDirFixed
+      Directories="$(ResgenTemporaryDirectory)"
+      ContinueOnError="WarnAndContinue"
+  />
 
   <Touch Files="$(_AndroidResgenFlagFile)" AlwaysCreate="True" />
   <ItemGroup>
@@ -2260,7 +2263,10 @@ because xbuild doesn't support framework reference assemblies.
   </CopyGeneratedJavaResourceClasses>
 
   <!-- Delete our temporary directory -->
-  <RemoveDirFixed Directories="$(AaptTemporaryDirectory)" />
+  <RemoveDirFixed
+      Directories="$(AaptTemporaryDirectory)"
+      ContinueOnError="WarnAndContinue"
+  />
 
   <ItemGroup>
     <FileWrites Include="$(_PackagedResources)" />


### PR DESCRIPTION
Context: https://build.azdo.io/3575078
Context: https://build.azdo.io/3574952

Our CI builds have been hitting random failures such as:

    (_UpdateAndroidResgen target) ->
    error XARDF7024: System.IO.IOException: The directory is not empty.
    error XARDF7024:
    error XARDF7024:    at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
    error XARDF7024:    at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
    error XARDF7024:    at Xamarin.Android.Tasks.RemoveDirFixed.RunTask()

Or in another target:

    (_CreateBaseApk target) ->
    error XARDF7024: System.IO.IOException: The directory is not empty.
    error XARDF7024:
    error XARDF7024:    at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
    error XARDF7024:    at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
    error XARDF7024:    at Xamarin.Android.Tasks.RemoveDirFixed.RunTask()

In both of these places, we have the pattern:

    <CreateTemporaryDirectory>
      <Output TaskParameter="TemporaryDirectory" PropertyName="AaptTemporaryDirectory" />
    </CreateTemporaryDirectory>
    <!-- Then later on -->
    <RemoveDirFixed Directories="$(AaptTemporaryDirectory)" />

The temporary directory is created in C# via:

    TemporaryDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
    Directory.CreateDirectory (TemporaryDirectory);

I think a solution here is to make the `<RemoveDirFixed/>` call set to
`ContinueOnError="WarnAndContinue"`. I don't think we need to *fail*
the overall build in these scenarios.

The user is going to have leftover files in `%TEMP%`, and I don't
think there is much we can do. Changing this from a build *error* to a
*warning* is a general improvement if we are unable to delete the
directory. The error code will also be preserved.

I don't know if this will help our users at all, but should help our CI.