### PR TITLE
[Mono.Android] workaround for VS Windows test runner

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -347,6 +347,9 @@
     <ProjectReference Include="..\..\src\java-runtime\java-runtime.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <!--NOTE: a workaround for the test runner in VS Windows-->
+  <Target Name="GetTargetPath" />
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <!-- Only build the 'netcoreapp3.1' version of 'Mono.Android.dll' once for the latest stable Android version. -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' And '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">


### PR DESCRIPTION
Since e2854ee7, `Mono.Android.csproj` has multi-targeting:

    <TargetFrameworks>monoandroid10;netcoreapp3.1</TargetFrameworks>

I've been getting a weird issue with the unit test runner in VS
Windows.

If I run, `Xamarin.Android.Build.Tests.BuildTest.BuildBasicApplication`,
I get a popup that the build failed. It prompts to continue yes/no, and
the test continues to run regardless of the answer!

If I enable the build logging in the IDE using:

https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools

I see a build of `Xamarin.Android.Build.Tasks.csproj` fails with:

    Mono.Android.csproj error MSB4057: The target "GetTargetPath" does not exist in the project.

Yet the next build for `Xamarin.Android.Build.Tests.csproj` succeeds.
Everything works fine command-line.

I found that MSBuild targets for long-form MSBuild projects:

https://github.com/microsoft/msbuild/blob/64c8e4a18e7cf7f064fbad304ea7ed877cdaa0a1/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1782-L1797

There is a `GetTargetPath` target the IDE calls.

This does not exist at all for short-form projects. Since we are using
a short-form project and `TargetFrameworks=monoandroid10`, I think we
are getting some odd IDE behavior.

I just added an empty `GetTargetPath` target for now, which solves the
issue. Now I can run tests!