### PR TITLE
[Xamarin.Android.Build.Tasks] ResolveAssemblies l10n support part 2

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -92,6 +92,8 @@ ms.date: 01/24/2020
 + [XA2001](xa2001.md): Source file '{filename}' could not be found.
 + [XA2002](xa2002.md): Can not resolve reference: \`{missing}\`, referenced by {assembly}. Perhaps it doesn't exist in the Mono for Android profile?
 + XA2006: Could not resolve reference to '{member}' (defined in assembly '{assembly}') with scope '{scope}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.
++ XA2007: Exception while loading assemblies: {exception}
++ XA2008: In referenced assembly {assembly}, Java.Interop.DoNotPackageAttribute requires non-null file name.
 
 ## XA3xxx: Unmanaged code compilation
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -493,6 +493,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception while loading assemblies: {0}.
+        /// </summary>
+        internal static string XA2007 {
+            get {
+                return ResourceManager.GetString("XA2007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name..
+        /// </summary>
+        internal static string XA2008 {
+            get {
+                return ResourceManager.GetString("XA2008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not AOT the assembly: {0}.
         /// </summary>
         internal static string XA3001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -350,6 +350,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</comment>
   </data>
+  <data name="XA2007" xml:space="preserve">
+    <value>Exception while loading assemblies: {0}</value>
+    <comment>{0} - The exception message of the associated exception</comment>
+  </data>
+  <data name="XA2008" xml:space="preserve">
+    <value>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</value>
+    <comment>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</comment>
+  </data>
   <data name="XA3001" xml:space="preserve">
     <value>Could not AOT the assembly: {0}</value>
     <comment>The abbreviation "AOT" should not be translated.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Sestavení se nepovedlo zkompilovat AOT: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">AOT für Assembly nicht möglich: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">No se pudo aplicar AOT al ensamblado: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Impossible d'effectuer une compilation AOT de l'assembly : {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Non è stato possibile eseguire la compilazione AOT dell'assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">アセンブリを AOT できませんでした: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">어셈블리를 AOT할 수 없음: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Nie można utworzyć widoku AOT zestawu: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Não foi possível fazer AOT no assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Не удалось выполнить AOT для сборки: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Bütünleştirilmiş koda AOT uygulanamadı: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">无法 AOT 程序集: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -285,6 +285,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">無法對組件進行 AOT 編譯: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -100,14 +100,14 @@ namespace Xamarin.Android.Tasks
 					assemblies [assemblyName] = taskItem;
 				}
 			} catch (Exception ex) {
-				LogError ("Exception while loading assemblies: {0}", ex);
+				LogCodedError ("XA2007", Properties.Resources.XA2007, ex);
 				return;
 			}
 			try {
 				foreach (var assembly in topAssemblyReferences)
 					AddAssemblyReferences (resolver, assemblies, assembly, null);
 			} catch (Exception ex) {
-				LogError ("Exception while loading assemblies: {0}", ex);
+				LogCodedError ("XA2007", Properties.Resources.XA2007, ex);
 				return;
 			}
 
@@ -293,7 +293,7 @@ namespace Xamarin.Android.Tasks
 							if (arguments.FixedArguments.Length > 0) {
 								string file = arguments.FixedArguments [0].Value?.ToString ();
 								if (string.IsNullOrWhiteSpace (file))
-									LogError ("In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.", assembly.GetAssemblyName ().FullName);
+									LogCodedError ("XA2008", Properties.Resources.XA2008, assembly.GetAssemblyName ().FullName);
 								do_not_package_atts.Add (Path.GetFileName (file));
 							}
 						}


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/
Context: 0103d4fc07f1764eba11a9d0cbc2daed2c5368bd

Add codes to the remaining errors in `<ResolveAssemblies/>` that did not
yet have codes, and move the message strings into the `.resx` file so
that they are localizable.