### PR TITLE
[xabuild] remove lookup for $(AndroidSDKDirectory)

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -130,10 +130,6 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "NuGetRestoreTargets", paths.NuGetRestoreTargets);
 			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
-			if (!string.IsNullOrEmpty (paths.AndroidSdkDirectory))
-				SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
-			if (!string.IsNullOrEmpty (paths.AndroidNdkDirectory))
-				SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
 
 			var projectImportSearchPaths = toolsets.SelectSingleNode ("projectImportSearchPaths");
 			var searchPaths = projectImportSearchPaths.SelectSingleNode ($"searchPaths[@os='{paths.SearchPathsOS}']") as XmlElement;

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -112,10 +112,6 @@ namespace Xamarin.Android.Build
 
 		public string MonoAndroidToolsDirectory { get; private set; }
 
-		public string AndroidSdkDirectory { get; private set; }
-
-		public string AndroidNdkDirectory { get; private set; }
-
 		public string DotNetSdkPath { get; private set; }
 
 		public string NuGetTargets { get; private set; }
@@ -232,22 +228,6 @@ namespace Xamarin.Android.Build
 				if (Directory.Exists (roslyn))
 					RoslynTargetsPath = roslyn;
 			}
-
-			//Android SDK and NDK
-			var pathsTargets = Path.Combine (XABuildDirectory, "..", "..", "..", "build-tools", "scripts", "Paths.targets");
-			if (File.Exists (pathsTargets)) {
-				var androidSdkPath  = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-				if (string.IsNullOrEmpty (androidSdkPath)) {
-					androidSdkPath  = RunPathsTargets (pathsTargets, "GetAndroidSdkFullPath");
-				}
-				AndroidSdkDirectory = androidSdkPath;
-
-				var androidNdkPath  = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
-				if (string.IsNullOrEmpty (androidNdkPath)) {
-					androidNdkPath  = RunPathsTargets (pathsTargets, "GetAndroidNdkFullPath");
-				}
-				AndroidNdkDirectory = androidNdkPath;
-			}
 		}
 
 		[DllImport ("libc")]
@@ -268,27 +248,6 @@ namespace Xamarin.Android.Build
 					Marshal.FreeHGlobal (buf);
 			}
 			return false;
-		}
-
-		string RunPathsTargets (string pathsTargets, string target)
-		{
-			var path = IsWindows ? Path.Combine(MSBuildBin, "MSBuild.exe") : "mono";
-			var args = $"/nologo /v:minimal /t:{target} \"{pathsTargets}\"";
-			if (!IsWindows) {
-				args = $"\"{Path.Combine (MSBuildBin, "MSBuild.dll")}\" {args}";
-			}
-
-			var psi = new ProcessStartInfo (path, args) {
-				CreateNoWindow         = true,
-				RedirectStandardOutput = true,
-				WindowStyle            = ProcessWindowStyle.Hidden,
-				UseShellExecute        = false,
-			};
-
-			using (var p = Process.Start (psi)) {
-				p.WaitForExit ();
-				return p.StandardOutput.ReadToEnd ().Trim ();
-			}
 		}
 
 		string FindLatestDotNetSdk (string dotNetPath)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4305

If you used `xabuild.exe`, such as:

    bin\Debug\bin\xabuild.exe Xamarin.Android-Tests.sln /restore /p:HOME=F:\d\build

There is a `RunPathsTargets` method that invokes:

    msbuild build-tools\scripts\Paths.targets

However, we don't parse any incoming `/p` arguments and pass them
forward to this MSBuild call.

After some thought, it seems we can just remove this code. It will
simplify `xabuild.exe`, which is already mostly hacks.

The only issue that arises from this, is if you did:

    xabuild C:\some\project\outside\xamarin-android\Foo.csproj

It will not use `$(AndroidToolchainDirectory)` as defined by
`Configuration.props`. It may find some other Android SDK such as
`C:\Program Files (x86)\Android\android-sdk\`. This is probably fine
as projects in `xamarin-android` will import `Configuration.props`.