### PR TITLE
[xaprepare] Don't require binaries when unable to install them

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/EssentialTools.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/EssentialTools.MacOS.cs
@@ -4,20 +4,30 @@ namespace Xamarin.Android.Prepare
 {
 	partial class EssentialTools : AppObject
 	{
-		public string BrewPath    { get; set; }
-		public string PkgutilPath { get; set; }
+		string brewPath;
+		string pkgutilPath;
+
+		public string BrewPath {
+			get => GetRequiredValue (brewPath, "brew");
+			set => brewPath = value;
+		}
+
+		public string PkgutilPath {
+			get => GetRequiredValue (pkgutilPath, "pkgutil");
+			set => pkgutilPath = value;
+		}
 
 		partial void InitOS (Context context)
 		{
 			Log.StatusLine ($"  {context.Characters.Bullet} homebrew", ConsoleColor.White);
-			if (String.IsNullOrEmpty (BrewPath))
+			if (String.IsNullOrEmpty (brewPath))
 				BrewPath = context.OS.Which ("brew", required: true);
-			Log.StatusLine ("     Found: ", BrewPath, tailColor: Log.DestinationColor);
+			ReportToolPath (brewPath);
 
 			Log.StatusLine ($"  {context.Characters.Bullet} pkgutil", ConsoleColor.White);
-			if (String.IsNullOrEmpty (PkgutilPath))
+			if (String.IsNullOrEmpty (pkgutilPath))
 				PkgutilPath = context.OS.Which ("/usr/sbin/pkgutil", required: true);
-			Log.StatusLine ($"    Found: ", PkgutilPath, tailColor: Log.DestinationColor);
+			ReportToolPath (pkgutilPath);
 
 			InitSharedUnixOS (context);
 		}

--- a/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
+++ b/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
@@ -4,26 +4,59 @@ namespace Xamarin.Android.Prepare
 {
 	partial class EssentialTools : AppObject
 	{
-		public string GitPath             { get; set; }
-		public string SevenZipPath        { get; set; }
+		string gitPath;
+		string sevenZipPath;
+		bool initialized;
+
+		public string GitPath {
+			get => GetRequiredValue (gitPath, "git");
+			set => gitPath = value;
+		}
+
+		public string SevenZipPath {
+			get => GetRequiredValue (sevenZipPath, "7zip");
+			set => sevenZipPath = value;
+		}
+
+		public bool IsInitialized => initialized;
 
 		public EssentialTools ()
 		{}
 
 		public void Init (Context context)
 		{
+			bool require = context.CheckCondition (KnownConditions.AllowProgramInstallation);
+
 			Log.StatusLine ();
 			Log.StatusLine ("Locating essential tool binaries", ConsoleColor.DarkGreen);
 
 			Log.StatusLine ($"  {context.Characters.Bullet} git", ConsoleColor.White);
-			GitPath = context.OS.Which ("git", required: true);
-			Log.StatusLine ("     Found: ", GitPath, tailColor: Log.DestinationColor);
+			GitPath = context.OS.Which ("git", required: require);
+			ReportToolPath (gitPath);
 
 			Log.StatusLine ($"  {context.Characters.Bullet} 7za", ConsoleColor.White);
-			SevenZipPath = context.OS.Which ("7za", required: true);
-			Log.StatusLine ("     Found: ", SevenZipPath, tailColor: Log.DestinationColor);
+			SevenZipPath = context.OS.Which ("7za", required: require);
+			ReportToolPath (sevenZipPath);
 
 			InitOS (context);
+			initialized = true;
+		}
+
+		void ReportToolPath (string path)
+		{
+			if (!String.IsNullOrEmpty (path))
+				Log.StatusLine ("     Found: ", path, tailColor: Log.DestinationColor);
+			else
+				Log.StatusLine ("   Missing: will be installed later");
+		}
+
+		string GetRequiredValue (string val, string name)
+		{
+			if (String.IsNullOrEmpty (val)) {
+				throw new InvalidOperationException ($"{name} not found but required by this scenario");
+			}
+
+			return val;
 		}
 
 		partial void InitOS (Context context);

--- a/build-tools/xaprepare/xaprepare/ToolRunners/PkgutilRunner.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/PkgutilRunner.MacOS.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 {
 	partial class PkgutilRunner : ToolRunner
 	{
-		protected override string DefaultToolExecutableName => Context.Instance?.Tools?.PkgutilPath ?? "pkgutil";
+		protected override string DefaultToolExecutableName => GetToolExecutableName ();
 		protected override string ToolName                  => "PkgUtil";
 
 		public PkgutilRunner (Context context, Log log = null, string toolPath = null)
@@ -79,6 +79,16 @@ namespace Xamarin.Android.Prepare
 			}
 
 			return runner;
+		}
+
+		string GetToolExecutableName ()
+		{
+			EssentialTools tools = Context.Instance?.Tools;
+
+			if (tools != null && tools.IsInitialized)
+				return tools.PkgutilPath;
+
+			return "pkgutil";
 		}
 	}
 }


### PR DESCRIPTION
`xaprepare` defines a set of binaries/programs which are deemed
essential and, thus, it enforces their presence before the scenario
runs.  However, there can be scenarios (e.g. `UpdateMono`) which
disallow installation of any programs and should any of the essential
programs be missing, we'd see a failure similar to:

    Required program '7za' could not be found
    System.InvalidOperationException: Required program '7za' could not be found
      at Xamarin.Android.Prepare.OS.Which (System.String programPath, System.Boolean required)
      at Xamarin.Android.Prepare.EssentialTools.Init (Xamarin.Android.Prepare.Context context)
      at Xamarin.Android.Prepare.Context+<Init>d__201.MoveNext ()
    --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult ()
      at Xamarin.Android.Prepare.App+<Run>d__3.MoveNext ()

Allow such scenarios to run in the broken environment by making it
possible to ignore certain missing programs.  Scenarios which disallow
installation of any programs must be very careful in what programs they
use.