### PR TITLE
[Xamarin.Android.Build.Tasks] CheckDuplicateJavaLibraries l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -82,6 +82,7 @@ ms.date: 01/24/2020
 + [XA1011](xa1011.md): Using ProGuard with the D8 DEX compiler is no longer supported. Please update \`$(AndroidLinkTool)\` to \`r8\`.
 + XA1012: Included layout root element override ID '{id}' is not valid.
 + XA1013: Failed to parse ID of node '{name}' in the layout file '{file}'.
++ XA1014: JAR library references with identical file names but different contents were found: {libraries}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.
 + XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
 + XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
 + XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -448,6 +448,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary..
+        /// </summary>
+        internal static string XA1014 {
+            get {
+                return ResourceManager.GetString("XA1014", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to More than one Android Wear project is specified as the paired project. It can be at most one..
         /// </summary>
         internal static string XA1015 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -325,6 +325,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>{0} - The Android resource XML element name
 {1} - The path of the layout file</comment>
   </data>
+  <data name="XA1014" xml:space="preserve">
+    <value>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</value>
+    <comment>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</comment>
+  </data>
   <data name="XA1015" xml:space="preserve">
     <value>More than one Android Wear project is specified as the paired project. It can be at most one.</value>
     <comment>The following are literal names and should not be translated: Android Wear</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Android.Tasks
 			var jars = MonoAndroidHelper.DistinctFilesByContent (jarFilePaths).ToArray ();
 			var dups = MonoAndroidHelper.GetDuplicateFileNames (jars, new string [] {"classes.jar"});
 			if (dups.Any ()) {
-				Log.LogError ("You have Jar libraries, {0}, that have the identical name with inconsistent file contents. Please make sure to remove any conflicting libraries in EmbeddedJar, InputJar and AndroidJavaLibrary.", String.Join (", ", dups.ToArray ()));
+				Log.LogCodedError ("XA1014", Properties.Resources.XA1014, String.Join (", ", dups.ToArray ()));
 				return false;
 			}
 			

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
@@ -1,11 +1,9 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Xamarin.Android.Tasks;
-using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests {
 
@@ -36,25 +34,11 @@ namespace Xamarin.Android.Build.Tests {
 		{
 			Directory.CreateDirectory (path);
 			string jar1 = Path.Combine (path, "library.jar");
-			using (Stream resourceStream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.classes.jar"))
-			using (FileStream fileStream = File.Create (jar1))
-				resourceStream.CopyTo (fileStream);
+			File.WriteAllText (jar1, "jar1");
 
-			Directory.CreateDirectory (Path.Combine (path, "Hello (World)"));
-			string jar2 = Path.Combine (path, "Hello (World)", "library.jar");
-			File.WriteAllBytes (jar2, Convert.FromBase64String (@"
-UEsDBBQACAgIAMl8lUsAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
-AAAAFBLAwQUAAgICADJfJVLAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0
-xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqBAlY6BnEG5oaKWj4FyUm56QqOOcXFeQXJZYA1Wv
-ycvFyAQBQSwcIbrokAkQAAABFAAAAUEsDBBQACAgIAIJ8lUsAAAAAAAAAAAAAAAASAAAAc2FtcGxl
-L0hlbGxvLmNsYXNzO/Vv1z4GBgYTBkEuBhYGXg4GPnYGfnYGAUYGNpvMvMwSO0YGZg3NMEYGFuf8l
-FRGBn6fzLxUv9LcpNSikMSkHKAIa3l+UU4KI4OIhqZPVmJZon5OYl66fnBJUWZeujUjA1dwfmlRcq
-pbJkgtl0dqTk6+HkgZDwMrAxvQFrCIIiMDT3FibkFOqj6Yz8gggDDKPykrNbmEQZGBGehCEGBiYAR
-pBpLsQJ4skGYE0qxa2xkYNwIZjAwcQJINIggkORm4oEqloUqZhZg2oClkB5LcYLN5AFBLBwjQMrpO
-0wAAABMBAABQSwECFAAUAAgICADJfJVLAAAAAAIAAAAAAAAACQAEAAAAAAAAAAAAAAAAAAAATUVUQ
-S1JTkYv/soAAFBLAQIUABQACAgIAMl8lUtuuiQCRAAAAEUAAAAUAAAAAAAAAAAAAAAAAD0AAABNRV
-RBLUlORi9NQU5JRkVTVC5NRlBLAQIUABQACAgIAIJ8lUvQMrpO0wAAABMBAAASAAAAAAAAAAAAAAA
-AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA"));
+			Directory.CreateDirectory (Path.Combine (path, "jar2"));
+			string jar2 = Path.Combine (path, "jar2", "library.jar");
+			File.WriteAllText (jar2, "jar2");
 
 			var task = new CheckDuplicateJavaLibraries {
 				BuildEngine = engine,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xamarin.Android.Tasks;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	[Category ("Node-2")]
+	[Parallelizable (ParallelScope.Self)]
+	public class CheckDuplicateJavaLibrariesTests : BaseTest {
+		List<BuildErrorEventArgs> errors;
+		List<BuildWarningEventArgs> warnings;
+		List<BuildMessageEventArgs> messages;
+		MockBuildEngine engine;
+		string path;
+
+		[SetUp]
+		public void Setup ()
+		{
+			engine = new MockBuildEngine (TestContext.Out,
+				errors: errors = new List<BuildErrorEventArgs> (),
+				warnings: warnings = new List<BuildWarningEventArgs> (),
+				messages: messages = new List<BuildMessageEventArgs> ());
+
+			path = Path.Combine (Root, "temp", TestName);
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = path;
+		}
+
+		[Test]
+		public void XA1014ConflictingJarNames ()
+		{
+			Directory.CreateDirectory (path);
+			string jar1 = Path.Combine (path, "library.jar");
+			using (Stream resourceStream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.classes.jar"))
+			using (FileStream fileStream = File.Create (jar1))
+				resourceStream.CopyTo (fileStream);
+
+			Directory.CreateDirectory (Path.Combine (path, "Hello (World)"));
+			string jar2 = Path.Combine (path, "Hello (World)", "library.jar");
+			File.WriteAllBytes (jar2, Convert.FromBase64String (@"
+UEsDBBQACAgIAMl8lUsAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
+AAAAFBLAwQUAAgICADJfJVLAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0
+xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqBAlY6BnEG5oaKWj4FyUm56QqOOcXFeQXJZYA1Wv
+ycvFyAQBQSwcIbrokAkQAAABFAAAAUEsDBBQACAgIAIJ8lUsAAAAAAAAAAAAAAAASAAAAc2FtcGxl
+L0hlbGxvLmNsYXNzO/Vv1z4GBgYTBkEuBhYGXg4GPnYGfnYGAUYGNpvMvMwSO0YGZg3NMEYGFuf8l
+FRGBn6fzLxUv9LcpNSikMSkHKAIa3l+UU4KI4OIhqZPVmJZon5OYl66fnBJUWZeujUjA1dwfmlRcq
+pbJkgtl0dqTk6+HkgZDwMrAxvQFrCIIiMDT3FibkFOqj6Yz8gggDDKPykrNbmEQZGBGehCEGBiYAR
+pBpLsQJ4skGYE0qxa2xkYNwIZjAwcQJINIggkORm4oEqloUqZhZg2oClkB5LcYLN5AFBLBwjQMrpO
+0wAAABMBAABQSwECFAAUAAgICADJfJVLAAAAAAIAAAAAAAAACQAEAAAAAAAAAAAAAAAAAAAATUVUQ
+S1JTkYv/soAAFBLAQIUABQACAgIAMl8lUtuuiQCRAAAAEUAAAAUAAAAAAAAAAAAAAAAAD0AAABNRV
+RBLUlORi9NQU5JRkVTVC5NRlBLAQIUABQACAgIAIJ8lUvQMrpO0wAAABMBAAASAAAAAAAAAAAAAAA
+AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA"));
+
+			var task = new CheckDuplicateJavaLibraries {
+				BuildEngine = engine,
+				JavaSourceFiles = new ITaskItem [] { new TaskItem (jar1), new TaskItem (jar2) }
+			};
+
+			Assert.IsFalse (task.Execute (), "Task should fail!");
+			BuildErrorEventArgs error = errors [0];
+			Assert.AreEqual ("XA1014", error.Code);
+			StringAssert.Contains ("library.jar", error.Message);
+		}
+	}
+}


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Add a code to the existing error in `<CheckDuplicateJavaLibraries/>`,
and move the message string into the `.resx` file so that it is
localizable.

Other changes:

Remove "you" from the message.