### PR TITLE
[Bindings.targets] Warn about deprecated jar2xml and XamarinAndroid values.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -134,6 +134,8 @@ ms.date: 01/24/2020
 + XA4228: Unable to find specified //activity-alias/@android:targetActivity: '{targetActivity}'
 + XA4229: Unrecognized \`TransformFile\` root element: {element}.
 + XA4230: Error parsing XML: {exception}
++ XA4231: The Android class parser '$(AndroidClassParser)' is deprecated and will be removed in a future version of Xamarin.Android. Use 'class-parse' instead.
++ XA4232: The Android code generator '$(AndroidCodegenTarget)' is deprecated and will be removed in a future version of Xamarin.Android. Use 'XAJavaInterop1' instead.
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -134,8 +134,8 @@ ms.date: 01/24/2020
 + XA4228: Unable to find specified //activity-alias/@android:targetActivity: '{targetActivity}'
 + XA4229: Unrecognized \`TransformFile\` root element: {element}.
 + XA4230: Error parsing XML: {exception}
-+ XA4231: The Android class parser '$(AndroidClassParser)' is deprecated and will be removed in a future version of Xamarin.Android. Use 'class-parse' instead.
-+ XA4232: The Android code generator '$(AndroidCodegenTarget)' is deprecated and will be removed in a future version of Xamarin.Android. Use 'XAJavaInterop1' instead.
++ [XA4231](xa4231.md): The Android class parser value 'jar2xml' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.
++ [XA4232](xa4232.md): The Android code generation target 'XamarinAndroid' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/guides/messages/xa4231.md
+++ b/Documentation/guides/messages/xa4231.md
@@ -1,0 +1,29 @@
+---
+title: Xamarin.Android warning XA4231
+description: XA4231 warning code
+ms.date: 04/23/2020
+---
+# Xamarin.Android warning XA4231
+
+## Example messages
+
+```
+warning XA4231: The Android class parser value 'jar2xml' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.
+```
+
+## Issue
+
+The Android class parser `jar2xml` has been deprecated.
+
+## Solution
+
+To resolve this warning, update the **Android Class Parser** setting in the Visual
+Studio project property pages or the **.jar file parser** setting in Visual
+Studio for Mac to **class-parse**.  This corresponds to the `class-parse` value
+for the `AndroidClassParser` MSBuild property in the _.csproj_ file:
+
+```xml
+<PropertyGroup>
+  <AndroidClassParser>class-parse</AndroidClassParser>
+</PropertyGroup>
+```

--- a/Documentation/guides/messages/xa4232.md
+++ b/Documentation/guides/messages/xa4232.md
@@ -1,0 +1,30 @@
+---
+title: Xamarin.Android warning XA4232
+description: XA4232 warning code
+ms.date: 04/23/2020
+---
+# Xamarin.Android warning XA4232
+
+## Example messages
+
+```
+warning XA4232: The Android code generation target 'XamarinAndroid' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.
+```
+
+## Issue
+
+The Android code generation target `XamarinAndroid` has been deprecated.
+
+## Solution
+
+To resolve this warning, update the **Android Codegen target** setting in the
+Visual Studio project property pages or the **Code generation target** setting
+in Visual Studio for Mac to **XAJavaInterop1**.  This corresponds to the
+`XAJavaInterop1` value for the `AndroidCodegenTarget` MSBuild property in the
+_.csproj_ file:
+
+```xml
+<PropertyGroup>
+  <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+</PropertyGroup>
+```

--- a/Documentation/release-notes/4577.md
+++ b/Documentation/release-notes/4577.md
@@ -1,0 +1,42 @@
+### Bindings projects XA4231 warning for deprecated jar2xml parser
+
+Any bindings project that has the `AndroidClassParser` MSBuild property set to
+the old `jar2xml` parser or any other unrecognized value will now get a XA4231
+build warning:
+
+```
+warning XA4231: The Android class parser 'jar2xml' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse' instead.
+```
+
+To resolve this warning, update the **Android Class Parser** setting in the Visual
+Studio project property pages or the **.jar file parser** setting in Visual
+Studio for Mac to **class-parse**.  This corresponds to the `class-parse` value
+for the `AndroidClassParser` MSBuild property in the _.csproj_ file:
+
+```xml
+<PropertyGroup>
+  <AndroidClassParser>class-parse</AndroidClassParser>
+</PropertyGroup>
+```
+
+### Bindings projects XA4232 warning for deprecated XamarinAndroid code generation target
+
+Any bindings project that has the `AndroidCodegenTarget` MSBuild property set to
+the old `XamarinAndroid` code generation target or any other unrecognized value
+will now get a XA4232 build warning:
+
+```
+warning XA4232: The Android code generation target value 'XamarinAndroid' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.
+```
+
+To resolve this warning, update the **Android Codegen target** setting in the
+Visual Studio project property pages or the **Code generation target** setting
+in Visual Studio for Mac to **XAJavaInterop1**.  This corresponds to the
+`XAJavaInterop1` value for the `AndroidCodegenTarget` MSBuild property in the
+_.csproj_ file:
+
+```xml
+<PropertyGroup>
+  <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+</PropertyGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -862,6 +862,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Android class parser value &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use &apos;class-parse&apos;..
+        /// </summary>
+        internal static string XA4231 {
+            get {
+                return ResourceManager.GetString("XA4231", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Android code generator value &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use &apos;XAJavaInterop1&apos;..
+        /// </summary>
+        internal static string XA4232 {
+            get {
+                return ResourceManager.GetString("XA4232", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI..
         /// </summary>
         internal static string XA4300 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -862,7 +862,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Android class parser value &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use &apos;class-parse&apos;..
+        ///   Looks up a localized string similar to The Android class parser value &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use &apos;class-parse&apos;..
         /// </summary>
         internal static string XA4231 {
             get {
@@ -871,7 +871,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Android code generator value &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use &apos;XAJavaInterop1&apos;..
+        ///   Looks up a localized string similar to The Android code generation target &apos;{0}&apos; is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use &apos;XAJavaInterop1&apos;..
         /// </summary>
         internal static string XA4232 {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -560,12 +560,14 @@ In this message, "root element" refers to the root element of an XML file.
     <comment>{0} - The exception message and stack trace of the associated exception</comment>
   </data>
   <data name="XA4231" xml:space="preserve">
-    <value>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</value>
-    <comment>The value 'class-parse' should not be translated.</comment>
+    <value>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</value>
+    <comment>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</comment>
   </data>
   <data name="XA4232" xml:space="preserve">
-    <value>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</value>
-    <comment>The value 'XAJavaInterop1' should not be translated.</comment>
+    <value>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</value>
+    <comment>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</comment>
   </data>
   <data name="XA4300" xml:space="preserve">
     <value>Native library '{0}' will not be bundled because it has an unsupported ABI.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -559,6 +559,14 @@ In this message, "root element" refers to the root element of an XML file.
     <value>Error parsing XML: {0}</value>
     <comment>{0} - The exception message and stack trace of the associated exception</comment>
   </data>
+  <data name="XA4231" xml:space="preserve">
+    <value>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</value>
+    <comment>The value 'class-parse' should not be translated.</comment>
+  </data>
+  <data name="XA4232" xml:space="preserve">
+    <value>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</value>
+    <comment>The value 'XAJavaInterop1' should not be translated.</comment>
+  </data>
   <data name="XA4300" xml:space="preserve">
     <value>Native library '{0}' will not be bundled because it has an unsupported ABI.</value>
     <comment>The abbreviation "ABI" should not be translated.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">Nativní knihovna {0} se nezahrne do sady prostředků, protože má nepodporované ABI.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">Die native Bibliothek "{0}" wird nicht gebündelt, weil sie eine nicht unterstützte ABI umfasst.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">La biblioteca nativa "{0}" no se empaquetará porque tiene un conjunto ABI no admitido.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">La bibliothèque native '{0}' n'est pas incluse dans le bundle, car elle a un ABI non pris en charge.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">La libreria nativa '{0}' non verrà inclusa nel bundle perché contiene un ABI non supportato.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">サポートされていない ABI が含まれるため、ネイティブ ライブラリ '{0}' はバンドルされません。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">네이티브 라이브러리 '{0}'은(는) 지원되지 않는 ABI를 포함하므로 함께 제공되지 않습니다.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">Biblioteka natywna „{0}” nie zostanie umieszczona w pakiecie, ponieważ zawiera nieobsługiwany zestaw ABI.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">A biblioteca nativa '{0}' não será empacotada porque tem uma ABI sem suporte.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">Собственная библиотека "{0}" не будет добавлена в пакет, так как она содержит неподдерживаемый ABI.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">'{0}' yerel kitaplığı desteklenmeyen bir ABI içerdiğinden gruplanmaz.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">不会捆绑本机库“{0}”，因为它具有不受支持的 ABI。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -537,6 +537,16 @@ In this message, "root element" refers to the root element of an XML file.
         <target state="new">Error parsing XML: {0}</target>
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
+      <trans-unit id="XA4231">
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
+        <note>The value 'class-parse' should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4232">
+        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
+        <note>The value 'XAJavaInterop1' should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="translated">原生程式庫 '{0}' 具有不受支援的 ABI，因此不會與該程式庫配套。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -538,14 +538,16 @@ In this message, "root element" refers to the root element of an XML file.
         <note>{0} - The exception message and stack trace of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA4231">
-        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</source>
-        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'class-parse'.</target>
-        <note>The value 'class-parse' should not be translated.</note>
+        <source>The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</source>
+        <target state="new">The Android class parser value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'class-parse'.</target>
+        <note>The following are literal names and should not be translated: class-parse
+{0} - The name of the current class parser value</note>
       </trans-unit>
       <trans-unit id="XA4232">
-        <source>The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</source>
-        <target state="new">The Android code generator value '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update Project Properties to use 'XAJavaInterop1'.</target>
-        <note>The value 'XAJavaInterop1' should not be translated.</note>
+        <source>The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</source>
+        <target state="new">The Android code generation target '{0}' is deprecated and will be removed in a future version of Xamarin.Android. Update the project properties to use 'XAJavaInterop1'.</target>
+        <note>The following are literal names and should not be translated: XAJavaInterop1
+{0} - The name of the current code generation target</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -14,6 +14,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 ***********************************************************************************************
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="Xamarin.Android.Tasks.AndroidWarning" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ApiXmlAnalyzer" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.BindingsGenerator" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GetApiLevelFromFramework" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -133,8 +134,25 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	</GetReferenceAssemblyPaths>
 </Target>
 
+  <!-- Warn about deprecated configurations.
+       Do it here because we want them to appear on every build,
+       even if we aren't rerunning generator -->
+  <Target Name="_WarnAboutDeprecatedConfigurations">
+    <AndroidWarning Code="XA4231"
+      ResourceName="XA4231"
+      FormatArguments="$(AndroidClassParser)"
+      Condition=" '$(AndroidClassParser)' != 'class-parse' "
+    />
+
+    <AndroidWarning Code="XA4232"
+      ResourceName="XA4232"
+      FormatArguments="$(AndroidCodegenTarget)"
+      Condition=" '$(AndroidCodegenTarget)' != 'XAJavaInterop1' "
+    />
+  </Target>
+
   <!-- Find all the needed SDKs -->
-  <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
+  <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework;_WarnAboutDeprecatedConfigurations">
 
     <Error Text="Could not locate Android SDK." Condition="'$(_AndroidSdkDirectory)'==''" />
     <Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(_JavaSdkDirectory)'==''" />


### PR DESCRIPTION
Both `<AndroidClassParser>jar2xml</AndroidClassParser>` and `<AndroidCodegenTarget>XamarinAndroid</AndroidCodegenTarget>` were replaced 5+ years ago by `class-parse` and `XAJavaInterop1` respectively.

We already are not adding new features to them, like DIM, NRT, and Kotlin improvements, so projects using them are not benefiting from our improvements.

We would also like to some day stop maintaining these configurations.  As such, add warnings to Bindings project builds if these configurations are still used:

```
XA4231: The Android class parser value 'jar2xml' is deprecated and will be removed in 
a future version of Xamarin.Android. Update the project properties to use 'class-parse'.
```
```
XA4232: The Android code generation target 'XamarinAndroid' is deprecated and will 
be removed in a future version of Xamarin.Android. Update the project properties to 
use 'XAJavaInterop1'.
```