### PR TITLE
[tests] Let Xamarin.Android-Tests.sln load in VSMac without errors

### DIFF
--- a/Xamarin.Android-Tests.sln
+++ b/Xamarin.Android-Tests.sln
@@ -52,7 +52,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.BindingReso
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.BindingResolveImports-Tests", "tests\ResolveImports\Xamarin.Android.BindingResolveImports-Tests\Xamarin.Android.BindingResolveImports-Tests.csproj", "{B297008B-C313-455E-B230-E119589D2D79}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Xamarin.Forms.Performance.Integration", "tests\Xamarin.Forms-Performance-Integration\Xamarin.Forms.Performance.Integration.csproj", "{195BE9C2-1F91-40DC-BD6D-DE860BF083FB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Performance.Integration", "tests\Xamarin.Forms-Performance-Integration\Xamarin.Forms.Performance.Integration.csproj", "{195BE9C2-1F91-40DC-BD6D-DE860BF083FB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Performance.Integration.Droid", "tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj", "{576312CC-83FF-48B1-A473-488CDC7121AD}"
 EndProject


### PR DESCRIPTION
The VSMac was complaining loading the XF test subproject:

    Error while trying to load the project 'tests/Xamarin.Forms-Performance-Integration/Xamarin.Forms.Performance.Integration.csproj': Project Xamarin.Forms.Performance.Integration is being loaded as a Shared Assets project but has a different file extension. Please check the project type GUID in the solution file is correct.

The GUID used means: Visual C#: {FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}
https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/adding-items-to-the-add-new-item-dialog-boxes?view=vs-2019