### PR TITLE
[tests] Use `adb logcat -d` to dump logcat buffer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Build.Tests
 				RunAdbCommand ($"shell screencap {remote}");
 				RunAdbCommand ($"pull {remote} \"{local}\"");
 				RunAdbCommand ($"shell rm {remote}");
-				RunAdbCommand ($"logcat > {deviceLog}", timeout: 5);
+				RunAdbCommand ($"logcat -d > {deviceLog}");
 				TestContext.AddTestAttachment (local);
 				TestContext.AddTestAttachment (deviceLog);
 			}


### PR DESCRIPTION
Currently, the on-device MSBuild integration tests (and possibly others)
fail to properly record the full logcat buffer of the test run because
they run `adb logcat`, wait 5 seconds and kill the process. This results
in most log (if not all) files to be cut short (the sizes I saw were
between 20 and 80k) and thus not contain the useful information like the
process crash. The crash information is found towards the end of the
logcat, with the amount of text that is produced now that is at around
400k.

logcat supports the `-d` option which makes the command dump the buffer
to output and exit, thus removing the need to monitor and kill the
command after a timeout is reached.

This commit adds the `-d` argument and also reverts the 5s timeout to
the standard timeout for all adb commands in the test suite (currently
30s).

The change will, hopefully, let us enjoy reading all the crashes we
encounter in our tests on CI bots :)