### PR TITLE
[Xamarin.Android.Build.Tasks] fix for API R and <GetJavaPlatformJar/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -97,9 +97,22 @@ namespace Xamarin.Android.Tasks
 			string targetFrameworkVersion = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (AndroidSdkPlatform);
 			string targetSdkVersion       = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (target);
 
-			int frameworkSdk, targetSdk;
-			if (int.TryParse (targetFrameworkVersion, out frameworkSdk) &&
-					int.TryParse (targetSdkVersion, out targetSdk) &&
+			if (!int.TryParse (targetFrameworkVersion, out int frameworkSdk)) {
+				// AndroidSdkPlatform is likely a *preview* API level; use it.
+				Log.LogWarningForXmlNode (
+						code:             "XA4211",
+						file:             AndroidManifest,
+						node:             target_sdk,
+						message:          Properties.Resources.XA4211,
+						messageArgs:      new [] {
+							targetSdkVersion,
+							MonoAndroidHelper.SupportedVersions.GetIdFromFrameworkVersion (targetFrameworkVersion),
+							MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (targetFrameworkVersion),
+						}
+				);
+				return targetFrameworkVersion;
+			}
+			if (int.TryParse (targetSdkVersion, out int targetSdk) &&
 					targetSdk < frameworkSdk) {
 				Log.LogWarningForXmlNode (
 						code:             "XA4211",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -599,10 +599,7 @@ namespace App1
 		[Test]
 		public void CheckTheCorrectRuntimeAssemblyIsUsedFromNuget ()
 		{
-			string monoandroidFramework;
-			using (var builder = new Builder ()) {
-				monoandroidFramework = builder.LatestMultiTargetFrameworkVersion ();
-			}
+			string monoandroidFramework = "monoandroid10.0";
 			string path = Path.Combine (Root, "temp", TestName);
 			var ns = new DotNetStandard () {
 				ProjectName = "Dummy",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -411,5 +411,18 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (targetFrameworkVersion, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {targetFrameworkVersion}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
+
+		[Test]
+		public void LatestTFV_OldTargetSdkVersion ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				UseLatestPlatformSdk = false,
+			};
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:targetSdkVersion=\"19\" />");
+			using (var b = CreateApkBuilder ()) {
+				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -167,15 +167,6 @@ namespace Xamarin.ProjectTools
 			return lastFrameworkVersion;
 		}
 
-		public string LatestMultiTargetFrameworkVersion ()
-		{
-			GetTargetFrameworkVersionRange (out string _, out string _, out string _, out string lastFrameworkVersion);
-			lastFrameworkVersion = lastFrameworkVersion.Replace ("v", string.Empty);
-			if (lastFrameworkVersion != "10.0")
-				lastFrameworkVersion = lastFrameworkVersion.Replace (".", string.Empty);
-			return $"monoandroid{lastFrameworkVersion}";
-		}
-
 		public string LatestTargetFrameworkVersion (out string apiLevel) {
 			GetTargetFrameworkVersionRange (out string _, out string _, out apiLevel, out string lastFrameworkVersion);
 			return lastFrameworkVersion;
@@ -197,7 +188,7 @@ namespace Xamarin.ProjectTools
 				if (!Version.TryParse (v, out version))
 					continue;
 
-				string frameworkVersion = "v" + version.ToString (2);
+				string frameworkVersion = "v" + version.ToString ();
 				string apiLevel         = GetApiLevelFromInfoPath (Path.Combine (dir, "AndroidApiInfo.xml"));
 				if (firstVersion == null || version < firstVersion) {
 					firstVersion            = version;


### PR DESCRIPTION
One of our QA tests was failing when using
`TargetFrameworkVersion=v10.0.99`:

    C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25\bin\javac.exe -J-Dfile.encoding=UTF8 obj\Release\10099\android\src\mono\MonoRuntimeProvider.java:25: error: cannot find symbol (TaskId:163)
                String[] splitApks = applicationInfo.splitPublicSourceDirs; (TaskId:163)
                                                    ^ (TaskId:163)
        symbol:   variable splitPublicSourceDirs (TaskId:163)
        location: variable applicationInfo of type ApplicationInfo (TaskId:163)
    Note: obj\Release\10099\android\src\crc64e49dab49335e9709\ButtonActivity.java uses unchecked or unsafe operations. (TaskId:163)
    Note: Recompile with -Xlint:unchecked for details. (TaskId:163)

`splitPublicSourceDirs` is available starting with API 21, what is
going on?

    Task "GetJavaPlatformJar" (TaskId:17)
      Task Parameter:AndroidSdkPlatform=30 (TaskId:17)
      Task Parameter:AndroidManifest=Properties\AndroidManifest.xml (TaskId:17)
      Output Property: JavaPlatformJarPath=C:\Program Files %28x86%29\Android\android-sdk\platforms\android-19\android.jar (TaskId:17)
      Output Property: _AndroidTargetSdkVersion=19 (TaskId:17)

So the `AndroidManifest.xml` in this project has:

    <uses-sdk android:targetSdkVersion="19" />

But this could wouldn't be able to parse an API level of R:

    string targetFrameworkVersion = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (AndroidSdkPlatform);
    string targetSdkVersion       = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (target);

`AndroidApiInfo.xml` for API R right now is:

    <AndroidApiInfo>
      <Id>R</Id>
      <Level>30</Level>
      <Name>R</Name>
      <Version>v10.0.99</Version>
      <Stable>False</Stable>
    </AndroidApiInfo>

Reworked `<GetJavaPlatformJar/>` to accept an API name of R, but emit
the `XA4211` warning.

I was able to reproduce this issue in a test, but I needed a small fix
in `GetTargetFrameworkVersionRange`. It was returning `v10.0` for
`v10.0.99`, due to only using the first two version parts.

I also felt that the `CheckTheCorrectRuntimeAssemblyIsUsedFromNuget`
test could just hardcode `monoandroid10.0`, as that will continue to
work for new API levels. I could not get `monoandroid10.0.99` to work.
The test is testing the `monoandroid10.0` assembly is used over
`netstandard2.0`.

Co-Authored-By: Jonathan Pryor <jonpryor@vt.edu>