### PR TITLE
Return of the Strings

### DIFF
--- a/Documentation/release-notes/4487.md
+++ b/Documentation/release-notes/4487.md
@@ -1,0 +1,6 @@
+#### Application behavior on device and emulator
+
+  * [GitHub 4415](https://github.com/xamarin/xamarin-android/issues/4415):
+    Starting in Xamarin.Android 10.2.100.7, *System.NotSupportedException:
+    Cannot create instance of type ... no Java peer type found* caused certain
+    apps to crash during launch after incremental deployments.

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -670,8 +670,8 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
-		static extern IntPtr monodroid_typemap_managed_to_java (byte[] mvid, int token);
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		static extern unsafe IntPtr monodroid_typemap_managed_to_java (Type type, byte* mvid);
 
 		internal static void LogTypemapTrace (StackTrace st)
 		{
@@ -685,19 +685,24 @@ namespace Android.Runtime {
 			}
 		}
 
-		internal static string TypemapManagedToJava (Type type)
+		internal static unsafe string TypemapManagedToJava (Type type)
 		{
 			if (mvid_bytes == null)
 				mvid_bytes = new byte[16];
 
-			Span<byte> mvid = new Span<byte>(mvid_bytes);
-			byte[] mvid_slow = null;
+			var mvid = new Span<byte>(mvid_bytes);
+			byte[] mvid_data = null;
 			if (!type.Module.ModuleVersionId.TryWriteBytes (mvid)) {
 				monodroid_log (LogLevel.Warn, LogCategories.Default, $"Failed to obtain module MVID using the fast method, falling back to the slow one");
-				mvid_slow = type.Module.ModuleVersionId.ToByteArray ();
+				mvid_data = type.Module.ModuleVersionId.ToByteArray ();
+			} else {
+				mvid_data = mvid_bytes;
 			}
 
-			IntPtr ret = monodroid_typemap_managed_to_java (mvid_slow == null ? mvid_bytes : mvid_slow, type.MetadataToken);
+			IntPtr ret;
+			fixed (byte* mvidptr = mvid_data) {
+				ret = monodroid_typemap_managed_to_java (type, mvidptr);
+			}
 
 			if (ret == IntPtr.Zero) {
 				if (LogTypemapMissStackTrace) {

--- a/src/Mono.Android/Test/Java.Interop/JnienvTest.cs
+++ b/src/Mono.Android/Test/Java.Interop/JnienvTest.cs
@@ -383,19 +383,16 @@ namespace Java.InteropTests
 			Assert.AreEqual (null, m);
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
-		static extern IntPtr monodroid_typemap_managed_to_java (byte[] mvid, int token);
-
 		[Test]
 		public void ManagedToJavaTypeMapping ()
 		{
 			Type type = typeof(Activity);
-			var m = monodroid_typemap_managed_to_java (type.Module.ModuleVersionId.ToByteArray (), type.MetadataToken);
-			Assert.AreNotEqual (IntPtr.Zero, m, "`Activity` subclasses Java.Lang.Object, it should be in the typemap!");
+			string m = JNIEnv.TypemapManagedToJava (type);
+			Assert.AreNotEqual (null, m, "`Activity` subclasses Java.Lang.Object, it should be in the typemap!");
 
 			type = typeof (JnienvTest);
-			m = monodroid_typemap_managed_to_java (type.Module.ModuleVersionId.ToByteArray (), type.MetadataToken);
-			Assert.AreEqual (IntPtr.Zero, m, "`JnienvTest` does *not* subclass Java.Lang.Object, it should *not* be in the typemap!");
+			m = JNIEnv.TypemapManagedToJava (type);
+			Assert.AreEqual (null, m, "`JnienvTest` does *not* subclass Java.Lang.Object, it should *not* be in the typemap!");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -402,7 +402,7 @@ namespace Xamarin.Android.Tasks
 		void WriteTypeMappings (List<TypeDefinition> types)
 		{
 			var tmg = new TypeMapGenerator ((string message) => Log.LogDebugMessage (message), SupportedAbis);
-			if (!tmg.Generate (SkipJniAddNativeMethodRegistrationAttributeScan, types, TypemapOutputDirectory, GenerateNativeAssembly, out ApplicationConfigTaskState appConfState))
+			if (!tmg.Generate (Debug, SkipJniAddNativeMethodRegistrationAttributeScan, types, TypemapOutputDirectory, GenerateNativeAssembly, out ApplicationConfigTaskState appConfState))
 				throw new XamarinAndroidException (4308, Properties.Resources.XA4308);
 			GeneratedBinaryTypeMaps = tmg.GeneratedBinaryTypeMaps.ToArray ();
 			BuildEngine4.RegisterTaskObject (ApplicationConfigTaskState.RegisterTaskObjectKey, appConfState, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public bool TypeMapMode { get; set; }
 
+		[Required]
+		public bool Debug { get; set; }
+
+		[Required]
+		public bool InstantRunEnabled { get; set; }
+
 		[Output]
 		public ITaskItem[] AssemblySources { get; set; }
 
@@ -53,9 +59,11 @@ namespace Xamarin.Android.Tasks
 				if (!TypeMapMode)
 					continue;
 
-				item = new TaskItem (Path.Combine (NativeSourcesDir, $"{baseName}.{abi}-managed.inc"));
-				item.SetMetadata ("abi", abi);
-				includes.Add (item);
+				if (!InstantRunEnabled && !Debug) {
+					item = new TaskItem (Path.Combine (NativeSourcesDir, $"{baseName}.{abi}-managed.inc"));
+					item.SetMetadata ("abi", abi);
+					includes.Add (item);
+				}
 			}
 
 			if (haveArmV7SharedSource) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -832,7 +832,6 @@ namespace Lib2
 		readonly string [] ExpectedAssemblyFiles = new [] {
 			Path.Combine ("android", "environment.armeabi-v7a.o"),
 			Path.Combine ("android", "environment.armeabi-v7a.s"),
-			Path.Combine ("android", "typemaps.armeabi-v7a-managed.inc"),
 			Path.Combine ("android", "typemaps.armeabi-v7a-shared.inc"),
 			Path.Combine ("android", "typemaps.armeabi-v7a.o"),
 			Path.Combine ("android", "typemaps.armeabi-v7a.s"),

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ARMNativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ARMNativeAssemblerTargetProvider.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Android.Tasks
 		public override string AbiName => Is64Bit ? ARMV8a : ARMV7a;
 		public override uint MapModulesAlignBits => Is64Bit ? 3u : 2u;
 		public override uint MapJavaAlignBits { get; } = 2;
+		public override uint DebugTypeMapAlignBits => Is64Bit ? 3u : 2u;
 
 		public ARMNativeAssemblerTargetProvider (bool is64Bit)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblerTargetProvider.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Android.Tasks
 		public abstract string AbiName { get; }
 		public abstract uint MapModulesAlignBits { get; }
 		public abstract uint MapJavaAlignBits { get; }
+		public abstract uint DebugTypeMapAlignBits { get; }
 
 		public virtual string MapType <T> ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
@@ -6,16 +6,16 @@ namespace Xamarin.Android.Tasks
 {
 	class NativeTypeMappingData
 	{
-		public TypeMapGenerator.ModuleData[] Modules { get; }
+		public TypeMapGenerator.ModuleReleaseData[] Modules { get; }
 		public IDictionary<string, string> AssemblyNames { get; }
 		public string[] JavaTypeNames                    { get; }
-		public TypeMapGenerator.TypeMapEntry[] JavaTypes { get; }
+		public TypeMapGenerator.TypeMapReleaseEntry[] JavaTypes { get; }
 
 		public uint MapModuleCount { get; }
 		public uint JavaTypeCount  { get; }
 		public uint JavaNameWidth  { get; }
 
-		public NativeTypeMappingData (Action<string> logger, TypeMapGenerator.ModuleData[] modules, int javaNameWidth)
+		public NativeTypeMappingData (Action<string> logger, TypeMapGenerator.ModuleReleaseData[] modules, int javaNameWidth)
 		{
 			Modules = modules ?? throw new ArgumentNullException (nameof (modules));
 
@@ -24,11 +24,11 @@ namespace Xamarin.Android.Tasks
 
 			AssemblyNames = new Dictionary<string, string> (StringComparer.Ordinal);
 
-			var tempJavaTypes = new Dictionary<string, TypeMapGenerator.TypeMapEntry> (StringComparer.Ordinal);
+			var tempJavaTypes = new Dictionary<string, TypeMapGenerator.TypeMapReleaseEntry> (StringComparer.Ordinal);
 			int managedStringCounter = 0;
 			var moduleComparer = new TypeMapGenerator.ModuleUUIDArrayComparer ();
 
-			foreach (TypeMapGenerator.ModuleData data in modules) {
+			foreach (TypeMapGenerator.ModuleReleaseData data in modules) {
 				data.AssemblyNameLabel = $"map_aname.{managedStringCounter++}";
 				AssemblyNames.Add (data.AssemblyNameLabel, data.AssemblyName);
 
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Tasks
 				if (moduleIndex < 0)
 					throw new InvalidOperationException ($"Unable to map module with MVID {data.Mvid} to array index");
 
-				foreach (TypeMapGenerator.TypeMapEntry entry in data.Types) {
+				foreach (TypeMapGenerator.TypeMapReleaseEntry entry in data.Types) {
 					entry.ModuleIndex = moduleIndex;
 					if (tempJavaTypes.ContainsKey (entry.JavaName))
 						continue;
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Tasks
 			var javaNames = tempJavaTypes.Keys.ToArray ();
 			Array.Sort (javaNames, StringComparer.Ordinal);
 
-			var javaTypes = new TypeMapGenerator.TypeMapEntry[javaNames.Length];
+			var javaTypes = new TypeMapGenerator.TypeMapReleaseEntry[javaNames.Length];
 			for (int i = 0; i < javaNames.Length; i++) {
 				javaTypes[i] = tempJavaTypes[javaNames[i]];
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
@@ -1,0 +1,140 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.Android.Tasks
+{
+	class TypeMappingDebugNativeAssemblyGenerator : NativeAssemblyGenerator
+	{
+		const string JavaToManagedSymbol = "map_java_to_managed";
+		const string ManagedToJavaSymbol = "map_managed_to_java";
+		const string TypeMapSymbol = "type_map"; // MUST match src/monodroid/xamarin-app.hh
+
+		readonly string baseFileName;
+		readonly bool sharedBitsWritten;
+		readonly TypeMapGenerator.ModuleDebugData data;
+
+		public TypeMappingDebugNativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider, TypeMapGenerator.ModuleDebugData data, string baseFileName, bool sharedBitsWritten, bool sharedIncludeUsesAbiPrefix = false)
+			: base (targetProvider, baseFileName, sharedIncludeUsesAbiPrefix)
+		{
+			if (String.IsNullOrEmpty (baseFileName))
+				throw new ArgumentException("must not be null or empty", nameof (baseFileName));
+			this.data = data ?? throw new ArgumentNullException (nameof (data));
+
+			this.baseFileName = baseFileName;
+			this.sharedBitsWritten = sharedBitsWritten;
+		}
+
+		protected override void WriteSymbols (StreamWriter output)
+		{
+			bool haveJavaToManaged = data.JavaToManagedMap != null && data.JavaToManagedMap.Count > 0;
+			bool haveManagedToJava = data.ManagedToJavaMap != null && data.ManagedToJavaMap.Count > 0;
+
+			using (var sharedOutput = MemoryStreamPool.Shared.CreateStreamWriter (output.Encoding)) {
+				WriteSharedBits (sharedOutput, haveJavaToManaged, haveManagedToJava);
+				sharedOutput.Flush ();
+				MonoAndroidHelper.CopyIfStreamChanged (sharedOutput.BaseStream, SharedIncludeFile);
+			}
+
+			if (haveJavaToManaged || haveManagedToJava) {
+				output.Write (Indent);
+				output.Write (".include");
+				output.Write (Indent);
+				output.Write ('"');
+				output.Write (Path.GetFileName (SharedIncludeFile));
+				output.WriteLine ('"');
+
+				output.WriteLine ();
+			}
+
+			uint size = 0;
+			WriteCommentLine (output, "Managed to java map: START", indent: false);
+			WriteSection (output, $".data.rel.{ManagedToJavaSymbol}", hasStrings: false, writable: true);
+			WriteStructureSymbol (output, ManagedToJavaSymbol, alignBits: TargetProvider.DebugTypeMapAlignBits, isGlobal: false);
+			if (haveManagedToJava) {
+				foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.ManagedToJavaMap) {
+					size += WritePointer (output, entry.ManagedLabel);
+					size += WritePointer (output, entry.JavaLabel);
+				}
+			}
+			WriteStructureSize (output, ManagedToJavaSymbol, size, alwaysWriteSize: true);
+			WriteCommentLine (output, "Managed to java map: END", indent: false);
+			output.WriteLine ();
+
+			size = 0;
+			WriteCommentLine (output, "Java to managed map: START", indent: false);
+			WriteSection (output, $".data.rel.{JavaToManagedSymbol}", hasStrings: false, writable: true);
+			WriteStructureSymbol (output, JavaToManagedSymbol, alignBits: TargetProvider.DebugTypeMapAlignBits, isGlobal: false);
+			if (haveJavaToManaged) {
+				foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.JavaToManagedMap) {
+					size += WritePointer (output, entry.JavaLabel);
+					size += WritePointer (output, entry.ManagedLabel);
+				}
+			}
+			WriteStructureSize (output, JavaToManagedSymbol, size, alwaysWriteSize: true);
+			WriteCommentLine (output, "Java to managed map: END", indent: false);
+			output.WriteLine ();
+
+			// MUST match src/monodroid/xamarin-app.hh
+			WriteCommentLine (output, "TypeMap structure");
+			WriteSection (output, $".data.rel.ro.{TypeMapSymbol}", hasStrings: false, writable: true);
+			WriteStructureSymbol (output, TypeMapSymbol, alignBits: TargetProvider.DebugTypeMapAlignBits, isGlobal: true);
+
+			size = WriteStructure (output, packed: false, structureWriter: () => WriteTypeMapStruct (output));
+
+			WriteStructureSize (output, TypeMapSymbol, size);
+		}
+
+		// MUST match the TypeMap struct from src/monodroid/xamarin-app.hh
+		uint WriteTypeMapStruct (StreamWriter output)
+		{
+			uint size = 0;
+
+			WriteCommentLine (output, "entry_count");
+			size += WriteData (output, data.EntryCount);
+
+			WriteCommentLine (output, "assembly_name (unused in this mode)");
+			size += WritePointer (output);
+
+			WriteCommentLine (output, "data (unused in this mode)");
+			size += WritePointer (output);
+
+			WriteCommentLine (output, "java_to_managed");
+			size += WritePointer (output, JavaToManagedSymbol);
+
+			WriteCommentLine (output, "managed_to_java");
+			size += WritePointer (output, ManagedToJavaSymbol);
+
+			return size;
+		}
+
+		void WriteSharedBits (StreamWriter output, bool haveJavaToManaged, bool haveManagedToJava)
+		{
+			string label;
+
+			if (haveJavaToManaged) {
+				WriteCommentLine (output, "Java type names: START");
+				foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.JavaToManagedMap) {
+					label = $"java_type_name.{entry.JavaIndex}";
+					WriteData (output, entry.JavaName, label, isGlobal: false);
+					entry.JavaLabel = MakeLocalLabel (label);
+					output.WriteLine ();
+				}
+				WriteCommentLine (output, "Java type names: END");
+				output.WriteLine ();
+			}
+
+			if (haveManagedToJava) {
+				WriteCommentLine (output, "Managed type names: START");
+				foreach (TypeMapGenerator.TypeMapDebugEntry entry in data.ManagedToJavaMap) {
+					label = $"managed_type_name.{entry.ManagedIndex}";
+					WriteData (output, entry.ManagedName, label, isGlobal: false);
+					entry.ManagedLabel = MakeLocalLabel (label);
+				}
+				WriteCommentLine (output, "Managed type names: END");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
@@ -5,20 +5,16 @@ using System.Linq;
 
 namespace Xamarin.Android.Tasks
 {
-	class TypeMappingNativeAssemblyGenerator : NativeAssemblyGenerator
+	class TypeMappingReleaseNativeAssemblyGenerator : NativeAssemblyGenerator
 	{
 		readonly string baseFileName;
 		readonly NativeTypeMappingData mappingData;
 		readonly bool sharedBitsWritten;
 
-		public TypeMappingNativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider, NativeTypeMappingData mappingData, string baseFileName, bool sharedBitsWritten, bool sharedIncludeUsesAbiPrefix = false)
+		public TypeMappingReleaseNativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider, NativeTypeMappingData mappingData, string baseFileName, bool sharedBitsWritten, bool sharedIncludeUsesAbiPrefix = false)
 			: base (targetProvider, baseFileName, sharedIncludeUsesAbiPrefix)
 		{
 			this.mappingData = mappingData ?? throw new ArgumentNullException (nameof (mappingData));
-
-			if (String.IsNullOrEmpty (baseFileName))
-				throw new ArgumentException("must not be null or empty", nameof (baseFileName));
-
 			this.baseFileName = baseFileName;
 			this.sharedBitsWritten = sharedIncludeUsesAbiPrefix ? false : sharedBitsWritten;
 		}
@@ -93,13 +89,13 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void WriteManagedMaps (StreamWriter output, string moduleSymbolName, IEnumerable<TypeMapGenerator.TypeMapEntry> entries)
+		void WriteManagedMaps (StreamWriter output, string moduleSymbolName, IEnumerable<TypeMapGenerator.TypeMapReleaseEntry> entries)
 		{
 			if (entries == null)
 				return;
 
 			var tokens = new Dictionary<uint, uint> ();
-			foreach (TypeMapGenerator.TypeMapEntry entry in entries) {
+			foreach (TypeMapGenerator.TypeMapReleaseEntry entry in entries) {
 				int idx = Array.BinarySearch (mappingData.JavaTypeNames, entry.JavaName, StringComparer.Ordinal);
 				if (idx < 0)
 					throw new InvalidOperationException ($"Could not map entry '{entry.JavaName}' to array index");
@@ -138,7 +134,7 @@ namespace Xamarin.Android.Tasks
 
 			uint size = 0;
 			int moduleCounter = 0;
-			foreach (TypeMapGenerator.ModuleData data in mappingData.Modules) {
+			foreach (TypeMapGenerator.ModuleReleaseData data in mappingData.Modules) {
 				string mapName = $"module{moduleCounter++}_managed_to_java";
 				string duplicateMapName;
 
@@ -160,7 +156,7 @@ namespace Xamarin.Android.Tasks
 			output.WriteLine ();
 		}
 
-		uint WriteMapModule (StreamWriter output, string mapName, string duplicateMapName, TypeMapGenerator.ModuleData data)
+		uint WriteMapModule (StreamWriter output, string mapName, string duplicateMapName, TypeMapGenerator.ModuleReleaseData data)
 		{
 			uint size = 0;
 			WriteCommentLine (output, $"module_uuid: {data.Mvid}");
@@ -205,7 +201,7 @@ namespace Xamarin.Android.Tasks
 
 			uint size = 0;
 			int entryCount = 0;
-			foreach (TypeMapGenerator.TypeMapEntry entry in mappingData.JavaTypes) {
+			foreach (TypeMapGenerator.TypeMapReleaseEntry entry in mappingData.JavaTypes) {
 				size += WriteJavaMapEntry (output, entry, entryCount++);
 			}
 
@@ -214,7 +210,7 @@ namespace Xamarin.Android.Tasks
 			output.WriteLine ();
 		}
 
-		uint WriteJavaMapEntry (StreamWriter output, TypeMapGenerator.TypeMapEntry entry, int entryIndex)
+		uint WriteJavaMapEntry (StreamWriter output, TypeMapGenerator.TypeMapReleaseEntry entry, int entryIndex)
 		{
 			uint size = 0;
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/X86NativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/X86NativeAssemblerTargetProvider.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tasks
 		public override string AbiName => Is64Bit ? X86_64 : X86;
 		public override uint MapModulesAlignBits => Is64Bit ? 4u : 2u;
 		public override uint MapJavaAlignBits => Is64Bit ? 4u : 2u;
+		public override uint DebugTypeMapAlignBits => Is64Bit ? 4u : 2u;
 
 		public X86NativeAssemblerTargetProvider (bool is64Bit)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -935,6 +935,9 @@ because xbuild doesn't support framework reference assemblies.
 		<_NuGetAssetsFile      Condition=" Exists('$(ProjectLockFile)') ">$(ProjectLockFile)</_NuGetAssetsFile>
 		<_NuGetAssetsFile      Condition=" '$(_NuGetAssetsFile)' == '' and Exists('packages.config') ">packages.config</_NuGetAssetsFile>
 		<_NuGetAssetsTimestamp Condition=" '$(_NuGetAssetsFile)' != '' ">$([System.IO.File]::GetLastWriteTime('$(_NuGetAssetsFile)').Ticks)</_NuGetAssetsTimestamp>
+		<_TypeMapKind Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">mvid</_TypeMapKind>
+		<_TypeMapKind Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(_InstantRunEnabled)' == 'True' ">strings-files</_TypeMapKind>
+		<_TypeMapKind Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(_InstantRunEnabled)' != 'True' ">strings-asm</_TypeMapKind>
 	</PropertyGroup>
 	<ItemGroup>
 		<!-- List of items we want to trigger a build if changed -->
@@ -965,6 +968,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
 		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
+		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
 	</ItemGroup>
 	<MakeDir Directories="$(_AndroidStampDirectory)" Condition="!Exists('$(_AndroidStampDirectory)')" />
 	<WriteLinesToFile
@@ -1728,6 +1732,8 @@ because xbuild doesn't support framework reference assemblies.
   <PrepareAbiItems
       BuildTargetAbis="@(_BuildTargetAbis)"
       NativeSourcesDir="$(_NativeAssemblySourceDir)"
+      InstantRunEnabled="$(_InstantRunEnabled)"
+      Debug="$(AndroidIncludeDebugSymbols)"
       TypeMapMode="True">
     <Output TaskParameter="AssemblySources" ItemName="_TypeMapAssemblySource" />
     <Output TaskParameter="AssemblyIncludes" ItemName="_TypeMapAssemblyInclude" />
@@ -1847,6 +1853,8 @@ because xbuild doesn't support framework reference assemblies.
   <PrepareAbiItems
     BuildTargetAbis="@(_BuildTargetAbis)"
     NativeSourcesDir="$(_NativeAssemblySourceDir)"
+    InstantRunEnabled="$(_InstantRunEnabled)"
+    Debug="$(AndroidIncludeDebugSymbols)"
     TypeMapMode="false">
       <Output TaskParameter="AssemblySources" ItemName="_EnvironmentAssemblySource" />
   </PrepareAbiItems>

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -146,12 +146,13 @@ if(ENABLE_NDK)
     add_definitions("-D__ANDROID_API_Q__=29")
   endif()
 
-  link_directories("${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
+  set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
+  link_directories("${XA_LIBRARY_OUTPUT_DIRECTORY}")
 else()
   set(CMAKE_REQUIRED_DEFINITIONS "-D__USE_GNU")
   check_cxx_symbol_exists(gettid unistd.h HAVE_GETTID_IN_UNISTD_H)
   if(HAVE_GETTID_IN_UNISTD_H)
-	add_definitions("-DHAVE_GETTID_IN_UNISTD_H")
+    add_definitions("-DHAVE_GETTID_IN_UNISTD_H")
   endif()
 
   # MinGW needs it for {v,a}sprintf
@@ -166,7 +167,7 @@ else()
       set(HOST_BUILD_NAME "host-Linux")
 
       if(EXISTS "/.flatpak-info")
-		add_definitions("-DLINUX_FLATPAK")
+        add_definitions("-DLINUX_FLATPAK")
       endif()
     endif()
   endif()
@@ -196,10 +197,12 @@ else()
       endif()
     endif()
 
-    link_directories("${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
+    set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
+    link_directories("${XA_LIBRARY_OUTPUT_DIRECTORY}")
   endif()
 
   if(DEFINED HOST_BUILD_NAME)
+    set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${HOST_BUILD_NAME}")
     link_directories("${XA_LIB_TOP_DIR}/${HOST_BUILD_NAME}")
     include_directories("${DEFAULT_BIN_DIR}/include/${HOST_BUILD_NAME}")
     include_directories("${DEFAULT_BIN_DIR}/include/${HOST_BUILD_NAME}/eglib")
@@ -289,21 +292,29 @@ endif()
 
 set(XAMARIN_APP_STUB_SOURCES ${SOURCES_DIR}/application_dso_stub.cc)
 add_library(xamarin-app SHARED ${XAMARIN_APP_STUB_SOURCES})
+if (ENABLE_NDK)
+  # Only Android builds need to go in separate directories, desktop builds have the same ABI
+  set_target_properties(
+    xamarin-app
+    PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${XA_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}"
+    )
+endif()
 
 if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
   set(XAMARIN_DEBUG_APP_HELPER_SOURCES
-	${SOURCES_DIR}/basic-android-system.cc
-	${SOURCES_DIR}/basic-utilities.cc
-	${SOURCES_DIR}/cpu-arch-detect.cc
-	${SOURCES_DIR}/debug-app-helper.cc
-	${SOURCES_DIR}/new_delete.cc
-	${SOURCES_DIR}/shared-constants.cc
-	)
+    ${SOURCES_DIR}/basic-android-system.cc
+    ${SOURCES_DIR}/basic-utilities.cc
+    ${SOURCES_DIR}/cpu-arch-detect.cc
+    ${SOURCES_DIR}/debug-app-helper.cc
+    ${SOURCES_DIR}/new_delete.cc
+    ${SOURCES_DIR}/shared-constants.cc
+    )
   add_library(xamarin-debug-app-helper SHARED ${XAMARIN_DEBUG_APP_HELPER_SOURCES})
   target_compile_definitions(
-	xamarin-debug-app-helper
-	PUBLIC -DDEBUG_APP_HELPER
-	)
+    xamarin-debug-app-helper
+    PUBLIC -DDEBUG_APP_HELPER
+    )
 endif()
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} MONO_ANDROID_SUFFIX)

--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -5,12 +5,27 @@
 
 // This file MUST have "valid" values everywhere - the DSO it is compiled into is loaded by the
 // designer on desktop.
+#if defined (DEBUG) || !defined (ANDROID)
+static TypeMapEntry java_to_managed[] = {};
+
+static TypeMapEntry managed_to_java[] = {};
+
+// MUST match src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+const TypeMap type_map = {
+	0,
+	nullptr,
+	nullptr,
+	java_to_managed,
+	managed_to_java
+};
+#else
 const uint32_t map_module_count = 0;
 const uint32_t java_type_count = 0;
 const uint32_t java_name_width = 0;
 
 const TypeMapModule map_modules[] = {};
 const TypeMapJava map_java[] = {};
+#endif
 
 ApplicationConfig application_config = {
 	/*.uses_mono_llvm =*/ false,

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -175,6 +175,119 @@ EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nme
 	return nullptr;
 }
 
+#if defined (DEBUG) || !defined (ANDROID)
+int
+EmbeddedAssemblies::compare_type_name (const char *type_name, const TypeMapEntry *entry)
+{
+	if (entry == nullptr)
+		return 1;
+
+	return strcmp (type_name, entry->from);
+}
+
+MonoReflectionType*
+EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
+{
+	const TypeMapEntry *entry = nullptr;
+
+	if (application_config.instant_run_enabled) {
+		TypeMap *module;
+		for (size_t i = 0; i < type_map_count; i++) {
+			module = &type_maps[i];
+			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, module->java_to_managed, module->entry_count);
+			if (entry != nullptr)
+				break;
+		}
+	} else {
+		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, type_map.java_to_managed, type_map.entry_count);
+	}
+
+	if (XA_UNLIKELY (entry == nullptr)) {
+		log_warn (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name);
+		return nullptr;
+	}
+
+	const char *managed_type_name = entry->to;
+	log_debug (LOG_DEFAULT, "typemap: Java type '%s' corresponds to managed type '%s'", java_type_name, managed_type_name);
+
+	MonoType *type = mono_reflection_type_from_name (const_cast<char*>(managed_type_name), nullptr);
+	if (XA_UNLIKELY (type == nullptr)) {
+		log_warn (LOG_ASSEMBLY, "typemap: managed type '%s' (mapped from Java type '%s') could not be loaded", managed_type_name, java_type_name);
+		return nullptr;
+	}
+
+	MonoReflectionType *ret = mono_type_get_object (mono_domain_get (), type);
+	if (XA_UNLIKELY (ret == nullptr)) {
+		log_warn (LOG_ASSEMBLY, "typemap: unable to instantiate managed type '%s'", managed_type_name);
+		return nullptr;
+	}
+
+	return ret;
+}
+#else
+MonoReflectionType*
+EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
+{
+	TypeMapModule *module;
+	const TypeMapJava *java_entry = binary_search<const char, TypeMapJava, compare_java_name, true> (java_type_name, map_java, java_type_count, java_name_width);
+	if (java_entry == nullptr) {
+		log_warn (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name);
+		return nullptr;
+	}
+
+	if (java_entry->module_index >= map_module_count) {
+		log_warn (LOG_ASSEMBLY, "typemap: mapping from Java type '%s' to managed type has invalid module index", java_type_name);
+		return nullptr;
+	}
+
+	module = const_cast<TypeMapModule*>(&map_modules[java_entry->module_index]);
+	const TypeMapModuleEntry *entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&java_entry->type_token_id, module->map, module->entry_count);
+	if (entry == nullptr) {
+		log_warn (LOG_ASSEMBLY, "typemap: unable to find mapping from Java type '%s' to managed type with token ID %u in module [%s]", java_type_name, java_entry->type_token_id, MonoGuidString (module->module_uuid).get ());
+		return nullptr;
+	}
+	uint32_t type_token_id = java_entry->type_token_id;
+
+	if (module->image == nullptr) {
+		module->image = mono_image_loaded (module->assembly_name);
+		if (module->image == nullptr) {
+			// TODO: load
+			log_error (LOG_ASSEMBLY, "typemap: assembly '%s' not loaded yet!", module->assembly_name);
+		}
+
+		if (module->image == nullptr) {
+			log_error (LOG_ASSEMBLY, "typemap: unable to load assembly '%s' when looking up managed type corresponding to Java type '%s'", module->assembly_name, java_type_name);
+			return nullptr;
+		}
+	}
+
+	log_debug (LOG_ASSEMBLY, "typemap: java type '%s' corresponds to managed token id %u (0x%x)", java_type_name, type_token_id, type_token_id);
+	MonoClass *klass = mono_class_get (module->image, static_cast<uint32_t>(type_token_id));
+	if (klass == nullptr) {
+		log_error (LOG_ASSEMBLY, "typemap: unable to find managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", type_token_id, module->assembly_name, java_type_name);
+		return nullptr;
+	}
+
+	MonoReflectionType *ret = mono_type_get_object (mono_domain_get (), mono_class_get_type (klass));
+	if (ret == nullptr) {
+		log_warn (LOG_ASSEMBLY, "typemap: unable to instantiate managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", type_token_id, module->assembly_name, java_type_name);
+		return nullptr;
+	}
+
+	return ret;
+}
+
+int
+EmbeddedAssemblies::compare_java_name (const char *java_name, const TypeMapJava *entry)
+{
+	if (entry == nullptr || entry->java_name[0] == '\0') {
+		return -1;
+	}
+
+	return strcmp (java_name, reinterpret_cast<const char*>(entry->java_name));
+}
+#endif
+
 MonoReflectionType*
 EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 {
@@ -195,70 +308,8 @@ EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 		return nullptr;
 	}
 
-	int32_t type_token_id = -1;
-	TypeMapModule *module;
-#if defined (DEBUG) || !defined (ANDROID)
-	if (application_config.instant_run_enabled) {
-		size_t idx = 0;
-		for (; idx < module_count; idx++) {
-			const uint8_t *java_entry = binary_search<const char, uint8_t, compare_java_name, true> (java_type_name.get (), modules[idx].java_map, modules[idx].entry_count, modules[idx].java_name_width + 3);
-			if (java_entry == nullptr)
-				continue;
-			type_token_id = *reinterpret_cast<const int32_t*>(java_entry + modules[idx].java_name_width);
-			break;
-		}
+	MonoReflectionType *ret = typemap_java_to_managed (java_type_name.get ());
 
-		if (idx >= module_count) {
-			log_error (LOG_ASSEMBLY, "typemap: unable to find module with Java type '%s' mapping", java_type_name.get ());
-			return nullptr;
-		}
-
-		module = &modules[idx];
-	} else {
-#endif
-		const TypeMapJava *java_entry = binary_search<const char, TypeMapJava, compare_java_name, true> (java_type_name.get (), map_java, java_type_count, java_name_width);
-		if (java_entry == nullptr) {
-			log_warn (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name.get ());
-			return nullptr;
-		}
-
-		if (java_entry->module_index >= map_module_count) {
-			log_warn (LOG_ASSEMBLY, "typemap: mapping from Java type '%s' to managed type has invalid module index", java_type_name.get ());
-			return nullptr;
-		}
-
-		module = const_cast<TypeMapModule*>(&map_modules[java_entry->module_index]);
-		const TypeMapModuleEntry *entry = binary_search <int32_t, TypeMapModuleEntry, compare_type_token> (&java_entry->type_token_id, module->map, module->entry_count);
-		if (entry == nullptr) {
-			log_warn (LOG_ASSEMBLY, "typemap: unable to find mapping from Java type '%s' to managed type with token ID %u in module [%s]", java_type_name.get (), java_entry->type_token_id, MonoGuidString (module->module_uuid).get ());
-			return nullptr;
-		}
-		type_token_id = java_entry->type_token_id;
-#if defined (DEBUG) || !defined (ANDROID)
-	}
-#endif
-
-	if (module->image == nullptr) {
-		module->image = mono_image_loaded (module->assembly_name);
-		if (module->image == nullptr) {
-			// TODO: load
-			log_error (LOG_ASSEMBLY, "typemap: assembly '%s' not loaded yet!", module->assembly_name);
-		}
-
-		if (module->image == nullptr) {
-			log_error (LOG_ASSEMBLY, "typemap: unable to load assembly '%s' when looking up managed type corresponding to Java type '%s'", module->assembly_name, java_type_name.get ());
-			return nullptr;
-		}
-	}
-
-	log_debug (LOG_ASSEMBLY, "typemap: java type '%s' corresponds to managed token id %u (0x%x)", java_type_name.get (), type_token_id, type_token_id);
-	MonoClass *klass = mono_class_get (module->image, static_cast<uint32_t>(type_token_id));
-	if (klass == nullptr) {
-		log_error (LOG_ASSEMBLY, "typemap: unable to find managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", type_token_id, module->assembly_name, java_type_name.get ());
-		return nullptr;
-	}
-
-	MonoReflectionType *ret = mono_type_get_object (mono_domain_get (), mono_class_get_type (klass));
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
 
@@ -268,54 +319,107 @@ EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 	return ret;
 }
 
-int
-EmbeddedAssemblies::compare_java_name (const char *java_name, const TypeMapJava *entry)
-{
-	if (entry == nullptr || entry->java_name[0] == '\0') {
-		return -1;
-	}
-
-	return strcmp (java_name, reinterpret_cast<const char*>(entry->java_name));
-}
-
 #if defined (DEBUG) || !defined (ANDROID)
-int
-EmbeddedAssemblies::compare_java_name (const char *java_name, const uint8_t *entry)
+inline const TypeMapEntry*
+EmbeddedAssemblies::typemap_managed_to_java (const char *managed_type_name)
 {
-	if (entry == nullptr)
-		return 1;
+	const TypeMapEntry *entry = nullptr;
 
-	return strcmp (java_name, reinterpret_cast<const char*>(entry));
-}
-#endif // DEBUG || !ANDROID
-
-const char*
-EmbeddedAssemblies::typemap_managed_to_java (const uint8_t *mvid, const int32_t token)
-{
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		timing = new Timing ();
-		total_time.mark_start ();
+	if (application_config.instant_run_enabled) {
+		TypeMap *module;
+		for (size_t i = 0; i < type_map_count; i++) {
+			module = &type_maps[i];
+			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, module->managed_to_java, module->entry_count);
+			if (entry != nullptr)
+				break;
+		}
+	} else {
+		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, type_map.managed_to_java, type_map.entry_count);
 	}
 
+	return entry;
+}
+
+inline const char*
+EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, [[maybe_unused]] const uint8_t *mvid)
+{
+	constexpr char error_message[] = "typemap: unable to find mapping to a Java type from managed type '%s'";
+
+	simple_pointer_guard<char[], false> type_name (mono_type_get_name_full (type, MONO_TYPE_NAME_FORMAT_REFLECTION));
+	MonoImage *image = mono_class_get_image (klass);
+	const char *image_name = mono_image_get_name (image);
+	size_t type_name_len = strlen (type_name.get ());
+	size_t image_name_len = strlen (image_name);
+	size_t full_name_size = type_name_len + image_name_len + 3;
+	const TypeMapEntry *entry = nullptr;
+
+	if (full_name_size > 512) { // Arbitrary, we should be below this limit in most cases
+		char full_name[full_name_size];
+
+		char *p = full_name;
+		memmove (p, type_name.get (), type_name_len);
+		p += type_name_len;
+		*p++ = ',';
+		*p++ = ' ';
+		memmove (p, image_name, image_name_len);
+		p += image_name_len;
+		*p = '\0';
+
+		entry = typemap_managed_to_java (full_name);
+
+		if (XA_UNLIKELY (entry == nullptr)) {
+			log_warn (LOG_ASSEMBLY, error_message, full_name);
+		}
+	} else {
+		simple_pointer_guard<char> full_name = utils.string_concat (type_name.get (), ", ", image_name);
+		entry = typemap_managed_to_java (full_name.get ());
+		if (XA_UNLIKELY (entry == nullptr)) {
+			log_warn (LOG_ASSEMBLY, error_message, full_name.get ());
+		}
+	}
+
+	if (XA_UNLIKELY (entry == nullptr)) {
+		return nullptr;
+	}
+
+	return entry->to;
+}
+#else
+inline int
+EmbeddedAssemblies::compare_type_token (const uint32_t *token, const TypeMapModuleEntry *entry)
+{
+	if (entry == nullptr) {
+		log_fatal (LOG_ASSEMBLY, "typemap: compare_type_token: entry is nullptr");
+		exit (FATAL_EXIT_MISSING_ASSEMBLY);
+	}
+
+	if (*token < entry->type_token_id)
+		return -1;
+	if (*token > entry->type_token_id)
+		return 1;
+	return 0;
+}
+
+inline int
+EmbeddedAssemblies::compare_mvid (const uint8_t *mvid, const TypeMapModule *module)
+{
+	return memcmp (mvid, module->module_uuid, sizeof(module->module_uuid));
+}
+
+inline const char*
+EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, const uint8_t *mvid)
+{
 	if (mvid == nullptr) {
 		log_warn (LOG_ASSEMBLY, "typemap: no mvid specified in call to typemap_managed_to_java");
 		return nullptr;
 	}
 
+	uint32_t token = mono_class_get_type_token (klass);
 	const TypeMapModule *map;
 	size_t map_entry_count;
-#if defined (DEBUG) || !defined (ANDROID)
-	if (application_config.instant_run_enabled) {
-		map = modules;
-		map_entry_count = module_count;
-	} else {
-#endif
-		map = map_modules;
-		map_entry_count = map_module_count;
-#if defined (DEBUG) || !defined (ANDROID)
-	}
-#endif
+	map = map_modules;
+	map_entry_count = map_module_count;
+
 	const TypeMapModule *match = binary_search<uint8_t, TypeMapModule, compare_mvid> (mvid, map, map_entry_count);
 	if (match == nullptr) {
 		log_warn (LOG_ASSEMBLY, "typemap: module matching MVID [%s] not found.", MonoGuidString (mvid).get ());
@@ -329,11 +433,11 @@ EmbeddedAssemblies::typemap_managed_to_java (const uint8_t *mvid, const int32_t 
 
 	log_debug (LOG_ASSEMBLY, "typemap: MVID [%s] maps to assembly %s, looking for token %d (0x%x), table index %d", MonoGuidString (mvid).get (), match->assembly_name, token, token, token & 0x00FFFFFF);
 	// Each map entry is a pair of 32-bit integers: [TypeTokenID][JavaMapArrayIndex]
-	const TypeMapModuleEntry *entry = binary_search <int32_t, TypeMapModuleEntry, compare_type_token> (&token, match->map, match->entry_count);
+	const TypeMapModuleEntry *entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&token, match->map, match->entry_count);
 	if (entry == nullptr) {
 		if (match->duplicate_count > 0 && match->duplicate_map != nullptr) {
 			log_debug (LOG_ASSEMBLY, "typemap: searching module [%s] duplicate map for token %u (0x%x)", MonoGuidString (mvid).get (), token, token);
-			entry = binary_search <int32_t, TypeMapModuleEntry, compare_type_token> (&token, match->duplicate_map, match->duplicate_count);
+			entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&token, match->duplicate_map, match->duplicate_count);
 		}
 
 		if (entry == nullptr) {
@@ -343,40 +447,18 @@ EmbeddedAssemblies::typemap_managed_to_java (const uint8_t *mvid, const int32_t 
 	}
 
 	uint32_t java_entry_count;
-#if defined (DEBUG) || !defined (ANDROID)
-	if (application_config.instant_run_enabled) {
-		java_entry_count = match->entry_count;
-	} else {
-#endif
-		java_entry_count = java_type_count;
-#if defined (DEBUG) || !defined (ANDROID)
-	}
-#endif
+	java_entry_count = java_type_count;
 	if (entry->java_map_index >= java_entry_count) {
 		log_warn (LOG_ASSEMBLY, "typemap: type with token %d (0x%x) in module {%s} (%s) has invalid Java type index %u", token, token, MonoGuidString (mvid).get (), match->assembly_name, entry->java_map_index);
 		return nullptr;
 	}
 
 	const char *ret;
-#if defined (DEBUG) || !defined (ANDROID)
-	if (application_config.instant_run_enabled) {
-		ret = reinterpret_cast<char*>(match->java_map + ((match->java_name_width + 4) * entry->java_map_index));
-	} else {
-#endif
-		const TypeMapJava *java_entry = reinterpret_cast<const TypeMapJava*> (reinterpret_cast<const uint8_t*>(map_java) + ((sizeof(TypeMapJava) + java_name_width) * entry->java_map_index));
-		ret = reinterpret_cast<const char*>(reinterpret_cast<const uint8_t*>(java_entry) + 8);
-#if defined (DEBUG) || !defined (ANDROID)
-	}
-#endif
+	const TypeMapJava *java_entry = reinterpret_cast<const TypeMapJava*> (reinterpret_cast<const uint8_t*>(map_java) + ((sizeof(TypeMapJava) + java_name_width) * entry->java_map_index));
+	ret = reinterpret_cast<const char*>(reinterpret_cast<const uint8_t*>(java_entry) + 8);
 
 	if (XA_UNLIKELY (ret == nullptr)) {
 		log_warn (LOG_ASSEMBLY, "typemap: empty Java type name returned for entry at index %u", entry->java_map_index);
-	}
-
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
-
-		Timing::info (total_time, "Typemap.managed_to_java: end, total time");
 	}
 
 	log_debug (
@@ -391,22 +473,32 @@ EmbeddedAssemblies::typemap_managed_to_java (const uint8_t *mvid, const int32_t 
 
 	return ret;
 }
+#endif
 
-int
-EmbeddedAssemblies::compare_type_token (const int32_t *token, const TypeMapModuleEntry *entry)
+const char*
+EmbeddedAssemblies::typemap_managed_to_java (MonoReflectionType *reflection_type, const uint8_t *mvid)
 {
-	if (entry == nullptr) {
-		log_fatal (LOG_ASSEMBLY, "typemap: compare_type_token: entry is nullptr");
-		exit (FATAL_EXIT_MISSING_ASSEMBLY);
+	timing_period total_time;
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		timing = new Timing ();
+		total_time.mark_start ();
 	}
 
-	return *token - entry->type_token_id;
-}
+	MonoType *type = mono_reflection_type_get_type (reflection_type);
+	if (type == nullptr) {
+		log_warn (LOG_DEFAULT, "Failed to map reflection type to MonoType");
+		return nullptr;
+	}
 
-int
-EmbeddedAssemblies::compare_mvid (const uint8_t *mvid, const TypeMapModule *module)
-{
-	return memcmp (mvid, module->module_uuid, sizeof(module->module_uuid));
+	const char *ret = typemap_managed_to_java (type, mono_type_get_class (type), mvid);
+
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		total_time.mark_end ();
+
+		Timing::info (total_time, "Typemap.managed_to_java: end, total time");
+	}
+
+	return ret;
 }
 
 EmbeddedAssemblies::md_mmap_info
@@ -545,10 +637,8 @@ EmbeddedAssemblies::typemap_read_header ([[maybe_unused]] int dir_fd, const char
 uint8_t*
 EmbeddedAssemblies::typemap_load_index (TypeMapIndexHeader &header, size_t file_size, int index_fd)
 {
-	constexpr size_t UUID_SIZE = 16;
-
-	size_t entry_size = header.module_file_name_width + UUID_SIZE;
-	size_t data_size = entry_size * module_count;
+	size_t entry_size = header.module_file_name_width;
+	size_t data_size = entry_size * type_map_count;
 	if (sizeof(header) + data_size > file_size) {
 		log_error (LOG_ASSEMBLY, "typemap: index file is too small, expected %u, found %u bytes", data_size + sizeof(header), file_size);
 		return nullptr;
@@ -562,9 +652,8 @@ EmbeddedAssemblies::typemap_load_index (TypeMapIndexHeader &header, size_t file_
 	}
 
 	uint8_t *p = data;
-	for (size_t i = 0; i < module_count; i++) {
-		memcpy (modules[i].module_uuid, p, UUID_SIZE);
-		modules[i].assembly_name = reinterpret_cast<char*>(p + UUID_SIZE);
+	for (size_t i = 0; i < type_map_count; i++) {
+		type_maps[i].assembly_name = reinterpret_cast<char*>(p);
 		p += entry_size;
 	}
 
@@ -585,8 +674,8 @@ EmbeddedAssemblies::typemap_load_index (int dir_fd, const char *dir_path, const 
 		goto cleanup;
 	}
 
-	module_count = header.entry_count;
-	modules = new TypeMapModule[module_count]();
+	type_map_count = header.entry_count;
+	type_maps = new TypeMap[type_map_count]();
 	data = typemap_load_index (header, file_size, fd);
 
   cleanup:
@@ -597,72 +686,72 @@ EmbeddedAssemblies::typemap_load_index (int dir_fd, const char *dir_path, const 
 }
 
 bool
-EmbeddedAssemblies::typemap_load_file (BinaryTypeMapHeader &header, const char *dir_path, const char *file_path, int file_fd, TypeMapModule &module)
+EmbeddedAssemblies::typemap_load_file (BinaryTypeMapHeader &header, const char *dir_path, const char *file_path, int file_fd, TypeMap &module)
 {
 	size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, header.assembly_name_length, 1);
 	module.assembly_name = new char[alloc_size];
 
 	ssize_t nread = do_read (file_fd, module.assembly_name, header.assembly_name_length);
+	if (nread != static_cast<ssize_t>(header.assembly_name_length)) {
+		log_error (LOG_ASSEMBLY, "tyemap: failed to read map assembly name from '%s/%s': %s", dir_path, file_path, strerror (errno));
+		return false;
+	}
+
 	module.assembly_name [header.assembly_name_length] = 0;
 	module.entry_count = header.entry_count;
 
 	log_debug (
 		LOG_ASSEMBLY,
-		"typemap: '%s/%s':: entry count == %u; duplicate entry count == %u; Java type name field width == %u; MVID == %s; assembly name length == %u; assembly name == %s",
-		dir_path, file_path, header.entry_count, header.duplicate_count, header.java_name_width,
-		MonoGuidString (header.module_uuid).get (), header.assembly_name_length, module.assembly_name
+		"typemap: '%s/%s':: entry count == %u; Java name field width == %u; Managed name width == %u; assembly name length == %u; assembly name == %s",
+		dir_path, file_path, header.entry_count, header.java_name_width, header.managed_name_width, header.assembly_name_length, module.assembly_name
 	);
 
-	alloc_size = MULTIPLY_WITH_OVERFLOW_CHECK (size_t, header.java_name_width + 4, header.entry_count);
-	module.java_name_width = header.java_name_width;
-	module.java_map = new uint8_t[alloc_size];
-	nread = do_read (file_fd, module.java_map, alloc_size);
-	if (nread != static_cast<ssize_t>(alloc_size)) {
-		log_error (LOG_ASSEMBLY, "typemap: failed to read %u bytes (java-to-managed) from module file %s/%s. %s", alloc_size, dir_path, file_path, strerror (errno));
+	// [name][index]
+	size_t java_entry_size = header.java_name_width + sizeof(uint32_t);
+	size_t managed_entry_size = header.managed_name_width + sizeof(uint32_t);
+	size_t data_size = ADD_WITH_OVERFLOW_CHECK (
+		size_t,
+		header.entry_count * java_entry_size,
+		header.entry_count * managed_entry_size
+	);
+
+	module.data = new uint8_t [data_size];
+	nread = do_read (file_fd, module.data, data_size);
+	if (nread != static_cast<ssize_t>(data_size)) {
+		log_error (LOG_ASSEMBLY, "tyemap: failed to read map data from '%s/%s': %s", dir_path, file_path, strerror (errno));
 		return false;
 	}
 
-	module.map = new TypeMapModuleEntry[header.entry_count];
-	alloc_size = MULTIPLY_WITH_OVERFLOW_CHECK (size_t, sizeof(TypeMapModuleEntry), header.entry_count);
-	nread = do_read (file_fd, module.map, alloc_size);
-	if (nread != static_cast<ssize_t>(alloc_size)) {
-		log_error (LOG_ASSEMBLY, "typemap: failed to read %u bytes (managed-to-java) from module file %s/%s. %s", alloc_size, dir_path, file_path, strerror (errno));
-		return false;
-	}
+	module.java_to_managed = new TypeMapEntry [module.entry_count];
+	module.managed_to_java = new TypeMapEntry [module.entry_count];
 
-	// alloc_size = module.java_name_width + 1;
-	// auto chars = new char[alloc_size]();
-	// uint8_t *p = module.java_map;
-	// log_debug (LOG_ASSEMBLY, "Java entries in %s/%s", dir_path, file_path);
-	// for (size_t i = 0; i < module.entry_count; i++) {
-	// 	memcpy (chars, p, module.java_name_width);
-	// 	uint32_t token = *reinterpret_cast<const uint32_t*>(p + module.java_name_width);
-	// 	log_debug (LOG_ASSEMBLY, "  %04u: %s; %u (0x%x)", i, chars, token, token);
-	// 	p += module.java_name_width + 4;
-	// }
-	// delete[] chars;
+	uint8_t *java_start = module.data;
+	uint8_t *managed_start = module.data + (module.entry_count * java_entry_size);
+	uint8_t *java_pos = java_start;
+	uint8_t *managed_pos = managed_start;
+	TypeMapEntry *cur;
 
-	// log_debug (LOG_ASSEMBLY, "Managed entries in %s/%s", dir_path, file_path);
-	// for (size_t i = 0; i < module.entry_count; i++) {
-	// 	log_debug (LOG_ASSEMBLY, "  %04u: token %u (0x%x); index %u", i, module.map[i].type_token_id, module.map[i].type_token_id, module.map[i].java_map_index);
-	// }
+	for (size_t i = 0; i < module.entry_count; i++) {
+		cur = &module.java_to_managed[i];
+		cur->from = reinterpret_cast<char*>(java_pos);
 
-	if (header.duplicate_count == 0)
-		return true;
+		uint32_t idx = *(reinterpret_cast<uint32_t*>(java_pos + header.java_name_width));
+		cur->to = reinterpret_cast<char*>(managed_start + (managed_entry_size * idx));
+		java_pos += java_entry_size;
 
-	module.duplicate_map = new TypeMapModuleEntry[header.duplicate_count];
-	alloc_size = MULTIPLY_WITH_OVERFLOW_CHECK (size_t, sizeof(TypeMapModuleEntry), header.duplicate_count);
-	nread = do_read (file_fd, module.duplicate_map, alloc_size);
-	if (nread != static_cast<ssize_t>(alloc_size)) {
-		log_error (LOG_ASSEMBLY, "typemap: failed to read %u bytes (managed-to-java duplicates) from module file %s/%s. %s", alloc_size, dir_path, file_path, strerror (errno));
-		return false;
+		cur = &module.managed_to_java[i];
+		cur->from = reinterpret_cast<char*>(managed_pos);
+
+		idx = *(reinterpret_cast<uint32_t*>(managed_pos + header.managed_name_width));
+		cur->to = reinterpret_cast<char*>(java_start + (java_entry_size * idx));
+		managed_pos += managed_entry_size;
 	}
 
 	return true;
 }
 
 bool
-EmbeddedAssemblies::typemap_load_file (int dir_fd, const char *dir_path, const char *file_path, TypeMapModule &module)
+EmbeddedAssemblies::typemap_load_file (int dir_fd, const char *dir_path, const char *file_path, TypeMap &module)
 {
 	log_debug (LOG_ASSEMBLY, "typemap: loading TypeMap file '%s/%s'", dir_path, file_path);
 
@@ -671,11 +760,10 @@ EmbeddedAssemblies::typemap_load_file (int dir_fd, const char *dir_path, const c
 	size_t file_size;
 	int fd = -1;
 
-	module.java_map = nullptr;
-	module.map = nullptr;
-	module.duplicate_map = nullptr;
+	module.java_to_managed = nullptr;
+	module.managed_to_java = nullptr;
 
-	if (!typemap_read_header (dir_fd, "TypeMap", dir_path, file_path, MODULE_MAGIC, header, file_size, fd)) {
+	if (!typemap_read_header (dir_fd, "TypeMap", dir_path, file_path, MODULE_MAGIC_NAMES, header, file_size, fd)) {
 		ret = false;
 		goto cleanup;
 	}
@@ -687,12 +775,10 @@ EmbeddedAssemblies::typemap_load_file (int dir_fd, const char *dir_path, const c
 		close (fd);
 
 	if (!ret) {
-		delete[] module.java_map;
-		module.java_map = nullptr;
-		delete[] module.map;
-		module.map = nullptr;
-		delete[] module.duplicate_map;
-		module.duplicate_map = nullptr;
+		delete[] module.java_to_managed;
+		module.java_to_managed = nullptr;
+		delete[] module.managed_to_java;
+		module.managed_to_java = nullptr;
 	}
 
 	return ret;
@@ -730,9 +816,9 @@ EmbeddedAssemblies::try_load_typemaps_from_directory (const char *path)
 		exit (FATAL_EXIT_NO_ASSEMBLIES); // TODO: use a new error code here
 	}
 
-	for (size_t i = 0; i < module_count; i++) {
-		TypeMapModule &module = modules[i];
-		if (!typemap_load_file (dir_fd, dir_path, module.assembly_name, module)) {
+	for (size_t i = 0; i < type_map_count; i++) {
+		TypeMap *module = &type_maps[i];
+		if (!typemap_load_file (dir_fd, dir_path, module->assembly_name, *module)) {
 			continue;
 		}
 	}

--- a/src/monodroid/jni/external-api.cc
+++ b/src/monodroid/jni/external-api.cc
@@ -158,12 +158,6 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 	return monodroidRuntime.get_display_dpi (x_dpi, y_dpi);
 }
 
-MONO_API const char *
-monodroid_typemap_managed_to_java (const uint8_t *mvid, const int32_t token)
-{
-	return embeddedAssemblies.typemap_managed_to_java (mvid, token);
-}
-
 MONO_API int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix)
 {
 	embeddedAssemblies.set_assemblies_prefix (prefix);

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -178,6 +178,8 @@ namespace xamarin::android::internal
 		static void thread_end (MonoProfiler *prof, uintptr_t tid);
 		static MonoReflectionType* typemap_java_to_managed (MonoString *java_type_name);
 
+		static const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid);
+
 #if defined (DEBUG)
 		void set_debug_env_vars (void);
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -921,6 +921,7 @@ void
 MonodroidRuntime::init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader)
 {
 	mono_add_internal_call ("Java.Interop.TypeManager::monodroid_typemap_java_to_managed", reinterpret_cast<const void*>(typemap_java_to_managed));
+	mono_add_internal_call ("Android.Runtime.JNIEnv::monodroid_typemap_managed_to_java", reinterpret_cast<const void*>(typemap_managed_to_java));
 
 	struct JnienvInitializeArgs init = {};
 	init.javaVm                 = osBridge.get_jvm ();
@@ -1409,6 +1410,12 @@ MonoReflectionType*
 MonodroidRuntime::typemap_java_to_managed (MonoString *java_type_name)
 {
 	return embeddedAssemblies.typemap_java_to_managed (java_type_name);
+}
+
+const char*
+MonodroidRuntime::typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid)
+{
+	return embeddedAssemblies.typemap_managed_to_java (type, mvid);
 }
 
 inline void

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -285,13 +285,13 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Install (proj), "packaging should have succeeded. 0");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
-				Assert.IsNull (ZipHelper.ReadFileFromZip (apk, "MonoAndroid.0.typemap"), $"MonoAndroid.0.typemap should NOT be in {apk}.");
+				Assert.IsNull (ZipHelper.ReadFileFromZip (apk, "Mono.Android.typemap"), $"Mono.Android.typemap should NOT be in {apk}.");
 				var logLines = b.LastBuildOutput;
 				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_BuildApkFastDev\" completely.") ||
 					l.Contains ("Target _BuildApkFastDev needs to be built")),
 					"Apk should have been built");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_Upload\" completely")), "_Upload target should have run");
-				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Mono.Android.0.typemap")), "Mono.Android.0.typemap should have been uploaded");
+				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Mono.Android.typemap")), "Mono.Android.typemap should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("typemap.index")), "typemap.index should have been uploaded");
 			}
 		}

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -6,10 +6,10 @@ Build_From_Clean_DontIncludeRestore,10000
 Build_No_Changes,3250
 Build_CSharp_Change,4450
 Build_AndroidResource_Change,4150
-Build_AndroidManifest_Change,4350
+Build_AndroidManifest_Change,4400
 Build_Designer_Change,3600
-Build_JLO_Change,8700
-Build_CSProj_Change,9500
+Build_JLO_Change,9100
+Build_CSProj_Change,9800
 Build_XAML_Change,9400
 Build_XAML_Change_RefAssembly,6000
 Install_CSharp_Change,5000


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4415
Context: https://github.com/xamarin/xamarin-android/commit/ce2bc689a19cb45f7d7bfdd371c16c54b018a020

This commit partially reverts ce2bc689a19cb45f7d7bfdd371c16c54b018a020
in the sense that it restores the use of type names for Java-to-Managed
and Managed-to-Java type lookups for **Debug** builds only.

The reason for the change is that in order for the MVID and type token
based lookups to work we need two things:

  - for the MVID to remain unchanged in each mapped assembly
  - for the type token to remain unchanged in each mapped assembly

However, in incremental builds neither of the above requirements is
met **unless** the application is fully rebuilt and, thus, the typemaps
are regenerated from scratch, which obviously doesn't sit well with the
incremental nature of incremental builds :)

With MVID/token id maps, every change to any source code that's built
into a mapped assembly, may cause the assembly to change its MVID and
renaming of any type, removing or adding a type, will rearrange the type
definition table in the resulting assembly, thus changing the type token
ids (which are basically offsets into the type definition table in the
PE executable). This is what may cause an app to crash on the runtime
with an exception similar to:

    android.runtime.JavaProxyThrowable: System.NotSupportedException: Cannot create instance of type 'com.glmsoftware.OBDNowProto.SettingsFragmentCompat': no Java peer type found.
      at Java.Interop.JniPeerMembers+JniInstanceMethods..ctor (System.Type declaringType) [0x0004b] in <e3e4dfa992a7411b85acfe193481be3e>:0
      at Java.Interop.JniPeerMembers+JniInstanceMethods.GetConstructorsForType (System.Type declaringType) [0x00031] in <e3e4dfa992a7411b85acfe193481be3e>:0
      at Java.Interop.JniPeerMembers+JniInstanceMethods.StartCreateInstance (System.String constructorSignature, System.Type declaringType, Java.Interop.JniArgumentValue* parameters) [0x00038] in <e3e4dfa992a7411b85acfe193481be3e>:0
      at AndroidX.Preference.PreferenceFragmentCompat..ctor () [0x00034] in <005e3ae6340747e1aea6d08b095cf286>:0
      at com.glmsoftware.OBDNowProto.SettingsFragmentCompat..ctor () [0x00026] in <a8dbee4be1674aa08cce57b50f21e347>:0
      at com.glmsoftware.OBDNowProto.SettingsActivity.OnCreate (Android.OS.Bundle bundle) [0x00083] in <a8dbee4be1674aa08cce57b50f21e347>:0
      at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_savedInstanceState) [0x00011] in <c56099afccf04721853684f376a89527>:0
        at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.3(intptr,intptr,intptr)
        at crc64596a13587a898911.SettingsActivity.n_onCreate(Native Method)
        at crc64596a13587a898911.SettingsActivity.onCreate(SettingsActivity.java:40)
        at android.app.Activity.performCreate(Activity.java:7825)
        at android.app.Activity.performCreate(Activity.java:7814)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1306)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)

Thus, we need to revert the Debug builds to the variation of the old
string-based type name mapping. This commit implements it in a slightly
leaner form than it was implemented before
ce2bc689a19cb45f7d7bfdd371c16c54b018a020 landed in that only one copy of
each set of type names (Java and managed) is maintained in both memory
and on disk, at a tiny (sub millisecond) expense at the run time to fix
up pointers between the two tables.