### PR TITLE
[.NET 5] Start adding some project capabilities

### DIFF
--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
@@ -16,4 +16,11 @@
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.Tooling.targets" />
 
+  <!-- Automatically supply project capabilities for IDE use -->
+  <ItemGroup>
+    <ProjectCapability Include="Mobile" />
+    <ProjectCapability Include="Android" />
+    <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4383

Visual Studio uses CPS to load SDK-style projects. In CPS, most things
are keyed-off so-called [capabilities][0] which replace other methods that
were used previously like project type GUIDs.

While capabilities can be defined in the IDE, they make most sense to be
directly expressed in the targets themselves where CPS will pick them up
automatically.

After discussing with @kzu, simply using `Android` could be confusing
with native C++ Android project that export the same capability. By
combining `Managed + Mobile + Android` we can make a clear distinction
that we are dealing with a Xamarin.Android project.

[0]: https://github.com/microsoft/VSProjectSystem/blob/master/doc/overview/about_project_capabilities.md