### PR TITLE
[tests] raise acceptable timings for performance tests

### DIFF
--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,13 +2,13 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,10000
+Build_From_Clean_DontIncludeRestore,10250
 Build_No_Changes,3250
 Build_CSharp_Change,4450
 Build_AndroidResource_Change,4150
-Build_AndroidManifest_Change,4400
+Build_AndroidManifest_Change,4500
 Build_Designer_Change,3600
-Build_JLO_Change,9100
+Build_JLO_Change,9500
 Build_CSProj_Change,9800
 Build_XAML_Change,9400
 Build_XAML_Change_RefAssembly,6000


### PR DESCRIPTION
Context: https://build.azdo.io/3616517
Context: https://github.com/xamarin/xamarin-android/pull/4487

7117414c raised the acceptable build times for three tests:

* `Build_From_Clean_DontIncludeRestore`
* `Build_AndroidManifest_Change`
* `Build_JLO_Change`

Unfortunately, we didn't increase the times enough. I raised them a
bit more, so they should pass more reliably.

In a future PR, we could consider using the ABI of the connected
emulator/device to only build & generate an APK for that specific
device. I could see this improving the regressed timings here, as the
`_GenerateJavaStubs` and native assembly compilation are taking
additional time per-ABI.