### PR TITLE
ApiCompat enhancements

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -10,8 +10,8 @@
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20162.4" IncludeAssets="none" />
-    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20162.4" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20181.7" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20181.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CodeGenDiff.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CodeGenDiff.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public sealed class CodeGenDiff
+	{
+		public static List<string> GenerateMissingItems (string codeGenPath, string contractAssembly, string implementationAssembly)
+		{
+			var contract = GenerateObjectDescription (codeGenPath, contractAssembly);
+			var implementation = GenerateObjectDescription (codeGenPath, implementationAssembly);
+
+			return Diff (contract, implementation);
+		}
+
+		static List<string> Diff (ObjectDescription contract, ObjectDescription implementation)
+		{
+			System.Diagnostics.Trace.Assert (contract.Item == implementation.Item, "Comparing object should be the same.");
+
+			var missingItems = new List<string> ();
+			var internalMissingItems = new List<string> ();
+
+			foreach (var obj in contract.InnerObjects) {
+				var implObj = implementation.InnerObjects.SingleOrDefault (i => i.Item == obj.Item);
+				if (implObj == null) {
+					internalMissingItems.Add ($"-{obj.Item}");
+					continue;
+				}
+
+				internalMissingItems.AddRange (Diff (obj, implObj));
+			}
+
+			foreach (var att in contract.Attributes) {
+				if (!implementation.Attributes.Contains (att)) {
+					missingItems.Add ($"-{att}");
+				}
+			}
+
+			if (contract.Item == "root") {
+				return internalMissingItems;
+			}
+
+			if (internalMissingItems.Any () || missingItems.Any ()) {
+				missingItems.Add ($"{contract.Item}");
+				if (internalMissingItems.Any ()) {
+					missingItems.Add ("{");
+					missingItems.AddRange (internalMissingItems);
+					missingItems.Add ("}");
+				}
+			}
+
+			return missingItems;
+		}
+
+		static ObjectDescription GenerateObjectDescription (string codeGenPath, string assembly)
+		{
+			ObjectDescription currentObject = new ObjectDescription () { Item = "root" };
+			var objectStack = new Stack<ObjectDescription> ();
+			objectStack.Push (currentObject);
+
+			var codeGen = Path.Combine (codeGenPath, "Microsoft.DotNet.GenAPI.exe");
+			using (var genApiProcess = new Process ()) {
+
+				genApiProcess.StartInfo.FileName = codeGen;
+				genApiProcess.StartInfo.Arguments = $"\"{assembly}\"";
+
+				genApiProcess.StartInfo.UseShellExecute = false;
+				genApiProcess.StartInfo.CreateNoWindow = true;
+				genApiProcess.StartInfo.RedirectStandardOutput = true;
+				genApiProcess.StartInfo.RedirectStandardError = true;
+				genApiProcess.EnableRaisingEvents = true;
+
+				var line = 0;
+
+				void dataReceived (object sender, DataReceivedEventArgs args)
+				{
+					line++;
+					var content = args.Data?.Trim ();
+
+					if (string.IsNullOrWhiteSpace (content) || content.StartsWith ("//", StringComparison.OrdinalIgnoreCase) || content.StartsWith ("Unable to resolve assembly", StringComparison.OrdinalIgnoreCase)) {
+						return;
+					}
+
+					if (content.StartsWith ("[", StringComparison.OrdinalIgnoreCase)) {
+						if (!string.IsNullOrWhiteSpace (currentObject.Item)) {
+							var newObject = new ObjectDescription ();
+							currentObject.InnerObjects.Add (newObject);
+							objectStack.Push (newObject);
+							currentObject = newObject;
+						}
+
+						currentObject.Attributes.Add (content);
+						return;
+					}
+
+					if (content.StartsWith ("{", StringComparison.OrdinalIgnoreCase)) {
+						currentObject.InternalCounter++;
+						return;
+					}
+
+					if (content.StartsWith ("}", StringComparison.OrdinalIgnoreCase)) {
+						currentObject.InternalCounter--;
+						System.Diagnostics.Debug.Assert (currentObject.InternalCounter >= 0);
+						if (currentObject.InternalCounter == 0) {
+							objectStack.Pop ();
+							if (objectStack.Count > 0) {
+								currentObject = objectStack.Peek ();
+							}
+						}
+
+						return;
+					}
+
+					if (content.StartsWith ("namespace ") || content.IndexOf (" interface ") != -1 || content.IndexOf (" class ") != -1 || content.IndexOf (" partial struct ") != -1 || content.IndexOf (" enum ") != -1) {
+						if (string.IsNullOrWhiteSpace (currentObject.Item)) {
+							currentObject.Item = content;
+						} else {
+							var newObject = new ObjectDescription () { Item = content };
+							currentObject.InnerObjects.Add (newObject);
+							objectStack.Push (newObject);
+							currentObject = newObject;
+						}
+
+						return;
+					}
+
+
+					if (string.IsNullOrWhiteSpace (currentObject.Item)) {
+						currentObject.Item = content;
+						objectStack.Pop ();
+						currentObject = objectStack.Peek ();
+					} else {
+						var newObject = new ObjectDescription () { Item = content };
+						currentObject.InnerObjects.Add (newObject);
+					}
+				}
+
+
+				genApiProcess.OutputDataReceived += dataReceived;
+				genApiProcess.ErrorDataReceived += dataReceived;
+
+				genApiProcess.Start ();
+				genApiProcess.BeginOutputReadLine ();
+				genApiProcess.BeginErrorReadLine ();
+
+				genApiProcess.WaitForExit ();
+
+				genApiProcess.CancelOutputRead ();
+				genApiProcess.CancelErrorRead ();
+
+			}
+
+			return currentObject;
+		}
+
+		class ObjectDescription
+		{
+			public string Item;
+
+			public HashSet<string> Attributes = new HashSet<string> ();
+
+			public List<ObjectDescription> InnerObjects = new List<ObjectDescription> ();
+
+			public int InternalCounter;
+		}
+	}
+}

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.GitDiff" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckApiCompatibility" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
@@ -188,38 +187,23 @@
       Name="_CheckApiCompatibility"
       Condition=" '$(DisableApiCompatibilityCheck)' != 'True' "
       AfterTargets="CopyFilesToOutputDirectory"
+
       Inputs="$(TargetPath);@(ApiCompatibilityFiles)"
       Outputs="$(IntermediateOutputPath)CheckApiCompatibility.stamp">
     <CheckApiCompatibility
-        ContinueOnError="ErrorAndContinue"
-        ApiCompatPath="$(XAPackagesDir)\microsoft.dotnet.apicompat\5.0.0-beta.20162.4\tools\net472\"
+        ApiCompatPath="$(XAPackagesDir)\microsoft.dotnet.apicompat\5.0.0-beta.20181.7\tools\net472\"
+        CodeGenPath="$(XAPackagesDir)\microsoft.dotnet.genapi\5.0.0-beta.20181.7\tools\net472\"
         ApiLevel="$(AndroidFrameworkVersion)"
         LastStableApiLevel="$(AndroidLatestStableFrameworkVersion)"
         TargetImplementationPath="$(OutputPath)"
         ApiCompatibilityPath="$(ApiCompatibilityDir)"
     />
-    <PropertyGroup>
-      <_RunApiDiff Condition=" '$(MSBuildLastTaskResult)' == 'False' ">True</_RunApiDiff>
-      <_GenAPI>"$(XAPackagesDir)\microsoft.dotnet.genapi\5.0.0-beta.20162.4\tools\net472\Microsoft.DotNet.GenAPI.exe"</_GenAPI>
-      <_ContractRefSrc>"$(ApiCompatibilityDir)\reference\Mono.Android.dll.cs"</_ContractRefSrc>
-      <_TargetRefSrc>"$(TargetPath).cs"</_TargetRefSrc>
-    </PropertyGroup>
-    <Exec
-        Condition=" '$(_RunApiDiff)' == 'True' "
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_GenAPI) &quot;$(TargetPath)&quot; > $(_TargetRefSrc)"
-    />
-    <GitDiff
-        Condition=" '$(_RunApiDiff)' == 'True' "
-        ContinueOnError="ErrorAndContinue"
-        Arguments="--no-index $(_ContractRefSrc) $(_TargetRefSrc)"
-        WorkingDirectory="$(MSBuildThisFileDirectory)"
-    />
-    <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)CheckApiCompatibility.stamp" />
-    </ItemGroup>
     <Touch
         Files="$(IntermediateOutputPath)CheckApiCompatibility.stamp"
         AlwaysCreate="True"
     />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)CheckApiCompatibility.stamp" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1092,6 +1092,9 @@
   <!-- Similarly, API-18 only had android.graphics.Bitmap.isPremultiplied(); Don't merge with the API-19+ Bitmap.setPremultiplied() method. -->
   <attr api-since="19" path="/api/package[@name='android.graphics']/class[@name='Bitmap']/method[@name='setPremultiplied']" name="propertyName" />
 
+  <!-- API-R adds a Connection.getVideoState() method, but we can't "merge" getVideoState() & setVideoState() into a single property w/o breaking API compat -->
+  <attr api-since="23" path="/api/package[@name='android.telecom']/class[@jni-signature='Landroid/telecom/Connection;']/method[@name='setVideoState']" name="propertyName" />
+
   <!-- Deprecate Any Class in the API less than 10. Do This last so we override any other deprecate comments -->
   <attr api-until="9" path="/api/package/class" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>
   <attr api-until="9" path="/api/package/interface" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>
@@ -1391,7 +1394,7 @@
        When there's more than one method on the Interface (API-30+), the attribute needs to go on the Method instead. -->
   <attr api-until="30" path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']" name="argsType">MediaCasEventArgs</attr>
   <attr api-since="30" path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']" name="argsType">MediaCasEventArgs</attr>
-  
+
   <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']/parameter[@name='MediaCas']" name="managedName">mediaCas</attr>
 
   <!-- Until API Level 26, android.graphics.Color was static. In API Level 26,
@@ -1554,7 +1557,7 @@
 
   <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.
        To preserve backwards compatibility, we need to "un-nest" anything added before API-30 -->
-  
+
   <!-- Handle everything that has always existed (no @merge.SourceFile) -->
   <attr api-since="30" path="/api/package/interface[not(@merge.SourceFile)]" name="unnest">true</attr>
   <attr api-since="30" path="/api/package/class[not(@merge.SourceFile)]" name="unnest">true</attr>

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1093,9 +1093,7 @@
   <attr api-since="19" path="/api/package[@name='android.graphics']/class[@name='Bitmap']/method[@name='setPremultiplied']" name="propertyName" />
 
   <!-- API-R adds a Connection.getVideoState() method, but we can't "merge" getVideoState() & setVideoState() into a single property w/o breaking API compat -->
-  <!--
   <attr api-since="23" path="/api/package[@name='android.telecom']/class[@jni-signature='Landroid/telecom/Connection;']/method[@name='setVideoState']" name="propertyName" />
-    -->
 
   <!-- Deprecate Any Class in the API less than 10. Do This last so we override any other deprecate comments -->
   <attr api-until="9" path="/api/package/class" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1336,7 +1336,7 @@
   in very early age of this product, and then Google introduced name conflicts.
   (It's all Xamarin's fault to have introduced enumification, after all. -->
   <attr path="/api/package[@name='android.media']/class[@name='AudioFocusRequest']" name="managedName" api-since="26">AudioFocusRequestClass</attr>
-  
+
   <!-- FIXME: fix build and enable these packages -->
   <remove-node path="/api/package[@name='java.time']" api-since="26" />
   <remove-node path="/api/package[@name='java.time.chrono']" api-since="26" />
@@ -1396,7 +1396,7 @@
        When there's more than one method on the Interface (API-30+), the attribute needs to go on the Method instead. -->
   <attr api-until="30" path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']" name="argsType">MediaCasEventArgs</attr>
   <attr api-since="30" path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']" name="argsType">MediaCasEventArgs</attr>
-
+  
   <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']/parameter[@name='MediaCas']" name="managedName">mediaCas</attr>
 
   <!-- Until API Level 26, android.graphics.Color was static. In API Level 26,

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1093,7 +1093,9 @@
   <attr api-since="19" path="/api/package[@name='android.graphics']/class[@name='Bitmap']/method[@name='setPremultiplied']" name="propertyName" />
 
   <!-- API-R adds a Connection.getVideoState() method, but we can't "merge" getVideoState() & setVideoState() into a single property w/o breaking API compat -->
+  <!--
   <attr api-since="23" path="/api/package[@name='android.telecom']/class[@jni-signature='Landroid/telecom/Connection;']/method[@name='setVideoState']" name="propertyName" />
+    -->
 
   <!-- Deprecate Any Class in the API less than 10. Do This last so we override any other deprecate comments -->
   <attr api-until="9" path="/api/package/class" name="deprecated">This platform is deprecated. Please re-target your app for a minumum of API-10</attr>
@@ -1334,7 +1336,7 @@
   in very early age of this product, and then Google introduced name conflicts.
   (It's all Xamarin's fault to have introduced enumification, after all. -->
   <attr path="/api/package[@name='android.media']/class[@name='AudioFocusRequest']" name="managedName" api-since="26">AudioFocusRequestClass</attr>
-
+  
   <!-- FIXME: fix build and enable these packages -->
   <remove-node path="/api/package[@name='java.time']" api-since="26" />
   <remove-node path="/api/package[@name='java.time.chrono']" api-since="26" />
@@ -1557,7 +1559,7 @@
 
   <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.
        To preserve backwards compatibility, we need to "un-nest" anything added before API-30 -->
-
+  
   <!-- Handle everything that has always existed (no @merge.SourceFile) -->
   <attr api-since="30" path="/api/package/interface[not(@merge.SourceFile)]" name="unnest">true</attr>
   <attr api-since="30" path="/api/package/class[not(@merge.SourceFile)]" name="unnest">true</attr>

--- a/tests/api-compatibility/api-compatibility.targets
+++ b/tests/api-compatibility/api-compatibility.targets
@@ -8,7 +8,7 @@
         Text="Please set the %24(ContractAssembly) property!"
     />
     <PropertyGroup>
-      <_GenAPI>"$(XAPackagesDir)\microsoft.dotnet.genapi\5.0.0-beta.20078.1\tools\net472\Microsoft.DotNet.GenAPI.exe"</_GenAPI>
+      <_GenAPI>"$(XAPackagesDir)\microsoft.dotnet.genapi\5.0.0-beta.20181.7\tools\net472\Microsoft.DotNet.GenAPI.exe"</_GenAPI>
       <_CilStrip>"$(XAInstallPrefix)\xbuild\Xamarin\Android\cil-strip.exe"</_CilStrip>
       <_ContractRefDll>$(MSBuildThisFileDirectory)\reference\Mono.Android.dll</_ContractRefDll>
       <_ContractRefSrc>$(MSBuildThisFileDirectory)\reference\Mono.Android.dll.cs</_ContractRefSrc>
@@ -33,11 +33,5 @@
         Prefix="$(MSBuildThisFileDirectory)\reference\"
         Overwrite="True"
     />
-    <!--
-    <Exec
-        Command="zip Mono.Android.zip Mono.Android.dll Mono.Android.dll.cs"
-        WorkingDirectory="$(MSBuildThisFileDirectory)\reference"
-    />
-    -->
   </Target>
 </Project>


### PR DESCRIPTION
Fixing the issue were ApiCompat is not reporting errors on master. That issue caused that some breakages got passed on master. see https://github.com/xamarin/xamarin-android/pull/4485

Enabling netcoreapp3.1 assemblies to also be part of apicompat checks. it will check only against reference.
Updating the arcade package reference to use version 20181.7
The new version allows to provide a baseline file with validations to make sure baseline content has no unused/garbage on it.
The new ApiCompat capability allows us to do a major cleanup on CheckApiCompatibility task.
Also the new version allows to specify assemblies instead of folders, so now we don't need to move files around anymore to run it. Another good cleanup
Removing the previous way of diff'ing assemblies with GenApi using gitdiff, now if ApiCompat fails we generate genapi for both contract and implementation and do an internal logic to diff it, only printing the missing items, this new way provides a much better experience when visualizing the missing items.

Also fixing the breakage on master by updating metadata, you can read the description on https://github.com/xamarin/xamarin-android/pull/4485 for more details.