### PR TITLE
[Xamarin.Android.Build.Tasks] Use @(ProguardConfiguration) for R8 multidex

### DIFF
--- a/Documentation/release-notes/r8-multidex-config.md
+++ b/Documentation/release-notes/r8-multidex-config.md
@@ -1,0 +1,9 @@
+### R8 now uses ProguardConfiguration items when code shrinking is disabled
+
+In previous versions, Xamarin.Android did not yet pass `ProguardConfiguration`
+items to the R8 tool when the **Code shrinker** setting, corresponding to the
+`AndroidLinkTool` MSBuild property, was disabled.
+
+Project authors who added a `--pg-conf` option to the `AndroidR8ExtraArguments`
+MSBuild property to work around this limitation in the past can now transition
+to the standard `ProguardConfiguration` mechanism.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -104,23 +104,6 @@ namespace Xamarin.Android.Tasks
 						}
 					}
 				}
-				if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
-					var configs = ProguardConfigurationFiles
-						.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
-						.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
-						.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
-						.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
-						.Replace ("{project}", string.Empty) // current directory anyways.
-						.Split (';')
-						.Select (s => s.Trim ())
-						.Where (s => !string.IsNullOrWhiteSpace (s));
-					foreach (var file in configs) {
-						if (File.Exists (file))
-							cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
-						else
-							Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
-					}
-				}
 			} else {
 				//NOTE: we may be calling r8 *only* for multi-dex, and all shrinking is disabled
 				cmd.AppendSwitch ("--no-tree-shaking");
@@ -138,6 +121,23 @@ namespace Xamarin.Android.Tasks
 				File.WriteAllLines (temp, lines);
 				tempFiles.Add (temp);
 				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);
+			}
+			if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
+				var configs = ProguardConfigurationFiles
+					.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
+					.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
+					.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
+					.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
+					.Replace ("{project}", string.Empty) // current directory anyways.
+					.Split (';')
+					.Select (s => s.Trim ())
+					.Where (s => !string.IsNullOrWhiteSpace (s));
+				foreach (var file in configs) {
+					if (File.Exists (file))
+						cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
+					else
+						Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
+				}
 			}
 
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1338,6 +1338,56 @@ namespace UnnamedProject {
 		}
 
 		[Test]
+		public void MultiDexR8ConfigWithNoCodeShrinking ([Values (true, false)] bool useConfig)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				DexTool = "d8",
+			};
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			/* The source for the library is a single class:
+			*
+			abstract class ExtendsClassValue extends ClassValue<Boolean> {}
+			*
+			* The reason `ClassValue` is used for this test is precisely that it
+			* does not exist in `android.jar`.  This means the library cannot be
+			* compiled using `@(AndroidJavaSource)`.  It was instead compiled
+			* using `javac ExtendsClassValue.java` and then manually archived
+			* using `jar cvf ExtendsClassValue.jar
+			* ExtendsClassValue.class`.
+			*/
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "ExtendsClassValue.jar") { BinaryContent = () => Convert.FromBase64String (@"
+UEsDBBQACAgIAChzjVAAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
+AAAAFBLAwQUAAgICAAoc41QAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My
+0xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqBAlY6BnoGpkqaPhmJhflF+enlWjycvFyAQBQS
+wcIv1FGtTsAAAA7AAAAUEsDBBQACAgIABxzjVAAAAAAAAAAAAAAAAAXAAAARXh0ZW5kc0NsYXNzV
+mFsdWUuY2xhc3NtT7sKwkAQnNWYaHwExVaw9AHa2CkWilZi46M/9ZCT8wJ5iL9lJVj4AX6UuEmjh
+Qu7M8wwu+zr/XgCGMBzkUXJQdlBhWCPlFHRmJBttbcEa+ofJMFbKCOX8Xkng7XYaVYKK3U0IooD5
+t3FSVxEXwtz7E+1CMOt0LEc/agT39dSmOF4SHBXfhzs5Vwla2qbUH4jvSRRgoUcoTq7RtIcwq9Lq
+P+7YzWR4Q+SIm4OM9rMGoyJkuvcQbfUdnjaqUgcyjNmUICbYvEDUEsHCB4E1g/HAAAAEgEAAFBLA
+QIUABQACAgIAChzjVAAAAAAAgAAAAAAAAAJAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi/+ygAAU
+EsBAhQAFAAICAgAKHONUL9RRrU7AAAAOwAAABQAAAAAAAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BT
+klGRVNULk1GUEsBAhQAFAAICAgAHHONUB4E1g/HAAAAEgEAABcAAAAAAAAAAAAAAAAAugAAAEV4d
+GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
+				") });
+			if (useConfig)
+				proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
+					TextContent = () => "-dontwarn java.lang.ClassValue"
+				});
+			using (var builder = CreateApkBuilder ()) {
+				Assert.True (builder.Build (proj), "Build should have succeeded.");
+				string warning = builder.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build succeeded."))
+						.FirstOrDefault (x => x.Contains ("R8 : warning : Missing class: java.lang.ClassValue"));
+				if (useConfig) {
+					Assert.IsNull (warning, "Build should have completed without an R8 warning for `java.lang.ClassValue`.");
+					return;
+				}
+				Assert.IsNotNull (warning, "Build should have completed with an R8 warning for `java.lang.ClassValue`.");
+			}
+		}
+
+		[Test]
 		public void BasicApplicationRepetitiveBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -318,14 +318,18 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
 	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
 
-	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == ''">
+	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == '' And '$(AndroidLinkTool)' != ''">
 		{sdk.dir}tools\proguard\proguard-android.txt;
 		{intermediate.common.xamarin};
 		{intermediate.references};
 		{intermediate.application};
 		@(ProguardConfiguration);
 	</ProguardConfigFiles>
-	
+	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == '' And '$(AndroidLinkTool)' == ''">
+		{sdk.dir}tools\proguard\proguard-android.txt;
+		@(ProguardConfiguration);
+	</ProguardConfigFiles>
+
 	<_AndroidMainDexListFile>$(IntermediateOutputPath)multidex.keep</_AndroidMainDexListFile>
 	
 	<AndroidManifestPlaceholders Condition="'$(AndroidManifestPlaceholders)' == ''"></AndroidManifestPlaceholders>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4369#issuecomment-610553571
Context: https://developercommunity.visualstudio.com/content/problem/979562/r8-warning-missing-class-javalangclassvalue.html
Context: https://github.com/xamarin/AndroidX/issues/74

Currently, Xamarin.Android always uses `com.android.tools.r8.R8` to
generate DEX files if `$(AndroidDexTool)`=`d8` and
`$(AndroidEnableMultiDex)`=`True`, even if `$(AndroidLinkTool)`=``.

This causes some tricky behavior because, unlike DX and
`com.android.tools.r8.D8`, R8 always performs dependency checks,
including [warning about missing Java classes][0].  As a consequence,
switching from `$(AndroidDexTool)`=`dx` to `$(AndroidDexTool)`=`d8`
while `$(AndroidEnableMultiDex)`=`True` can introduce new build
warnings, somewhat unexpectedly.

Commit 6ee55837 improved the user experience around this scenario by
suppressing the additional error that R8 was emitting when it emitted
any `Missing class` warnings.

Add another improvement for this scenario by adjusting `<R8/>` to pass
`@(ProguardConfiguration)` items to R8, regardless of whether code
shrinking is enabled or not.  This allows the normal expected R8
configuration file mechanism to work in multidex-only mode.

Leave the lines that add `proguard_xamarin.cfg` and the lines that
generate a ProGuard configuration file based on `AcwMapFile` where they
are because `-keep` and `-keepclassmembers` rules are not relevant in
multidex-only mode.

TODO:

Android Studio avoids this tricky scenario altogether by using D8 rather
than R8 unless code shrinking is enabled.  Because D8 is designed to
have only a `--main-dex-list` option and no `--main-dex-rules` option,
Android Studio pre-processes any `--main-dex-rules` files into the
`--main-dex-list` format using a separate [`D8MainDexListTask`][1] step
that runs [`com.android.tools.r8.GenerateMainDexList`][2] before calling
D8.

Xamarin.Android could consider switching to that same approach.  On the
other hand, the warnings that R8 produces are accurate.  They indicate
missing dependencies that could cause apps to abort at run time.
Getting warnings for those issues at build time is an advantage of the
current approach.

[0]: https://r8.googlesource.com/r8/+/refs/tags/1.5.68/src/main/java/com/android/tools/r8/R8.java#291
[1]: https://android.googlesource.com/platform/tools/base/+/81f184dbf8d7caefd09ee7309c1427425da6415c/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/TaskManager.java#2206
[2]: https://r8.googlesource.com/r8/+/refs/tags/1.5.68/src/main/java/com/android/tools/r8/GenerateMainDexListCommand.java