### PR TITLE
[tests] CheckAapt2WarningsDoNotGenerateErrors non-parallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -319,6 +319,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
+		[NonParallelizable] // Commonly fails NuGet restore
 		public void CheckAapt2WarningsDoNotGenerateErrors ()
 		{
 			//https://github.com/xamarin/xamarin-android/issues/3083


### PR DESCRIPTION
Context: https://build.azdo.io/3615798
Context: https://build.azdo.io/3615816

This test commonly fails with:

    (Restore target) ->
    NuGet.targets(124,5): error : Could not find file '/Users/runner/runners/2.165.2/work/1/s/packages/xamarin.forms/2.3.4.231/ltlis65w.fez'.
        0 Warning(s)
        1 Error(s)

Looking at the other tests that use
`KnownPackages.XamarinForms_2_3_4_231`, they already have
`[NonParallelizable]`.

I think we should do the same for this test.