### PR TITLE
[tests] update URL for AarContentExtraction

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2339,7 +2339,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		public void AarContentExtraction ([Values (false, true)] bool useAapt2)
 		{
 			var aar = new AndroidItem.AndroidAarLibrary ("Jars\\android-crop-1.0.1.aar") {
-				WebContent = "https://jcenter.bintray.com/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
+				// https://mvnrepository.com/artifact/com.soundcloud.android/android-crop/1.0.1
+				WebContent = "https://repo1.maven.org/maven2/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
 			};
 			var proj = new XamarinAndroidApplicationProject () {
 				OtherBuildItems = {


### PR DESCRIPTION
Context: https://build.azdo.io/3589171
Context: https://mvnrepository.com/artifact/com.soundcloud.android/android-crop/1.0.1

We've seen `AarContentExtraction` fail such as:

```
  System.Net.WebException : Error: SecureChannelFailure (Remote prematurely closed connection.)
  ----> System.IO.IOException : Remote prematurely closed connection.
    at System.Net.WebConnection.CreateStream (System.Net.WebOperation operation, System.Boolean reused, System.Threading.CancellationToken cancellationToken) [0x0021a] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebConnection.InitConnection (System.Net.WebOperation operation, System.Threading.CancellationToken cancellationToken) [0x00141] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebOperation.Run () [0x0009a] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebCompletionSource`1[T].WaitForCompletion () [0x00094] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.HttpWebRequest.RunWithTimeoutWorker[T] (System.Threading.Tasks.Task`1[TResult] workerTask, System.Int32 timeout, System.Action abort, System.Func`1[TResult] aborted, System.Threading.CancellationTokenSource cts) [0x000f8] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.HttpWebRequest.GetResponse () [0x00016] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebClient.GetWebResponse (System.Net.WebRequest request) [0x00000] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebClient.DownloadBits (System.Net.WebRequest request, System.IO.Stream writeStream) [0x000e6] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebClient.DownloadFile (System.Uri address, System.String fileName) [0x00088] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at System.Net.WebClient.DownloadFile (System.String address, System.String fileName) [0x00008] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at Xamarin.ProjectTools.DownloadedCache.GetAsFile (System.String url) [0x0006e] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at Xamarin.ProjectTools.BuildItem+<>c__DisplayClass70_0.<set_WebContent>b__0 () [0x00005] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at Xamarin.ProjectTools.XamarinProject+<>c.<Save>b__103_1 (Xamarin.ProjectTools.BuildItem s) [0x00054] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at System.Linq.Enumerable+SelectListIterator`2[TSource,TResult].MoveNext () [0x00048] in <be3e5e14d9284eadb7ed6d5bb8f47852>:0
    at System.Collections.Generic.List`1[T].AddEnumerable (System.Collections.Generic.IEnumerable`1[T] enumerable) [0x00059] in <fa1c70bff5424f0bbf617c0b03a3a060>:0
    at System.Collections.Generic.List`1[T].InsertRange (System.Int32 index, System.Collections.Generic.IEnumerable`1[T] collection) [0x000f4] in <fa1c70bff5424f0bbf617c0b03a3a060>:0
    at System.Collections.Generic.List`1[T].AddRange (System.Collections.Generic.IEnumerable`1[T] collection) [0x00000] in <fa1c70bff5424f0bbf617c0b03a3a060>:0
    at Xamarin.ProjectTools.XamarinProject.Save (System.Boolean saveProject) [0x00165] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at Xamarin.ProjectTools.ProjectBuilder.Save (Xamarin.ProjectTools.XamarinProject project, System.Boolean doNotCleanupOnUpdate, System.Boolean saveProject) [0x00000] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at Xamarin.ProjectTools.ProjectBuilder.Build (Xamarin.ProjectTools.XamarinProject project, System.Boolean doNotCleanupOnUpdate, System.String[] parameters, System.Boolean saveProject, System.Collections.Generic.Dictionary`2[TKey,TValue] environmentVariables) [0x00000] in <e4b0484c5eb0495b9292e1e804ef5747>:0
    at Xamarin.Android.Build.Tests.BuildTest.AarContentExtraction (System.Boolean useAapt2) [0x0006f] in <bf01906856b94ba4824a56130ccd09cd>:0
    at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
    at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <fa1c70bff5424f0bbf617c0b03a3a060>:0
  --IOException
    at Mono.Net.Security.AsyncProtocolRequest.ProcessOperation (System.Threading.CancellationToken cancellationToken) [0x000e3] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
    at Mono.Net.Security.AsyncProtocolRequest.StartOperation
```
Looking at maven, it seems like the URL we are using is old?

I switched to use the latest URL that maven is showing for this package.