### PR TITLE
[docs] Update release note for R8 -ignorewarnings

### DIFF
--- a/Documentation/release-notes/4509.md
+++ b/Documentation/release-notes/4509.md
@@ -1,42 +1,142 @@
-### R8 uses `-ignorewarnings` to suppress common build errors
+### R8 configured to suppress common build errors
 
-Developers could hit a common problem in applications using Google
-Play Services:
+Xamarin.Android now configures R8 to skip emitting an error for Java dependency
+warnings such as:
 
-    Warning: Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
-    Error: Compilation can't be completed because some library classes are missing.
-
-The correct fix is to adjust `AndroidManifest.xml` in the project:
-
-```xml
-<application ...>
-  <uses-library android:name="org.apache.http.legacy" android:required="false" />
-</application>
+```
+R8 : warning : Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
+R8 : warning : Missing class: java.lang.ClassValue
+R8 : error : Compilation can't be completed because some library classes are missing.
 ```
 
-This issue could be encountered if:
+This allows a more gradual transition to R8, particularly for projects that are
+using R8 for multidex only and not code shrinking.
 
-* `AndroidDexTool=d8` (this is default in Xamarin.Android 10.2 and higher)
-* `AndroidEnableMultiDex=True` or `AndroidLinkTool=r8`
-
-When using `AndroidDexTool=dx`, the same project would not encounter a
-build error--just warnings. However, `r8` is more strict and converts
-the `library classes are missing` warning into a failure.
-
-Xamarin.Android now applies a setting that will make `r8` more lenient
-to keep things closer to the existing `dx` behavior. By automatically
-passing `-ignorewarnings`, `r8` will not fail the build, but still
-emit warnings.
-
-To disable this behavior, a new `$(AndroidR8IgnoreWarnings)` MSBuild
-property can be set to `False` in your `.csproj` file:
+Although R8 warnings will no longer cause the build to fail, project authors are
+encouraged to address the warnings at their earliest convenience and then set R8
+back to its original stricter behavior.  To restore the original behavior, set
+the `AndroidR8IgnoreWarnings` MSBuild property to `false` in the _.csproj_ file:
 
 ```xml
 <PropertyGroup>
-  <AndroidR8IgnoreWarnings>False</AndroidR8IgnoreWarnings>
+  <AndroidR8IgnoreWarnings>false</AndroidR8IgnoreWarnings>
 </PropertyGroup>
 ```
 
-See the [ProGuard manual][proguard] for details about ProGuard rule syntax.
+#### Example: How to solve _Missing class: org.apache.http.client_
 
-[proguard]: https://www.guardsquare.com/products/proguard/manual/usage
+```
+R8 : warning : Missing class: org.apache.http.client.methods.HttpEntityEnclosingRequestBase
+```
+
+##### Best solution
+
+Update any NuGet packages or Java dependencies that use the Apache HTTP client
+to newer versions that use `java.net.HttpURLConnection` instead.  This is the
+best solution because starting in Android 6.0 Marshmallow (API level 23), [the
+Apache HTTP client is deprecated in favor of the more efficient
+`HttpURLConnection`][android-6-apache-http].
+
+##### Second-best solution
+
+If new library versions are not yet available that use `HttpURLConnection`,
+then, where possible, update any NuGet packages that use Apache HTTP client to
+newer versions that include a `UsesLibraryAttribute` for org.apache.http.legacy:
+
+```cs
+[assembly: UsesLibrary("org.apache.http.legacy", false)]
+```
+
+NuGet package authors who cannot yet update all dependencies to use
+`HttpURLConnection` are encouraged to add this attribute to their projects as
+soon as possible.
+
+This attribute automatically generates the following element under the
+`<application>` node of _AndroidManifest.xml_ for any app that references the
+NuGet package:
+
+```xml
+<uses-library android:name="org.apache.http.legacy" android:required="false" />
+```
+
+##### Fallback solution
+
+If updated NuGet package versions are not yet available with the attribute, then
+add the same `UsesLibraryAttribute` directly to the application project instead:
+
+```cs
+[assembly: UsesLibrary("org.apache.http.legacy", false)]
+```
+
+##### Background information
+
+The _Missing class: org.apache.http.client_ warning indicates that the app has a
+Java dependency on the Apache HTTP client.  Starting in [Android 6.0 Marshmallow
+(API level 23)][android-6-apache-http], that client was deprecated and moved out
+of _android.jar_ into its own _org.apache.http.legacy.jar_ library.  As a
+result, applications that use Apache HTTP client on Android 6.0 or higher will
+only be able to call the APIs successfully if they declare the use of
+org.apache.http.legacy via a [`<uses-library>`][uses-library] element in
+_AndroidManifest.xml_.  Otherwise, the API calls will fail with exceptions
+similar to:
+
+```
+Java.Lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/impl/client/DefaultHttpClient
+```
+
+#### Example: How to solve _Missing class: java.lang.ClassValue_
+
+```
+R8 : warning : Missing class: java.lang.ClassValue
+```
+
+##### Solution
+
+It is typically safe to suppress this warning:
+
+ 1. Add a new text file to the project, named for example _proguard-rules.pro_.
+
+ 2. Set the contents of the file to:
+
+    ```
+    -dontwarn java.lang.ClassValue
+    ```
+
+ 3. Edit the _.csproj_ file in a text editor and add `--pg-conf
+    proguard-rules.pro` to the `AndroidR8ExtraArguments` MSBuild property, for
+    example by adding the following lines:
+
+    ```xml
+    <PropertyGroup>
+      <AndroidR8ExtraArguments>--pg-conf proguard-rules.pro</AndroidR8ExtraArguments>
+    </PropertyGroup>
+    ```
+
+    (If the project is configured to use R8 for code shrinking, an easier option
+    is to set the **Build Action** of _proguard-rules.pro_ to
+    **ProguardConfiguration** in the Visual Studio **Properties** window, but
+    that approach is not yet supported when using R8 for multidex only.)
+
+##### Background information
+
+The _Missing class: java.lang.ClassValue_ warning indicates that the app
+references a library that uses `java.lang.ClassValue`.  Typically this happens
+when the app references a library that was built to run on multiple Java
+platforms.  On Android, the `java.lang.ClassValue` type does not exist in the
+[java.lang package][java-lang-android].
+
+One known scenario that produces this warning is when an app references the
+Xamarin.Firebase.Firestore NuGet package, which depends on the cross-platform
+Google Guava library.  Guava uses `java.lang.ClassValue`, but it only uses it on
+platforms where it is available, so it is safe to suppress the _Missing class:
+java.lang.ClassValue_ warning for that library.
+
+A future version of the Xamarin.Guava.Google NuGet package will provide the
+`-dontwarn java.lang.ClassValue` R8 rule to suppress the warning automatically.
+In the mean time, application authors can suppress the warning by adding the
+rule to their app projects directly.
+
+[xa-10-2-d8]: https://docs.microsoft.com/xamarin/android/release-notes/10/10.2#d8-enabled-by-default-for-all-projects
+[android-6-apache-http]: https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client
+[uses-library]: https://developer.android.com/guide/topics/manifest/uses-library-element
+[java-lang-android]: https://developer.android.com/reference/java/lang/package-summary


### PR DESCRIPTION
Restructure the R8 `-ignorewarnings` release note to provide details
about two examples of common warnings and errors that users have seen
when using R8 for multidex.

Remove the description about "just warnings" when using `dx` because in
my local testing, using DX for multidex did not produce any related
warnings, at least not for these two common known scenarios.