### PR TITLE
[.NET 5] Remove framework assemblies from Xamarin.Android.Sdk

### DIFF
--- a/build-tools/Xamarin.Android.App/Xamarin.Android.App.Ref.proj
+++ b/build-tools/Xamarin.Android.App/Xamarin.Android.App.Ref.proj
@@ -34,7 +34,9 @@ by projects that use the Xamarin.Android.App framework in .NET 5.
 
     <ItemGroup>
       <_PackageFiles Include="@(_AndroidAppPackAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\AndroidApiInfo.xml" PackagePath="data" />
+      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\AndroidApiInfo.xml" PackagePath="data" />
     </ItemGroup>
   </Target>
 

--- a/build-tools/Xamarin.Android.App/Xamarin.Android.App.Ref.proj
+++ b/build-tools/Xamarin.Android.App/Xamarin.Android.App.Ref.proj
@@ -36,7 +36,7 @@ by projects that use the Xamarin.Android.App framework in .NET 5.
       <_PackageFiles Include="@(_AndroidAppPackAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\AndroidApiInfo.xml" PackagePath="data" />
+      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\netcoreapp3.1\AndroidApiInfo.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1467,7 +1467,12 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GetMonoPlatformJarPath">
-  <GetMonoPlatformJar TargetFrameworkDirectory="$(TargetFrameworkDirectory)">
+  <PropertyGroup>
+    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(TargetFrameworkDirectory)</_AndroidJarAndDexDirectory>
+    <!-- `@(ResolvedFrameworkReference)` is set through `_ResolveSdks` dependency on `ResolveFrameworkReferences`. -->
+    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\ref\$(TargetFramework)')</_AndroidJarAndDexDirectory>
+  </PropertyGroup>
+  <GetMonoPlatformJar TargetFrameworkDirectory="$(_AndroidJarAndDexDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
     <Output TaskParameter="MonoPlatformDexPath" PropertyName="MonoPlatformDexPath" />
   </GetMonoPlatformJar>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1467,12 +1467,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GetMonoPlatformJarPath">
-  <PropertyGroup>
-    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(TargetFrameworkDirectory)</_AndroidJarAndDexDirectory>
-    <!-- `@(ResolvedFrameworkReference)` is set through `_ResolveSdks` dependency on `ResolveFrameworkReferences`. -->
-    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\ref\$(TargetFramework)')</_AndroidJarAndDexDirectory>
-  </PropertyGroup>
-  <GetMonoPlatformJar TargetFrameworkDirectory="$(_AndroidJarAndDexDirectory)">
+  <GetMonoPlatformJar TargetFrameworkDirectory="$(_XATargetFrameworkDirectories)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
     <Output TaskParameter="MonoPlatformDexPath" PropertyName="MonoPlatformDexPath" />
   </GetMonoPlatformJar>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1467,7 +1467,11 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GetMonoPlatformJarPath">
-  <GetMonoPlatformJar TargetFrameworkDirectory="$(_XATargetFrameworkDirectories)">
+  <PropertyGroup>
+    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(TargetFrameworkDirectory)</_AndroidJarAndDexDirectory>
+    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' == 'True' ">$(_XATargetFrameworkDirectories)</_AndroidJarAndDexDirectory>
+  </PropertyGroup>
+  <GetMonoPlatformJar TargetFrameworkDirectory="$(_AndroidJarAndDexDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
     <Output TaskParameter="MonoPlatformDexPath" PropertyName="MonoPlatformDexPath" />
   </GetMonoPlatformJar>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -37,7 +37,8 @@ projects.
     </PropertyGroup>
     <ItemGroup>
       <FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
-      <Reference Include="$(_JavaInteropReferences)" />
+      <!-- These references are implicitly defined in .NET 5 -->
+      <Reference Include="$(_JavaInteropReferences)" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -44,8 +44,6 @@ projects.
 
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
     <_ResolveSdksDependsOnTargets>ResolveFrameworkReferences</_ResolveSdksDependsOnTargets>
-    <TargetFrameworkDirectory>$(MSBuildThisFileDirectory)..\lib\MonoAndroid\v10.0\</TargetFrameworkDirectory>
-    <_XATargetFrameworkDirectories>$(TargetFrameworkDirectory)</_XATargetFrameworkDirectories>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
     <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
@@ -54,15 +52,18 @@ projects.
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-      <_ResolveSdksDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\data\')</_ResolveSdksDirectories>
-      <_ResolveSdksDirectories Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(_XATargetFrameworkDirectories)</_ResolveSdksDirectories>
+      <!-- When using .NET 5, provide a list of paths to all framework reference directories, e.g.
+            `packages\xamarin.android.app.ref\10.3.99.160\ref\netcoreapp5.0\` and
+            `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.2.20160.6\ref\netcoreapp5.0\`
+      -->
+      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\ref\$(TargetFramework)')</_XATargetFrameworkDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
-        ReferenceAssemblyPaths="$(_ResolveSdksDirectories)">
+        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
       <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
       <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />

--- a/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.proj
+++ b/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.proj
@@ -33,24 +33,25 @@ the new entry point for short-form style Android projets in .NET 5.
       <ToolsSourceDir>$(XamarinAndroidSourcePath)bin\Build$(Configuration)\packs\tools\</ToolsSourceDir>
     </PropertyGroup>
     <ItemGroup>
-      <_MSBuildNonHostItemsUnix Include="@(MSBuildItemsUnix)" Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch(%(RelativePath), '.*host-$(HostOS).*'))"/>
-      <_MSBuildHostItemsUnix Include="@(MSBuildItemsUnix)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(RelativePath), '.*host-$(HostOS).*'))"/>
+      <AndroidSdkBuildTools Include="@(_MSBuildFiles);@(_MSBuildFilesWin)" >
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
+      </AndroidSdkBuildTools>
+      <AndroidSdkBuildTools Include="@(_MSBuildTargetsSrcFiles)" >
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
+      </AndroidSdkBuildTools>
+      <AndroidSdkBuildToolsUnix Include="@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSwab);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)" >
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
+      </AndroidSdkBuildToolsUnix>
     </ItemGroup>
     <!-- Copy only the required tools to new folder. Skip Unix item copying on Windows. -->
     <Copy
-        SourceFiles="@(MSBuildItemsWin)"
-        DestinationFiles="@(MSBuildItemsWin->'$(ToolsSourceDir)%(RelativePath)')"
+        SourceFiles="@(AndroidSdkBuildTools)"
+        DestinationFiles="@(AndroidSdkBuildTools->'$(ToolsSourceDir)%(RelativePath)')"
         SkipUnchangedFiles="True"
     />
     <Copy
-        SourceFiles="@(_MSBuildNonHostItemsUnix)"
-        DestinationFiles="@(_MSBuildNonHostItemsUnix->'$(ToolsSourceDir)%(RelativePath)')"
-        SkipUnchangedFiles="True"
-        Condition="$([MSBuild]::IsOSPlatform('osx'))"
-    />
-    <Copy
-        SourceFiles="@(_MSBuildHostItemsUnix)"
-        DestinationFolder="$(ToolsSourceDir)"
+        SourceFiles="@(AndroidSdkBuildToolsUnix)"
+        DestinationFiles="@(AndroidSdkBuildToolsUnix->'$(ToolsSourceDir)%(RelativePath)')"
         SkipUnchangedFiles="True"
         Condition="$([MSBuild]::IsOSPlatform('osx'))"
     />

--- a/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.proj
+++ b/src/Xamarin.Android.Sdk/Xamarin.Android.Sdk.proj
@@ -21,12 +21,12 @@ the new entry point for short-form style Android projets in .NET 5.
 
   <PropertyGroup>
     <BeforePack>
-      _GenerateXAPackContent;
+      _GenerateXASdkContent;
       $(BeforePack);
     </BeforePack>
   </PropertyGroup>
 
-  <Target Name="_GenerateXAPackContent"
+  <Target Name="_GenerateXASdkContent"
       DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions" >
     <PropertyGroup>
       <PackageVersion>$(_AndroidNETSdkVersion)</PackageVersion>
@@ -61,10 +61,10 @@ the new entry point for short-form style Android projets in .NET 5.
     />
     <ItemGroup>
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />
-      <!-- Only include @(FrameworkItemsWin), as it is a superset of @(FrameworkItemsUnix) -->
-      <_PackageFiles Include="@(FrameworkItemsWin)" PackagePath="lib\MonoAndroid\%(FrameworkItemsWin.RelativePath)" />
-      <_PackageFiles Include="$(XamarinAndroidSourcePath)\src\Xamarin.Android.Sdk\Sdk\**" PackagePath="Sdk" /> 
-      <_PackageFiles Include="$(XamarinAndroidSourcePath)\src\Xamarin.Android.Sdk\targets\**" PackagePath="targets" /> 
+      <_PackageFiles Include="$(XamarinAndroidSourcePath)\src\Xamarin.Android.Sdk\Sdk\**" PackagePath="Sdk" />
+      <_PackageFiles Include="$(XamarinAndroidSourcePath)\src\Xamarin.Android.Sdk\targets\**"
+          Exclude="$(XamarinAndroidSourcePath)\src\Xamarin.Android.Sdk\**\*.Lite.*"
+          PackagePath="targets" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
@@ -8,9 +8,7 @@
   <Import Project="Xamarin.Android.Sdk.Default.props" />
 
   <PropertyGroup>
-    <!-- Reset, so the full SDK install can override these in turn -->
-    <TargetFrameworkRootPath />
-    <FrameworkPathOverride />
+    <!-- Ensure $(UsingAndroidNETSdk) is not set to retain legacy behavior -->
     <UsingAndroidNETSdk />
     <!-- Reset, since we're overloading this prop as there is a VS-provided Xamarin.Android.Sdk.props already which we need to import  -->
     <XamarinAndroidSdkPropsImported>false</XamarinAndroidSdkPropsImported>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
@@ -6,9 +6,6 @@
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
     <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">1.8.0</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
-    <!-- We should always override the framework path so that XA resolves to its own mscorlib.dll -->
-    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\lib\</TargetFrameworkRootPath>
-    <FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' ">true</EnableDefaultOutputPaths>
     <DisableImplicitAndroidFrameworkReference Condition=" '$(DisableImplicitAndroidFrameworkReference)' == '' ">false</DisableImplicitAndroidFrameworkReference>


### PR DESCRIPTION
In .NET 5, all framework assemblies will be resolved from various
targeting and runtime packs.  Now that commit a5369517 has landed, we
should no longer be bundling these in the SDK.

All `MonoAndroid/v*` content has been removed. Additionally, the
host-specific BCL and runtime bits that were included have been
removed. `jnimarshamethod-gen` has been removed for now, as
it relies on this host BCL.

Updates the `Xamarin.Android.App.Ref` targeting pack to include both
`mono.android.jar` and `mono.android.dex`.  The `GetMonoPlatformJar`
task has been updated to resolve these items from the targeting pack
when using the .NET 5 Android SDK.

`Xamarin.Android.Tooling.targets` has been updated to conditionally
reference `$(_JavaInteropReferences)`, as these will be implicitly
referenced through `<FrameworkReference>`s in .NET 5.

`Xamarin.Android.Sdk.Lite` items have been removed from the full
`Xamarin.Android.Sdk`, this exclusion was accidentially removed in
commit a5369517.