### PR TITLE
[build] see if we can add Windows Defender exclusions

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -244,6 +244,8 @@ stages:
 
     - template: yaml-templates\kill-processes.yaml
 
+    - template: yaml-templates\windows-defender.yaml
+
     - template: yaml-templates\clean.yaml
 
     - task: UseDotNet@2

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -15,6 +15,8 @@ jobs:
 
     - template: kill-processes.yaml
 
+    - template: windows-defender.yaml
+
     - template: clean.yaml
 
     - template: setup-test-environment.yaml

--- a/build-tools/automation/yaml-templates/windows-defender.yaml
+++ b/build-tools/automation/yaml-templates/windows-defender.yaml
@@ -1,0 +1,8 @@
+steps:
+- powershell: |
+    $ErrorActionPreference = 'Continue'
+    Add-MpPreference -ExclusionPath "$env:UserProfile\android-toolchain"
+    Add-MpPreference -ExclusionPath "$env:UserProfile\android-archives"
+    Add-MpPreference -ExclusionPath "$(System.DefaultWorkingDirectory)"
+    $LastExitCode = 0
+  displayName: Windows Defender exclusion


### PR DESCRIPTION
Context: https://docs.microsoft.com/powershell/module/defender/add-mppreference

Our build and test phases on Windows currently hit `IOException` in
many random places.

This is a test to see if adding Windows Defender exclusions help
anything. It might also improve performance.