### PR TITLE
[Xamarin.Android.Build.Tasks] Remove TargetFrameworkDirectory usage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -150,7 +150,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   <Javac
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
-      TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
       StubSourceDirectory="$(_AndroidIntermediateJavaSourceDirectory)"
       JavaSourceFiles=""
       ToolPath="$(JavacToolPath)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -21,9 +21,6 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem[] Jars { get; set; }
 
-		[Required]
-		public string TargetFrameworkDirectory { get; set; }
-
 		protected override string ToolName {
 			get { return OS.IsWindows ? "javac.exe" : "javac"; }
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -54,8 +54,6 @@ namespace Xamarin.Android.Tasks
 			//     "-encoding" "UTF-8"
 			//     "@C:\Users\Jonathan\AppData\Local\Temp\tmp79c4ac38.tmp"
 
-			//var android_dir = MonoDroid.MonoDroidSdk.GetAndroidProfileDirectory (TargetFrameworkDirectory);
-
 			var cmd = new CommandLineBuilder ();
 
 			cmd.AppendSwitchIfNotNull ("-J-Dfile.encoding=", "UTF8");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2213,7 +2213,6 @@ because xbuild doesn't support framework reference assemblies.
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
     ClassesOutputDirectory="$(_AndroidIntermediateJavaClassDirectory)"
     ClassesZip="$(_AndroidIntermediateClassesZip)"
-    TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
     StubSourceDirectory="$(_AndroidIntermediateJavaSourceDirectory)"
     JavaSourceFiles="@(AndroidJavaSource)"
     ToolPath="$(JavacToolPath)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -23,7 +23,6 @@
 
 		<ItemGroup>
 			<_XACandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
-			<_XAInboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
 		</ItemGroup>
 		
 		<PropertyGroup>


### PR DESCRIPTION
The `TargetFrameworkDirectory` property is no longer set by the .NET
Core build system.  Removing seemingly dead references to this property
will help simplify the places where we need to override this value in
.NET 5.

I could not find any references of `_XAInboxNETStandardFolders` in any
relevant [GitHub sources][0], so I've removed that ItemGroup declaration
entirely.

`Javac` (and its parents) also don't seem to make use of this property
as far as I can tell, so those references have been removed.

[0]: https://github.com/search?q=_XAInboxNETStandardFolders&type=Code