### PR TITLE
LOC CHECKIN | xamarin/xamarin-android d16-6 | 20200406

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Nepovedlo se najít mono.android.jar.</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Neplatná hodnota $(AndroidManifestPlaceholders) pro zástupné symboly manifestu pro Android. Použijte prosím formát klíč1=hodnota1;klíč2=hodnota2. Zadaná hodnota: {0}</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Nelze přeložit odkaz: {0}, na který odkazuje {1}. Možná neexistuje v profilu Mono for Android.</target>
+        <target state="translated">Nelze přeložit odkaz: {0}, na který odkazuje {1}. Možná neexistuje v profilu Mono for Android.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Nelze přeložit odkaz: {0}, na který odkazuje {1}. Přidejte prosím balíček NuGet nebo odkaz na sestavení pro {0} nebo odeberte odkaz na {2}.</target>
+        <target state="translated">Nelze přeložit odkaz: {0}, na který odkazuje {1}. Přidejte prosím balíček NuGet nebo odkaz na sestavení pro {0} nebo odeberte odkaz na {2}.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Soubor $(AndroidSigningKeyStore) {0} se nepovedlo najít.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Název vložené aplikace pro Wear se liší od názvu balíčku aplikace pro kapesní zařízení ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">"mono.android.jar" wurde nicht gefunden.</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Ungültiger $(AndroidManifestPlaceholders)-Wert für Android-Manifestplatzhalter. Verwenden Sie das Format "Schlüssel1=Wert1;Schlüssel2=Wert2". Der angegebene Wert lautete "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Möglicherweise ist er nicht im Mono für Android-Profil vorhanden.</target>
+        <target state="translated">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Möglicherweise ist er nicht im Mono für Android-Profil vorhanden.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Fügen Sie einen Verweis auf ein NuGet-Paket oder eine Assembly für "{0}" hinzu, oder entfernen Sie den Verweis auf "{2}".</target>
+        <target state="translated">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Fügen Sie einen Verweis auf ein NuGet-Paket oder eine Assembly für "{0}" hinzu, oder entfernen Sie den Verweis auf "{2}".</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Die $(AndroidSigningKeyStore)-Datei "{0}" wurde nicht gefunden.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Der Name des eingebetteten Wear-App-Pakets weicht vom Namen des Handheld-App-Pakets ab ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">No se encontró mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Valor de "$(AndroidManifestPlaceholders)" no válido para los marcadores de posición del manifiesto de Android. Use el formato "clave1=valor1;clave2=valor2". El valor especificado era "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">No se puede resolver la referencia "{0}", a la que hace referencia {1}. ¿Puede que no exista en el perfil de Mono para Android?</target>
+        <target state="translated">No se puede resolver la referencia "{0}", a la que hace referencia {1}. ¿Puede que no exista en el perfil de Mono para Android?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">No se puede resolver la referencia "{0}", a la que hace referencia {1}. Agregue un paquete NuGet o una referencia de ensamblado para "{0}", o bien quite la referencia a "{2}".</target>
+        <target state="translated">No se puede resolver la referencia "{0}", a la que hace referencia {1}. Agregue un paquete NuGet o una referencia de ensamblado para "{0}", o bien quite la referencia a "{2}".</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">No se ha encontrado el archivo "{0}" de "$(AndroidSigningKeyStore)".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">El nombre del paquete de la aplicación Wear que se ha insertado es distinto del nombre del paquete de la aplicación para dispositivos de mano ({0}! = {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Fichier mono.android.jar introuvable</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Valeur '$(AndroidManifestPlaceholders)' non valide pour les espaces réservés de manifeste Android. Utilisez le format 'clé1=valeur1;clé2=valeur2'. La valeur spécifiée est : '{0}'</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Impossible de résoudre la référence '{0}', référencée par {1}. Peut-être qu'elle n'existe pas dans le profil Mono pour Android ?</target>
+        <target state="translated">Impossible de résoudre la référence '{0}', référencée par {1}. Peut-être qu'elle n'existe pas dans le profil Mono pour Android ?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Impossible de résoudre la référence '{0}', référencée par {1}. Ajoutez un paquet NuGet ou une référence d'assembly pour '{0}', ou supprimez la référence à '{2}'.</target>
+        <target state="translated">Impossible de résoudre la référence '{0}', référencée par {1}. Ajoutez un paquet NuGet ou une référence d'assembly pour '{0}', ou supprimez la référence à '{2}'.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Le fichier '$(AndroidSigningKeyStore)' '{0}' est introuvable.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Le nom du package d'application Wear embarqué diffère du nom du package d'application du terminal portable ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Non è stato possibile trovare mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Il valore di `$(AndroidManifestPlaceholders)` non è valido per i segnaposto di manifesti Android. Usare il formato `key1=value1;key2=value2`. Il valore specificato è: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Non è possibile risolvere il riferimento `{0}`, a cui fa riferimento {1}. Forse non esiste nel profilo Mono per Android?</target>
+        <target state="translated">Non è possibile risolvere il riferimento `{0}`, a cui fa riferimento {1}. Forse non esiste nel profilo Mono per Android?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Non è possibile risolvere il riferimento `{0}`, a cui fa riferimento {1}. Aggiungere un pacchetto NuGet o un riferimento a un assembly per `{0}` oppure rimuovere il riferimento a `{2}`.</target>
+        <target state="translated">Non è possibile risolvere il riferimento `{0}`, a cui fa riferimento {1}. Aggiungere un pacchetto NuGet o un riferimento a un assembly per `{0}` oppure rimuovere il riferimento a `{2}`.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Non è stato possibile trovare il file `{0}` di `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Il nome del pacchetto dell'app Wear incorporata è diverso da quello dell'app palmare ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">mono.android.jar が見つかりませんでした</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Android マニフェストのプレースホルダーの `$(AndroidManifestPlaceholders)` 値が無効です。`key1=value1;key2=value2` の形式を使用してください。指定された値: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">{1} によって参照されている参照 '{0}' を解決できません。Mono for Android プロファイル内にそれが存在しないと思われます。</target>
+        <target state="translated">{1} によって参照されている参照 '{0}' を解決できません。Mono for Android プロファイル内にそれが存在しないと思われます。</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">{1} によって参照されている参照 '{0}' を解決できません。'{0}' の NuGet パッケージまたはアセンブリ参照を追加するか、'{2}' への参照を削除してください。</target>
+        <target state="translated">{1} によって参照されている参照 '{0}' を解決できません。'{0}' の NuGet パッケージまたはアセンブリ参照を追加するか、'{2}' への参照を削除してください。</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">'$(AndroidSigningKeyStore)' ファイル '{0}' が見つかりませんでした。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">組み込みの Wear アプリ パッケージ名がハンドヘルド アプリ パッケージ名と異なります ({0}! = {1})。</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">mono.android.jar을 찾을 수 없습니다.</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Android 매니페스트 자리 표시자에 대한 '$(AndroidManifestPlaceholders)' 값이 잘못되었습니다. 'key1=value1;key2=value2' 형식을 사용하세요. 지정된 값은 '{0}'입니다.</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">{1}에서 참조하는 '{0}' 참조를 확인할 수 없습니다. Mono for Android 프로필에 해당 참조가 없는 것 같습니다.</target>
+        <target state="translated">{1}에서 참조하는 '{0}' 참조를 확인할 수 없습니다. Mono for Android 프로필에 해당 참조가 없는 것 같습니다.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">{1}에서 참조하는 '{0}' 참조를 확인할 수 없습니다. '{0}'에 대한 NuGet 패키지 또는 어셈블리 참조를 추가하거나 '{2}'에 대한 참조를 제거하세요.</target>
+        <target state="translated">{1}에서 참조하는 '{0}' 참조를 확인할 수 없습니다. '{0}'에 대한 NuGet 패키지 또는 어셈블리 참조를 추가하거나 '{2}'에 대한 참조를 제거하세요.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">'$(AndroidSigningKeyStore)' 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">포함된 Wear 앱 패키지 이름이 핸드헬드 앱 패키지 이름과 다릅니다({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Nie można było znaleźć pliku mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Nieprawidłowa wartość „$(AndroidManifestPlaceholders)” dla symboli zastępczych manifestu systemu Android. Użyj formatu „klucz1=wartość1; klucz2=wartość2”. Podana wartość: „{0}”</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Nie można rozpoznać odwołania „{0}” przywoływanego przez element {1}. Być może nie istnieje ono w profilu platformy Mono dla systemu Android?</target>
+        <target state="translated">Nie można rozpoznać odwołania „{0}” przywoływanego przez element {1}. Być może nie istnieje ono w profilu platformy Mono dla systemu Android?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Nie można rozpoznać odwołania „{0}” przywoływanego przez element {1}. Dodaj odwołanie do pakietu lub zestawu NuGet dla elementu „{0}” lub usuń odwołanie do elementu „{2}”.</target>
+        <target state="translated">Nie można rozpoznać odwołania „{0}” przywoływanego przez element {1}. Dodaj odwołanie do pakietu lub zestawu NuGet dla elementu „{0}” lub usuń odwołanie do elementu „{2}”.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Nie można odnaleźć pliku „$(AndroidSigningKeyStore)” („{0}”).</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Nazwa pakietu osadzonej aplikacji systemu Wear jest inna niż nazwa pakietu aplikacji dla urządzenia podręcznego ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Não foi possível encontrar o mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Valor de `$(AndroidManifestPlaceholders)` inválido para os espaços reservados do manifesto do Android. Use o formato `key1=value1;key2=value2`. O valor especificado era: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Não é possível resolver a referência: `{0}`, referenciada por {1}. É possível que ela não exista no perfil do Mono para Android?</target>
+        <target state="translated">Não é possível resolver a referência: `{0}`, referenciada por {1}. É possível que ela não exista no perfil do Mono para Android?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Não é possível resolver a referência: `{0}`, referenciada por {1}. Adicione um pacote NuGet ou uma referência de assembly para `{0}` ou remova a referência a `{2}`.</target>
+        <target state="translated">Não é possível resolver a referência: `{0}`, referenciada por {1}. Adicione um pacote NuGet ou uma referência de assembly para `{0}` ou remova a referência a `{2}`.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Não foi possível localizar o arquivo `{0}` de `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">O nome do pacote do aplicativo Wear inserido difere do nome do pacote do aplicativo portátil ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">Не удалось найти mono.android.jar.</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Недопустимое значение "$(AndroidManifestPlaceholders)" для заполнителей манифеста Android. Используйте формат "ключ1=значение1;ключ2=значение2". Указано значение: "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Возможно, он отсутствует в профиле Mono для Android.</target>
+        <target state="translated">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Возможно, он отсутствует в профиле Mono для Android.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Добавьте пакет NuGet или ссылку на сборку для "{0}" либо удалите ссылку на "{2}".</target>
+        <target state="translated">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Добавьте пакет NuGet или ссылку на сборку для "{0}" либо удалите ссылку на "{2}".</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">Не удалось найти файл "$(AndroidSigningKeyStore)" с именем "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Имя пакета приложения Wear для встроенных устройств отличается от имени пакета приложения для наладонных устройств ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">mono.android.jar bulunamadı</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Android bildirim yer tutucuları için `$(AndroidManifestPlaceholders)` değeri geçersiz. Lütfen `anahtar1=değer1;anahtar2=değer2` biçimini kullanın. Belirtilen değer: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">{1} tarafından başvurulan `{0}` başvurusu çözümlenemiyor. Mono for Android profilinde bulunmuyor olabilir.</target>
+        <target state="translated">{1} tarafından başvurulan `{0}` başvurusu çözümlenemiyor. Mono for Android profilinde bulunmuyor olabilir.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">{1} tarafından başvurulan `{0}` başvurusu çözümlenemiyor. Lütfen `{0}` için bir NuGet paketi veya bütünleştirilmiş kod başvurusu ekleyin ya da `{2}` başvurusunu kaldırın.</target>
+        <target state="translated">{1} tarafından başvurulan `{0}` başvurusu çözümlenemiyor. Lütfen `{0}` için bir NuGet paketi veya bütünleştirilmiş kod başvurusu ekleyin ya da `{2}` başvurusunu kaldırın.</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">`{0}` adlı `$(AndroidSigningKeyStore)` dosyası bulunamadı.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">Eklenmiş Wear uygulama paketi adı, el bilgisayarı uygulama paketi adından farklı ({0} != {1}).</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">找不到 mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Android 清单占位符的 `$(AndroidManifestPlaceholders)` 值无效。请使用 `key1=value1;key2=value2` 格式。指定的值为: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">无法解析引用: `{0}`,引用者为 {1}.它可能不存在于 Mono for Android 配置文件中?</target>
+        <target state="translated">无法解析引用: `{0}`,引用者为 {1}.它可能不存在于 Mono for Android 配置文件中?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">无法解析引用: `{0}`，引用者为 {1}。请为 `{0}` 添加 NuGet 包或程序集引用，或删除对 `{2}` 的引用。</target>
+        <target state="translated">无法解析引用: `{0}`，引用者为 {1}。请为 `{0}` 添加 NuGet 包或程序集引用，或删除对 `{2}` 的引用。</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">找不到“$(AndroidSigningKeyStore)”文件“{0}”。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">嵌入的 Wear 应用包名称与手持式应用包名称不同({0} != {1})。</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -48,7 +48,7 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0002">
         <source>Could not find mono.android.jar</source>
-        <target state="new">Could not find mono.android.jar</target>
+        <target state="translated">找不到 mono.android.jar</target>
         <note>The following are literal names and should not be translated: mono.android.jar</note>
       </trans-unit>
       <trans-unit id="XA0003">
@@ -235,7 +235,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1010">
         <source>Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</source>
-        <target state="new">Invalid `$(AndroidManifestPlaceholders)` value for Android manifest placeholders. Please use `key1=value1;key2=value2` format. The specified value was: `{0}`</target>
+        <target state="translated">Android 資訊清單預留位置的 `$(AndroidManifestPlaceholders)` 值無效。請使用 `key1=value1;key2=value2` 格式。指定的值為: `{0}`</target>
         <note>The following are literal names and should not be translated: `$(AndroidManifestPlaceholders)`</note>
       </trans-unit>
       <trans-unit id="XA2000">
@@ -251,13 +251,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="needs-review-translation">無法解析參考: `{0}`，參考方為 {1}。或許該參考不存在於 Android 的 Mono 設定檔中?</target>
+        <target state="translated">無法解析參考: `{0}`，參考方為 {1}。或許該參考不存在於 Android 的 Mono 設定檔中?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
       <trans-unit id="XA2002_NuGet">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Please add a NuGet package or assembly reference for `{0}`, or remove the reference to `{2}`.</source>
-        <target state="needs-review-translation">無法解析參考: `{0}`，參考方為 {1}。請為 `{0}` 新增 NuGet 套件或組件參考，或移除對 `{2}` 的參考。</target>
+        <target state="translated">無法解析參考: `{0}`，參考方為 {1}。請為 `{0}` 新增 NuGet 套件或組件參考，或移除對 `{2}` 的參考。</target>
         <note>{0} - The name of the missing assembly
 {1} -  The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`
 {2} - The name of the first assembly in the chain of references. Example: System.Memory</note>
@@ -447,7 +447,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4310">
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="new">`$(AndroidSigningKeyStore)` file `{0}` could not be found.</target>
+        <target state="translated">找不到 `$(AndroidSigningKeyStore)` 檔案 `{0}`。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
       </trans-unit>
       <trans-unit id="XA5101">
@@ -532,7 +532,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5211">
         <source>Embedded Wear app package name differs from handheld app package name ({0} != {1}).</source>
-        <target state="new">Embedded Wear app package name differs from handheld app package name ({0} != {1}).</target>
+        <target state="translated">內嵌 Wear 應用程式套件名稱與手持功能應用程式套件名稱不同 ({0} != {1})。</target>
         <note>The following are literal names and should not be translated: Wear
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 In this message, the term "handheld app" means "app for handheld devices."


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-android/pull/4532

This backport excludes the changes related to XA0031 because those are
for 231bf2a4381af4996c795e27fa65b15d63e3fc0b, which is only present on
master.