### PR TITLE
[Xamarin.Android.Build.Tasks] remove usage of $(TFV) in _ResolveSdks

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -1,0 +1,32 @@
+# .NET 5 and Xamarin.Android
+
+_NOTE: this document is very likely to change, as the requirements for
+.NET 5 are better understood._
+
+A .NET 5 project for Xamarin.Android will look something like:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0-android</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+See the [Target Framework Names in .NET 5][net5spec] spec for details.
+
+[net5spec]: https://github.com/dotnet/designs/blob/5e921a9dc8ecce33b3195dcdb6f10ef56ef8b9d7/accepted/2020/net5/net5.md
+
+## Changes to MSBuild tasks
+
+In .NET 5 the behavior of the following MSBuild tasks will change, but
+"legacy" projects will stay the same:
+
+* `<ValidateJavaVersion/>` - used to require Java 1.6, 1.7, or 1.8
+  based on the version of the Android Build Tools or
+  `$(TargetFrameworkVersion)`. .NET 5 will require Java 1.8.
+
+* `<ResolveAndroidTooling/>` - used to support the
+  `$(AndroidUseLatestPlatformSdk)` setting or multiple
+  `$(TargetFrameworkVersion)`. .NET 5 will always target the latest
+  Android APIs for `Mono.Android.dll`.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -231,9 +231,11 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Designer.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DX.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.FSharp.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Legacy.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.props" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.SkipCases.projitems" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tooling.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Aidl.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Aidl.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.AndroidSdk.dll" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
@@ -16,7 +16,7 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-<Target Name="_InjectAaptDependencies" AfterTargets="_ResolveSdks" Condition=" '$(_AndroidUseAapt2)' != 'True' ">
+<Target Name="_InjectAaptDependencies" Condition=" '$(_AndroidUseAapt2)' != 'True' ">
   <PropertyGroup>
     <_UpdateAndroidResgenInputs>
       $(_UpdateAndroidResgenInputs);

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -23,7 +23,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 
-<Target Name="_InjectAapt2Dependencies" AfterTargets="_ResolveSdks" Condition=" '$(_AndroidUseAapt2)' == 'True' ">
+<Target Name="_InjectAapt2Dependencies" Condition=" '$(_AndroidUseAapt2)' == 'True' ">
   <PropertyGroup>
     <_SetLatestTargetFrameworkVersionDependsOnTargets>
       $(_SetLatestTargetFrameworkVersionDependsOnTargets);

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -167,10 +167,10 @@ In this message, the phrase "should not be reached" means that this error messag
     <comment>The abbreviation "JDK" should not be translated.</comment>
   </data>
   <data name="XA0031" xml:space="preserve">
-    <value>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</value>
-    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+    <value>Java SDK {0} or above is required when using {1}.</value>
+    <comment>
 {0} - The Java SDK version number
-{1} - The target framework version number</comment>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk=&quot;Xamarin.Android.Sdk&quot;&gt;`</comment>
   </data>
   <data name="XA0032" xml:space="preserve">
     <value>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">Když se používá $(TargetFrameworkVersion) {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">Když se používá $(TargetFrameworkVersion) {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">Bei Verwendung von $(TargetFrameworkVersion) {1} ist Java SDK {0} oder höher erforderlich.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">Bei Verwendung von $(TargetFrameworkVersion) {1} ist Java SDK {0} oder höher erforderlich.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">Se requiere el SDK de Java {0} o posterior cuando se use $(TargetFrameworkVersion) {1}.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">Se requiere el SDK de Java {0} o posterior cuando se use $(TargetFrameworkVersion) {1}.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">Le kit Java SDK {0} ou une version ultérieure est obligatoire pour l'utilisation de $(TargetFrameworkVersion) {1}.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">Le kit Java SDK {0} ou une version ultérieure est obligatoire pour l'utilisation de $(TargetFrameworkVersion) {1}.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">Quando si usa $(TargetFrameworkVersion) {1}, è richiesto Java SDK {0} o versione successiva.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">Quando si usa $(TargetFrameworkVersion) {1}, è richiesto Java SDK {0} o versione successiva.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">$(TargetFrameworkVersion) {1} を使用するときには、Java SDK {0} 以上が必要です。</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">$(TargetFrameworkVersion) {1} を使用するときには、Java SDK {0} 以上が必要です。</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">$(TargetFrameworkVersion) {1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">$(TargetFrameworkVersion) {1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">W przypadku używania platformy $(TargetFrameworkVersion) {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">W przypadku używania platformy $(TargetFrameworkVersion) {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">O SDK do Java {0} ou superior é necessário ao usar $(TargetFrameworkVersion) {1}.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">O SDK do Java {0} ou superior é necessário ao usar $(TargetFrameworkVersion) {1}.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">При использовании $(TargetFrameworkVersion) {1} требуется пакет SDK для Java версии {0} или более поздней версии.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">При использовании $(TargetFrameworkVersion) {1} требуется пакет SDK для Java версии {0} или более поздней версии.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">$(TargetFrameworkVersion) {1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">$(TargetFrameworkVersion) {1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">使用 $(TargetFrameworkVersion) {1} 时需要 Java SDK {0} 或更高版本。</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">使用 $(TargetFrameworkVersion) {1} 时需要 Java SDK {0} 或更高版本。</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -63,11 +63,11 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}.</source>
-        <target state="translated">使用 $(TargetFrameworkVersion) {1} 時，需要 Java SDK {0} 或更高版本。</target>
-        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+        <source>Java SDK {0} or above is required when using {1}.</source>
+        <target state="needs-review-translation">使用 $(TargetFrameworkVersion) {1} 時，需要 Java SDK {0} 或更高版本。</target>
+        <note>
 {0} - The Java SDK version number
-{1} - The target framework version number</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks.Legacy
+{
+	/// <summary>
+	/// ResolveAndroidTooling does lot of the grunt work ResolveSdks used to do:
+	/// - Modify TargetFrameworkVersion
+	/// - Calculate ApiLevel and ApiLevelName
+	/// - Find the paths of various Android tooling that other tasks need to call
+	/// </summary>
+	public class ResolveAndroidTooling : Xamarin.Android.Tasks.ResolveAndroidTooling
+	{
+		public bool UseLatestAndroidPlatformSdk { get; set; }
+
+		[Output]
+		public string TargetFrameworkVersion { get; set; }
+
+		protected override bool Validate ()
+		{
+			if (!ValidateApiLevels ())
+				return false;
+
+			if (!MonoAndroidHelper.SupportedVersions.FrameworkDirectories.Any (p => Directory.Exists (Path.Combine (p, TargetFrameworkVersion)))) {
+				Log.LogError (
+					subcategory: string.Empty,
+					errorCode: "XA0001",
+					helpKeyword: string.Empty,
+					file: ProjectFilePath,
+					lineNumber: 0,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: Properties.Resources.XA0001,
+					messageArgs: new [] {
+						TargetFrameworkVersion,
+					}
+				);
+				return false;
+			}
+
+			int apiLevel;
+			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
+				if (apiLevel < 26)
+					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, TargetFrameworkVersion, AndroidApiLevel);
+				if (apiLevel < 19)
+					Log.LogCodedWarning ("XA0117", Properties.Resources.XA0117, TargetFrameworkVersion);
+			}
+
+			return true;
+		}
+
+		protected override void LogOutputs ()
+		{
+			base.LogOutputs ();
+
+			Log.LogDebugMessage ($"  {nameof (TargetFrameworkVersion)}: {TargetFrameworkVersion}");
+		}
+
+		bool ValidateApiLevels ()
+		{
+			// Priority:
+			//    $(UseLatestAndroidPlatformSdk) > $(AndroidApiLevel) > $(TargetFrameworkVersion)
+			//
+			// If $(TargetFrameworkVersion) isn't set, and $(AndroidApiLevel) isn't
+			// set, act as if $(UseLatestAndroidPlatformSdk) is True
+			//
+			// If $(UseLatestAndroidPlatformSdk) is true, we do as it says: use the
+			// latest installed version.
+			//
+			// Otherwise, if $(AndroidApiLevel) is set, use it and set $(TargetFrameworkVersion).
+			//    Rationale: monodroid/samples/xbuild.make uses $(AndroidApiLevel)
+			//    to build for a specific API level.
+			// Otherwise, if $(TargetFrameworkVersion) is set, use it and set $(AndroidApiLevel).
+
+			UseLatestAndroidPlatformSdk = UseLatestAndroidPlatformSdk ||
+				(string.IsNullOrWhiteSpace (AndroidApiLevel) && string.IsNullOrWhiteSpace (TargetFrameworkVersion));
+
+			if (UseLatestAndroidPlatformSdk) {
+				int maxInstalled = GetMaxInstalledApiLevel ();
+				int maxSupported = GetMaxStableApiLevel ();
+				AndroidApiLevel = maxInstalled.ToString ();
+				if (maxInstalled > maxSupported) {
+					Log.LogDebugMessage ($"API Level {maxInstalled} is greater than the maximum supported API level of {maxSupported}. " +
+						"Support for this API will be added in a future release.");
+				}
+				if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
+					var userSelected = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+					// overwrite using user version only if it is 
+					// above the maxStableApi and a valid apiLevel.
+					if (userSelected != null && userSelected > maxSupported && userSelected <= maxInstalled) {
+						maxInstalled =
+							maxSupported = userSelected.Value;
+						AndroidApiLevel = userSelected.ToString ();
+					}
+				}
+
+				for (int apiLevel = maxSupported; apiLevel >= MonoAndroidHelper.SupportedVersions.MinStableVersion.ApiLevel; apiLevel--) {
+					var id = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiLevel);
+					var apiPlatformDir = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (id, MonoAndroidHelper.SupportedVersions);
+					if (apiPlatformDir != null && Directory.Exists (apiPlatformDir)) {
+						var targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (id);
+						if (targetFramework != null && MonoAndroidHelper.SupportedVersions.InstalledBindingVersions.Any (b => b.FrameworkVersion == targetFramework)) {
+							AndroidApiLevel = apiLevel.ToString ();
+							TargetFrameworkVersion = targetFramework;
+							break;
+						}
+					}
+				}
+				return TargetFrameworkVersion != null;
+			}
+
+			if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
+				TargetFrameworkVersion = TargetFrameworkVersion.Trim ();
+				string id = MonoAndroidHelper.SupportedVersions.GetIdFromFrameworkVersion (TargetFrameworkVersion);
+				if (id == null) {
+					Log.LogCodedError ("XA0000", Properties.Resources.XA0000_API_for_TargetFrameworkVersion, TargetFrameworkVersion);
+					return false;
+				}
+				AndroidApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id).ToString ();
+				return true;
+			}
+
+			if (!string.IsNullOrWhiteSpace (AndroidApiLevel)) {
+				AndroidApiLevel = AndroidApiLevel.Trim ();
+				TargetFrameworkVersion = GetTargetFrameworkVersionFromApiLevel ();
+				return TargetFrameworkVersion != null;
+			}
+
+			Log.LogCodedError ("XA0000", Properties.Resources.XA0000_API_or_TargetFrameworkVersion_Fail);
+			return false;
+		}
+
+
+		int GetMaxInstalledApiLevel ()
+		{
+			int maxApiLevel = int.MinValue;
+			string platformsDir = Path.Combine (AndroidSdkPath, "platforms");
+			if (Directory.Exists (platformsDir)) {
+				var apiIds = Directory.EnumerateDirectories (platformsDir)
+					.Select (platformDir => Path.GetFileName (platformDir))
+					.Where (dir => dir.StartsWith ("android-", StringComparison.OrdinalIgnoreCase))
+					.Select (dir => dir.Substring ("android-".Length))
+					.Select (apiName => MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiName));
+				foreach (var id in apiIds) {
+					int? v = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id);
+					if (!v.HasValue)
+						continue;
+					maxApiLevel = Math.Max (maxApiLevel, v.Value);
+				}
+			}
+			if (maxApiLevel < 0)
+				Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Android_Platforms,
+						platformsDir, Path.DirectorySeparatorChar, Android);
+			return maxApiLevel;
+		}
+
+		string GetTargetFrameworkVersionFromApiLevel ()
+		{
+			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
+			if (targetFramework != null)
+				return targetFramework;
+			Log.LogCodedError ("XA0000", Properties.Resources.XA0000_TargetFrameworkVersion_for_API, AndroidApiLevel);
+			return null;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
@@ -1,0 +1,70 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Text.RegularExpressions;
+
+namespace Xamarin.Android.Tasks.Legacy
+{
+	/// <summary>
+	/// ValidateJavaVersion's job is to shell out to java and javac to detect their version
+	/// </summary>
+	public class ValidateJavaVersion : Xamarin.Android.Tasks.ValidateJavaVersion
+	{
+		public string AndroidSdkBuildToolsVersion { get; set; }
+
+		public string TargetFrameworkVersion { get; set; }
+
+		protected override bool ValidateJava (string javaExe, Regex versionRegex)
+		{
+			Version requiredJavaForFrameworkVersion = GetJavaVersionForFramework ();
+			Version requiredJavaForBuildTools = GetJavaVersionForBuildTools ();
+			Version required = requiredJavaForFrameworkVersion > requiredJavaForBuildTools ? requiredJavaForFrameworkVersion : requiredJavaForBuildTools;
+
+			MinimumRequiredJdkVersion = required.ToString ();
+
+			try {
+				var versionNumber = GetVersionFromTool (javaExe, versionRegex);
+				if (versionNumber != null) {
+					Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
+					if (versionNumber < requiredJavaForFrameworkVersion) {
+						Log.LogCodedError ("XA0031", Properties.Resources.XA0031, requiredJavaForFrameworkVersion, $"$(TargetFrameworkVersion) {TargetFrameworkVersion}");
+					}
+					if (versionNumber < requiredJavaForBuildTools) {
+						Log.LogCodedError ("XA0032", Properties.Resources.XA0032, requiredJavaForBuildTools, AndroidSdkBuildToolsVersion);
+					}
+					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
+						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
+					}
+				}
+			} catch (Exception ex) {
+				Log.LogWarningFromException (ex);
+				Log.LogCodedWarning ("XA0034", Properties.Resources.XA0034, required);
+				return false;
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		Version GetJavaVersionForFramework ()
+		{
+			var apiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+			if (apiLevel >= 24)
+				return new Version (1, 8);
+			else if (apiLevel == 23)
+				return new Version (1, 7);
+			else
+				return new Version (1, 6);
+		}
+
+		Version GetJavaVersionForBuildTools ()
+		{
+			Version buildTools;
+			if (!Version.TryParse (AndroidSdkBuildToolsVersion, out buildTools)) {
+				return Version.Parse (LatestSupportedJavaVersion);
+			}
+			if (buildTools >= new Version (24, 0, 1))
+				return new Version (1, 8);
+			return Version.Parse (MinimumSupportedJavaVersion);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using Xamarin.ProjectTools;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
-using System.Text;
 using Xamarin.Android.Tasks;
-using Microsoft.Build.Utilities;
+using Xamarin.ProjectTools;
+using ResolveAndroidTooling = Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling;
+using ValidateJavaVersion = Xamarin.Android.Tasks.Legacy.ValidateJavaVersion;
 
 namespace Xamarin.Android.Build.Tests {
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xamarin.Android.Tasks;
+using ValidateJavaVersion = Xamarin.Android.Tasks.Legacy.ValidateJavaVersion;
 
 namespace Xamarin.Android.Build.Tests
 {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -27,9 +27,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <UsingTask TaskName="Xamarin.Android.Tasks.RemoveDirFixed" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -66,6 +63,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <UseShortGeneratorFileNames Condition="'$(UseShortGeneratorFileNames)' == ''">False</UseShortGeneratorFileNames>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
+    <_AndroidIsBindingProject>True</_AndroidIsBindingProject>
   </PropertyGroup>
   
   <!-- Get our Build Actions to show up in VS -->
@@ -165,67 +163,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		<Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_XATargetFrameworkDirectories" />
 	</GetReferenceAssemblyPaths>
 </Target>
-
-  <Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
-    <ResolveSdks
-        AndroidSdkPath="$(AndroidSdkDirectory)"
-        AndroidNdkPath="$(AndroidNdkDirectory)"
-        JavaSdkPath="$(JavaSdkDirectory)"
-        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
-      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
-      <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
-      <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />
-      <Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
-      <Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
-      <Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
-      <Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
-      <Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
-    </ResolveSdks>
-    <ValidateJavaVersion
-        TargetFrameworkVersion="$(TargetFrameworkVersion)"
-        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-        JavaSdkPath="$(_JavaSdkDirectory)"
-        JavaToolExe="$(JavaToolExe)"
-        JavacToolExe="$(JavacToolExe)"
-        LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
-        MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
-      <Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
-      <Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
-    </ValidateJavaVersion>
-    <ResolveAndroidTooling
-        TargetFrameworkVersion="$(TargetFrameworkVersion)"
-        AndroidApiLevel="$(AndroidApiLevel)"
-        AndroidSdkPath="$(_AndroidSdkDirectory)"
-        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-        UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-        SequencePointsMode="$(AndroidSequencePointsMode)"
-        ProjectFilePath="$(MSBuildProjectFullPath)">
-      <Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
-      <Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
-      <Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
-      <Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
-      <Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
-    </ResolveAndroidTooling>
-    <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
-      <Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
-          Condition="'$(TargetFrameworkProfile)' != ''"
-      />
-    </CreateProperty>
-    <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)">
-      <Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
-          Condition="'$(TargetFrameworkProfile)' == ''"
-      />
-    </CreateProperty>
-    <CreateProperty Value="$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)">
-      <Output TaskParameter="Value" PropertyName="TargetFrameworkMonikerAssemblyAttributesPath"
-       Condition="'$(TargetFrameworkMoniker)' != ''"
-    />
-    </CreateProperty>
-    <ItemGroup>
-      <FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
-      <Reference Include="$(_JavaInteropReferences)" />
-    </ItemGroup>
-  </Target>
 
   <!-- Find all the needed SDKs -->
   <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
@@ -613,6 +550,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Legacy.targets" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
 
   <!--
   *******************************************

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -117,10 +117,16 @@
     <None Include="Xamarin.Android.FSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Android.Legacy.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Android.PCLSupport.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Xamarin.Android.PCLSupport.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Android.Tooling.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Xamarin.Android.VisualBasic.targets">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -25,10 +25,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidApkSigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AppendCustomMetadataToItemGroup" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidPackageName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ResolveJdkJvmPath" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Compile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Link" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -407,6 +403,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Legacy.targets" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
 
 <Target Name="_WriteLockFile" Condition=" '$(_AndroidDetectParallelBuilds)' == 'True' ">
   <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
@@ -752,110 +750,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Condition=" '$(AndroidUseLatestPlatformSdk)' == 'True' "
     BeforeTargets="_GetRestoreTargetFrameworksOutput"
     DependsOnTargets="_SetLatestTargetFrameworkVersion">
-</Target>
-
-<PropertyGroup>
-	<_SetLatestTargetFrameworkVersionDependsOnTargets>
-		_ResolveSdks;
-	</_SetLatestTargetFrameworkVersionDependsOnTargets>
-</PropertyGroup>
-
-<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="$(_SetLatestTargetFrameworkVersionDependsOnTargets)">
-</Target>
-
-<Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
-	<PropertyGroup>
-    <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-	</PropertyGroup>
-	<ResolveSdks
-			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
-			AndroidSdkPath="$(AndroidSdkDirectory)"
-			AndroidNdkPath="$(AndroidNdkDirectory)"
-			JavaSdkPath="$(JavaSdkDirectory)"
-			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
-		<Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
-		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
-		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />
-		<Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
-		<Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
-		<Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
-		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
-		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
-		<Output TaskParameter="MonoAndroidLibPath"        PropertyName="MonoAndroidLibDirectory" />
-		<Output TaskParameter="AndroidBinUtilsPath"       PropertyName="AndroidBinUtilsDirectory" Condition=" '$(AndroidBinUtilsDirectory)' == '' " />
-	</ResolveSdks>
-	<ResolveJdkJvmPath
-			JavaSdkPath="$(_JavaSdkDirectory)"
-			Condition=" '$(DesignTimeBuild)' != 'True' And '$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(JdkJvmPath)' == '' ">
-		<Output TaskParameter="JdkJvmPath"                PropertyName="JdkJvmPath" />
-	</ResolveJdkJvmPath>
-	<ValidateJavaVersion
-			Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
-			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
-			TargetFrameworkVersion="$(TargetFrameworkVersion)"
-			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-			JavaSdkPath="$(_JavaSdkDirectory)"
-			JavaToolExe="$(JavaToolExe)"
-			JavacToolExe="$(JavacToolExe)"
-			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
-			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
-		<Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
-		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
-	</ValidateJavaVersion>
-	<ResolveAndroidTooling
-			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
-			TargetFrameworkVersion="$(TargetFrameworkVersion)"
-			AndroidApiLevel="$(AndroidApiLevel)"
-			AndroidApplication="$(AndroidApplication)"
-			AndroidSdkPath="$(_AndroidSdkDirectory)"
-			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-			AndroidUseAapt2="$(AndroidUseAapt2)"
-			AotAssemblies="$(AotAssemblies)"
-			Aapt2ToolPath="$(Aapt2ToolPath)"
-			SequencePointsMode="$(_AndroidSequencePointsMode)"
-			ProjectFilePath="$(MSBuildProjectFullPath)"			
-			LintToolPath="$(LintToolPath)"
-			ZipAlignPath="$(ZipAlignToolPath)">
-		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
-		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
-		<Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
-		<Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
-		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
-		<Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
-		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
-		<Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
-		<Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
-		<Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
-		<Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
-		<Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
-		<Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />
-	</ResolveAndroidTooling>
-	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
-		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
-				Condition="'$(TargetFrameworkProfile)' != ''"
-		/>
-		<Output TaskParameter="Value" PropertyName="NuGetTargetMoniker"
-				Condition="'$(TargetFrameworkProfile)' != ''"
-		/>
-	</CreateProperty>
-	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)">
-		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
-				Condition="'$(TargetFrameworkProfile)' == ''"
-		/>
-		<Output TaskParameter="Value" PropertyName="NuGetTargetMoniker"
-				Condition="'$(TargetFrameworkProfile)' == ''"
-		/>
-	</CreateProperty>
-	<CreateProperty Value="$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)">
-		<Output TaskParameter="Value" PropertyName="TargetFrameworkMonikerAssemblyAttributesPath"
-				Condition="'$(TargetFrameworkMoniker)' != ''"
-		/>
-	</CreateProperty>
-	<ItemGroup>
-		<FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
-		<Reference Include="$(_JavaInteropReferences)" />
-	</ItemGroup>
 </Target>
 
 <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -1,0 +1,61 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Legacy.targets
+
+This file contains MSBuild targets for "legacy" Xamarin.Android
+projects. .NET 5 projects will not import this file.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+  <Target Name="_ResolveAndroidTooling">
+    <ValidateJavaVersion
+        Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
+        ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        JavaSdkPath="$(_JavaSdkDirectory)"
+        JavaToolExe="$(JavaToolExe)"
+        JavacToolExe="$(JavacToolExe)"
+        LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+        MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
+      <Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
+      <Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
+    </ValidateJavaVersion>
+    <ResolveAndroidTooling
+        ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        AndroidApiLevel="$(AndroidApiLevel)"
+        AndroidApplication="$(AndroidApplication)"
+        AndroidSdkPath="$(_AndroidSdkDirectory)"
+        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+        AndroidUseAapt2="$(AndroidUseAapt2)"
+        AotAssemblies="$(AotAssemblies)"
+        Aapt2ToolPath="$(Aapt2ToolPath)"
+        SequencePointsMode="$(_AndroidSequencePointsMode)"
+        ProjectFilePath="$(MSBuildProjectFullPath)"			
+        LintToolPath="$(LintToolPath)"
+        ZipAlignPath="$(ZipAlignToolPath)">
+      <Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
+      <Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
+      <Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
+      <Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
+      <Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
+      <Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
+      <Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
+      <Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
+      <Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
+      <Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
+      <Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
+      <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
+      <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />
+    </ResolveAndroidTooling>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -1,0 +1,72 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Tooling.targets
+
+This file contains any calls to the <ResolveSdks/> or
+<ResolveJdkJvmPath/> MSBuild tasks. It is imported and used by
+"legacy" Xamarin.Android projects, binding projects, and .NET 5
+projects.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveJdkJvmPath" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+  <PropertyGroup>
+    <_SetLatestTargetFrameworkVersionDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' == 'True'">
+      _ResolveSdks;
+      _ResolveAndroidTooling;
+    </_SetLatestTargetFrameworkVersionDependsOnTargets>
+    <_SetLatestTargetFrameworkVersionDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' != 'True'">
+      _ResolveSdks;
+      _ResolveAndroidTooling;
+      _InjectAaptDependencies;
+      _InjectAapt2Dependencies;
+    </_SetLatestTargetFrameworkVersionDependsOnTargets>
+  </PropertyGroup>
+
+  <Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="$(_SetLatestTargetFrameworkVersionDependsOnTargets)">
+    <PropertyGroup>
+      <TargetFrameworkMoniker Condition=" '$(TargetFrameworkProfile)' == '' ">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
+      <TargetFrameworkMoniker Condition=" '$(TargetFrameworkProfile)' != '' ">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)</TargetFrameworkMoniker>
+      <NuGetTargetMoniker>$(TargetFrameworkMoniker)</NuGetTargetMoniker>
+      <TargetFrameworkMonikerAssemblyAttributesPath>$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
+      <Reference Include="$(_JavaInteropReferences)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
+    <PropertyGroup>
+      <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
+    </PropertyGroup>
+    <ResolveSdks
+        ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        AndroidSdkPath="$(AndroidSdkDirectory)"
+        AndroidNdkPath="$(AndroidNdkDirectory)"
+        JavaSdkPath="$(JavaSdkDirectory)"
+        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
+      <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
+      <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />
+      <Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
+      <Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
+      <Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
+      <Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
+      <Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
+      <Output TaskParameter="MonoAndroidLibPath"        PropertyName="MonoAndroidLibDirectory" />
+      <Output TaskParameter="AndroidBinUtilsPath"       PropertyName="AndroidBinUtilsDirectory" Condition=" '$(AndroidBinUtilsDirectory)' == '' " />
+    </ResolveSdks>
+    <ResolveJdkJvmPath
+        JavaSdkPath="$(_JavaSdkDirectory)"
+        Condition=" '$(DesignTimeBuild)' != 'True' And '$(_AndroidIsBindingProject)' != 'True' And '$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(JdkJvmPath)' == '' ">
+      <Output TaskParameter="JdkJvmPath"                PropertyName="JdkJvmPath" />
+    </ResolveJdkJvmPath>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Tooling.targets
@@ -1,0 +1,57 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Sdk.Tooling.targets
+
+This file contains .NET 5-specific calls to the <ValidateJavaVersion/>
+and <ResolveAndroidTooling/> MSBuild tasks. These MSBuild tasks are
+called for "legacy" projects in Xamarin.Android.Legacy.targets.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
+  <Target Name="_ResolveAndroidTooling">
+    <ValidateJavaVersion
+        Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
+        ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        JavaSdkPath="$(_JavaSdkDirectory)"
+        JavaToolExe="$(JavaToolExe)"
+        JavacToolExe="$(JavacToolExe)"
+        LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+        MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
+      <Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
+      <Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
+    </ValidateJavaVersion>
+    <ResolveAndroidTooling
+        ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        AndroidApiLevel="$(AndroidApiLevel)"
+        AndroidApplication="$(AndroidApplication)"
+        AndroidSdkPath="$(_AndroidSdkDirectory)"
+        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        AndroidUseAapt2="$(AndroidUseAapt2)"
+        AotAssemblies="$(AotAssemblies)"
+        Aapt2ToolPath="$(Aapt2ToolPath)"
+        SequencePointsMode="$(_AndroidSequencePointsMode)"
+        ProjectFilePath="$(MSBuildProjectFullPath)"			
+        LintToolPath="$(LintToolPath)"
+        ZipAlignPath="$(ZipAlignToolPath)">
+      <Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
+      <Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
+      <Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
+      <Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
+      <Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
+      <Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
+      <Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
+      <Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
+      <Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
+      <Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
+      <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
+      <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />
+    </ResolveAndroidTooling>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
@@ -3,6 +3,9 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
+    <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
+    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">1.8.0</LatestSupportedJavaVersion>
+    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <!-- We should always override the framework path so that XA resolves to its own mscorlib.dll -->
     <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\lib\</TargetFrameworkRootPath>
     <FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
@@ -7,11 +7,13 @@
 
   <PropertyGroup>
     <XamarinAndroidSdkTargetsImported>true</XamarinAndroidSdkTargetsImported>
+    <_XamarinAndroidBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.Tooling.targets" />
 
 </Project>


### PR DESCRIPTION
As we migrate to .NET 5, we need a way for short-form MSBuild projects
to run a different set of MSBuild tasks/targets within the codebase.

At the top level `Xamarin.Android.Sdk.targets` will be imported
instead of `Xamarin.Android.CSharp.targets`. We can define
`$(UsingAndroidNETSdk)` as `true`, which is similar to
`$(UsingMicrosoftNETSdk)` already present for short-form MSBuild
projects.

Based on `$(UsingAndroidNETSdk)`:

* Existing long-form projects can import
  `Xamarin.Android.Legacy.targets`
* New short-form project can import other new files as needed.

The first two MSBuild tasks to change are:

* `<ValidateJavaVersion/>`
* `<ResolveAndroidTooling/>`

Both of these tasks rely on `$(TargetFrameworkVersion)`; however, we
can make versions of these tasks that don't need to use
`$(TargetFrameworkVersion)` at all.

`<ValidateJavaVersion/>` can just require Java 1.8 going forward.

`<ResolveAndroidTooling/>` will have any logic around
`$(TargetFrameworkVersion)` or `$(AndroidUseLatestPlatformSdk)` and
just targets the latest supported Android API level.

To make the two versions of these tasks:

* The core code of these tasks will remain.
* A new `Tasks\Legacy` folder and `Xamarin.Android.Tasks.Legacy`
  namespace will be created.
* Any "legacy" code can be moved into these classes that will inherit
  from the core tasks.
* Any MSBuild targets using these tasks will be included in
  `Xamarin.Android.Legacy.targets` via `$(UsingAndroidNETSdk)` as well
  as any `<UsingTask/>` declarations.

## Binding Projects ##

Since Binding projects have their own calls to
`<ValidateJavaVersion/>` and `<ResolveAndroidTooling/>`, now is the
time to consolidate this. We had some duplicated code here.

I moved the common targets into `Xamarin.Android.Tooling.targets`, all
projects will now use the `_ResolveSdks` target from this file.

I had to introduce a private property:

    <_AndroidIsBindingProject>True</_AndroidIsBindingProject>

We can use this to detect if the current project is a binding project
or not. This may evolve as we fully understand what needs to happen
for .NET 5.