### PR TITLE
[.NET 5] map $(RuntimeIdentifier) to $(AndroidSupportedAbis)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RuntimeIdentifierToAbi.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// For .NET 5 projects, this parses $(RuntimeIdentifer) (or RID) into $(AndroidSupportedAbis)
+	/// 
+	/// NOTE: .NET 5 does not currently support multiple RIDs, so this will need to be modified once that is available.
+	/// </summary>
+	public class RuntimeIdentifierToAbi : AndroidTask
+	{
+		public override string TaskPrefix => "RIAB";
+
+		public string RuntimeIdentifier { get; set; }
+
+		[Output]
+		public string SupportedAbis { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (!string.IsNullOrEmpty (RuntimeIdentifier)) {
+				SupportedAbis = MonoAndroidHelper.RuntimeIdentifierToAbi (RuntimeIdentifier);
+			}
+			if (string.IsNullOrEmpty (SupportedAbis)) {
+				// Default to a single, default ABI if blank
+				SupportedAbis = "arm64-v8a";
+			}
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -14,6 +14,8 @@ namespace Xamarin.ProjectTools
 		public string AndroidSdkPath { get; set; } = AndroidSdkResolver.GetAndroidSdkPath ();
 		public string AndroidNdkPath { get; set; } = AndroidSdkResolver.GetAndroidNdkPath ();
 
+		public string ProjectDirectory { get; private set; }
+
 		const string Executable = "dotnet";
 		readonly XASdkProject project;
 		readonly string projectOrSolution;
@@ -22,6 +24,7 @@ namespace Xamarin.ProjectTools
 		{
 			this.project = project;
 			this.projectOrSolution = projectOrSolution;
+			ProjectDirectory = Path.GetDirectoryName (projectOrSolution);
 		}
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -256,17 +256,6 @@ namespace Xamarin.Android.Tasks
 			"x86_64",
 		};
 
-		static readonly Dictionary<string, string> RidAbiMap = new Dictionary<string, string> {
-			{ "android.21-arm64", "arm64-v8a" },
-			{ "android.21-arm", "armeabi-v7a" },
-			{ "android.21-x86", "x86" },
-			{ "android.21-x64", "x86_64" },
-			{ "android-arm64", "arm64-v8a" },
-			{ "android-arm", "armeabi-v7a" },
-			{ "android-x86", "x86" },
-			{ "android-x64", "x86_64" },
-		};
-
 		public static string GetNativeLibraryAbi (string lib)
 		{
 			// The topmost directory the .so file is contained within
@@ -296,9 +285,7 @@ namespace Xamarin.Android.Tasks
 			// Check for a RuntimeIdentifier
 			var rid = lib.GetMetadata ("RuntimeIdentifier");
 			if (!string.IsNullOrWhiteSpace (rid)) {
-				if (RidAbiMap.ContainsKey (rid)) {
-					lib_abi = RidAbiMap [rid];
-				}
+				lib_abi = RuntimeIdentifierToAbi (rid);
 			}
 			
 			if (!string.IsNullOrWhiteSpace (lib_abi))
@@ -691,6 +678,39 @@ namespace Xamarin.Android.Tasks
 				return newfile;
 			}
 			return string.Empty;
+		}
+
+		/// <summary>
+		/// Converts .NET 5 RIDs to Android ABIs or an empty string if no match.
+		/// 
+		/// Known RIDs:
+		/// "android.21-arm64" -> "arm64-v8a"
+		/// "android.21-arm"   -> "armeabi-v7a"
+		/// "android.21-x86"   -> "x86"
+		/// "android.21-x64"   -> "x86_64"
+		/// "android-arm64"    -> "arm64-v8a"
+		/// "android-arm"      -> "armeabi-v7a"
+		/// "android-x86"      -> "x86"
+		/// "android-x64"      -> "x86_64"
+		/// </summary>
+		public static string RuntimeIdentifierToAbi (string runtimeIdentifier)
+		{
+			if (string.IsNullOrEmpty (runtimeIdentifier)) {
+				return "";
+			}
+			if (runtimeIdentifier.EndsWith ("-arm64", StringComparison.OrdinalIgnoreCase)) {
+				return "arm64-v8a";
+			}
+			if (runtimeIdentifier.EndsWith ("-arm", StringComparison.OrdinalIgnoreCase)) {
+				return "armeabi-v7a";
+			}
+			if (runtimeIdentifier.EndsWith ("-x86", StringComparison.OrdinalIgnoreCase)) {
+				return "x86";
+			}
+			if (runtimeIdentifier.EndsWith ("-x64", StringComparison.OrdinalIgnoreCase)) {
+				return "x86_64";
+			}
+			return "";
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -241,7 +241,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Obsolete build property: should be removed in the future releases -->
 	<AndroidMultiDexSupportJar></AndroidMultiDexSupportJar>
 		
-	<AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
+	<AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' And '$(UsingAndroidNETSdk)' != 'True' ">armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
 
 	<!--- Default Lint Enabled and Disabled Checks -->
 	<AndroidLintEnabledIssues Condition=" '$(AndroidLintEnabledIssues)' == '' "></AndroidLintEnabledIssues>

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.Tooling.targets
@@ -13,6 +13,7 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
 
   <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.RuntimeIdentifierToAbi" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <Target Name="_ResolveAndroidTooling">
     <ValidateJavaVersion
@@ -52,6 +53,12 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
       <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
       <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />
     </ResolveAndroidTooling>
+    <RuntimeIdentifierToAbi
+        Condition=" '$(AndroidApplication)' == 'true' "
+        RuntimeIdentifier="$(RuntimeIdentifier)"
+        SupportedAbis="$(AndroidSupportedAbis)">
+      <Output TaskParameter="SupportedAbis" PropertyName="AndroidSupportedAbis" />
+    </RuntimeIdentifierToAbi>
   </Target>
 
 </Project>


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/rid-catalog

.NET Core has a concept of `$(RuntimeIdentifier)` (or RID), which
means you would `publish` an `arm64-v8a` build for Android via:

    dotnet publish foo.csproj --runtime-identifier android-arm64 --self-contained

To make this work with our existing MSBuild targets we will need to
map RIDs to `$(AndroidSupportedAbis)`. I made a helper method that
looks for the second `-arm64` portion of the RID.

There is still work ongoing to support multiple RIDs in a single build
in .NET 5. We will need to rework things when this is available.

I updated the .NET 5 MSBuild tests to validate multiple RIDs.