### PR TITLE
Bump to mono/mono/2020-02@ecde0860

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@34f5275d1db891e25af17d743b425cc318e6e7df
-mono/mono:2020-02@fda73998f929f9af2020e8e125afd15c7d504c0c
+mono/mono:2020-02@ecde08600b274d782bdd89f3ef7dd41849e40ddf


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/fda73998f929f9af2020e8e125afd15c7d504c0c...ecde08600b274d782bdd89f3ef7dd41849e40ddf

Context: https://github.com/mono/mono/issues/18127
Context: https://github.com/mono/mono/issues/19377
Context: https://github.com/xamarin/xamarin-android/pull/4487

  * mono/mono@ecde08600b2: [runtime] Allocate the memory for gshared gparams from image sets. (#19361) (#19419)
  * mono/mono@8fb93012925: [meta] Add mono_type_get_name_full to public API (#19415)
  * mono/mono@7bfb441fb4c: Fix Windows .msi build using newer xar
  * mono/mono@e77cea19105: Fix Windows .msi build with recent cygwin updates