### PR TITLE
[Xamarin.Android.Build.Tasks] Add localizable message tasks

### DIFF
--- a/Documentation/workflow/Localization.md
+++ b/Documentation/workflow/Localization.md
@@ -22,6 +22,14 @@ so when adding a new message, follow these steps:
     Log.LogCodedError ("XA0000", Properties.Resources.XA0000);
     ```
 
+    Or, to log a message directly from an MSBuild target, pass the name of the
+    generated property to the `ResourceName` parameter of the `<AndroidError/>`
+    or `<AndroidWarning/>` task instead:
+
+    ```xml
+    <AndroidError Code="XA0000" ResourceName="Properties.Resources.XA0000" />
+    ```
+
  3. After adding the new message, build `Xamarin.Android.Build.Tasks.csproj`
     locally.  This will run the targets from [dotnet/xliff-tasks][xliff-tasks]
     to update the `.xlf` [XLIFF][xliff] localization files with the latest

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidError.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidError.cs
@@ -1,0 +1,38 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Provides a localizable way to log an error from an MSBuild target.
+	/// </summary>
+	public class AndroidError : Task
+	{
+		/// <summary>
+		/// Error code
+		/// </summary>
+		[Required]
+		public string Code { get; set; }
+
+		/// <summary>
+		/// The name of the resource from Properties\Resources.resx that contains the message
+		/// </summary>
+		[Required]
+		public string ResourceName { get; set; }
+
+		/// <summary>
+		/// The string format arguments to use for any numbered format items in the resource provided by ResourceName
+		/// </summary>
+		public string [] FormatArguments { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogCodedError (
+				Code,
+				Properties.Resources.ResourceManager.GetString (ResourceName, Properties.Resources.Culture),
+				FormatArguments
+			);
+			return false;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidWarning.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidWarning.cs
@@ -1,0 +1,38 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Provides a localizable way to log a warning from an MSBuild target.
+	/// </summary>
+	public class AndroidWarning : Task
+	{
+		/// <summary>
+		/// Warning code
+		/// </summary>
+		[Required]
+		public string Code { get; set; }
+
+		/// <summary>
+		/// The name of the resource from Properties\Resources.resx that contains the message
+		/// </summary>
+		[Required]
+		public string ResourceName { get; set; }
+
+		/// <summary>
+		/// The string format arguments to use for any numbered format items in the resource provided by ResourceName
+		/// </summary>
+		public string [] FormatArguments { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogCodedWarning (
+				Code,
+				Properties.Resources.ResourceManager.GetString (ResourceName, Properties.Resources.Culture),
+				FormatArguments
+			);
+			return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -21,6 +21,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidComputeResPaths" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidSignPackage" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidCreateDebugKey" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidError" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidWarning" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidZipAlign" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidApkSigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AppendCustomMetadataToItemGroup" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />


### PR DESCRIPTION
The built-in `<Error/>` and `<Warning/>` tasks from MSBuild do not
provide a way to look up string resources, so they don't allow logging
localizable warnings and errors from MSBuild targets.

Add custom `<AndroidError/>` and `<AndroidWarning/>` tasks to handle
this scenario.

This approach is inspired by the [`<NETSdkError/>`][0] and
[`<NETSdkWarning/>`][1] tasks in dotnet/sdk.

[0]: https://github.com/dotnet/sdk/blob/56a9d827c8408f98ab27caceae2c8e1936281401/src/Tasks/Common/NETSdkError.cs
[1]: https://github.com/dotnet/sdk/blob/56a9d827c8408f98ab27caceae2c8e1936281401/src/Tasks/Common/NETSdkWarning.cs