### PR TITLE
[Xamarin.Android.Build.Tasks] Wear application tasks l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -85,6 +85,9 @@ ms.date: 01/24/2020
 + [XA1011](xa1011.md): Using ProGuard with the D8 DEX compiler is no longer supported. Please update \`$(AndroidLinkTool)\` to \`r8\`.
 + XA1012: Included layout root element override ID '{id}' is not valid.
 + XA1013: Failed to parse ID of node '{name}' in the layout file '{file}'.
++ XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
++ XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
++ XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.
 
 ## XA2xxx: Linker
 
@@ -133,6 +136,7 @@ ms.date: 01/24/2020
 + [XA4308](xa4308.md): Failed to generate type maps
 + [XA4309](xa4309.md): 'MultiDexMainDexList' file '{file}' does not exist.
 + [XA4310](xa4310.md): \`$(AndroidSigningKeyStore)\` file \`{keystore}\` could not be found.
++ XA4311: The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.
 
 ## XA5xxx: GCC and toolchain
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -448,6 +448,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to More than one Android Wear project is specified as the paired project. It can be at most one..
+        /// </summary>
+        internal static string XA1015 {
+            get {
+                return ResourceManager.GetString("XA1015", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target Wear application&apos;s project &apos;{0}&apos; does not specify required &apos;AndroidManifest&apos; project property..
+        /// </summary>
+        internal static string XA1016 {
+            get {
+                return ResourceManager.GetString("XA1016", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target Wear application&apos;s AndroidManifest.xml does not specify required &apos;package&apos; attribute..
+        /// </summary>
+        internal static string XA1017 {
+            get {
+                return ResourceManager.GetString("XA1017", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {
@@ -849,6 +876,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4310 {
             get {
                 return ResourceManager.GetString("XA4310", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The application won&apos;t contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the &quot;SignAndroidPackage&quot; target..
+        /// </summary>
+        internal static string XA4311 {
+            get {
+                return ResourceManager.GetString("XA4311", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -325,6 +325,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>{0} - The Android resource XML element name
 {1} - The path of the layout file</comment>
   </data>
+  <data name="XA1015" xml:space="preserve">
+    <value>More than one Android Wear project is specified as the paired project. It can be at most one.</value>
+    <comment>The following are literal names and should not be translated: Android Wear</comment>
+  </data>
+  <data name="XA1016" xml:space="preserve">
+    <value>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</value>
+    <comment>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</comment>
+  </data>
+  <data name="XA1017" xml:space="preserve">
+    <value>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</value>
+    <comment>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
@@ -542,6 +557,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
   <data name="XA4310" xml:space="preserve">
     <value>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</value>
     <comment>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</comment>
+  </data>
+  <data name="XA4311" xml:space="preserve">
+    <value>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</value>
+    <comment>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
   </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Soubor $(AndroidSigningKeyStore) {0} se nepovedlo najít.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Die $(AndroidSigningKeyStore)-Datei "{0}" wurde nicht gefunden.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">No se ha encontrado el archivo "{0}" de "$(AndroidSigningKeyStore)".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Le fichier '$(AndroidSigningKeyStore)' '{0}' est introuvable.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Non è stato possibile trovare il file `{0}` di `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">'$(AndroidSigningKeyStore)' ファイル '{0}' が見つかりませんでした。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">'$(AndroidSigningKeyStore)' 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Nie można odnaleźć pliku „$(AndroidSigningKeyStore)” („{0}”).</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Não foi possível localizar o arquivo `{0}` de `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Не удалось найти файл "$(AndroidSigningKeyStore)" с именем "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">`{0}` adlı `$(AndroidSigningKeyStore)` dosyası bulunamadı.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">找不到“$(AndroidSigningKeyStore)”文件“{0}”。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">找不到 `$(AndroidSigningKeyStore)` 檔案 `{0}`。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
@@ -25,13 +25,13 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			if (ProjectFiles.Length != 1)
-				Log.LogError ("More than one Android Wear project is specified as the paired project. It can be at most one.");
+				Log.LogCodedError ("XA1015", Properties.Resources.XA1015);
 			
 			var wearProj = ProjectFiles.First ();
 			var manifestXml = XDocument.Load (wearProj.ItemSpec)
 				.Root.Elements (msbuildNS + "PropertyGroup").Elements (msbuildNS + "AndroidManifest").Select (e => e.Value).FirstOrDefault ();
 			if (string.IsNullOrEmpty (manifestXml))
-				Log.LogError ("Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.", wearProj);
+				Log.LogCodedError ("XA1016", Properties.Resources.XA1016, wearProj);
 			manifestXml = Path.Combine (Path.GetDirectoryName (wearProj.ItemSpec), manifestXml.Replace ('\\', Path.DirectorySeparatorChar));
 
 			ApplicationManifestFile = manifestXml;
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Tasks
 
 			ApplicationPackageName = AndroidAppManifest.CanonicalizePackageName (XDocument.Load (manifestXml).Root.Attributes ("package").Select (a => a.Value).FirstOrDefault ());
 			if (string.IsNullOrEmpty (ApplicationPackageName))
-				Log.LogError ("Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.");
+				Log.LogCodedError ("XA1017", Properties.Resources.XA1017);
 			
 			Log.LogDebugMessage ("  [Output] ApplicationPackageName: " + ApplicationPackageName);
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Tasks
 				Log.LogCodedError ("XA5211", Properties.Resources.XA5211, wearPackageName, PackageName);
 
 			if (!File.Exists (WearApplicationApkPath)) {
-				Log.LogWarning ("This application won't contain the paired Wear package because the Wear application package .apk is not created yet. If you are using MSBuild or XBuild, you have to invoke \"SignAndroidPackage\" target.");
+				Log.LogCodedWarning ("XA4311", Properties.Resources.XA4311);
 				return true;
 			}
 


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Add codes to the existing warnings and errors in the Wear application
tasks, and move the message strings into the `.resx` file so that they
are localizable.

Other changes:

Remove "you" from one of the messages.