### PR TITLE
Merge apkdiff from upstream

### DIFF
--- a/tools/apkdiff/ApkDescription.cs
+++ b/tools/apkdiff/ApkDescription.cs
@@ -209,7 +209,7 @@ namespace apkdiff {
 					continue;
 
 				if (Program.AssemblyRegressionThreshold != 0 && entryDiff is AssemblyDiff && diff.Value > Program.AssemblyRegressionThreshold) {
-					Program.Error ($"Assembly size differs more than {Program.AssemblyRegressionThreshold:#,0} bytes.");
+					Program.Error ($"Assembly '{diff.Key}' size increase {diff.Value:#,0} is {diff.Value - Program.AssemblyRegressionThreshold:#,0} bytes more than the threshold {Program.AssemblyRegressionThreshold:#,0}.");
 					Program.RegressionCount ++;
 				}
 

--- a/tools/apkdiff/ApkDescription.cs
+++ b/tools/apkdiff/ApkDescription.cs
@@ -8,8 +8,8 @@ using Xamarin.Tools.Zip;
 
 namespace apkdiff {
 
-	struct FileInfo {
-		public long Size;
+	struct FileProperties : ISizeProvider {
+		public long Size { get; set; }
 	}
 
 	[DataContract (Namespace = "apk")]
@@ -19,11 +19,15 @@ namespace apkdiff {
 		string Comment;
 
 		[DataMember]
-		long PackageSize;
+		public long PackageSize { get; protected set; }
 		string PackagePath;
 
+		ZipArchive Archive;
+
 		[DataMember]
-		readonly Dictionary<string, FileInfo> Entries = new Dictionary<string, FileInfo> ();
+		readonly Dictionary<string, FileProperties> Entries = new Dictionary<string, FileProperties> ();
+
+		Dictionary<string, (long Difference, long OriginalTotal)> totalDifferences = new Dictionary<string, (long, long)> ();
 
 		public static ApkDescription Load (string path)
 		{
@@ -54,7 +58,7 @@ namespace apkdiff {
 
 		void LoadApk (string path)
 		{
-			var zip = ZipArchive.Open (path, FileMode.Open);
+			Archive = ZipArchive.Open (path, FileMode.Open);
 
 			if (Program.Verbose)
 				Program.ColorWriteLine ($"Loading apk '{path}'", ConsoleColor.Yellow);
@@ -62,7 +66,7 @@ namespace apkdiff {
 			PackageSize = new System.IO.FileInfo (path).Length;
 			PackagePath = path;
 
-			foreach (var entry in zip) {
+			foreach (var entry in Archive) {
 				var name = entry.FullName;
 
 				if (Entries.ContainsKey (name)) {
@@ -70,7 +74,7 @@ namespace apkdiff {
 					continue;
 				}
 
-				Entries [name] = new FileInfo { Size = (long)entry.Size };
+				Entries [name] = new FileProperties { Size = (long)entry.Size };
 
 				if (Program.Verbose)
 					Program.ColorWriteLine ($"  {entry.Size,12} {name}", ConsoleColor.Gray);
@@ -103,12 +107,63 @@ namespace apkdiff {
 			}
 		}
 
-		void PrintDifference (string key, long diff, string comment = null)
+		static ConsoleColor PrintDifferenceStart (string key, long diff, string comment = null, string padding = null)
 		{
-			var color = diff > 0 ? ConsoleColor.Red : ConsoleColor.Green;
-			Program.ColorWrite ($"  {diff:+;-;+}{Math.Abs (diff),12}", color);
+			var color = diff == 0 ? ConsoleColor.Gray : diff > 0 ? ConsoleColor.Red : ConsoleColor.Green;
+			Program.ColorWrite ($"{padding}  {diff:+;-;+}{Math.Abs (diff),12:#,0}", color);
 			Program.ColorWrite ($" {key}", ConsoleColor.Gray);
-			Program.ColorWriteLine (comment, color);
+			Program.ColorWrite (comment, color);
+
+			return color;
+		}
+
+		static public void PrintDifference (string key, long diff, string comment = null, string padding = null)
+		{
+			PrintDifferenceStart (key, diff, comment, padding);
+			Console.WriteLine ();
+		}
+
+		static public void PrintDifference (string key, long diff, long orig, string comment = null, string padding = null)
+		{
+			var color = PrintDifferenceStart (key, diff, comment, padding);
+
+			if (orig != 0)
+				Program.ColorWrite ($" {(float)diff/orig:0.00%} (of {orig:#,0})", color);
+
+			Console.WriteLine ();
+		}
+
+		void AddToTotal (string entry, long size)
+		{
+			var entryDiff = EntryDiff.ForExtension (Path.GetExtension (entry));
+			if (entryDiff == null)
+				return;
+
+			var diffType = entryDiff.Name;
+			if (!totalDifferences.ContainsKey (diffType))
+				totalDifferences.Add (diffType, (0, size));
+			else {
+				var info = totalDifferences [diffType];
+				totalDifferences [diffType] = (info.Difference, info.OriginalTotal + size);
+			}
+		}
+
+		bool AddToDifference (string entry, long diff, out EntryDiff entryDiff)
+		{
+			entryDiff = EntryDiff.ForExtension (Path.GetExtension (entry));
+
+			if (entryDiff == null)
+				return false;
+
+			var diffType = entryDiff.Name;
+			if (!totalDifferences.ContainsKey (diffType))
+				totalDifferences.Add (diffType, (diff, 0));
+			else {
+				var info = totalDifferences [diffType];
+				totalDifferences [diffType] = (info.Difference + diff, info.OriginalTotal);
+			}
+
+			return true;
 		}
 
 		public void Compare (ApkDescription other)
@@ -116,16 +171,21 @@ namespace apkdiff {
 			var keys = Entries.Keys.Union (other.Entries.Keys);
 			var differences = new Dictionary<string, long> ();
 			var singles = new HashSet<string> ();
+			var comparingApks = Archive != null && other.Archive != null;
 
 			Program.ColorWriteLine ("Size difference in bytes ([*1] apk1 only, [*2] apk2 only):", ConsoleColor.Yellow);
 
-			foreach (var key in Entries.Keys) {
+			foreach (var entry in Entries) {
+				var key = entry.Key;
 				if (other.Entries.ContainsKey (key)) {
-					differences [key] = other.Entries [key].Size - Entries [key].Size;
+					var otherEntry = other.Entries [key];
+					differences [key] = otherEntry.Size - Entries [key].Size;
 				} else {
 					differences [key] = -Entries [key].Size;
 					singles.Add (key);
 				}
+
+				AddToTotal (key, Entries [key].Size);
 			}
 
 			foreach (var key in other.Entries.Keys) {
@@ -140,14 +200,53 @@ namespace apkdiff {
 				if (diff.Value == 0)
 					continue;
 
-				PrintDifference (diff.Key, diff.Value, singles.Contains (diff.Key) ? $" *{(diff.Value > 0 ? 2 : 1)}" : null);
+				var single = singles.Contains (diff.Key);
+
+				PrintDifference (diff.Key, diff.Value, single ? $" *{(diff.Value > 0 ? 2 : 1)}" : null);
+
+				EntryDiff entryDiff;
+				if (!AddToDifference (diff.Key, diff.Value, out entryDiff))
+					continue;
+
+				if (Program.AssemblyRegressionThreshold != 0 && entryDiff is AssemblyDiff && diff.Value > Program.AssemblyRegressionThreshold) {
+					Program.Error ($"Assembly size differs more than {Program.AssemblyRegressionThreshold:#,0} bytes.");
+					Program.RegressionCount ++;
+				}
+
+				if (comparingApks && !single)
+					CompareEntries (new KeyValuePair<string, FileProperties> (diff.Key, Entries [diff.Key]), new KeyValuePair<string, FileProperties> (diff.Key, other.Entries [diff.Key]), other, entryDiff);
 			}
 
 			Program.ColorWriteLine ("Summary:", ConsoleColor.Green);
 			if (Program.Verbose)
 				Program.ColorWriteLine ($"  apk1: {PackageSize,12}  {PackagePath}\n  apk2: {other.PackageSize,12}  {other.PackagePath}", ConsoleColor.Gray);
 
-			PrintDifference ("Package size difference", other.PackageSize - PackageSize);
+			foreach (var total in totalDifferences)
+				PrintDifference (total.Key, total.Value.Difference, total.Value.OriginalTotal);
+
+			PrintDifference ("Package size difference", other.PackageSize - PackageSize, PackageSize);
+		}
+
+		void CompareEntries (KeyValuePair<string, FileProperties> entry, KeyValuePair<string, FileProperties> other, ApkDescription otherApk, EntryDiff diff)
+		{
+			var tmpDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			var tmpDirOther = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+
+			if (Program.Verbose)
+				Program.ColorWriteLine ($"Extracting '{entry.Key}' to {tmpDir} and {tmpDirOther} temporary directories", ConsoleColor.Gray);
+
+			Directory.CreateDirectory (tmpDir);
+
+			var zipEntry = Archive.ReadEntry (entry.Key, true);
+			zipEntry.Extract (tmpDir, entry.Key);
+
+			var zipEntryOther = otherApk.Archive.ReadEntry (other.Key, true);
+			zipEntryOther.Extract (tmpDirOther, other.Key);
+
+			diff.Compare (Path.Combine (tmpDir, entry.Key), Path.Combine (tmpDirOther, other.Key), "  ");
+
+			Directory.Delete (tmpDir, true);
+			Directory.Delete (tmpDirOther, true);
 		}
 	}
 }

--- a/tools/apkdiff/AssemblyDiff.cs
+++ b/tools/apkdiff/AssemblyDiff.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace apkdiff {
+	public class AssemblyDiff : EntryDiff {
+
+		MetadataReader reader1;
+		MetadataReader reader2;
+
+		public AssemblyDiff ()
+		{
+		}
+
+		public override string Name { get { return "Assemblies"; } }
+
+		TypeDefinition GetTypeDefinition (MetadataReader reader, TypeDefinitionHandle handle, out string fullName)
+		{
+			var typeDef = reader.GetTypeDefinition (handle);
+			var name = reader.GetString (typeDef.Name);
+			var nspace = reader.GetString (typeDef.Namespace);
+
+			fullName = "";
+
+			if (typeDef.IsNested) {
+				string declTypeFullName;
+
+				GetTypeDefinition (reader, typeDef.GetDeclaringType (), out declTypeFullName);
+				fullName += declTypeFullName + "/";
+			}
+
+			if (!string.IsNullOrEmpty (nspace))
+				fullName += nspace + ".";
+
+			fullName += name;
+
+			return typeDef;
+		}
+
+		public override void Compare (string file, string other, string padding)
+		{
+			var per1 = new PEReader (File.OpenRead (file));
+			var per2 = new PEReader (File.OpenRead (other));
+
+			reader1 = per1.GetMetadataReader ();
+			reader2 = per2.GetMetadataReader ();
+
+			var types1 = new Dictionary<string, TypeDefinition> (reader1.TypeDefinitions.Count);
+			var types2 = new Dictionary<string, TypeDefinition> (reader2.TypeDefinitions.Count);
+
+			string fullName;
+
+			foreach (var typeHandle in reader1.TypeDefinitions) {
+				var td = GetTypeDefinition (reader1, typeHandle, out fullName);
+				types1 [fullName] = td;
+			}
+
+			foreach (var typeHandle in reader2.TypeDefinitions) {
+				var td = GetTypeDefinition (reader2, typeHandle, out fullName);
+				types2 [fullName] = td;
+			}
+
+			foreach (var pair in types1) {
+				if (!types2.ContainsKey (pair.Key)) {
+					Console.WriteLine ($"{padding}  -             Type {pair.Key}");
+				} else
+					CompareTypes (types1 [pair.Key], types2 [pair.Key], padding + "  ");
+			}
+
+			foreach (var pair in types2) {
+				if (!types1.ContainsKey (pair.Key)) {
+					Console.WriteLine ($"{padding}  +             Type {pair.Key}");
+				}
+			}
+		}
+
+		string GetTypeName (MetadataReader reader, EntityHandle handle)
+		{
+			string fullName = "";
+
+			if (handle.Kind == HandleKind.TypeDefinition) {
+				GetTypeDefinition (reader, (TypeDefinitionHandle) handle, out fullName);
+
+				return fullName;
+			}
+
+			if (handle.Kind != HandleKind.TypeReference)
+				return null;
+
+			var typeRef = reader.GetTypeReference ((TypeReferenceHandle)handle);
+			var nspace = reader.GetString (typeRef.Namespace);
+
+			if (!string.IsNullOrEmpty (nspace))
+				fullName += nspace + ".";
+
+			return fullName += reader.GetString (typeRef.Name);
+		}
+
+		Dictionary<string, CustomAttribute> GetCustomAttributes (MetadataReader reader, CustomAttributeHandleCollection cac)
+		{
+			var dict = new Dictionary<string, CustomAttribute> ();
+
+			foreach (var handle in cac) {
+				var ca = reader.GetCustomAttribute (handle);
+				var cHandle = ca.Constructor;
+
+				string typeName;
+
+				switch (cHandle.Kind) {
+				case HandleKind.MethodDefinition:
+					var methodDef = reader.GetMethodDefinition ((MethodDefinitionHandle)cHandle);
+
+					typeName = GetTypeName (reader, methodDef.GetDeclaringType ());
+					break;
+				case HandleKind.MemberReference:
+					var memberDef = reader.GetMemberReference ((MemberReferenceHandle)cHandle);
+
+					typeName = GetTypeName (reader, memberDef.Parent);
+					break;
+				default:
+					Program.Warning ($"Unexpected EntityHandle kind: {cHandle.Kind}");
+					continue;
+				}
+
+				dict [typeName] = ca;
+			}
+
+			return dict;
+		}
+
+		void CompareCustomAttributes (CustomAttributeHandleCollection cac1, CustomAttributeHandleCollection cac2, string padding)
+		{
+			var dict1 = GetCustomAttributes (reader1, cac1);
+			var dict2 = GetCustomAttributes (reader2, cac2);
+
+			foreach (var pair in dict1) {
+				if (!dict2.ContainsKey (pair.Key)) {
+					Console.WriteLine ($"{padding}  -             CustomAttribute {pair.Key}");
+				}
+			}
+
+			foreach (var pair in dict2) {
+				if (!dict1.ContainsKey (pair.Key)) {
+					Console.WriteLine ($"{padding}  +             CustomAttribute {pair.Key}");
+				}
+			}
+		}
+
+		void CompareTypes (TypeDefinition type1, TypeDefinition type2, string padding)
+		{
+			CompareCustomAttributes (type1.GetCustomAttributes (), type2.GetCustomAttributes (), padding);
+		}
+	}
+}

--- a/tools/apkdiff/EntryDiff.cs
+++ b/tools/apkdiff/EntryDiff.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace apkdiff {
+	public abstract class EntryDiff {
+
+		public abstract string Name { get; }
+
+		public static EntryDiff ForExtension (string extension)
+		{
+			switch (extension) {
+			case ".dll":
+				return new AssemblyDiff ();
+			case ".so":
+				return new SharedLibraryDiff ();
+			}
+
+			return null;
+		}
+
+		public abstract void Compare (string file, string other, string padding = null);
+	}
+}

--- a/tools/apkdiff/ISizeProvider.cs
+++ b/tools/apkdiff/ISizeProvider.cs
@@ -1,0 +1,5 @@
+﻿namespace apkdiff {
+	public interface ISizeProvider {
+		long Size { get; }
+	}
+}

--- a/tools/apkdiff/Program.cs
+++ b/tools/apkdiff/Program.cs
@@ -28,13 +28,13 @@ namespace apkdiff {
 				desc1.Compare (desc2);
 
 				if (ApkRegressionThreshold != 0 && (desc2.PackageSize - desc1.PackageSize) > ApkRegressionThreshold) {
-					Error ($"PackageSize differ more than {ApkRegressionThreshold:#,0} bytes. apk1 size: {desc1.PackageSize:#,0} bytes, apk2 size: {desc2.PackageSize:#,0} bytes.");
+					Error ($"PackageSize increase {desc2.PackageSize - desc1.PackageSize:#,0} is {desc2.PackageSize - desc1.PackageSize - ApkRegressionThreshold:#,0} bytes more than the threshold {ApkRegressionThreshold:#,0}. apk1 size: {desc1.PackageSize:#,0} bytes, apk2 size: {desc2.PackageSize:#,0} bytes.");
 					RegressionCount ++;
 				}
 			}
 
 			if (RegressionCount > 0) {
-				Error ($"Size regression occured, {RegressionCount:#,0} test(s) failed.");
+				Error ($"Size regression occured, {RegressionCount:#,0} check(s) failed.");
 				Environment.Exit (3);
 			}
 		}

--- a/tools/apkdiff/Program.cs
+++ b/tools/apkdiff/Program.cs
@@ -12,6 +12,10 @@ namespace apkdiff {
 		public static bool SaveDescriptions;
 		public static bool Verbose;
 
+		public static long AssemblyRegressionThreshold;
+		public static long ApkRegressionThreshold;
+		public static int RegressionCount;
+
 		public static void Main (string [] args)
 		{
 			var (path1, path2) = ProcessArguments (args);
@@ -22,12 +26,23 @@ namespace apkdiff {
 				var desc2 = ApkDescription.Load (path2);
 
 				desc1.Compare (desc2);
+
+				if (ApkRegressionThreshold != 0 && (desc2.PackageSize - desc1.PackageSize) > ApkRegressionThreshold) {
+					Error ($"PackageSize differ more than {ApkRegressionThreshold:#,0} bytes. apk1 size: {desc1.PackageSize:#,0} bytes, apk2 size: {desc2.PackageSize:#,0} bytes.");
+					RegressionCount ++;
+				}
+			}
+
+			if (RegressionCount > 0) {
+				Error ($"Size regression occured, {RegressionCount:#,0} test(s) failed.");
+				Environment.Exit (3);
 			}
 		}
 
 		static (string, string) ProcessArguments (string [] args)
 		{
 			var help = false;
+			int helpExitCode = 0;
 			var options = new OptionSet {
 				$"Usage: {Name}.exe OPTIONS* <package1.[apk|aab][desc]> [<package2.[apk|aab][desc]>]",
 				"",
@@ -42,6 +57,12 @@ namespace apkdiff {
 				{ "h|help|?",
 					"Show this message and exit",
 				  v => help = v != null },
+				{ "test-apk-size-regression=",
+					"Check whether apk size increased more than {BYTES}",
+				  v => ApkRegressionThreshold = long.Parse (v) },
+				{ "test-assembly-size-regression=",
+					"Check whether any assembly size increased more than {BYTES}",
+				  v => AssemblyRegressionThreshold = long.Parse (v) },
 				{ "s|save-descriptions",
 					"Save .[apk|aab]desc description files next to the package(s)",
 				  v => SaveDescriptions = true },
@@ -52,10 +73,23 @@ namespace apkdiff {
 
 			var remaining = options.Parse (args);
 
+			foreach (var s in remaining) {
+				if (s.Length > 0 && (s [0] == '-' || s [0] == '/') && !File.Exists (s)) {
+					Error ($"Unknown option: {s}");
+					help = true;
+					helpExitCode = 99;
+				}
+			}
+
 			if (help || args.Length < 1) {
 				options.WriteOptionDescriptions (Out);
 
-				Environment.Exit (0);
+				Environment.Exit (helpExitCode);
+			}
+
+			if (remaining.Count != 2 && (ApkRegressionThreshold != 0 || AssemblyRegressionThreshold != 0)) {
+				Error ("Please specify 2 APK packages for regression testing.");
+				Environment.Exit (2);
 			}
 
 			if (remaining.Count != 2 && (remaining.Count != 1 || !SaveDescriptions)) {

--- a/tools/apkdiff/SharedLibraryDiff.cs
+++ b/tools/apkdiff/SharedLibraryDiff.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace apkdiff {
+	public class SharedLibraryDiff : EntryDiff {
+		public SharedLibraryDiff ()
+		{
+		}
+
+		public override string Name { get { return "Shared libraries"; } }
+
+		string RunCommand (string cmd, string arguments)
+		{
+			String output;
+
+			using (var p = new System.Diagnostics.Process ()) {
+
+				p.StartInfo.UseShellExecute = false;
+				p.StartInfo.RedirectStandardError = true;
+				p.StartInfo.RedirectStandardOutput = true;
+				p.StartInfo.FileName = cmd;
+				p.StartInfo.Arguments = arguments;
+
+				try {
+					p.Start ();
+				} catch {
+					Program.Warning ($"Unable to run '{p.StartInfo.FileName}' command");
+
+					return null;
+				}
+
+				output = p.StandardOutput.ReadToEnd ();
+				var error = p.StandardError.ReadToEnd ();
+
+				if (error.Length > 0)
+					Program.Error ($"nm error output:\n{error}");
+
+				p.WaitForExit ();
+			}
+
+			return output;
+		}
+
+		string HomeDir {
+			get {
+				return Environment.GetEnvironmentVariable ("HOME");
+			}
+		}
+
+		string AndroidToolsDir {
+			get {
+				return HomeDir + "/android-toolchain/toolchains/x86-clang/bin";
+			}
+		}
+
+		string RunNMCmd (string file)
+		{
+			return RunCommand ($"{AndroidToolsDir}/x86_64-linux-android-nm", $"-S --size-sort -D {file}");
+		}
+
+		string RunSizeCmd (string file)
+		{
+			return RunCommand ($"{AndroidToolsDir}/x86_64-linux-android-size", $"-A {file}");
+		}
+
+		struct SymbolInfo : ISizeProvider {
+			public long Size { get; set; }
+		}
+
+		Dictionary<string, SymbolInfo> ParseNMOutput (string output)
+		{
+			var symbols = new Dictionary<string, SymbolInfo> ();
+
+			foreach (var line in output.Split (new char [] { '\n' })) {
+				var cols = line.Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+				if (cols.Length != 4)
+					continue;
+
+				symbols [cols [3]] = new SymbolInfo () { Size = int.Parse (cols [1], System.Globalization.NumberStyles.HexNumber) };
+			}
+
+			return symbols;
+		}
+
+		struct SectionInfo : ISizeProvider {
+			public long Size { get; set; }
+		}
+
+		Dictionary<string, SectionInfo> ParseSizeOutput (string output)
+		{
+			var sections = new Dictionary<string, SectionInfo> ();
+
+			int skipLines = 2;
+
+			foreach (var line in output.Split (new char [] { '\n' })) {
+				if (skipLines > 0) {
+					skipLines--;
+					continue;
+				}
+
+				var cols = line.Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+				if (cols.Length != 3)
+					continue;
+
+				sections [cols [0]] = new SectionInfo () { Size = int.Parse (cols [1]) };
+			}
+
+			return sections;
+		}
+
+		void CompareSections (string file, string other, string padding)
+		{
+			var scs1 = ParseSizeOutput (RunSizeCmd (file));
+			var scs2 = ParseSizeOutput (RunSizeCmd (other));
+
+			Program.ColorWriteLine ($"{padding}                Section size difference", ConsoleColor.Yellow);
+
+			var differences = new Dictionary<string, long> ();
+			var singles = new HashSet<string> ();
+
+			foreach (var entry in scs1) {
+				var key = entry.Key;
+
+				if (scs2.ContainsKey (key)) {
+					var otherEntry = scs2 [key];
+					differences [key] = otherEntry.Size - scs1 [key].Size;
+				} else {
+					differences [key] = -scs1 [key].Size;
+					singles.Add (key);
+				}
+			}
+
+			foreach (var key in scs2.Keys) {
+				if (scs1.ContainsKey (key))
+					continue;
+
+				differences [key] = scs2 [key].Size;
+				singles.Add (key);
+			}
+
+			foreach (var diff in differences.OrderByDescending (v => v.Value)) {
+				if (diff.Value == 0)
+					continue;
+
+				var single = singles.Contains (diff.Key);
+
+				ApkDescription.PrintDifference (diff.Key, diff.Value, single ? $" *{(diff.Value > 0 ? 2 : 1)}" : null, padding);
+			}
+		}
+
+		void CompareSymbols (string file, string other, string padding)
+		{
+			var sym1 = ParseNMOutput (RunNMCmd (file));
+			var sym2 = ParseNMOutput (RunNMCmd (other));
+
+			Program.ColorWriteLine ($"{padding}                Symbol size difference", ConsoleColor.Yellow);
+
+			var differences = new Dictionary<string, long> ();
+			var singles = new HashSet<string> ();
+
+			foreach (var entry in sym1) {
+				var key = entry.Key;
+
+				if (sym2.ContainsKey (key)) {
+					var otherEntry = sym2 [key];
+					differences [key] = otherEntry.Size - sym1 [key].Size;
+				} else {
+					differences [key] = -sym1 [key].Size;
+					singles.Add (key);
+				}
+			}
+
+			foreach (var key in sym2.Keys) {
+				if (sym1.ContainsKey (key))
+					continue;
+
+				differences [key] = sym2 [key].Size;
+				singles.Add (key);
+			}
+
+			foreach (var diff in differences.OrderByDescending (v => v.Value)) {
+				if (diff.Value == 0)
+					continue;
+
+				var single = singles.Contains (diff.Key);
+
+				ApkDescription.PrintDifference (diff.Key, diff.Value, single ? $" *{(diff.Value > 0 ? 2 : 1)}" : null, padding);
+			}
+		}
+
+		public override void Compare (string file, string other, string padding)
+		{
+			CompareSections (file, other, padding);
+			CompareSymbols (file, other, padding);
+		}
+	}
+}

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
   </ItemGroup>
   <Import Project="$(XAPackagesDir)\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets" Condition="Exists('$(XAPackagesDir)\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets')" />
   <Import Project="apkdiff.targets" />


### PR DESCRIPTION
Besides the other changes we want the regression testing.

Example output:

    apkdiff.exe --test-apk-size-regression=51200 --test-assembly-size-regression=51200 Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc bin\TestDebug\Xamarin.Forms_Performance_Integration-Signed.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      +  26,749,952 assemblies/Mono.Android.dll
    Error: apkdiff: Assembly 'assemblies/Mono.Android.dll' size increase 26,749,952 is 26,698,752 bytes more than the threshold 51,200.
      +  14,655,424 assemblies/Mono.Android.pdb *2
      +   2,423,388 lib/x86/libmonosgen-2.0.so
      +   2,413,568 assemblies/mscorlib.dll
    Error: apkdiff: Assembly 'assemblies/mscorlib.dll' size increase 2,413,568 is 2,362,368 bytes more than the threshold 51,200.
      +   2,025,076 classes.dex
      +   1,755,580 lib/armeabi-v7a/libmonosgen-2.0.so
      +   1,683,644 assemblies/mscorlib.pdb *2
      +   1,511,544 assemblies/Xamarin.Android.Support.v7.AppCompat.dll
    Error: apkdiff: Assembly 'assemblies/Xamarin.Android.Support.v7.AppCompat.dll' size increase 1,511,544 is 1,460,344 bytes more than the threshold 51,200.
    ...
    Summary:
      +  43,001,792 Assemblies 303.25% (of 14,180,480)
      +  10,653,224 Shared libraries 89.86% (of 11,855,444)
      +  66,973,060 Package size difference 318.80% (of 21,007,581)
    Error: apkdiff: PackageSize increase 66,973,060 is 66,921,860 bytes more than the threshold 51,200. apk1 size: 21,007,581 bytes, apk2 size: 87,980,641 bytes.
    Error: apkdiff: Size regression occured, 39 check(s) failed.

Changes:

    dc6cfc Update the handling of an unknown option
    3b825e Handle unknown option
    897547 Support aab packages
    812215 Add new regression options
    fbac82 Use thousand separator in regression prints
    e5aef1 Count regression failures and report the count
    11ba62 Added assembly size regression testing
    e7ee8e Added apk size regression testing implementation
    b95995 Set platform target
    a74d02 Fix white space
    3afd5a Print also percentage in package size difference
    fd8d3e Show assemblies and shared libraries total differences in summary
    130598 Add section sizes example
    b1ee9a Update LibZipSharp to newer version
    d84b35 Compare shared libraries section sizes
    3a3ceb Added another example output
    4e094f Add initial assembly comparison
    7efe90 Compare shared libraries symbols and their sizes
    fcac80 Improve csproj file
    3a479d Update solution/project files to load in VS/Mac without issues