### PR TITLE
[xaprepare] Use separate backing field for NetCoreBinDir

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -285,7 +285,7 @@ namespace Xamarin.Android.Prepare
 
 			public static string TestBinDir                          => GetCachedPath (ref testBinDir, ()                          => Path.Combine (Configurables.Paths.BinDirRoot, $"Test{ctx.Configuration}"));
 			public static string BinDir                              => GetCachedPath (ref binDir, ()                              => Path.Combine (Configurables.Paths.BinDirRoot, ctx.Configuration));
-			public static string NetCoreBinDir                       => GetCachedPath (ref binDir, ()                              => Path.Combine (Configurables.Paths.BinDirRoot, $"{ctx.Configuration}-netcoreapp3.1"));
+			public static string NetCoreBinDir                       => GetCachedPath (ref netCoreBinDir, ()                       => Path.Combine (Configurables.Paths.BinDirRoot, $"{ctx.Configuration}-netcoreapp3.1"));
 			public static string BuildBinDir                         => GetCachedPath (ref buildBinDir, ()                         => Path.Combine (Configurables.Paths.BinDirRoot, $"Build{ctx.Configuration}"));
 			public static string MingwBinDir                         => GetCachedPath (ref mingwBinDir, ()                         => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidMxeFullPath), "bin"));
 			public static string ProfileAssembliesProjitemsPath      => GetCachedPath (ref profileAssembliesProjitemsPath, ()      => Path.Combine (BuildBinDir, "ProfileAssemblies.projitems"));
@@ -366,6 +366,7 @@ namespace Xamarin.Android.Prepare
 			static string buildBinDir;
 			static string mingwBinDir;
 			static string binDir;
+			static string netCoreBinDir;
 			static string monoSDKsOutputDir;
 			static string androidToolchainBinDirectory;
 			static string monoProfileDir;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/295aff28371fc9f3cbe1e1f937eb7fa6634ad670

Do not store location of the bin directory and the netcore bin directory
in the same variable as the first property to be accessed will make "the
other" path to never be used which may lead to hard to detect issues.