### PR TITLE
[CI] Ensure test sources are recursively cloned

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -229,6 +229,8 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     steps:
     - checkout: self
       submodules: recursive
@@ -667,6 +669,8 @@ stages:
     displayName: BCL With Emulator - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 180
+    workspace:
+      clean: all
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
@@ -777,6 +781,8 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -260,9 +260,13 @@ stages:
         $ts = Get-Date -Format FileDateTimeUniversal
         $log = "xavsixdowngrade-$ts.log"
         $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru
-        Get-Content "${env:TEMP}\$log" | Write-Host
+        try {
+          Get-Content "${env:TEMP}\$log" | Write-Host -ErrorAction Stop
+          Remove-Item "${env:TEMP}\$log" -ErrorAction Stop
+        } catch {
+          Write-Host "Could not access downgrade log at ${env:TEMP}\$log"
+        }
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
-        Remove-Item "${env:TEMP}\$log"
       displayName: downgrade XA to stable
       ignoreLASTEXITCODE: true
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -229,8 +229,6 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
     steps:
     - checkout: self
       submodules: recursive
@@ -781,8 +779,6 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -260,13 +260,9 @@ stages:
         $ts = Get-Date -Format FileDateTimeUniversal
         $log = "xavsixdowngrade-$ts.log"
         $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru
-        try {
-          Get-Content "${env:TEMP}\$log" | Write-Host -ErrorAction Stop
-          Remove-Item "${env:TEMP}\$log" -ErrorAction Stop
-        } catch {
-          Write-Host "Could not access downgrade log at ${env:TEMP}\$log"
-        }
+        Get-Content "${env:TEMP}\$log" | Write-Host
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
+        Remove-Item "${env:TEMP}\$log"
       displayName: downgrade XA to stable
       ignoreLASTEXITCODE: true
 

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -3,6 +3,10 @@ parameters:
   provisionExtraArgs: -vv -f
 
 steps:
+- checkout: self
+  clean: true
+  submodules: recursive
+
 - template: run-installer.yaml
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3576092&view=logs&jobId=8556562a-ae5f-5bd1-7c4d-bf1af4b6f1e1&j=58fa601a-973f-52de-d6ce-8b812c2da347&t=1e1c7f4c-cb47-45a2-8ea1-a12add99e69f

We've been seeing some test jobs failing due to an error when building
`Xamarin.Android.Tools.BootstrapTasks.csproj`. After reviewing the build
log, it seems that we may be missing a required submodule:

    warning : The referenced project '../../external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj' does not exist.

Attempt to fix this build failure by always recursively checking out
xamarin-android for test jobs which require it.

Some `workspace: clean: all` additions have also been made for
consistency across jobs.