### PR TITLE
[Xamarin.Android.Build.Tasks] Add XA1011 error for D8 with ProGuard

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -82,6 +82,7 @@ ms.date: 01/24/2020
 + [XA1008](xa1008.md): The TargetFrameworkVersion (Android API level {compileSdk}) is lower than the targetSdkVersion ({targetSdk}).
 + [XA1009](xa1009.md): The {assembly} is Obsolete. Please upgrade to {assembly} {version}
 + [XA1010](xa1010.md): Invalid \`$(AndroidManifestPlaceholders)\` value for Android manifest placeholders. Please use \`key1=value1;key2=value2\` format. The specified value was: `{placeholders}`
++ [XA1011](xa1011.md): Using ProGuard with the D8 DEX compiler is no longer supported. Please update \`$(AndroidLinkTool)\` to \`r8\`.
 + XA1012: Included layout root element override ID '{id}' is not valid.
 + XA1013: Failed to parse ID of node '{name}' in the layout file '{file}'.
 

--- a/Documentation/guides/messages/xa1011.md
+++ b/Documentation/guides/messages/xa1011.md
@@ -1,0 +1,28 @@
+---
+title: Xamarin.Android error XA1011
+description: XA1011 error code
+ms.date: 04/03/2020
+---
+# Xamarin.Android error XA1011
+
+## Example messages
+
+```
+error XA1011: Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.
+```
+
+## Issue
+
+The project has `$(AndroidDexTool)` set to `d8` and `$(AndroidLinkTool)` set to
+`ProGuard`.  In the past this configuration was allowed, but now only the R8
+code shrinker is supported for use with the D8 DEX compiler.
+
+## Solution
+
+Update the `$(AndroidLinkTool)` MSBuild property to `r8` to select the R8 code
+shrinker.  This property corresponds to the **Code shrinker** setting in the
+Visual Studio project properties pages.
+
+R8 might in some cases produce new build warnings or errors compared to
+ProGuard, so the ProGuard rules for the project might require a few updates to
+resolve any new warnings or errors that appear after this change.

--- a/Documentation/release-notes/4414.md
+++ b/Documentation/release-notes/4414.md
@@ -1,5 +1,0 @@
-### For D8 DEX compiler, R8 now used automatically instead of ProGuard
-
-Xamarin.Android now selects the R8 code shrinker automatically for projects that
-have the **Dex compiler** (`$(AndroidDexTool)`) set to **d8** and **Code
-shrinker** (`$(AndroidLinkTool)`) set to **ProGuard**.

--- a/Documentation/release-notes/xa1011.md
+++ b/Documentation/release-notes/xa1011.md
@@ -1,0 +1,28 @@
+### XA1011 error when using D8 with ProGuard
+
+Any project using the D8 DEX compiler that has either **Code shrinker**
+(`$(AndroidLinkTool)`) set to **ProGuard** or the older
+`$(AndroidEnableProguard)` MSBuild property set to `true` will now get a XA1011
+build error:
+
+```
+error XA1011: Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.
+```
+
+In the past this configuration was allowed, but now only the R8 code shrinker is
+supported for use with the D8 DEX compiler.
+
+To resolve this error, update the **Code shrinker** setting in the Visual Studio
+project property pages to **r8**.  This corresponds to the `r8` value for the
+`$(AndroidLinkTool)` MSBuild property in the *.csproj* file:
+
+```xml
+<PropertyGroup>
+  <AndroidLinkTool>r8</AndroidLinkTool>
+</PropertyGroup>
+```
+
+> [!NOTE]
+> R8 might in some cases produce new build warnings or errors compared to
+> ProGuard, so the ProGuard rules for the project might require a few updates to
+> resolve any new warnings or errors that appear after this change.

--- a/Documentation/workflow/Localization.md
+++ b/Documentation/workflow/Localization.md
@@ -23,11 +23,11 @@ so when adding a new message, follow these steps:
     ```
 
     Or, to log a message directly from an MSBuild target, pass the name of the
-    generated property to the `ResourceName` parameter of the `<AndroidError/>`
-    or `<AndroidWarning/>` task instead:
+    resource to the `ResourceName` parameter of the `<AndroidError/>` or
+    `<AndroidWarning/>` task instead:
 
     ```xml
-    <AndroidError Code="XA0000" ResourceName="Properties.Resources.XA0000" />
+    <AndroidError Code="XA0000" ResourceName="XA0000" />
     ```
 
  3. After adding the new message, build `Xamarin.Android.Build.Tasks.csproj`

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -421,6 +421,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`..
+        /// </summary>
+        internal static string XA1011 {
+            get {
+                return ResourceManager.GetString("XA1011", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Included layout root element override ID &apos;{0}&apos; is not valid..
         /// </summary>
         internal static string XA1012 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -312,6 +312,10 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</value>
     <comment>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</comment>
   </data>
+  <data name="XA1011" xml:space="preserve">
+    <value>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</value>
+    <comment>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</comment>
+  </data>
   <data name="XA1012" xml:space="preserve">
     <value>Included layout root element override ID '{0}' is not valid.</value>
     <comment>{0} - The Android resource ID name</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Neplatná hodnota $(AndroidManifestPlaceholders) pro zástupné symboly manifestu pro Android. Použijte prosím formát klíč1=hodnota1;klíč2=hodnota2. Zadaná hodnota: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Ungültiger $(AndroidManifestPlaceholders)-Wert für Android-Manifestplatzhalter. Verwenden Sie das Format "Schlüssel1=Wert1;Schlüssel2=Wert2". Der angegebene Wert lautete "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Valor de "$(AndroidManifestPlaceholders)" no válido para los marcadores de posición del manifiesto de Android. Use el formato "clave1=valor1;clave2=valor2". El valor especificado era "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Valeur '$(AndroidManifestPlaceholders)' non valide pour les espaces réservés de manifeste Android. Utilisez le format 'clé1=valeur1;clé2=valeur2'. La valeur spécifiée est : '{0}'</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Il valore di `$(AndroidManifestPlaceholders)` non è valido per i segnaposto di manifesti Android. Usare il formato `key1=value1;key2=value2`. Il valore specificato è: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Android マニフェストのプレースホルダーの `$(AndroidManifestPlaceholders)` 値が無効です。`key1=value1;key2=value2` の形式を使用してください。指定された値: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Android 매니페스트 자리 표시자에 대한 '$(AndroidManifestPlaceholders)' 값이 잘못되었습니다. 'key1=value1;key2=value2' 형식을 사용하세요. 지정된 값은 '{0}'입니다.</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Nieprawidłowa wartość „$(AndroidManifestPlaceholders)” dla symboli zastępczych manifestu systemu Android. Użyj formatu „klucz1=wartość1; klucz2=wartość2”. Podana wartość: „{0}”</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Valor de `$(AndroidManifestPlaceholders)` inválido para os espaços reservados do manifesto do Android. Use o formato `key1=value1;key2=value2`. O valor especificado era: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Недопустимое значение "$(AndroidManifestPlaceholders)" для заполнителей манифеста Android. Используйте формат "ключ1=значение1;ключ2=значение2". Указано значение: "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Android bildirim yer tutucuları için `$(AndroidManifestPlaceholders)` değeri geçersiz. Lütfen `anahtar1=değer1;anahtar2=değer2` biçimini kullanın. Belirtilen değer: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Android 清单占位符的 `$(AndroidManifestPlaceholders)` 值无效。请使用 `key1=value1;key2=value2` 格式。指定的值为: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -238,6 +238,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Android 資訊清單預留位置的 `$(AndroidManifestPlaceholders)` 值無效。請使用 `key1=value1;key2=value2` 格式。指定的值為: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
+      <trans-unit id="XA1011">
+        <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
+        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
+      </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
         <target state="new">Included layout root element override ID '{0}' is not valid.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1099,6 +1099,16 @@ namespace UnamedProject
 				LinkTool = linkTool,
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildProguard Enabled Project(1){isRelease}{dexTool}{linkTool}"))) {
+				if (dexTool == "d8" && linkTool == "proguard") {
+					b.ThrowOnBuildFailure = false;
+					Assert.IsFalse (b.Build (proj), "Build should have failed.");
+					string error = b.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA1011:"));
+					Assert.IsNotNull (error, "Build should have failed with XA1011.");
+					return;
+				}
+
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				if (isRelease && !string.IsNullOrEmpty (linkTool)) {
@@ -1315,6 +1325,8 @@ namespace UnnamedProject {
 			proj.EnableProguard =
 				proj.IsRelease = true;
 			proj.LinkTool = linkTool;
+			if (linkTool == "proguard")
+				proj.DexTool = "dx";
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
@@ -2598,6 +2610,15 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 ",
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InItAndÜmläüts({enableMultiDex}{dexTool}{linkTool})"))) {
+				if (dexTool == "d8" && linkTool == "proguard") {
+					b.ThrowOnBuildFailure = false;
+					Assert.IsFalse (b.Build (proj), "Build should have failed.");
+					string error = b.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA1011:"));
+					Assert.IsNotNull (error, "Build should have failed with XA1011.");
+					return;
+				}
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -303,7 +303,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- NOTE: $(AndroidLinkTool) would be blank if code shrinking is not used at all -->
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == '' And '$(AndroidEnableProguard)' == 'True' ">proguard</AndroidLinkTool>
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidEnableDesugar)' == 'True' ">r8</AndroidLinkTool>
-	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' ">r8</AndroidLinkTool>
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
@@ -565,6 +564,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="None" Condition="'$(AndroidLinkMode)' == 'SdkOnly' And '$(AndroidUseSharedRuntime)' == 'true'">
 		<Output TaskParameter="Value" PropertyName="AndroidLinkMode" />
 	</CreateProperty>
+	<AndroidError Code="XA1011"
+		ResourceName="XA1011"
+		Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "
+	/>
 </Target>
 
 <Target Name="UpdateGeneratedFiles"


### PR DESCRIPTION
Context: 5563a79cbb6931818b06ddfb0c83d6957e3df480
Somewhat related: https://github.com/xamarin/xamarin-android/pull/4509#issuecomment-608640547

Rather than automatically changing `$(AndroidLinkTool)` from `proguard`
to `r8` when `$(AndroidDexTool)`=`d8`, provide an error that instructs
project authors to update the property themselves.

The motivation for this approach is that we have seen some cases where
changing from ProGuard to R8 can change behavior.  Forcing project
authors to change `$(AndroidLinkTool)` themselves will help let them
know that they should pay attention for any potential changes to Java
code shrinking behavior after the change.