### PR TITLE
[Xamarin.Android.Build.Tasks] Remove unused error from AndroidApkSigner

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -51,16 +51,6 @@ namespace Xamarin.Android.Tasks
 
 		public string AdditionalArguments { get; set; }
 
-		public override bool RunTask ()
-		{
-			if (!File.Exists (GenerateFullPathToTool ())) {
-				Log.LogError ($"'{GenerateFullPathToTool ()}' does not exist. You need to install android-sdk build-tools 26.0.1 or above.");
-				return false;
-			}
-
-			return base.RunTask ();
-		}
-
 		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)
 		{
 			if (value.StartsWith ("env:", StringComparison.Ordinal)) {


### PR DESCRIPTION
Thanks to b28a93ad223f3610067aef63c427afb17a23e7d7, the error check in
`AndroidApkSigner.RunTask()` is no longer needed.  Before that commit,
`RunTask()` was validating the path of `apksigner` or `apksigner.bat`.
But now that `AndroidApkSigner` inherits from `JavaToolTask`, the check
is just revalidating the path of `java`.

One option would be to update the check to validate the path of
`apksigner.jar` instead, but that isn't needed because
`<ResolveAndroidTooling/>` already validates that path.  So the check
can just be removed.