### PR TITLE
[docs] Put newest download locations first in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,27 +23,34 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 # Downloads
 
-| Platform        | Status |
+## Current
+
+| Platform        | Link   |
 |-----------------|--------|
-| **Commercial Xamarin.Android 9.0 (d15-8)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.0, macOS+VS2017][commercial-d15-8-macOS-x86_64-icon]][commercial-d15-8-macOS-x86_64-status] |
-| **Commercial Xamarin.Android 9.1 (d15-9)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.1, macOS+VS2017][commercial-d15-9-macOS-x86_64-icon]][commercial-d15-9-macOS-x86_64-status] |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-0-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                                        | [Download][commercial-d16-0-macOS-x86_64]   |
-| **Commercial Xamarin.Android 9.3 (d16-1)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-1-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.3 (d16-1)** for macOS                                        | [Download][commercial-d16-1-macOS-x86_64]   |
-| **Commercial Xamarin.Android 9.4 (d16-2)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-2-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.4 (d16-2)** for macOS                                        | [Download][commercial-d16-2-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.0 (d16-3)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-3-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.0 (d16-3)** for macOS                                       | [Download][commercial-d16-3-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.1 (d16-4)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-4-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.1 (d16-4)** for macOS                                       | [Download][commercial-d16-4-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.2 (d16-5)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-5-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.2 (d16-5)** for macOS                                       | [Download][commercial-d16-5-macOS-x86_64]   |
 | **Commercial Xamarin.Android 10.3 (d16-6) Preview** for Windows+Visual Studio 2019 Preview  | [Download][commercial-d16-6-Windows-x86_64] |
 | **Commercial Xamarin.Android 10.3 (d16-6) Preview** for macOS                               | [Download][commercial-d16-6-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.2 (d16-5)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-5-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.2 (d16-5)** for macOS                                       | [Download][commercial-d16-5-macOS-x86_64]   |
 | **OSS Xamarin.Android 10.3.99 (master)** for macOS &amp; Windows+Visual Studio 2019\*       | [![Open Source Xamarin.Android 10.3.99, macOS+VS2019][oss-master-macOS-x86_64-icon]][oss-master-macOS-x86_64-artifacts] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
+
+## Previous
+
+| Platform        | Link   |
+|-----------------|--------|
+| **Commercial Xamarin.Android 10.1 (d16-4)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-4-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.1 (d16-4)** for macOS                                       | [Download][commercial-d16-4-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.0 (d16-3)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-3-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.0 (d16-3)** for macOS                                       | [Download][commercial-d16-3-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.4 (d16-2)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-2-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.4 (d16-2)** for macOS                                        | [Download][commercial-d16-2-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-1-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for macOS                                        | [Download][commercial-d16-1-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-0-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                                        | [Download][commercial-d16-0-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.1 (d15-9)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.1, macOS+VS2017][commercial-d15-9-macOS-x86_64-icon]][commercial-d15-9-macOS-x86_64-status] |
+| **Commercial Xamarin.Android 9.0 (d15-8)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.0, macOS+VS2017][commercial-d15-8-macOS-x86_64-icon]][commercial-d15-8-macOS-x86_64-status] |
 
 [commercial-d15-8-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-8/badge/icon
 [commercial-d15-8-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-8/


### PR DESCRIPTION
When the xamarin-macios team recently added a downloads section to their
README, they noticed that users were by default picking the first link,
so they decided to switch the order to sort from newest to oldest.

Update the commercial download locations in the xamarin-android README
to use newest-to-oldest order like the xamarin-macios README.

Leave the OSS master download as the last entry because that link is
expected to be used less frequently than the links for the commercial
versions.