### PR TITLE
Save apkdesc files to output path

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ApkDiffCheckRegression.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ApkDiffCheckRegression.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			var apkDescFile = Path.Combine (ApkDescDirectory, $"{Path.GetFileNameWithoutExtension (Package)}{ApkDescSuffix}{Path.GetExtension (Package)}desc");
 			var cmd = new CommandLineBuilder ();
 			cmd.AppendSwitch ("-s");
-			cmd.AppendSwitch ($"--save-description-1={apkDescFile}");
+			cmd.AppendSwitch ($"--save-description-2={apkDescFile}");
 			cmd.AppendSwitch ($"--test-apk-size-regression={ApkSizeThreshold}");
 			cmd.AppendSwitch ($"--test-assembly-size-regression={AssemblySizeThreshold}");
 			cmd.AppendFileNameIfNotNull (ReferenceDescription);

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ApkDiffCheckRegression.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ApkDiffCheckRegression.cs
@@ -11,6 +11,12 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 	public class ApkDiffCheckRegression : ToolTask
 	{
 		[Required]
+		public string ApkDescDirectory { get; set; }
+
+		[Required]
+		public string ApkDescSuffix { get; set; }
+
+		[Required]
 		public string ApkDiffTool { get; set; }
 
 		[Required]
@@ -32,8 +38,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
+			var apkDescFile = Path.Combine (ApkDescDirectory, $"{Path.GetFileNameWithoutExtension (Package)}{ApkDescSuffix}{Path.GetExtension (Package)}desc");
 			var cmd = new CommandLineBuilder ();
 			cmd.AppendSwitch ("-s");
+			cmd.AppendSwitch ($"--save-description-1={apkDescFile}");
 			cmd.AppendSwitch ($"--test-apk-size-regression={ApkSizeThreshold}");
 			cmd.AppendSwitch ($"--test-assembly-size-regression={AssemblySizeThreshold}");
 			cmd.AppendFileNameIfNotNull (ReferenceDescription);

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -330,6 +330,8 @@
     </PropertyGroup>
     <ApkDiffCheckRegression
         Condition="Exists('$(_ApkSizesReferenceDirectory)\$([System.IO.Path]::GetFileNameWithoutExtension(%(_AllArchives.Identity)))-$(Configuration)$(TestsFlavor)$([System.IO.Path]::GetExtension(%(_AllArchives.Identity)))desc')"
+        ApkDescDirectory="$(OutputPath)"
+        ApkDescSuffix="-$(Configuration)$(TestsFlavor)"
         ApkDiffTool="$(ApkDiffPath)"
         Package="%(_AllArchives.Identity)"
         ReferenceDescription="$(_ApkSizesReferenceDirectory)\$([System.IO.Path]::GetFileNameWithoutExtension(%(_AllArchives.Identity)))-$(Configuration)$(TestsFlavor)$([System.IO.Path]::GetExtension(%(_AllArchives.Identity)))desc"

--- a/tools/apkdiff/ApkDescription.cs
+++ b/tools/apkdiff/ApkDescription.cs
@@ -29,7 +29,7 @@ namespace apkdiff {
 
 		Dictionary<string, (long Difference, long OriginalTotal)> totalDifferences = new Dictionary<string, (long, long)> ();
 
-		public static ApkDescription Load (string path)
+		public static ApkDescription Load (string path, string saveDescriptionPath = null)
 		{
 			if (!File.Exists (path)) {
 				Program.Error ($"File '{path}' does not exist.");
@@ -42,7 +42,7 @@ namespace apkdiff {
 			case ".aab":
 				var nd = new ApkDescription ();
 
-				nd.LoadApk (path);
+				nd.LoadApk (path, saveDescriptionPath);
 
 				return nd;
 			case ".apkdesc":
@@ -56,7 +56,7 @@ namespace apkdiff {
 			}
 		}
 
-		void LoadApk (string path)
+		void LoadApk (string path, string saveDescriptionPath = null)
 		{
 			Archive = ZipArchive.Open (path, FileMode.Open);
 
@@ -81,7 +81,7 @@ namespace apkdiff {
 			}
 
 			if (Program.SaveDescriptions) {
-				var descPath = Path.ChangeExtension (path, Path.GetExtension (path) + "desc");
+				var descPath = saveDescriptionPath ?? Path.ChangeExtension (path, Path.GetExtension (path) + "desc");
 
 				Program.ColorWriteLine ($"Saving apk description to '{descPath}'", ConsoleColor.Yellow);
 				SaveDescription (descPath);
@@ -231,9 +231,10 @@ namespace apkdiff {
 		{
 			var tmpDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			var tmpDirOther = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			var padding = "  ";
 
 			if (Program.Verbose)
-				Program.ColorWriteLine ($"Extracting '{entry.Key}' to {tmpDir} and {tmpDirOther} temporary directories", ConsoleColor.Gray);
+				Program.ColorWriteLine ($"{padding}Extracting '{entry.Key}' to {tmpDir} and {tmpDirOther} temporary directories", ConsoleColor.Gray);
 
 			Directory.CreateDirectory (tmpDir);
 
@@ -243,7 +244,7 @@ namespace apkdiff {
 			var zipEntryOther = otherApk.Archive.ReadEntry (other.Key, true);
 			zipEntryOther.Extract (tmpDirOther, other.Key);
 
-			diff.Compare (Path.Combine (tmpDir, entry.Key), Path.Combine (tmpDirOther, other.Key), "  ");
+			diff.Compare (Path.Combine (tmpDir, entry.Key), Path.Combine (tmpDirOther, other.Key), padding);
 
 			Directory.Delete (tmpDir, true);
 			Directory.Delete (tmpDirOther, true);

--- a/tools/apkdiff/AssemblyDiff.cs
+++ b/tools/apkdiff/AssemblyDiff.cs
@@ -41,37 +41,39 @@ namespace apkdiff {
 
 		public override void Compare (string file, string other, string padding)
 		{
-			var per1 = new PEReader (File.OpenRead (file));
-			var per2 = new PEReader (File.OpenRead (other));
+			using (var per1 = new PEReader (File.OpenRead (file))) {
+				using (var per2 = new PEReader (File.OpenRead (other))) {
 
-			reader1 = per1.GetMetadataReader ();
-			reader2 = per2.GetMetadataReader ();
+					reader1 = per1.GetMetadataReader ();
+					reader2 = per2.GetMetadataReader ();
 
-			var types1 = new Dictionary<string, TypeDefinition> (reader1.TypeDefinitions.Count);
-			var types2 = new Dictionary<string, TypeDefinition> (reader2.TypeDefinitions.Count);
+					var types1 = new Dictionary<string, TypeDefinition> (reader1.TypeDefinitions.Count);
+					var types2 = new Dictionary<string, TypeDefinition> (reader2.TypeDefinitions.Count);
 
-			string fullName;
+					string fullName;
 
-			foreach (var typeHandle in reader1.TypeDefinitions) {
-				var td = GetTypeDefinition (reader1, typeHandle, out fullName);
-				types1 [fullName] = td;
-			}
+					foreach (var typeHandle in reader1.TypeDefinitions) {
+						var td = GetTypeDefinition (reader1, typeHandle, out fullName);
+						types1 [fullName] = td;
+					}
 
-			foreach (var typeHandle in reader2.TypeDefinitions) {
-				var td = GetTypeDefinition (reader2, typeHandle, out fullName);
-				types2 [fullName] = td;
-			}
+					foreach (var typeHandle in reader2.TypeDefinitions) {
+						var td = GetTypeDefinition (reader2, typeHandle, out fullName);
+						types2 [fullName] = td;
+					}
 
-			foreach (var pair in types1) {
-				if (!types2.ContainsKey (pair.Key)) {
-					Console.WriteLine ($"{padding}  -             Type {pair.Key}");
-				} else
-					CompareTypes (types1 [pair.Key], types2 [pair.Key], padding + "  ");
-			}
+					foreach (var pair in types1) {
+						if (!types2.ContainsKey (pair.Key)) {
+							Console.WriteLine ($"{padding}  -             Type {pair.Key}");
+						} else
+							CompareTypes (types1 [pair.Key], types2 [pair.Key], padding + "  ");
+					}
 
-			foreach (var pair in types2) {
-				if (!types1.ContainsKey (pair.Key)) {
-					Console.WriteLine ($"{padding}  +             Type {pair.Key}");
+					foreach (var pair in types2) {
+						if (!types1.ContainsKey (pair.Key)) {
+							Console.WriteLine ($"{padding}  +             Type {pair.Key}");
+						}
+					}
 				}
 			}
 		}

--- a/tools/apkdiff/DexDiff.cs
+++ b/tools/apkdiff/DexDiff.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace apkdiff
+{
+	class DexDiff : EntryDiff
+	{
+		public override string Name { get { return "Davik executables"; } }
+
+		public override void Compare (string file, string other, string padding)
+		{
+			using (var dex1 = new DexFile (file, padding)) {
+				using (var dex2 = new DexFile (other, padding)) {
+
+					if (dex1.linkSize != dex2.linkSize)
+						ApkDescription.PrintDifference ("link section size", dex2.linkSize - dex1.linkSize, "", padding);
+
+					if (dex1.stringIdsSize != dex2.stringIdsSize)
+						ApkDescription.PrintDifference ("strings count", dex2.stringIdsSize - dex1.stringIdsSize, "", padding);
+
+					if (dex1.typeIdsSize != dex2.typeIdsSize)
+						ApkDescription.PrintDifference ("types count", dex2.typeIdsSize - dex1.typeIdsSize, "", padding);
+
+					if (dex1.protoIdsSize != dex2.protoIdsSize)
+						ApkDescription.PrintDifference ("prototypes count", dex2.protoIdsSize - dex1.protoIdsSize, "", padding);
+
+					if (dex1.fieldIdsSize != dex2.fieldIdsSize)
+						ApkDescription.PrintDifference ("fields count", dex2.fieldIdsSize - dex1.fieldIdsSize, "", padding);
+
+					if (dex1.methodIdsSize != dex2.methodIdsSize)
+						ApkDescription.PrintDifference ("methods count", dex2.methodIdsSize - dex1.methodIdsSize, "", padding);
+
+					if (dex1.classDefsSize != dex2.classDefsSize)
+						ApkDescription.PrintDifference ("classes count", dex2.classDefsSize - dex1.classDefsSize, "", padding);
+
+					if (dex1.dataSize != dex2.dataSize)
+						ApkDescription.PrintDifference ("data section size", dex2.dataSize - dex1.dataSize, "", padding);
+
+				}
+			}
+		}
+	}
+
+	class DexFile : IDisposable
+	{
+		// header
+		internal uint checksum;
+		internal byte [] signature;
+		internal uint fileSize;
+		internal uint linkSize;
+		internal uint linkOffset;
+		internal uint mapOffset;
+		internal uint stringIdsSize;
+		internal uint stringIdsOffset;
+		internal uint typeIdsSize;
+		internal uint typeIdsOffset;
+		internal uint protoIdsSize;
+		internal uint protoIdsOffset;
+		internal uint fieldIdsSize;
+		internal uint fieldIdsOffset;
+		internal uint methodIdsSize;
+		internal uint methodIdsOffset;
+		internal uint classDefsSize;
+		internal uint classDefsOffset;
+		internal uint dataSize;
+		internal uint dataOffset;
+
+		BinaryReader reader;
+		FileStream stream;
+		string padding;
+
+		public DexFile (string file, string padding = null)
+		{
+			this.padding = padding;
+
+			if (Program.Verbose)
+				Console.WriteLine ($"{padding}Reading DEX file: {file}");
+
+			stream = File.Open (file, FileMode.Open);
+			reader = new BinaryReader (stream);
+
+			ReadHeader ();
+		}
+
+		void ReadHeader ()
+		{
+			byte[] magicDEX = { 0x64, 0x65, 0x78, 0x0a, 0x30, 0x33, 0x39, 0x00 };
+
+			var magicBytes = reader.ReadBytes (8);
+
+			for (int i = 0; i < 8; i++) {
+				if (Program.Verbose && i == 6)
+					Console.WriteLine ($"{padding}DEX file version: {magicBytes [i]:X}");
+
+				if (i != 6 && magicBytes [i] != magicDEX [i])
+					throw new FileLoadException ("not DEX file");
+			}
+
+			checksum = reader.ReadUInt32 ();
+			signature = reader.ReadBytes (20);
+			fileSize = reader.ReadUInt32 ();
+
+			var headerSize = reader.ReadUInt32 ();
+			if (headerSize != 0x70)
+				throw new FileLoadException ($"DEX header has wrong size: {headerSize:X} instead of 0x70");
+
+			var endianTag = reader.ReadUInt32 ();
+			if (endianTag != 0x12345678)
+				throw new FileLoadException ($"DEX header wrong endianness: {endianTag:X} instead of 0x12345678");
+
+			linkSize = reader.ReadUInt32 ();
+			linkOffset = reader.ReadUInt32 ();
+			mapOffset = reader.ReadUInt32 ();
+
+			stringIdsSize = reader.ReadUInt32 ();
+			stringIdsOffset = reader.ReadUInt32 ();
+
+			typeIdsSize = reader.ReadUInt32 ();
+			typeIdsOffset = reader.ReadUInt32 ();
+
+			protoIdsSize = reader.ReadUInt32 ();
+			protoIdsOffset = reader.ReadUInt32 ();
+
+			fieldIdsSize = reader.ReadUInt32 ();
+			fieldIdsOffset = reader.ReadUInt32 ();
+
+			methodIdsSize = reader.ReadUInt32 ();
+			methodIdsOffset = reader.ReadUInt32 ();
+
+			classDefsSize = reader.ReadUInt32 ();
+			classDefsOffset = reader.ReadUInt32 ();
+
+			dataSize = reader.ReadUInt32 ();
+			dataOffset = reader.ReadUInt32 ();
+		}
+
+		private bool disposedValue = false;
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (!disposedValue) {
+				if (disposing) {
+					reader.Dispose ();
+					stream.Dispose ();
+				}
+
+				disposedValue = true;
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+		}
+	}
+}

--- a/tools/apkdiff/EntryDiff.cs
+++ b/tools/apkdiff/EntryDiff.cs
@@ -12,6 +12,8 @@ namespace apkdiff {
 				return new AssemblyDiff ();
 			case ".so":
 				return new SharedLibraryDiff ();
+			case ".dex":
+				return new DexDiff ();
 			}
 
 			return null;

--- a/tools/apkdiff/Program.cs
+++ b/tools/apkdiff/Program.cs
@@ -10,6 +10,7 @@ namespace apkdiff {
 
 		public static string Comment;
 		public static bool SaveDescriptions;
+		public static string SaveDescription1, SaveDescription2;
 		public static bool Verbose;
 
 		public static long AssemblyRegressionThreshold;
@@ -20,10 +21,10 @@ namespace apkdiff {
 		{
 			var (path1, path2) = ProcessArguments (args);
 
-			var desc1 = ApkDescription.Load (path1);
+			var desc1 = ApkDescription.Load (path1, SaveDescription1);
 
 			if (path2 != null) {
-				var desc2 = ApkDescription.Load (path2);
+				var desc2 = ApkDescription.Load (path2, SaveDescription2);
 
 				desc1.Compare (desc2);
 
@@ -64,8 +65,14 @@ namespace apkdiff {
 					"Check whether any assembly size increased more than {BYTES}",
 				  v => AssemblyRegressionThreshold = long.Parse (v) },
 				{ "s|save-descriptions",
-					"Save .[apk|aab]desc description files next to the package(s)",
+					"Save .[apk|aab]desc description files next to the package(s) or to the specified path",
 				  v => SaveDescriptions = true },
+				{ "save-description-1=",
+					"Save .[apk|aab]desc description for first package to {PATH}",
+				  v => SaveDescription1 = v },
+				{ "save-description-2=",
+					"Save .[apk|aab]desc description for second package to {PATH}",
+				  v => SaveDescription2 = v },
 				{ "v|verbose",
 					"Output information about progress during the run of the tool",
 				  v => Verbose = true },

--- a/tools/apkdiff/README.md
+++ b/tools/apkdiff/README.md
@@ -1,8 +1,10 @@
 **apkdiff** is a tool to compare Android packages
 
+Upstream repository: https://github.com/radekdoulik/apkdiff
+Location of the tool included in Xamarin.Android: https://github.com/xamarin/xamarin-android/tree/master/tools/apkdiff
+
 ```
-Usage: apkdiff.exe OPTIONS* <package1.[apk|aab][desc]> [<package2.[apk|aab][
-desc]>]
+Usage: apkdiff.exe OPTIONS* <package1.[apk|aab][desc]> [<package2.[apk|aab][desc]>]
 
 Compares APK/AAB packages content or APK/AAB package with content description
 
@@ -11,8 +13,19 @@ Copyright 2020 Microsoft Corporation
 Options:
   -c, --comment=VALUE        Comment to be saved inside description file
   -h, --help, -?             Show this message and exit
+      --test-apk-size-regression=BYTES
+                             Check whether apk size increased more than BYTES
+      --test-assembly-size-regression=BYTES
+                             Check whether any assembly size increased more
+                               than BYTES
   -s, --save-descriptions    Save .[apk|aab]desc description files next to the
-                               package(s)
+                               package(s) or to the specified path
+      --save-description-1=PATH
+                             Save .[apk|aab]desc description for first package
+                               to PATH
+      --save-description-2=PATH
+                             Save .[apk|aab]desc description for second package
+                               to PATH
   -v, --verbose              Output information about progress during the run
                                of the tool
 ```
@@ -38,4 +51,138 @@ Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
   -       77792 lib/x86/libmonosgen-2.0.so
 Summary:
   -       46984 Package size difference
+```
+
+### Example output with shared libraries and assemblies details
+```
+mono apkdiff.exe Xamarin.Forms_Performance_Integration-Signed-NewNDK-Default.apk Xamarin.Forms_Performance_Integration-Signed-NewNTR-Default.apk 
+Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
+  +       42496 assemblies/Mono.Android.dll
+    +             Type Java.Nio.ByteBuffer
+    +             Type Java.Nio.ByteBuffer/__<$>_jni_marshal_methods
+    +             Type Java.Nio.ByteBufferInvoker
+    +             Type Java.Nio.Channels.FileChannel
+    +             Type Java.Nio.Channels.FileChannel/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.FileChannelInvoker
+    +             Type Java.Nio.Channels.FileChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IByteChannel
+    +             Type Java.Nio.Channels.IByteChannelInvoker
+    +             Type Java.Nio.Channels.IByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IChannel
+    +             Type Java.Nio.Channels.IChannelInvoker
+    +             Type Java.Nio.Channels.IChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IGatheringByteChannel
+    +             Type Java.Nio.Channels.IGatheringByteChannelInvoker
+    +             Type Java.Nio.Channels.IGatheringByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IInterruptibleChannel
+    +             Type Java.Nio.Channels.IInterruptibleChannelInvoker
+    +             Type Java.Nio.Channels.IInterruptibleChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IReadableByteChannel
+    +             Type Java.Nio.Channels.IReadableByteChannelInvoker
+    +             Type Java.Nio.Channels.IReadableByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IScatteringByteChannel
+    +             Type Java.Nio.Channels.IScatteringByteChannelInvoker
+    +             Type Java.Nio.Channels.IScatteringByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.ISeekableByteChannel
+    +             Type Java.Nio.Channels.ISeekableByteChannelInvoker
+    +             Type Java.Nio.Channels.ISeekableByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.IWritableByteChannel
+    +             Type Java.Nio.Channels.IWritableByteChannelInvoker
+    +             Type Java.Nio.Channels.IWritableByteChannelInvoker/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.Spi.AbstractInterruptibleChannel
+    +             Type Java.Nio.Channels.Spi.AbstractInterruptibleChannel/__<$>_jni_marshal_methods
+    +             Type Java.Nio.Channels.Spi.AbstractInterruptibleChannelInvoker
+    +             Type Java.IO.FileInputStream
+    +             Type Java.IO.FileInputStream/__<$>_jni_marshal_methods
+  +        6264 lib/armeabi-v7a/libxamarin-app.so
+                  Symbol size difference
+    +        3480 mj_typemap
+    +        2784 jm_typemap
+  +        6264 lib/x86/libxamarin-app.so
+                  Symbol size difference
+    +        3480 mj_typemap
+    +        2784 jm_typemap
+  +        3584 assemblies/Java.Interop.dll
+    -             Type Java.Interop.JniRuntime/JniValueManager/<>c__DisplayClass38_0
+    -             Type Java.Interop.JniRuntime/JniTypeManager/<CreateGetTypesEnumerator>d__18
+    -             Type Java.Interop.JniRuntime/JniTypeManager/<CreateGetTypesForSimpleReferenceEnumerator>d__20
+    +             Type Microsoft.CodeAnalysis.EmbeddedAttribute
+    +             Type System.Runtime.CompilerServices.NullableAttribute
+    +             Type System.Diagnostics.CodeAnalysis.AllowNullAttribute
+    +             Type System.Diagnostics.CodeAnalysis.MaybeNullAttribute
+    +             Type System.Diagnostics.CodeAnalysis.NotNullAttribute
+    +             Type System.Diagnostics.CodeAnalysis.NotNullWhenAttribute
+    +             Type System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute
+    +             Type Java.Interop.JniRuntime/JniValueManager/<>c__DisplayClass37_0
+    +             Type Java.Interop.JniRuntime/JniTypeManager/<CreateGetTypesEnumerator>d__17
+    +             Type Java.Interop.JniRuntime/JniTypeManager/<CreateGetTypesForSimpleReferenceEnumerator>d__19
+  -         512 assemblies/mscorlib.dll
+Summary:
+  +       45056 Package size difference
+```
+### Shared libraries section sizes comparison example
+```
+        Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
+          +      376724 lib/x86/libsqlite3_xamarin.so
+                          Section size difference
+            +      316967 .debug_loc
+            +       60924 .debug_info
+            +       15176 .debug_ranges
+            +        4038 .debug_line
+            +        1952 .debug_str
+            +         127 .debug_abbrev
+            +          44 .rodata
+            +          40 .eh_frame_hdr
+            +           8 .data.rel.ro
+            -           4 .eh_frame
+            -           4 .data
+            -           8 .gnu.version
+            -          12 .got.plt
+            -          16 .gnu.hash
+            -          16 .hash
+            -          24 .rel.plt
+            -          38 .dynstr
+            -          48 .plt
+            -          64 .dynsym
+            -          84 .comment
+            -       23984 .text
+```
+### Size regression test example
+```
+apkdiff.exe --test-apk-size-regression=51200
+--test-assembly-size-regression=51200 Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc TestDebug\Xamarin.Forms_Performance_Integration-Signed.apk
+Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
+  +  26,749,952 assemblies/Mono.Android.dll
+Error: apkdiff: Assembly size differs more than 51,200 bytes.
+  +  14,655,424 assemblies/Mono.Android.pdb *2
+  +   2,423,388 lib/x86/libmonosgen-2.0.so
+  +   2,413,568 assemblies/mscorlib.dll
+Error: apkdiff: Assembly size differs more than 51,200 bytes.
+...
+Summary:
+  +  43,001,792 Assemblies 303.25% (of 14,180,480)
+  +  10,653,224 Shared libraries 89.86% (of 11,855,444)
+  +  66,973,060 Package size difference 318.80% (of 21,007,581)
+Error: apkdiff: PackageSize differ more than 51,200 bytes. apk1 size: 21,007,581 bytes, apk2 size: 87,980,641 bytes.
+Error: apkdiff: Size regression occured, 39 test(s) failed.
+```
+### Comparison including DEX file example
+```
+apkdiff Xamarin.Forms_Performance_Integration-Signed-orig.apk Xamarin.Forms_Performance_Integration-Signed.apk
+Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
+  +     255,792 classes.dex
+    +       2,023 strings count
+    +         260 types count
+    +         409 prototypes count
+    +       1,100 fields count
+    +       2,548 methods count
+    +         237 classes count
+    +     204,984 data section size
+  +         512 assemblies/System.dll
+  -          20 AndroidManifest.xml
+Summary:
+  +     255,792 Davik executables 13.15% (of 1,944,832)
+  +         512 Assemblies 0.00% (of 14,180,480)
+  +           0 Shared libraries 0.00% (of 11,856,152)
+  +     106,496 Package size difference 0.51% (of 21,007,581)
 ```


### PR DESCRIPTION
Add the configuration and the flavor to the filename, save them to `$(OutputPath)` .
This way we can just copy the files when we need update reference apkdesc's.

Also merge apkdiff changes from upstream

* radekdoulik/apkdiff@cb0083b: Fix indentation, put the XA link  on separate line
* radekdoulik/apkdiff@092e40a: Added links to the upstream repo and XA location
* radekdoulik/apkdiff@cdb7593: Added DEX comparison example
* radekdoulik/apkdiff@17f242b: Update usage info in README.md
* radekdoulik/apkdiff@1dbdb00: Added options to specify path of saved description
* radekdoulik/apkdiff@e6390f6: Initial DEX comparison
* radekdoulik/apkdiff@7c8d5d8: Dispose PEReaders

Mostly to have the options to save descriptions to specified path. Also
contains the DEX files comparison.