### PR TITLE
[xaprepare] Disable unused XML documentation

### DIFF
--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -22,7 +22,6 @@
     <ExternalConsole>true</ExternalConsole>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>7.1</LangVersion>
-    <DocumentationFile>bin\Debug\xaprepare.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -32,7 +31,6 @@
     <ExternalConsole>true</ExternalConsole>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>7.1</LangVersion>
-    <DocumentationFile>bin\Release\xaprepare.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
The property:
```
<DocumentationFile>bin\Debug\xaprepare.xml</DocumentationFile>
```

causes several warnings to be generated like:
```
Application\KnownConditions.cs(3,14): warning CS1591: Missing XML comment for publicly visible type or member 'KnownConditions' [C:\A\vs2019xam000000-1\_work\1\s\build-tools\xaprepare\xaprepare\xaprepare.csproj]
Application\RefreshableComponent.cs(5,14): warning CS1591: Missing XML comment for publicly visible type or member 'RefreshableComponent' [C:\A\vs2019xam000000-1\_work\1\s\build-tools\xaprepare\xaprepare\xaprepare.csproj]
Application\RefreshableComponent.cs(7,3): warning CS1591: Missing XML comment for publicly visible type or member 'RefreshableComponent.None' [C:\A\vs2019xam000000-1\_work\1\s\build-tools\xaprepare\xaprepare\xaprepare.csproj]
Application\RefreshableComponent.cs(8,3): warning CS1591: Missing XML comment for publicly visible type or member 'RefreshableComponent.AndroidSDK' [C:\A\vs2019xam000000-1\_work\1\s\build-tools\xaprepare\xaprepare\xaprepare.csproj]
...
```

Because the resulting documentation file is never used, this PR disables it to prevent the warnings.