### PR TITLE
[Xamarin.Android.Build.Tasks] Tidy generated l10n resource files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Java SDK {0} or above is required when using $(TargetFrameworkVersion) {1}..
+        ///   Looks up a localized string similar to Java SDK {0} or above is required when using {1}..
         /// </summary>
         internal static string XA0031 {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -175,7 +175,7 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Java SDK {0} or above is required when using {1}.</value>
     <comment>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk=&quot;Xamarin.Android.Sdk&quot;&gt;`</comment>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</comment>
   </data>
   <data name="XA0032" xml:space="preserve">
     <value>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</value>


### PR DESCRIPTION
Context: 231bf2a4381af4996c795e27fa65b15d63e3fc0b

The generated comment in the `Resources.Designer.cs` file was not yet
updated to account for the changes from commit 231bf2a4, and the comment
in the `.resx` file was using a `&quot;` character entity reference that
Visual Studio was replacing with `"` any time it saved the file.

Add those automatic changes now so there won't be any need to worry
about them getting included unintentionally as part of some unrelated
future change to the `.resx` file.