### PR TITLE
[.NET 5] fix warning for $(TFV) of 5.0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
@@ -11,9 +11,10 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.RuntimeIdentifierToAbi" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling"      AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.RuntimeIdentifierToAbi"     AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion"        AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <Target Name="_ResolveAndroidTooling">
     <ValidateJavaVersion
@@ -59,6 +60,14 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
         SupportedAbis="$(AndroidSupportedAbis)">
       <Output TaskParameter="SupportedAbis" PropertyName="AndroidSupportedAbis" />
     </RuntimeIdentifierToAbi>
+  </Target>
+
+  <Target Name="_CheckGoogleSdkRequirements"
+      Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
+    <CheckGoogleSdkRequirements
+        ApiLevel="$(_AndroidApiLevel)"
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    />
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
@@ -14,8 +14,15 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "CGS";
 
-		[Required]
+		/// <summary>
+		/// This will be blank for .NET 5 builds
+		/// </summary>
 		public string TargetFrameworkVersion { get; set; }
+
+		/// <summary>
+		/// This is used instead of TargetFrameworkVersion for .NET 5 builds
+		/// </summary>
+		public int ApiLevel { get; set; }
 
 		[Required]
 		public string ManifestFile { get; set; }
@@ -24,7 +31,9 @@ namespace Xamarin.Android.Tasks
 		{
 			ManifestDocument manifest = new ManifestDocument (ManifestFile);
 
-			var compileSdk = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+			var compileSdk = string.IsNullOrEmpty (TargetFrameworkVersion) ?
+				ApiLevel :
+				MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 
 			if (!int.TryParse (manifest.GetMinimumSdk (), out int minSdk)) {
 				minSdk = 1;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Android.Build.Tests
 
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Publish (), "`dotnet publish` should succeed");
+			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
 
 			var apk = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath,
 				runtimeIdentifier, "UnnamedProject.UnnamedProject.apk");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -30,11 +30,9 @@ namespace Xamarin.ProjectTools
 		public IEnumerable<string> LastBuildOutput {
 			get {
 				if (!string.IsNullOrEmpty (buildLogFullPath) && File.Exists (buildLogFullPath)) {
-					foreach (var line in File.ReadLines (buildLogFullPath, Encoding.UTF8)) {
-						yield return line;
-					}
+					return File.ReadLines (buildLogFullPath, Encoding.UTF8);
 				}
-				yield return String.Empty;
+				return Enumerable.Empty<string> ();
 			}
 		}
 		public TimeSpan LastBuildTime { get; protected set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Xamarin.ProjectTools
@@ -82,6 +83,15 @@ namespace Xamarin.ProjectTools
 		{
 			var arguments = GetDefaultCommandLineArgs ("publish", target);
 			return Execute (arguments.ToArray ());
+		}
+
+		public IEnumerable<string> LastBuildOutput {
+			get {
+				if (!string.IsNullOrEmpty (BuildLogFile) && File.Exists (BuildLogFile)) {
+					return File.ReadLines (BuildLogFile, Encoding.UTF8);
+				}
+				return Enumerable.Empty<string> ();
+			}
 		}
 
 		List<string> GetDefaultCommandLineArgs (string verb, string target = null)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -40,7 +40,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateAdditionalResourceCacheDirectories" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateLayoutCodeBehind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateProjectDependencies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForRemovedItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForInvalidResourceFileNames" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileToDalvik" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -547,14 +546,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <Warning Code="XA0119"
       Text="Using Fast Deployment and Android App Bundles at the same time is not recommended. Use Fast Deployment for Debug configurations and Android App Bundles for Release configurations."
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidPackageFormat)' == 'aab' "
-  />
-</Target>
-
-<Target Name="_CheckGoogleSdkRequirements"
-    Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
-  <CheckGoogleSdkRequirements
-      TargetFrameworkVersion="$(TargetFrameworkVersion)"
-      ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
   />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -143,7 +143,8 @@ projects. .NET 5 projects will not import this file.
     </CleanDependsOn>
   </PropertyGroup>
 
-  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
   <Target Name="_GetReferenceAssemblyPaths">
@@ -243,6 +244,14 @@ projects. .NET 5 projects will not import this file.
     <ItemGroup>
       <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_CheckGoogleSdkRequirements"
+      Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
+    <CheckGoogleSdkRequirements
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    />
   </Target>
 
 </Project>


### PR DESCRIPTION
In our current .NET 5 builds, you always hit:

    warning XA1008: The TargetFrameworkVersion (Android API level 21) is lower than the targetSdkVersion (29).
    Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.

It is giving a warning for Google Play, because
`$(TargetFrameworkVersion)` is equal to 5.0.

To fix this, I modified the `<CheckGoogleSdkRequirements/>` MSBuild
task so that `TargetFrameworkVersion` is optional. For .NET 5 builds,
we can pass in `$(_AndroidApiLevel)` instead.

This way we will still get some important warnings for .NET 5 such as
`targetSdkVersion` or `minSdkVersion` that need to be changed in the
`AndroidManifest.xml` file.

I also fixed up `LastBuildOutput`, we needed the value for .NET 5
MSBuild tests and I removed unnecessary usage of `yield return`.