### PR TITLE
[AndroidClientHandler] Observe cancellation requests more

### DIFF
--- a/Documentation/release-notes/4589.md
+++ b/Documentation/release-notes/4589.md
@@ -1,0 +1,7 @@
+#### Application behavior on device and emulator
+
+  * [GitHub PR 4582](https://github.com/xamarin/xamarin-android/pull/4589):
+    `ObjectDisposedException` could in theory be thrown during cancellation of
+    `AndroidClientHandler` requests, depending on the particular timing of
+    cancellation and object disposal.  The time window where this can happen 
+    is now narrower.

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -436,7 +436,7 @@ namespace Xamarin.Android.Net
 				if (httpConnection.DoOutput)
 					await WriteRequestContentToOutput (request, httpConnection, cancellationToken);
 
-				statusCode = await Task.Run (() => (HttpStatusCode)httpConnection.ResponseCode).ConfigureAwait (false);
+				statusCode = await Task.Run (() => (HttpStatusCode)httpConnection.ResponseCode, cancellationToken).ConfigureAwait (false);
 				connectionUri = new Uri (httpConnection.URL?.ToString ()!);
 			} finally {
 				cancelRegistration.Dispose ();


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4550

It is possible that, in certain situations, a cancellation request
arriving from code external to `AndroidClientHandler` will not be
satisfied while starting the task to acquire connection status, because
the cancellation request appears after handler already established
connection to the remote host but before the request status is obtained.

Failure to check that the cancellation was requested may result in the
status retrieval task starting only to run into the issue that the
`AndroidClientHandler` object itself is already disposed (since the
cancellation request has been applied) and throw the
`ObjectDisposedException` instead of cancelling the status request
quietly.  Note that this is likely happen only in situations when the
application code aggressively cancels and collects (via calls to the
`GC` class) `AndroidClientHandler` instances or in other situations
which induce potential for timing issues in the TPL or `async/await`
state machine, thus leading to possible race conditions there.

This commit passes cancellation token to the task which runs the status
request, thus preventing it from starting in the situation described
above.  The possibility of a race condition still remains, but is
seriously reduced.