### PR TITLE
[tests] rework how debug.keystore is used in tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -33,7 +33,6 @@ namespace Xamarin.ProjectTools
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
 			ExtraNuGetConfigSources = new List<string> { XABuildPaths.BuildOutputDirectory };
 			GlobalPackagesFolder = Path.Combine (XABuildPaths.TopDirectory, "packages");
-			SetProperty ("_ApkDebugKeyStore", "debug.keystore");
 
 			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.AndroidManifest.xml")))
 				default_android_manifest = sr.ReadToEnd ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -24,7 +24,6 @@ namespace Xamarin.ProjectTools
 			SetProperty ("OutputType", "Library");
 			SetProperty ("MonoAndroidAssetsPrefix", "Assets");
 			SetProperty ("MonoAndroidResourcePrefix", "Resources");
-			SetProperty ("_ApkDebugKeyStore", "debug.keystore");
 
 			SetProperty (KnownProperties.AndroidUseLatestPlatformSdk, () => UseLatestPlatformSdk ? "True" : "False");
 			SetProperty (KnownProperties.TargetFrameworkVersion, () => TargetFrameworkVersion);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -313,9 +313,6 @@ namespace Xamarin.ProjectTools
 			if (!doNotCleanup) {
 				var dirFullPath = Path.GetFullPath (directory) + '/';
 				foreach (var fi in new DirectoryInfo (directory).GetFiles ("*", SearchOption.AllDirectories)) {
-					// Don't delete our debug.keystore file
-					if (fi.Name == "debug.keystore")
-						continue;
 					var subname = fi.FullName.Substring (dirFullPath.Length).Replace ('\\', '/');
 					if (subname.StartsWith ("bin", StringComparison.OrdinalIgnoreCase) || subname.StartsWith ("obj", StringComparison.OrdinalIgnoreCase))
 						continue;


### PR DESCRIPTION
Context: https://build.azdo.io/3576318

This partially reverts:

* 18957918
* b6eba4ea

Some tests that deploy to an emulator with fast deployment were
failing with:

    [MESSAGE] jarsigner error: java.lang.RuntimeException:
    keystore load: /Users/runner/.local/share/Xamarin/Mono for Android/debug.keystore (No such file or directory)

This is because `_CreateAndroidDebugSigningKey` created a
`debug.keystore` local to the project, and the system-wide one doesn't
exist. `androidtools` apparently will *only* use the system-wide key,
and fails if it does not exist.

18957918 was a little heavy-handed, it was aiming to just fix
`CodeBehindBuildTests.csproj`. I reverted the global change to set
`$(_ApkDebugKeyStore)` in all tests, to just set it in
`CodeBehindBuildTests.csproj`.

We also don't need the fix in b6eba4ea anymore.