### PR TITLE
[build] <RunParallelCmds/> should call LogError

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunParallelCmds.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 							var errOutput = errorOutput.ToString ();
 
 							if (proc.ExitCode != 0) {
-								LogMessage ($"Non-zero exit code: {proc.ExitCode}  Error output: {errOutput}", MessageImportance.High);
+								LogError ($"\"{proc.StartInfo.FileName} {proc.StartInfo.Arguments}\" failed with code: {proc.ExitCode}  Error output: {errOutput}");
 								success = false;
 							}
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3598843&view=logs&j=cac0e8d3-0ef5-5d2b-b57e-e8fde7204df3&s=14c5bb15-e916-5bc3-7b8f-0ac5dbe45c97&t=d0eaacf3-179f-5217-7519-cd03bc45e5e4&l=10948

We had a build fail that said:

    Process 'msbuild.exe' exited with code '1'.

And yet:

    0 Error(s)

The only to figure out the true error is to do something like:

    $ msbuild foo.binlog /v:diag | grep FAILED

This shows that `<RunParallelCmds/>` failed, but didn't log any
errors. This means `Execute()` returned `false`.

It looks like the real error is:

    Non-zero exit code: 1  Error output: ...

I changed it to call `LogError` instead of `LogMessage`, so it will be
easier to track down failures.