### PR TITLE
[build] [Mono.Android] Assign $(JavaCallableWrapperAbsAssembly) after $(OutputPath)

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -15,7 +15,6 @@
     <DefineConstants>$(DefineConstants);JAVA_INTEROP</DefineConstants>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\android-$(AndroidPlatformId)\</IntermediateOutputPath>
     <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>
-    <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
     <JavaCallableWrapperAfterTargets>CoreBuild</JavaCallableWrapperAfterTargets>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!-- @(Compile) ordering matters! See https://github.com/xamarin/java.interop/commit/d7dfa0bb7b03261d5eceb51ac22cd33aa15fa865 -->
@@ -33,6 +32,10 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <OutputPath>$(XAInstallPrefix)xbuild-frameworks\Xamarin.Android.App\$(TargetFramework)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">


### PR DESCRIPTION
I noticed that `GenerateJavaCallableWrappers` was building completely on
every incremental build for me locally:

	Target "GenerateJavaCallableWrappers: (TargetId:1260)" in file "C:\Source\xamarin-android\build-tools\scripts\JavaCallableWrappers.targets" from project "C:\Source\xamarin-android\src\Mono.Android\Mono.Android.csproj" (target "Build" depends on it):
	Building target "GenerateJavaCallableWrappers" completely.
	Input file "C:\Source\xamarin-android\Mono.Android.dll" does not exist.

The issue was that the refactoring to short-form project style in commit
a6e5d10a by chance moved the assignment of
`$(JavaCallableWrapperAbsAssembly)` to happen before the assignment of
`$(OutputPath)`, meaning that `$(JavaCallableWrapperAbsAssembly)` no
longer contained the correct path to the `Mono.Android.dll` output file.

Move the assignment of `$(JavaCallableWrapperAbsAssembly)` back after
`$(OutputPath)` to take care of that.