### PR TITLE
[Xamarin.Android.Build.Tasks] Add XA0123 & XA1019 for l10n

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -65,6 +65,7 @@ ms.date: 01/24/2020
 + [XA0119](xa0119.md): A non-ideal configuration was found in the project.
 + [XA0121](xa0121.md): Assembly '{assembly}' is using '[assembly: Java.Interop.JavaLibraryReferenceAttribute]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.
 + [XA0122](xa0122.md): Assembly '{assembly}' is using a deprecated attribute '[assembly: Java.Interop.DoNotPackageAttribute]'. Use a newer version of this NuGet package or notify the library author.
++ XA0123: Removing {issue} from {propertyName}. Lint {version} does not support this check.
 
 ## XA1xxx: Project related
 
@@ -87,6 +88,7 @@ ms.date: 01/24/2020
 + XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
 + XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.
 + XA1018: Specified AndroidManifest file does not exist: {file}.
++ XA1019: \`LibraryProjectProperties\` file \`{file}\` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original \`project.properties\` file directly from the Android library project directory.
 
 ## XA2xxx: Linker
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -340,6 +340,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Removing {0} from {1}. Lint {2} does not support this check..
+        /// </summary>
+        internal static string XA0123 {
+            get {
+                return ResourceManager.GetString("XA0123", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}.
         /// </summary>
         internal static string XA1000 {
@@ -489,6 +498,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA1018 {
             get {
                 return ResourceManager.GetString("XA1018", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to `LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project&apos;s intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory..
+        /// </summary>
+        internal static string XA1019 {
+            get {
+                return ResourceManager.GetString("XA1019", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -266,6 +266,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet</comment>
   </data>
+  <data name="XA0123" xml:space="preserve">
+    <value>Removing {0} from {1}. Lint {2} does not support this check.</value>
+    <comment>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</comment>
+  </data>
   <data name="XA1000" xml:space="preserve">
     <value>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</value>
     <comment>{0} - The file name
@@ -349,6 +357,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Specified AndroidManifest file does not exist: {0}.</value>
     <comment>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</comment>
+  </data>
+  <data name="XA1019" xml:space="preserve">
+    <value>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</value>
+    <comment>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</comment>
   </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Sestavení {0} používá zastaralý atribut [assembly: {1}]. Použijte novější verzi tohoto balíčku NuGet, nebo to oznamte autorovi knihovny.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Při parsování {0} došlo k problému. Pravděpodobnou příčinou je neúplný nebo neplatný kód XML. Výjimka: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Die Assembly "{0}" verwendet ein veraltetes Attribut "[assembly: {1}]". Verwenden Sie eine neuere Version dieses NuGet-Pakets, oder benachrichtigen Sie den Bibliotheksautor.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Problem beim Analysieren von "{0}". Dies ist wahrscheinlich auf eine unvollständige oder ungültige XML-Datei zurückzuführen. Ausnahme: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">El ensamblado "{0}" usa un atributo "[assembly: {1}]" en desuso. Utilice una versión más reciente de este paquete NuGet o informe al autor de la biblioteca.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Hubo un problema al analizar {0}. Probablemente se deba a un elemento XML incompleto o no válido. Excepción: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">L'assembly '{0}' utilise un attribut déprécié '[assembly : {1}]'. Utilisez une version plus récente de ce package NuGet ou notifiez l'auteur de la bibliothèque.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Un problème s'est produit durant l'analyse de {0}. Cela est probablement dû à du code XML incomplet ou non valide. Exception : {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">L'assembly '{0}' usa un attributo deprecato '[assembly: {1}]'. Usare una versione più recente di questo pacchetto NuGet o inviare una notifica all'autore della libreria.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Si è verificato un problema durante l'analisi di {0}, probabilmente a causa di codice XML incompleto o non valido. Eccezione: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">アセンブリ '{0}' は、非推奨の属性 '[assembly: {1}]' を使用しています。この NuGet パッケージの新しいバージョンを使用するか、ライブラリの作成者に連絡してください。</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">{0} の解析で問題が発生しました。不完全または無効な XML が原因である可能性があります。例外: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">'{0}' 어셈블리가 사용되지 않는 특성 '[assembly: {1}]'을(를) 사용하고 있습니다. 이 NuGet 패키지의 최신 버전을 사용하거나 라이브러리 작성자에게 알리세요.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">{0}을(를) 구문 분석하는 중 문제가 발생했습니다. XML이 불완전하거나 잘못된 것 같습니다. 예외: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Zestaw „{0}” korzysta z przestarzałego atrybutu „[assembly: {1}]”. Użyj nowszej wersji tego pakietu NuGet lub powiadom autora biblioteki.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Wystąpił problem podczas analizowania pliku {0}. Prawdopodobnie jest to spowodowane niekompletnym lub nieprawidłowym kodem XML. Wyjątek: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">O assembly '{0}' está usando um atributo preterido '[assembly: {1}]'. Use uma versão mais recente deste pacote NuGet ou notifique o autor da biblioteca.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Ocorreu um problema ao analisar {0}. Isso provavelmente se deve a XML incompleto ou inválido. Exceção: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">Сборка "{0}" использует устаревший атрибут "[assembly: {1}]". Используйте более новую версию этого пакета NuGet или уведомите автора библиотеки.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">Возникла проблема при синтаксическом анализе {0}. Возможная причина: неполный или недопустимый код XML. Исключение: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">'{0}' bütünleştirilmiş kodu, kullanım dışı '[assembly: {1}]' özniteliğini kullanıyor. Bu NuGet paketinin daha yeni bir sürümünü kullanın veya bu durumu kitaplık yazarına bildirin.</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">{0} ayrıştırılırken bir sorun oluştu. Bunun nedeni büyük olasılıkla tamamlanmamış veya geçersiz XML olabilir. Özel durum: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">程序集“{0}”使用已弃用的属性“[assembly: {1}]”。请使用此 NuGet 包的较新版本或通知库作者。</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">分析 {0} 时出现问题。这可能是由于 XML 不完整或无效。异常: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -183,6 +183,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="translated">組件 '{0}' 正在使用已取代的屬性 '[assembly: {1}]'。請使用此 NuGet 套件的較新版本，或通知程式庫作者。</target>
         <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
       </trans-unit>
+      <trans-unit id="XA0123">
+        <source>Removing {0} from {1}. Lint {2} does not support this check.</source>
+        <target state="new">Removing {0} from {1}. Lint {2} does not support this check.</target>
+        <note>The following are literal names and should not be translated: Lint
+When it appears in the middle of a sentence, "lint" is not capitalized.
+{0} - The literal name of a lint check, such as HardcodedDebugMode
+{1} - The literal name of the MSBuild property
+{2} - The lint version number</note>
+      </trans-unit>
       <trans-unit id="XA1000">
         <source>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</source>
         <target state="translated">剖析 {0} 時發生問題。此情況可能是 XML 不完整或無效所致。例外狀況: {1}</target>
@@ -283,6 +292,13 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
+      <trans-unit id="XA1019">
+        <source>`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</source>
+        <target state="new">`LibraryProjectProperties` file `{0}` is located in a parent directory of the bindings project's intermediate output directory. Please adjust the path to use the original `project.properties` file directly from the Android library project directory.</target>
+        <note>The following are literal names and should not be translated: LibraryProjectProperties, project.properties, Android
+In this message, the term "binding" means a piece of generated code that makes it easy to access an Android API written in Java from a Xamarin.Android project written in C# or F#.
+{0} - The path of the LibraryProjectProperties file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 		bool CopyLibraryContent (string projdir, bool isAar)
 		{
 			if (Path.GetFullPath (OutputDirectory).StartsWith (Path.GetFullPath (projdir), StringComparison.InvariantCultureIgnoreCase)) {
-				Log.LogError ("The source directory is under the output directory. Skip it.");
+				Log.LogCodedError ("XA1019", Properties.Resources.XA1019, Path.GetFullPath (projdir));
 				return false;
 			}
 			foreach (var subdir in Directory.GetDirectories (projdir)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -227,7 +227,7 @@ namespace Xamarin.Android.Tasks
 				var match = issueReplaceRegex.Match (DisabledIssues);
 				if (match.Success) {
 					issues = issues.Replace (match.Value, string.Empty);
-					Log.LogWarning ($"Removing {issueToRemove} from {issuePropertyName}. Lint {lintToolVersion} does not support this check.");
+					Log.LogCodedWarning ("XA0123", issueToRemove, issuePropertyName, lintToolVersion);
 				}
 			}
 			return issues;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -577,5 +577,24 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 				Assert.IsTrue (cs.Contains ("set {"), "(Baz) setter not generated.");
 			}
 		}
+
+		[Test]
+		public void BugzillaBug11964 ()
+		{
+			var proj = new XamarinAndroidBindingProject ();
+
+			proj.Sources.Add (new BuildItem ("LibraryProjectProperties", "project.properties") {
+				TextContent = () => ""
+			});
+
+			using (var builder = CreateDllBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				string error = builder.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA1019:"));
+				Assert.IsNotNull (error, "Build should have failed with XA1019.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Add XA0123 and XA1019 codes for existing build messages, and move the
message strings into the `.resx` file so that they are localizable.

Other changes:

Change the wording of the message for XA1019 to make it more
descriptive.  The new wording makes it easier to see that the message is
only relevant for an older style of Android library projects created via
`android create lib-project`.