### PR TITLE
[Mono.Android] Don't property-ify `Connection.setVideoState()`

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1092,6 +1092,9 @@
   <!-- Similarly, API-18 only had android.graphics.Bitmap.isPremultiplied(); Don't merge with the API-19+ Bitmap.setPremultiplied() method. -->
   <attr api-since="19" path="/api/package[@name='android.graphics']/class[@name='Bitmap']/method[@name='setPremultiplied']" name="propertyName" />
 
+  <!-- API-R adds a Connection.getVideoState() method, but we can't "merge" getVideoState() & setVideoState() into a single property w/o breaking API compat -->
+  <attr api-since="23" path="/api/package[@name='android.telecom']/class[@jni-signature='Landroid/telecom/Connection;']/method[@name='setVideoState']" name="propertyName" />
+
   <!-- Deprecate Any Class in the API less than 10. Do This last so we override any other deprecate comments -->
   <attr api-until="9" path="/api/package/class" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>
   <attr api-until="9" path="/api/package/interface" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>
@@ -1551,6 +1554,7 @@
   <!-- These are "default" method versions, so it's ok to remove them from an interface. -->
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationStart' and count(parameter)=2]" />
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationEnd' and count(parameter)=2]" />
+
 
   <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.
        To preserve backwards compatibility, we need to "un-nest" anything added before API-30 -->


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3594952&view=results

Cherry-picking PR #4468 to d16-6 resulted in a build break:

	error : CompatApi command: /Users/builder/azdo/_work/92/s/xamarin-android/packages/microsoft.dotnet.apicompat/5.0.0-beta.20162.4/tools/net472/Microsoft.DotNet.ApiCompat.exe "/Users/builder/azdo/_work/92/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v10.0/ApiCompatTemp" -i "/Users/builder/azdo/_work/92/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v10.0.99/ApiCompatTemp" --allow-default-interface-methods --exclude-attributes ../../tests/api-compatibility/api-compat-exclude-attributes.txt
	error : CheckApiCompatibility found nonacceptable Api breakages for ApiLevel: v10.0.99.
	error : Compat issues with assembly Mono.Android:
	error : MembersMustExist : Member 'public void Android.Telecom.Connection.SetVideoState(Android.Telecom.VideoProfileState)' does not exist in the implementation but it does exist in the contract.
	error : Total Issues: 2

The problem is that API-R added a new `Connection.getVideoState()`
method, which `generator` then attempted to merge with the existing
`Connection.setVideoState()` method added in API-23.

As we don't create "set-only" properties, `Connection.setVideoState()`
was bound as `Connection.SetVideoState()`, but in "merging" it with
`Connection.getVideoState()` to create a new `Connection.VideoState`
property, we *removed* `Connection.SetVideoState()`, resulting in a
compatibility break.

Disable "property-ification" of `Connection.setVideoState()` by adding
the `propertyName` attribute, setting it to an empty string.