### PR TITLE
[Xamarin.Android.Sdk] fixes for $(PackageVersion)

### DIFF
--- a/build-tools/create-packs/Packager.csproj
+++ b/build-tools/create-packs/Packager.csproj
@@ -4,8 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Xamarin.Android.Sdk</PackageId>
-    <PackageVersion Condition="Exists('..\..\bin\$(Configuration)\Version')">$([System.IO.File]::ReadAllText('..\..\bin\$(Configuration)\Version'))</PackageVersion>
-    <PackageVersion Condition="Exists('..\..\bin\$(Configuration)\Version.rev')">$(PackageVersion).$([System.IO.File]::ReadAllText('..\..\bin\$(Configuration)\Version.rev'))</PackageVersion>
+    <_VersionFile>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\Version</_VersionFile>
+    <_RevisionFile>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\Version.rev</_RevisionFile>
+    <PackageVersion Condition="Exists('$(_VersionFile)')">$([System.IO.File]::ReadAllText('$(_VersionFile)').Trim())</PackageVersion>
+    <PackageVersion Condition="Exists('$(_RevisionFile)')">$(PackageVersion).$([System.IO.File]::ReadAllText('$(_RevisionFile)').Trim())</PackageVersion>
     <PackageVersion Condition="'$(PackageVersion)' == ''">0.0.1</PackageVersion>
     <Authors>Xamarin</Authors>
     <Description>C# Tools and Bindings for the Android SDK</Description>

--- a/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.Lite.proj
+++ b/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.Lite.proj
@@ -2,8 +2,10 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Xamarin.Android.Sdk.Lite</PackageId>
-        <PackageVersion Condition="Exists('..\..\bin\$(Configuration)\Version')">$([System.IO.File]::ReadAllText('..\..\bin\$(Configuration)\Version'))</PackageVersion>
-        <PackageVersion Condition="Exists('..\..\bin\$(Configuration)\Version.rev')">$(PackageVersion).$([System.IO.File]::ReadAllText('..\..\bin\$(Configuration)\Version.rev'))</PackageVersion>
+        <_VersionFile>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\Version</_VersionFile>
+        <_RevisionFile>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\Version.rev</_RevisionFile>
+        <PackageVersion Condition="Exists('$(_VersionFile)')">$([System.IO.File]::ReadAllText('$(_VersionFile)').Trim())</PackageVersion>
+        <PackageVersion Condition="Exists('$(_RevisionFile)')">$(PackageVersion).$([System.IO.File]::ReadAllText('$(_RevisionFile)').Trim())</PackageVersion>
         <PackageVersion Condition="'$(PackageVersion)' == ''">1.0.0</PackageVersion>
         <Authors>Xamarin</Authors>
         <Description>Lightweight SDK that depends on an existing full installation of the Xamarin.Android SDK tools from Visual Studio</Description>


### PR DESCRIPTION
I found with ae136f0f, was that I was getting the following issue on
Windows:

    "C:\src\xamarin-android\src\Xamarin.Android.Sdk\Xamarin.Android.Sdk.Lite.proj" (Pack target) (1) ->
        Xamarin.Android.Sdk\Xamarin.Android.Sdk.Lite.proj(5,9): error MSB4184:
        The expression "[System.IO.File]::ReadAllText(..\..\bin\Debug\Version)" cannot be evaluated. Could not find file 'C:\bin\Debug\Version'.

It seems the property:

    <PackageVersion Condition="Exists('..\..\bin\$(Configuration)\Version')">$([System.IO.File]::ReadAllText('..\..\bin\$(Configuration)\Version'))</PackageVersion>

Somehow the evaluation of `Exists` and `ReadAllText` are doing
different things? Weird.

I refactored things to use `$(MSBuildThisFileDirectory)` and
intermediate properties for the file paths.

After that... I found that the value of `$(PackageVersion)` had line
breaks, such as:

    PackageVersion = 10.3.99
    .126

^^ included a trailing line break as well.

I added a `.Trim()` call for both `File.ReadAllText` calls.