### PR TITLE
[Xamarin.Android.Build.Tasks] -ignorewarnings option to make r8 less strict

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -1168,6 +1168,15 @@ resources.
   command-line options to pass to the **aapt** command when
   processing Android assets and resources.
 
+- **AndroidR8IgnoreWarnings** &ndash; Automatically specifies
+  the `-ignorewarnings` proguard rule for `r8`. This allows `r8`
+  to continue with dex compilation even if certain warnings are
+  encountered. Defaults to `True`, but can be set to `False` to
+  enforce more strict behavior. See the [ProGuard manual](https://www.guardsquare.com/products/proguard/manual/usage)
+  for details.
+
+  Added in Xamarin.Android 10.4.
+
 - **AndroidResgenFile** &ndash; Specifies the name of the Resource
   file to generate. The default template sets this to
   `Resource.designer.cs`.

--- a/Documentation/release-notes/4509.md
+++ b/Documentation/release-notes/4509.md
@@ -1,0 +1,42 @@
+### R8 uses `-ignorewarnings` to suppress common build errors
+
+Developers could hit a common problem in applications using Google
+Play Services:
+
+    Warning: Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
+    Error: Compilation can't be completed because some library classes are missing.
+
+The correct fix is to adjust `AndroidManifest.xml` in the project:
+
+```xml
+<application ...>
+  <uses-library android:name="org.apache.http.legacy" android:required="false" />
+</application>
+```
+
+This issue could be encountered if:
+
+* `AndroidDexTool=d8` (this is default in Xamarin.Android 10.2 and higher)
+* `AndroidEnableMultiDex=True` or `AndroidLinkTool=r8`
+
+When using `AndroidDexTool=dx`, the same project would not encounter a
+build error--just warnings. However, `r8` is more strict and converts
+the `library classes are missing` warning into a failure.
+
+Xamarin.Android now applies a setting that will make `r8` more lenient
+to keep things closer to the existing `dx` behavior. By automatically
+passing `-ignorewarnings`, `r8` will not fail the build, but still
+emit warnings.
+
+To disable this behavior, a new `$(AndroidR8IgnoreWarnings)` MSBuild
+property can be set to `False` in your `.csproj` file:
+
+```xml
+<PropertyGroup>
+  <AndroidR8IgnoreWarnings>False</AndroidR8IgnoreWarnings>
+</PropertyGroup>
+```
+
+See the [ProGuard manual][proguard] for details about ProGuard rule syntax.
+
+[proguard]: https://www.guardsquare.com/products/proguard/manual/usage

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -329,9 +329,12 @@ class MemTest {
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void BuildXamarinFormsMapsApplication ()
+		[NonParallelizable] // parallel NuGet restore causes failures
+		public void BuildXamarinFormsMapsApplication ([Values (true, false)] bool multidex)
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();
+			if (multidex)
+				proj.SetProperty ("AndroidEnableMultiDex", "True");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "first should have succeeded.");
 				b.BuildLogFile = "build2.log";

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -305,6 +305,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
+	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>
 	<AndroidPackageFormat       Condition=" '$(AndroidPackageFormat)' == '' ">apk</AndroidPackageFormat>
 	<AndroidUseAapt2            Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</AndroidUseAapt2>
 	<AndroidUseApkSigner        Condition=" '$(AndroidPackageFormat)' == 'aab' ">False</AndroidUseApkSigner>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -70,6 +70,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         EnableMultiDex="$(AndroidEnableMultiDex)"
         MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
         CustomMainDexListFiles="@(MultiDexMainDexList)"
+        IgnoreWarnings="$(AndroidR8IgnoreWarnings)"
         ExtraArguments="$(AndroidR8ExtraArguments)"
     />
     <D8


### PR DESCRIPTION
Context: https://www.guardsquare.com/products/proguard/manual/usage
Fixes: https://feedback.devdiv.io/959121
Fixes: https://feedback.devdiv.io/960245
Fixes: https://github.com/xamarin/xamarin-android/issues/4457

A common problem Xamarin.Android developers are running into is `r8`
failing with:

    Warning: Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
    Error: Compilation can't be completed because some library classes are missing.

The simplest way to hit this is:

  * Use Google Play Services
  * Use multi-dex

In this case, we are only using `r8` for multi-dex support and *not*
code shrinking. Developers aren't setting proguard rules at all in
this scenario.

The correct fix is to do this in `AndroidManifest.xml`:

      <uses-library android:name="org.apache.http.legacy" android:required="false" />
    </application>

This will automatically include `--lib` to
`android-sdk\platforms\android-29\optional\org.apache.http.legacy.jar`
in the call to `r8`.

This is just completely different behavior than you got using `dx`.
Even though the fix is *correct*, it's a problem developers don't want
to run into. Most of the time everything will work fine without doing
this.

This error message can surface in other forms beyond usage of
`org.apache.http.legacy`. One example: A NuGet package has a
dependency on Google Play Services, but doesn't actually include the
`<dependency/>` in its `.nuspec` file. The fix is to add a
`<PackageReference/>` in the project yourself.

What is really weird about this, is `r8` only fails on *some*
warnings, not all.

`r8` is completely fine to emit warnings like these and continue on:

    Warning: The rule `-keep public class * extends java.lang.annotation.Annotation {
    *;
    }` uses extends but actually matches implements.
    Warning in obj\Debug\lp\44\jl\classes.jar:com/google/android/gms/internal/zzam.class:
    Type `org.apache.http.impl.cookie.DateUtils` was not found, it is required for default or static interface methods desugaring of `long com.google.android.gms.internal.zzam.zzf(java.lang.String)`
    Warning in obj\Debug\lp\44\jl\classes.jar:com/google/android/gms/internal/zzas.class:
    Type `android.net.http.AndroidHttpClient` was not found, it is required for default or static interface methods desugaring of `com.google.android.gms.internal.zzs com.google.android.gms.internal.zzas.zza(android.content.Context, com.google.android.gms.internal.zzan)`
    Warning: Resource 'META-INF/MANIFEST.MF' already exists.

I found a configuration option for proguard rules that appears to do
what we want:

    -ignorewarnings

    Specifies to print any warnings about unresolved references and other
    important problems, but to continue processing in any case. Ignoring
    warnings can be dangerous. For instance, if the unresolved classes or
    class members are indeed required for processing, the processed code
    will not function properly. Only use this option if you know what
    you're doing!

Even though there is a scary message, this seems to do exactly what we
need:

  1. r8 continues with its job if there are warnings.
  2. We still actually *emit* the warnings.

The name `-ignorewarnings` is somewhat confusing as it does not
suppress them at all. It just prevents an overall failure.

I added a new `$(AndroidR8IgnoreWarnings)` (`True` by default) MSBuild
property that will automatically include the `-ignorewarnings` option
in the ProGuard configuration file Xamarin.Android generates.

I updated a test for this scenario.