### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore `global` Alias when emitting code.

### DIFF
--- a/Documentation/release-notes/4554.md
+++ b/Documentation/release-notes/4554.md
@@ -1,0 +1,6 @@
+#### Application and library build and deployment
+
+  * *error CS1681: You cannot redefine the global extern alias* prevented
+    building app projects successfully if the *.csproj* file included `global`
+    in the `<Aliases></Aliases>` metadata element of a referenced
+    Xamarin.Android class library.

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Tasks
 				var decl = type as CodeTypeDeclaration;
 				if (decl == null)
 					continue;
-				foreach (CodeTypeMember field in decl.Members) 
+				foreach (CodeTypeMember field in decl.Members)
 					resourceFields.Add (CreateIdentifier (type.Name, field.Name));
 			}
 		}
@@ -48,8 +48,8 @@ namespace Xamarin.Android.Tasks
 					if (string.IsNullOrEmpty (resourceDesignerName)) {
 						continue;
 					}
-					string alias = assemblyPath.GetMetadata ("Aliases");
-					bool hasAlias = !string.IsNullOrEmpty (alias);
+					string aliasMetaData = assemblyPath.GetMetadata ("Aliases");
+					bool hasAlias = !string.IsNullOrEmpty (aliasMetaData);
 					foreach (var handle in reader.TypeDefinitions) {
 						var typeDefinition = reader.GetTypeDefinition (handle);
 						if (!typeDefinition.IsNested) {
@@ -59,8 +59,14 @@ namespace Xamarin.Android.Tasks
 						var declaringTypeName = $"{reader.GetString (declaringType.Namespace)}.{reader.GetString (declaringType.Name)}";
 						if (declaringTypeName == resourceDesignerName) {
 							if (hasAlias) {
-								string [] aliases = alias.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
-								declaringTypeName = $"{aliases[0].Trim ()}::{declaringTypeName}";
+								string [] aliases = aliasMetaData.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
+								foreach (var alias in aliases) {
+									string aliasName = alias.Trim ();
+									if (string.Compare ("global", aliasName, StringComparison.Ordinal) == 0)
+										continue;
+									declaringTypeName = $"{aliasName}::{declaringTypeName}";
+									break;
+								}
 							}
 							CreateImportFor (declaringTypeName, typeDefinition, method, reader, hasAlias);
 						}


### PR DESCRIPTION
Fixes #4542

Our previous fix d18c824c did not take into account that users might
need to add `global` to their list of aliases in the `ProjectReferece`
MetaData. This then causes the following error

	Error CS1681: You cannot redefine the global extern alias (CS1681)

So to fix this we need to ignore the `global` entry if one is present.