### PR TITLE
[.NET 5] default to --self-contained=true

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -78,7 +78,6 @@ namespace Xamarin.ProjectTools
 		public bool Publish (string target = null)
 		{
 			var arguments = GetDefaultCommandLineArgs ("publish", target);
-			arguments.Add ("/p:SelfContained=True");
 			return Execute (arguments.ToArray ());
 		}
 

--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.props
@@ -25,6 +25,7 @@
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' And Exists('$(AndroidManifest)') ">true</AndroidApplication>
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
+    <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>


### PR DESCRIPTION
Currently with a .NET 5 build you have to do:

    dotnet publish foo.csproj --self-contained

Or:

    dotnet publish foo.csproj -p:SelfContained=true

On Android platforms, it doesn't make sense to have a
non-self-contained app. That would mean there is a system-wide .NET 5
installation, which is not going to happen on Android.

In .NET 5 running on Windows/MacOS, this means the application relies
on the BCL living in a system-wide directory somewhere.

To simplify the command-line arguments we should default
`$(SelfContained)` to `true` when it is an Android application.