### PR TITLE
Update DotNet5.md

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -64,4 +64,4 @@ Almost everything else happens during `donet publish`:
   after the linker.
 * Compile java code via `javac`
 * Convert java code to `.dex` via d8/r8
-* Create an `.apk` and sign it
+* Create an `.apk` or `.aab` and sign it


### PR DESCRIPTION
Added .aab format

Android App Bundle, `.aab` is now more common than `.apk`