### PR TITLE
[Xamarin.Android.Build.Tasks] Add XA1018 & XA4228 for l10n

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -86,6 +86,7 @@ ms.date: 01/24/2020
 + XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
 + XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
 + XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.
++ XA1018: Specified AndroidManifest file does not exist: {file}.
 
 ## XA2xxx: Linker
 
@@ -125,6 +126,7 @@ ms.date: 01/24/2020
 + XA4224: Malformed full class name '{name}'. Missing class name.
 + XA4225: Widget '{widget}' in layout '{layout}' has multiple instances with different types. The property type will be set to: {type}
 + XA4226: Resource item '{file}' does not have the required metadata item '{metadataName}'.
++ XA4228: Unable to find specified //activity-alias/@android:targetActivity: '{targetActivity}'
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -484,6 +484,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified AndroidManifest file does not exist: {0}..
+        /// </summary>
+        internal static string XA1018 {
+            get {
+                return ResourceManager.GetString("XA1018", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {
@@ -777,6 +786,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4226 {
             get {
                 return ResourceManager.GetString("XA4226", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find specified //activity-alias/@android:targetActivity: &apos;{0}&apos;.
+        /// </summary>
+        internal static string XA4228 {
+            get {
+                return ResourceManager.GetString("XA4228", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -345,6 +345,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
   </data>
+  <data name="XA1018" xml:space="preserve">
+    <value>Specified AndroidManifest file does not exist: {0}.</value>
+    <comment>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
@@ -510,6 +515,11 @@ In this mesage, the term "layout" means an Android UI layout.
     <value>Resource item '{0}' does not have the required metadata item '{1}'.</value>
     <comment>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</comment>
+  </data>
+  <data name="XA4228" xml:space="preserve">
+    <value>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</value>
+    <comment>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</comment>
   </data>
   <data name="XA4300" xml:space="preserve">
     <value>Native library '{0}' will not be bundled because it has an unsupported ABI.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			// Look for targetSdkVersion in the user's AndroidManifest.xml
 			if (!string.IsNullOrWhiteSpace (AndroidManifest)) {
 				if (!File.Exists (AndroidManifest)) {
-					Log.LogError ("Specified AndroidManifest.xml file does not exist: {0}.", AndroidManifest);
+					Log.LogCodedError ("XA1018", Properties.Resources.XA1018, AndroidManifest);
 					return false;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4246,6 +4246,22 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void XA1018 ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidManifest", "DoesNotExist");
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				string error = builder.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA1018:"));
+				Assert.IsNotNull (error, "Build should have failed with XA1018.");
+				StringAssert.Contains ("DoesNotExist", error, "Error should include the name of the nonexistent file");
+			}
+		}
+
+		[Test]
 		public void XA4310 ([Values ("apk", "aab")] string packageFormat)
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Android.Tasks {
 					alias.Remove ();
 					activity.AddAfterSelf (alias);
 				} else {
-					log.LogWarning ("unable to find target activity for activity alias: " + attr.Value);
+					log.LogCodedWarning ("XA4228", Properties.Resources.XA4228, attr.Value);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -591,7 +591,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="$(ProjectDir)$(AndroidManifest)" Condition="'$(AndroidManifest)' != ''">
 		<Output TaskParameter="Value" PropertyName="_AndroidManifestAbs"/>
 	</CreateProperty>
-	<Error Text="AndroidManifest file does not exist" Condition="'$(_AndroidManifestAbs)'!='' And !Exists ('$(_AndroidManifestAbs)')"/>
+	<AndroidError Code="XA1018"
+		ResourceName="XA1018"
+		FormatArguments="$(_AndroidManifestAbs)"
+		Condition="'$(_AndroidManifestAbs)'!='' And !Exists ('$(_AndroidManifestAbs)')" />
 
 	<GetAndroidPackageName ManifestFile="$(_AndroidManifestAbs)" AssemblyName="$(AssemblyName)">
 		<Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Add XA1018 and XA4228 codes for existing build messages, and move the
message strings into the `.resx` file so that they are localizable.

Other changes:

Use the XPath selector `//activity-alias/@android:targetActivity` in the
message for XA4228 to minimize ambiguity and make the message easier to
translate.