### PR TITLE
[.NET 5] initial implementation of "dotnet publish"

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -30,3 +30,38 @@ In .NET 5 the behavior of the following MSBuild tasks will change, but
   `$(AndroidUseLatestPlatformSdk)` setting or multiple
   `$(TargetFrameworkVersion)`. .NET 5 will always target the latest
   Android APIs for `Mono.Android.dll`.
+
+## Changes to MSBuild properties
+
+`$(AndroidUseIntermediateDesignerFile)` will be `True` by default.
+
+## dotnet cli
+
+There are currently two "verbs" we are aiming to get working in
+Xamarin.Android:
+
+    dotnet build
+    dotnet publish
+
+Currently in .NET Core (aka .NET 5), `dotnet publish` is where all the
+work to produce a self-contained "app" happens:
+
+* The linker via the `<IlLink/>` MSBuild task
+* .NET Core's version of AOT, named "ReadyToRun"
+
+https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#readytorun-images
+
+This means Xamarin.Android would run the following during `dotnet
+build`:
+
+* Run `aapt` to generate `Resource.designer.cs` and potentially emit
+  build errors for issues in `@(AndroidResource)` files.
+* Compile C# code
+
+Almost everything else happens during `donet publish`:
+
+* Generate java stubs, `AndroidManifest.xml`, etc. This must happen
+  after the linker.
+* Compile java code via `javac`
+* Convert java code to `.dex` via d8/r8
+* Create an `.apk` and sign it

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -48,7 +48,8 @@ variables:
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
-  DotNetCoreVersion: 3.1.100
+  # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
+  DotNetCoreVersion: 5.0.100-preview.1.20155.7
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -27,7 +27,7 @@ namespace Xamarin.ProjectTools
 		public XASdkProject (string sdkVersion = "")
 		{
 			Sdk = string.IsNullOrEmpty (sdkVersion) ? "Xamarin.Android.Sdk" : $"Xamarin.Android.Sdk/{sdkVersion}";
-			TargetFramework = "MonoAndroid10.0";
+			TargetFramework = "netcoreapp5.0";
 
 			PackageName = PackageName ?? string.Format ("{0}.{0}", ProjectName);
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -18,7 +18,6 @@ namespace Xamarin.ProjectTools
 			ProjectName = "UnnamedProject";
 			Sources = new List<BuildItem> ();
 			OtherBuildItems = new List<BuildItem> ();
-			SetProperty (CommonProperties, "DebugType", "full");
 			ItemGroupList.Add (Sources);
 			ItemGroupList.Add (OtherBuildItems);
 			Language = XamarinAndroidProjectLanguage.CSharp;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -125,37 +125,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <BuildDependsOn>
-      _SetupDesignTimeBuildForBuild;
-      AddLibraryJarsToBind;
-      $(BuildDependsOn);
-      BuildDocumentation;
-    </BuildDependsOn>
-
-    <CompileDependsOn>
-      _SetupDesignTimeBuildForCompile;
-      AddLibraryJarsToBind;
-      $(CompileDependsOn);
-    </CompileDependsOn>
-
-    <ResolveReferencesDependsOn>
-      $(ResolveReferencesDependsOn);
-      AddBindingsToCompile;
-      AddEmbeddedJarsAsResources;
-      AddEmbeddedReferenceJarsAsResources;
-      AddLibraryProjectsToCompile;
-      _AddNativeLibraryArchiveToCompile
-    </ResolveReferencesDependsOn>
-
-    <CleanDependsOn>
-      $(CleanDependsOn);
-      CleanBindingsOutput;
-      CleanLibraryProjectIntermediaries;
-      CleanNativeLibraryIntermediaries;
-    </CleanDependsOn>
-  </PropertyGroup>
-  
 <Target Name="_GetReferenceAssemblyPaths">
 	<GetReferenceAssemblyPaths
 			TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -558,116 +558,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 
-<PropertyGroup Condition="'$(AndroidBuildApplicationPackage)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)">
-  <_PostBuildTargets>
-    _CopyPackage;
-    _Sign
-  </_PostBuildTargets>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)">
-  <BuildDependsOn>
-    _ValidateLinkMode;
-    _CheckNonIdealConfigurations;
-    _SetupDesignTimeBuildForBuild;
-    _CreatePropertiesCache;
-    _CleanIntermediateIfNeeded;
-    _CheckProjectItems;
-    _CheckForContent;
-    _CheckTargetFramework;
-    _RemoveLegacyDesigner;
-    _ValidateAndroidPackageProperties;
-    $(BuildDependsOn);
-    _CompileDex;
-    $(_AfterCompileDex);
-    $(_PostBuildTargets)
-  </BuildDependsOn>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(AndroidApplication)' == '' Or !($(AndroidApplication))">
-  <BuildDependsOn>
-    _ValidateLinkMode;
-    _CheckNonIdealConfigurations;
-     _SetupDesignTimeBuildForBuild;
-    _CreatePropertiesCache;
-    _CleanIntermediateIfNeeded;
-    _AddAndroidDefines;
-    _CreateNativeLibraryArchive;
-    _AddAndroidEnvironmentToCompile;
-    _CheckForContent;
-    _CheckTargetFramework;
-    _RemoveLegacyDesigner;
-    _ValidateAndroidPackageProperties;
-    $(BuildDependsOn);
-  </BuildDependsOn>
-</PropertyGroup>
-
-<PropertyGroup>
-  <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' == 'True' ">
-    _PrepareAssemblies;
-    _CompileDex;
-    $(_AfterCompileDex);
-    _AddFilesToFileWrites;
-  </_BeforeIncrementalClean>
-  <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' != 'True' ">
-    _AddFilesToFileWrites;
-  </_BeforeIncrementalClean>
-  <CoreBuildDependsOn>
-    $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
-  </CoreBuildDependsOn>
-</PropertyGroup>
-  
- <PropertyGroup>
-   <CompileDependsOn>
-     _SetupDesignTimeBuildForCompile;
-     _AddAndroidDefines;
-     _IncludeLayoutBindingSources;
-     $(CompileDependsOn);
-   </CompileDependsOn>
- </PropertyGroup>
-
-<PropertyGroup >
-  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
-</PropertyGroup>
-
-<PropertyGroup>
-    <!-- no need to add those wear resources into C#, hence this order... -->
-	<CoreResolveReferencesDependsOn>
-		_SeparateAppExtensionReferences;
-		_PrepareWearApplication;
-		$(ResolveReferencesDependsOn);
-		_AddAndroidCustomMetaData;
-	</CoreResolveReferencesDependsOn>
-	<ResolveReferencesDependsOn>
-		$(CoreResolveReferencesDependsOn);
-		UpdateAndroidInterfaceProxies;
-		UpdateAndroidResources;
-		$(ApplicationResolveReferencesDependsOn);
-	</ResolveReferencesDependsOn>
-	<DeferredBuildDependsOn>$(DeferredBuildDependsOn);UpdateAndroidResources</DeferredBuildDependsOn>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)">
-	<PrepareForRunDependsOn>
-		$(PrepareForRunDependsOn);
-	</PrepareForRunDependsOn>
-</PropertyGroup>
-
-<PropertyGroup>
-  <PrepareForRunDependsOn>
-    $(PrepareForRunDependsOn);
-    _CollectMonoAndroidOutputs;
-  </PrepareForRunDependsOn>
-</PropertyGroup>
-
-<PropertyGroup>
-	<CleanDependsOn>
-		$(CleanDependsOn);
-		_CleanMonoAndroidIntermediateDir;
-		_CleanAndroidBuildPropertiesCache;
-	</CleanDependsOn>
-</PropertyGroup>
-
 <Target Name="_ValidateLinkMode">
 	<CreateProperty Value="None" Condition="'$(AndroidLinkMode)' == 'SdkOnly' And '$(AndroidUseSharedRuntime)' == 'true'">
 		<Output TaskParameter="Value" PropertyName="AndroidLinkMode" />
@@ -731,14 +621,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_AddAndroidDefines"
 		DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
-</Target>
-
-<Target Name="_GetReferenceAssemblyPaths">
-	<GetReferenceAssemblyPaths
-			TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"
-			RootPath="$(TargetFrameworkRootPath)">
-		<Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_XATargetFrameworkDirectories" />
-	</GetReferenceAssemblyPaths>
 </Target>
 
 <!--
@@ -1559,46 +1441,6 @@ because xbuild doesn't support framework reference assemblies.
 	</PropertyGroup>
 	<Warning Code="XA1009" Text="OpenTK 0.9.3 is Obsolete. Please upgrade to OpenTK 1.0"
 			Condition="$(_ObsoleteAssemblies.Contains('OpenTK.dll'))" />
-</Target>
-
-<Target Name="_ResolveAssemblies">
-	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
-	<ItemGroup>
-		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"
-				Condition="Exists ('$(OutDir)$(TargetFileName)')" />
-		<FilteredAssemblies Include="@(ReferenceCopyLocalPaths)"
-				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' And Exists('%(ReferenceCopyLocalPaths.Identity)') "/>
-		<FilteredAssemblies Include="@(_ReferencePath)"
-				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And Exists('%(_ReferencePath.Identity)') "/>
-	</ItemGroup>
-	<!-- Find all the assemblies this app requires -->
-	<ResolveAssemblies
-		Assemblies="@(FilteredAssemblies)"
-		I18nAssemblies="$(MandroidI18n)"
-		LinkMode="$(AndroidLinkMode)"
-		ProjectFile="$(MSBuildProjectFullPath)"
-		TargetFrameworkVersion="$(TargetFrameworkVersion)"
-		ProjectAssetFile="$(ProjectLockFile)"
-		TargetMoniker="$(NuGetTargetMoniker)"
-		ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
-      <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />
-      <Output TaskParameter="ResolvedUserAssemblies" ItemName="ResolvedUserAssemblies" />
-      <Output TaskParameter="ResolvedFrameworkAssemblies" ItemName="ResolvedFrameworkAssemblies" />
-      <Output TaskParameter="ResolvedSymbols" ItemName="ResolvedSymbols" />
-      <Output TaskParameter="ResolvedDoNotPackageAttributes" ItemName="_ResolvedDoNotPackageAttributes" />
-  </ResolveAssemblies>
-  <Hash ItemsToHash="@(ResolvedAssemblies)">
-    <Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
-  </Hash>
-  <WriteLinesToFile
-      File="$(_ResolvedUserAssembliesHashFile)"
-      Lines="$(_ResolvedUserAssembliesHash)"
-      Overwrite="true"
-      WriteOnlyWhenDifferent="true"
-  />
-  <ItemGroup>
-    <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_CreatePackageWorkspace">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -10,8 +10,149 @@ projects. .NET 5 projects will not import this file.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Condition=" '$(AndroidBuildApplicationPackage)' == 'True' And '$(AndroidApplication)' == 'True' ">
+    <_PostBuildTargets>
+      _CopyPackage;
+      _Sign
+    </_PostBuildTargets>
+  </PropertyGroup>
+
+  <!-- Application projects -->
+
+  <PropertyGroup Condition=" '$(AndroidApplication)' == 'True' And '$(_AndroidIsBindingProject)' != 'True' ">
+    <BuildDependsOn>
+      _ValidateLinkMode;
+      _CheckNonIdealConfigurations;
+      _SetupDesignTimeBuildForBuild;
+      _CreatePropertiesCache;
+      _CleanIntermediateIfNeeded;
+      _CheckProjectItems;
+      _CheckForContent;
+      _CheckTargetFramework;
+      _RemoveLegacyDesigner;
+      _ValidateAndroidPackageProperties;
+      $(BuildDependsOn);
+      _CompileDex;
+      $(_AfterCompileDex);
+      $(_PostBuildTargets)
+    </BuildDependsOn>
+    <_BeforeIncrementalClean>
+      _PrepareAssemblies;
+      _CompileDex;
+      $(_AfterCompileDex);
+      _AddFilesToFileWrites;
+    </_BeforeIncrementalClean>
+  </PropertyGroup>
+
+  <!-- Class library projects -->
+
+  <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' And '$(_AndroidIsBindingProject)' != 'True' ">
+    <BuildDependsOn>
+      _ValidateLinkMode;
+      _CheckNonIdealConfigurations;
+      _SetupDesignTimeBuildForBuild;
+      _CreatePropertiesCache;
+      _CleanIntermediateIfNeeded;
+      _AddAndroidDefines;
+      _CreateNativeLibraryArchive;
+      _AddAndroidEnvironmentToCompile;
+      _CheckForContent;
+      _CheckTargetFramework;
+      _RemoveLegacyDesigner;
+      _ValidateAndroidPackageProperties;
+      $(BuildDependsOn);
+    </BuildDependsOn>
+    <_BeforeIncrementalClean>
+      _AddFilesToFileWrites;
+    </_BeforeIncrementalClean>
+  </PropertyGroup>
+
+  <!-- Application *and* Class library projects -->
+
+  <PropertyGroup Condition=" '$(_AndroidIsBindingProject)' != 'True' ">
+    <CoreBuildDependsOn>
+      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
+    </CoreBuildDependsOn>
+    <CompileDependsOn>
+      _SetupDesignTimeBuildForCompile;
+      _AddAndroidDefines;
+      _IncludeLayoutBindingSources;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+    <CoreCompileDependsOn>
+      UpdateGeneratedFiles;
+      $(CoreCompileDependsOn)
+    </CoreCompileDependsOn>
+    <CoreResolveReferencesDependsOn>
+      _SeparateAppExtensionReferences;
+      _PrepareWearApplication;
+      $(ResolveReferencesDependsOn);
+      _AddAndroidCustomMetaData;
+    </CoreResolveReferencesDependsOn>
+    <ResolveReferencesDependsOn>
+      $(CoreResolveReferencesDependsOn);
+      UpdateAndroidInterfaceProxies;
+      UpdateAndroidResources;
+      $(ApplicationResolveReferencesDependsOn);
+    </ResolveReferencesDependsOn>
+    <DeferredBuildDependsOn>
+      $(DeferredBuildDependsOn);
+      UpdateAndroidResources;
+    </DeferredBuildDependsOn>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      _CollectMonoAndroidOutputs;
+    </PrepareForRunDependsOn>
+    <CleanDependsOn>
+      $(CleanDependsOn);
+      _CleanMonoAndroidIntermediateDir;
+      _CleanAndroidBuildPropertiesCache;
+    </CleanDependsOn>
+  </PropertyGroup>
+
+  <!-- Binding projects -->
+
+  <PropertyGroup Condition=" '$(_AndroidIsBindingProject)' == 'True' ">
+    <BuildDependsOn>
+      _SetupDesignTimeBuildForBuild;
+      AddLibraryJarsToBind;
+      $(BuildDependsOn);
+      BuildDocumentation;
+    </BuildDependsOn>
+
+    <CompileDependsOn>
+      _SetupDesignTimeBuildForCompile;
+      AddLibraryJarsToBind;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+
+    <ResolveReferencesDependsOn>
+      $(ResolveReferencesDependsOn);
+      AddBindingsToCompile;
+      AddEmbeddedJarsAsResources;
+      AddEmbeddedReferenceJarsAsResources;
+      AddLibraryProjectsToCompile;
+      _AddNativeLibraryArchiveToCompile
+    </ResolveReferencesDependsOn>
+
+    <CleanDependsOn>
+      $(CleanDependsOn);
+      CleanBindingsOutput;
+      CleanLibraryProjectIntermediaries;
+      CleanNativeLibraryIntermediaries;
+    </CleanDependsOn>
+  </PropertyGroup>
+
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+  <Target Name="_GetReferenceAssemblyPaths">
+    <GetReferenceAssemblyPaths
+        TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"
+        RootPath="$(TargetFrameworkRootPath)">
+      <Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_XATargetFrameworkDirectories" />
+    </GetReferenceAssemblyPaths>
+  </Target>
 
   <Target Name="_ResolveAndroidTooling">
     <ValidateJavaVersion
@@ -56,6 +197,52 @@ projects. .NET 5 projects will not import this file.
       <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
       <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />
     </ResolveAndroidTooling>
+  </Target>
+
+  <Target Name="_ResolveAssemblies">
+    <!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
+    <ItemGroup>
+      <FilteredAssemblies
+          Include="$(OutDir)$(TargetFileName)"
+          Condition="Exists ('$(OutDir)$(TargetFileName)')"
+      />
+      <FilteredAssemblies
+          Include="@(ReferenceCopyLocalPaths)"
+          Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' And Exists('%(ReferenceCopyLocalPaths.Identity)') "
+      />
+      <FilteredAssemblies
+          Include="@(_ReferencePath)"
+          Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And Exists('%(_ReferencePath.Identity)') "
+      />
+    </ItemGroup>
+    <!-- Find all the assemblies this app requires -->
+    <ResolveAssemblies
+        Assemblies="@(FilteredAssemblies)"
+        I18nAssemblies="$(MandroidI18n)"
+        LinkMode="$(AndroidLinkMode)"
+        ProjectFile="$(MSBuildProjectFullPath)"
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        ProjectAssetFile="$(ProjectLockFile)"
+        TargetMoniker="$(NuGetTargetMoniker)"
+        ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
+      <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />
+      <Output TaskParameter="ResolvedUserAssemblies" ItemName="ResolvedUserAssemblies" />
+      <Output TaskParameter="ResolvedFrameworkAssemblies" ItemName="ResolvedFrameworkAssemblies" />
+      <Output TaskParameter="ResolvedSymbols" ItemName="ResolvedSymbols" />
+      <Output TaskParameter="ResolvedDoNotPackageAttributes" ItemName="_ResolvedDoNotPackageAttributes" />
+    </ResolveAssemblies>
+    <Hash ItemsToHash="@(ResolvedAssemblies)">
+      <Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
+    </Hash>
+    <WriteLinesToFile
+        File="$(_ResolvedUserAssembliesHashFile)"
+        Lines="$(_ResolvedUserAssembliesHash)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -41,16 +41,27 @@ projects.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
+  <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
+    <_ResolveSdksDependsOnTargets>ResolveFrameworkReferences</_ResolveSdksDependsOnTargets>
+    <TargetFrameworkDirectory>$(MSBuildThisFileDirectory)..\lib\MonoAndroid\v10.0\</TargetFrameworkDirectory>
+    <_XATargetFrameworkDirectories>$(TargetFrameworkDirectory)</_XATargetFrameworkDirectories>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
+    <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
+  </PropertyGroup>
+
+  <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
+      <_ResolveSdksDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\data\')</_ResolveSdksDirectories>
+      <_ResolveSdksDirectories Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(_XATargetFrameworkDirectories)</_ResolveSdksDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
-        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+        ReferenceAssemblyPaths="$(_ResolveSdksDirectories)">
       <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
       <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.AssemblyResolution.targets
@@ -1,0 +1,62 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Sdk.AssemblyResolution.targets
+
+This file contains the .NET 5-specific implementation for the
+_ResolveAssemblies MSBuild target.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="_ResolveAssemblies" DependsOnTargets="ComputeFilesToPublish">
+
+    <!--
+        TODO: not yet complete.
+
+        Two things here are placeholders for later:
+
+        * %(HasMonoAndroidReference) is always True to disable
+          performance improvements around $(TargetFrameworkVersion)
+          detection.
+
+        * @(ReferencePath) should not be used. We should be able to
+          rely on @(ResolvedFileToPublish) when we have Mono's runtime
+          packs for .NET 5.
+    -->
+
+    <ItemGroup>
+      <ResolvedFrameworkAssemblies
+          Include="@(ReferencePath)"
+          Condition=" '%(ReferencePath.FrameworkReferenceName)' == 'Xamarin.Android.App' "
+          HasMonoAndroidReference="True"
+      />
+      <ResolvedUserAssemblies
+          Include="@(ReferencePath)"
+          Condition=" '%(ReferencePath.FrameworkReferenceName)' != 'Xamarin.Android.App' "
+          HasMonoAndroidReference="True"
+      />
+      <ResolvedUserAssemblies
+          Include="@(ResolvedFileToPublish)"
+          Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' "
+          HasMonoAndroidReference="True"
+      />
+      <ResolvedAssemblies Include="@(ResolvedFrameworkAssemblies);@(ResolvedUserAssemblies)" />
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(ResolvedAssemblies)">
+      <Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
+    </Hash>
+    <WriteLinesToFile
+        File="$(_ResolvedUserAssembliesHashFile)"
+        Lines="$(_ResolvedUserAssembliesHash)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.BuildOrder.targets
@@ -1,0 +1,98 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Sdk.BuildOrder.targets
+
+This file contains the .NET 5-specific setup for any $(FooDependsOn)
+properties that determine build ordering. For "legacy" Xamarin.Android
+projects, these properties are set in Xamarin.Android.Legacy.targets.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition=" '$(AndroidApplication)' == 'True' ">
+    <BuildDependsOn>
+      _ValidateLinkMode;
+      _CheckNonIdealConfigurations;
+      _SetupDesignTimeBuildForBuild;
+      _CreatePropertiesCache;
+      _CleanIntermediateIfNeeded;
+      _CheckProjectItems;
+      _CheckForContent;
+      _ValidateAndroidPackageProperties;
+      $(BuildDependsOn);
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
+    <BuildDependsOn>
+      _ValidateLinkMode;
+      _CheckNonIdealConfigurations;
+      _SetupDesignTimeBuildForBuild;
+      _CreatePropertiesCache;
+      _CleanIntermediateIfNeeded;
+      _AddAndroidDefines;
+      _CreateNativeLibraryArchive;
+      _AddAndroidEnvironmentToCompile;
+      _CheckForContent;
+      _ValidateAndroidPackageProperties;
+      $(BuildDependsOn);
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CompileDependsOn>
+      _SetupDesignTimeBuildForCompile;
+      _AddAndroidDefines;
+      _IncludeLayoutBindingSources;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+    <CoreCompileDependsOn>
+      UpdateGeneratedFiles;
+      $(CoreCompileDependsOn)
+    </CoreCompileDependsOn>
+    <CoreResolveReferencesDependsOn>
+      _SeparateAppExtensionReferences;
+      _PrepareWearApplication;
+      $(ResolveReferencesDependsOn);
+      _AddAndroidCustomMetaData;
+    </CoreResolveReferencesDependsOn>
+    <ResolveReferencesDependsOn>
+      $(CoreResolveReferencesDependsOn);
+      UpdateAndroidInterfaceProxies;
+      UpdateAndroidResources;
+      $(ApplicationResolveReferencesDependsOn);
+    </ResolveReferencesDependsOn>
+    <DeferredBuildDependsOn>
+      $(DeferredBuildDependsOn);
+      UpdateAndroidResources;
+    </DeferredBuildDependsOn>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      _CollectMonoAndroidOutputs;
+    </PrepareForRunDependsOn>
+    <CleanDependsOn>
+      $(CleanDependsOn);
+      _CleanMonoAndroidIntermediateDir;
+      _CleanAndroidBuildPropertiesCache;
+    </CleanDependsOn>
+  </PropertyGroup>
+
+  <!--
+    TODO: currently using a private property for hooking into `dotnet publish`
+
+    Revise after this lands: https://github.com/dotnet/sdk/pull/11073
+  -->
+
+  <PropertyGroup>
+    <_CorePublishTargets>
+      $(_CorePublishTargets);
+      _CompileDex;
+      $(_AfterCompileDex);
+      Package;
+      _Sign;
+    </_CorePublishTargets>
+  </PropertyGroup>
+
+</Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.DefaultItems.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.DefaultItems.props
@@ -20,13 +20,14 @@
   </ItemGroup>
 
   <!-- Default References -->
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">
-    <Reference Include="Mono.Android" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors" />
-    <Reference Include="System.Xml" />
+
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
+    <FrameworkReference
+        Include="Xamarin.Android.App"
+        IsImplicitlyDefined="true"
+        Pack="false"
+        PrivateAssets="All"
+    />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
@@ -14,4 +14,14 @@
     <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.fsproj'">$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.FSharp.targets</LanguageTargets>
   </PropertyGroup>
 
+  <!-- Default References -->
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
+    <Reference Include="Mono.Android" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
 </Project>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
@@ -29,6 +29,7 @@
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.targets
@@ -1,10 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ImportGroup Condition="'$(IsMultiTargetingBuild)' != 'true'">
-    <Import Project="Xamarin.Android.TargetFrameworkInference.targets"
-        Condition="'$(TargetFramework)' != '' AND !($(TargetFramework.Contains(',')) OR $(TargetFramework.Contains(';')))"/>
-  </ImportGroup>
-
   <PropertyGroup>
     <XamarinAndroidSdkTargetsImported>true</XamarinAndroidSdkTargetsImported>
     <_XamarinAndroidBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
@@ -14,6 +9,8 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.AssemblyResolution.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.BuildOrder.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.Tooling.targets" />
 
   <!-- Automatically supply project capabilities for IDE use -->


### PR DESCRIPTION
There are currently two "verbs" we are aiming to get working in
Xamarin.Android:

    dotnet build
    dotnet publish

Currently in .NET Core (aka .NET 5), `dotnet publish` is where all the
work to produce a self-contained "app" happens:

  * The linker via the `<IlLink/>` MSBuild task
  * .NET Core's version of AOT, named "ReadyToRun"

https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#readytorun-images

This means Xamarin.Android would run the following during `dotnet
build`:

  * Run `aapt` to generate `Resource.designer.cs` and potentially emit
    build errors for issues in `@(AndroidResource)` files.
  * Compile C# code

Almost everything else happens during `donet publish`:

  * Generate java stubs, `AndroidManifest.xml`, etc. This must happen
    after the linker.
  * Compile java code via `javac`
  * Convert java code to `.dex` via d8/r8
  * Create an `.apk` and sign it

This is highly subject to change, however.

To get everything working:

  * I moved any `$(FooDependsOn)` properties that determine MSBuild
    target ordering for "legacy" projects to
    `Xamarin.Android.Legacy.targets`.

  * The equivalent for .NET 5 will be in
    `Xamarin.Android.Sdk.BuildOrder.targets`.

  * I modified the private `$(_CorePublishTargets)` property to run
    Xamarin.Android-specific targets after `<IlLink/>`. This will
    change after this PR lands:

    https://github.com/dotnet/sdk/pull/11073

  * I moved the existing `_ResolveAssemblies` MSBuild target to
    `Xamarin.Android.Legacy.targets`.

  * The .NET 5 version of `_ResolveAssemblies` should be able to make
    use of item groups provided by MSBuild. This file lives in
    `Xamarin.Android.Sdk.AssemblyResolution.targets`. It will
    eventually change when we have Mono runtime packs for .NET 5.

Future changes:

  * We will need to use different item groups in the
    `_ResolveAssemblies` target once a Mono runtime pack for .NET 5 is
    available.

  * `dotnet publish` still uses the current Mono linker. We will need
    to refactor and integrate the new linker documented at:

https://github.com/mono/linker/tree/ec2cbdb894e11065f42b1223f664d9688b749323/src/linker#adding-custom-steps-to-the-linker