### PR TITLE
[build] fix failure with "manual clean" step

### DIFF
--- a/build-tools/automation/yaml-templates/clean.yaml
+++ b/build-tools/automation/yaml-templates/clean.yaml
@@ -1,6 +1,8 @@
 steps:
 - powershell: |
+    $ErrorActionPreference = 'Continue'
     git clean -xffd
     git submodule foreach --recursive git clean -xffd
     Remove-Item -Recurse $(Build.BinariesDirectory) -ErrorAction Ignore
+    $LastExitCode = 0
   displayName: manual clean


### PR DESCRIPTION
Context: https://build.azdo.io/3582251

Some builds have been failing with:

    git : fatal: not a git repository (or any of the parent directories): .git

I think we can set `$ErrorActionPreference` to ignore this failure. It
is probably happening for new build machines. The subsequent
`Checkout` step should create the git repository.