### PR TITLE
[.NET 5] exclude shared runtime APKs from Xamarin.Android.Sdk

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -376,12 +376,12 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jar2xml.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.AndroidTools.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.AndroidTools.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-arm64-v8a.apk" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-armeabi-v7a.apk" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.apk" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.xml" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86.apk" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86_64.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-arm64-v8a.apk"   Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-armeabi-v7a.apk" Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.apk"       Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.xml"       Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86.apk"         Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86_64.apk"      Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.Compatibility.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.Tasks.dll" />


### PR DESCRIPTION
Using `AndroidUseSharedRuntime=True` doesn't work in .NET 5 yet, and
it is still up in the air if we will support it.

For now, we can remove these from `Xamarin.Android.Sdk.nupkg` to save
on file size. This save ~164MB of file size on disk when the NuGet
package is extracted.