### PR TITLE
[ci] Prefer a stable .NET Core version

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -48,8 +48,9 @@ variables:
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
+  DotNetCoreVersion: 3.x
   # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
-  DotNetCoreVersion: 5.0.100-preview.1.20155.7
+  DotNetCorePreviewVersion: 5.0.100-preview.1.20155.7
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
@@ -97,6 +98,11 @@ stages:
 
     - script: echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/Library/Android/jdk"
       displayName: set JAVA_HOME
+
+    - task: UseDotNet@2
+      displayName: install .NET Core $(DotNetCorePreviewVersion)
+      inputs:
+        version: $(DotNetCorePreviewVersion)
 
     - task: UseDotNet@2
       displayName: install .NET Core $(DotNetCoreVersion)
@@ -239,6 +245,11 @@ stages:
     - template: yaml-templates\kill-processes.yaml
 
     - template: yaml-templates\clean.yaml
+
+    - task: UseDotNet@2
+      displayName: install .NET Core $(DotNetCorePreviewVersion)
+      inputs:
+        version: $(DotNetCorePreviewVersion)
 
     - task: UseDotNet@2
       displayName: install .NET Core $(DotNetCoreVersion)

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -32,6 +32,11 @@ steps:
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - task: UseDotNet@2
+  displayName: install .NET Core $(DotNetCorePreviewVersion)
+  inputs:
+    version: $(DotNetCorePreviewVersion)
+
+- task: UseDotNet@2
   displayName: install .NET Core $(DotNetCoreVersion)
   inputs:
     version: $(DotNetCoreVersion)


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3609773&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=65256bb7-a34c-5353-bc4d-c02ee25dc133

Some builds have been failing with the following error:

    BuildJniEnvironment_g_cs:
    dotnet "/Users/builder/azdo/_work/211/s/xamarin-android/external/Java.Interop/bin/BuildRelease-netcoreapp3.1/jnienv-gen.dll" Java.Interop/JniEnvironment.g.cs obj/Release/netcoreapp3.1//jni.c
    It was not possible to find any compatible framework version
    The framework 'Microsoft.NETCore.App', version '3.1.2' was not found.
        - The following frameworks were found:
            2.1.12 at [/Users/builder/azdo/_work/_tool/dotnet/shared/Microsoft.NETCore.App]
            3.1.0 at [/Users/builder/azdo/_work/_tool/dotnet/shared/Microsoft.NETCore.App]
            5.0.0-preview.1.20120.5 at [/Users/builder/azdo/_work/_tool/dotnet/shared/Microsoft.NETCore.App]

It seems we have a 3.1 version installed in this case, but perhaps it's
not new enough.  Attempt to fix the error by always installing both our
required preview and stable versions of .NET Core.  Installing the
stable version last should result in it being the preferred SDK (and the
latest appended to $PATH). Duplicating our `UseDotNet` usage, and the
side by side nature of .NET Core should allow our projects which require
a newer preview to continue to build.