### PR TITLE
[build] /restore no longer needed on Windows

### DIFF
--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -36,7 +36,7 @@ MSBuild version 15 or later is required.
 
  7. Build the project:
 
-        msbuild /restore Xamarin.Android.sln
+        msbuild Xamarin.Android.sln
 
 After the solution has built successfully, you can [use your
 build][using-your-build] to build Xamarin.Android application and library

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -274,11 +274,11 @@ stages:
         msbuildArguments: /t:Prepare /p:AutoProvision=true /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog
 
     - task: MSBuild@1
-      displayName: msbuild Xamarin.Android /t:Build
+      displayName: msbuild Xamarin.Android
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /restore /t:Build /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog
+        msbuildArguments: /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog
 
     - task: MSBuild@1
       displayName: msbuild create-vsix

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -23,5 +23,6 @@
     />
     <Exec Command="$(_XAPrepareExe) $(_XAPrepareStandardArgs) -a" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(_TopDir)\Xamarin.Android.BootstrapTasks.sln" Targets="Restore;Build" />
+    <MSBuild Projects="$(_TopDir)\Xamarin.Android.sln" Targets="Restore" />
   </Target>
 </Project>


### PR DESCRIPTION
On macOS,  you can generally build with just:

    make prepare all

On Windows:

    msbuild Xamarin.Android.sln /t:Prepare
    msbuild Xamarin.Android.sln

In 295aff28, we introduced some changes that now require a change to
the second step:

    msbuild Xamarin.Android.sln /restore

I think we can add a call at the end of `/t:Prepare`:

    <MSBuild Projects="$(_TopDir)\Xamarin.Android.sln" Targets="Restore" />

This way you don't have to remember the `/restore` switch.

Lastly, I updated the Windows `Build and Smoke Test` phase on Azure
DevOps, so it will build on Windows without `/restore`.