### PR TITLE
Add Locale to AppInsights plot tracking

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -708,7 +708,6 @@ stages:
     # UNDONE: Need plot definitions for the following files:
     #  TestResult-Mono.Android_TestsAppBundle-times.csv
     #  TestResult-Mono.Android_TestsMultiDex-times.csv
-    #  TestResult-Mono.Android_TestsMultiDex-values-$(ApkTestConfiguration).csv
     #  TestResult-Xamarin.Android.EmbeddedDSO_Test-times.csv
 
     - template: yaml-templates/plots-to-appinsights.yaml
@@ -718,14 +717,6 @@ stages:
         plotGroup: Test times
         plotTitle: Runtime merged
         plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_Tests-times.csv
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(ApkTestConfiguration)
-        plotGroup: Test size
-        plotTitle: Runtime test sizes
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_Tests-values-$(ApkTestConfiguration).csv
 
     - template: yaml-templates/plots-to-appinsights.yaml
       parameters:
@@ -750,14 +741,6 @@ stages:
         plotGroup: Test times
         plotTitle: Xamarin.Forms app startup
         plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Xamarin.Forms_Test-times.csv
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(ApkTestConfiguration)
-        plotGroup: Test times
-        plotTitle: Xamarin.Forms app
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Xamarin.Forms_Tests-values-$(ApkTestConfiguration).csv
 
     - template: yaml-templates/fail-on-issue.yaml
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -742,6 +742,14 @@ stages:
         plotTitle: Xamarin.Forms app startup
         plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Xamarin.Forms_Test-times.csv
 
+    - template: yaml-templates/plots-to-appinsights.yaml
+      parameters:
+        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
+        configuration: $(ApkTestConfiguration)
+        plotGroup: Test times
+        plotTitle: Locale
+        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Xamarin.Android.Locale_Tests-times.csv
+
     - template: yaml-templates/fail-on-issue.yaml
 
   # Check - "Xamarin.Android (Test BCL With Emulator - macOS)"

--- a/build-tools/plots-to-appinsights/Program.cs
+++ b/build-tools/plots-to-appinsights/Program.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Android.Tools.Plots
 					var appInsightsClientError = new AppInsights (settings.AppInsightsTelemetryKey);
 					var eventNameError = GetEventName (settings.Environment, Constants.TelemetryEventName_Error);
 					SendTelemetryError (appInsightsClientError, eventNameError, message, settings, Console.Out);
+					appInsightsClientError.Flush ();
 				}
 
 				if (result.Status.HasFlag (Status.ShowHelp) || result.Status != Status.OK) {


### PR DESCRIPTION
Removed the following plots as it appears the CSV file is no longer produced for these
 - Runtime test sizes
 - Xamarin.Forms app

Fixed a bug where the error for a missing CSV file isn't being sent to AppInsights by adding a call to Flush().