### PR TITLE
Bump to FSharp.Core 4.7.1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -341,12 +341,12 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package FSharp_Core_Latest = new Package {
 			Id = "FSharp.Core",
-			Version = "4.0.0.1",
-			TargetFramework = "monoandroid71",
+			Version = "4.7.1",
+			TargetFramework = "netstandard2.0",
 			References = {
 				new BuildItem.Reference ("mscorlib"),
 				new BuildItem.Reference ("FSharp.Core") {
-					MetadataValues = "HintPath=..\\packages\\FSharp.Core.4.0.0.1\\lib\\portable-net45+monoandroid10+monotouch10+xamarinios10\\FSharp.Core.dll"
+					MetadataValues = "HintPath=..\\packages\\FSharp.Core.4.7.1\\lib\\netstandard2.0\\FSharp.Core.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -89,6 +89,7 @@ namespace Xamarin.ProjectTools
 				base.Language = value;
 				if (value == XamarinAndroidProjectLanguage.FSharp) {
 					// add the stuff needed for FSharp
+					References.Add (new BuildItem.Reference ("System.Numerics"));
 					PackageReferences.Add (KnownPackages.FSharp_Core_Latest);
 					PackageReferences.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider_Runtime);
 					Sources.Remove (resourceDesigner);


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3592451&view=ms.vss-test-web.build-test-results-tab

We've been having lots of `FSharp.Core`-related tests fail of late,
e.g. from `BuildTest.BuildBasicApplicationFSharp()`:

	> Restoring packages for MonoAndroid,Version=v10.0... (TaskId:37)
	>   …
	>   GET https://api.nuget.org/v3-flatcontainer/fsharp.core/4.0.0.1/fsharp.core.4.0.0.1.nupkg (TaskId:37)
	>   OK https://api.nuget.org/v3-flatcontainer/fsharp.core/4.0.0.1/fsharp.core.4.0.0.1.nupkg 64ms (TaskId:37)
	> …
	> FSC : error FS0229: Error opening binary file 'C:\A\vs2019xam000009-1\_work\1\s\packages\fsharp.core\4.0.0.1\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll': Cannot read or write file
	> FSC : error FS3160: Problem reading assembly 'C:\A\vs2019xam000009-1\_work\1\s\packages\fsharp.core\4.0.0.1\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll': The exception has been reported. This internal exception should now be caught at an error recovery point on the stack. Original message: Error opening binary file 'C:\A\vs2019xam000009-1\_work\1\s\packages\fsharp.core\4.0.0.1\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll': Cannot read or write file)
	> error FS0073 : internal error : BuildFrameworkTcImports: no successful import of C:\A\vs2019xam000009-1\_work\1\s\packages\fsharp.core\4.0.0.1\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll

`fsharp.core.4.0.0.1.nupkg` contains the path
`lib/portable-net45%2Bmonoandroid10%2Bmonotouch10%2Bxamarinios10/FSharp.Core.dll`,
while the error message is looking for
`lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll`;
note `+` instead of `%2B`.

Let's see if using FSharp.Core 4.7.1 fixes things, as that just
provides a .NET Standard 2.0 library.