### PR TITLE
[AndroidClientHandler] Wrap Java exceptions in .NET ones

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -292,13 +292,13 @@ namespace Xamarin.Android.Net
 						throw new InvalidOperationException ("Request redirected but no new URI specified");
 					request.Method = redirectState.Method;
 				} catch (Java.Net.SocketTimeoutException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new WebException (ex.Message, ex, WebExceptionStatus.Timeout, null);
+					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.Timeout, null);
 				} catch (Java.Net.UnknownServiceException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new WebException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
+					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
 				} catch (Java.Lang.SecurityException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new WebException (ex.Message, ex, WebExceptionStatus.SecureChannelFailure, null);
+					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.SecureChannelFailure, null);
 				} catch (Java.IO.IOException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new WebException (ex.Message, ex, WebExceptionStatus.UnknownError, null);
+					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.UnknownError, null);
 				}
 			}
 		}
@@ -833,7 +833,7 @@ namespace Xamarin.Android.Net
 			try {
 				httpConnection.RequestMethod = request.Method.ToString ();
 			} catch (Java.Net.ProtocolException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-				throw new WebException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
+				throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
 			}
 
 			// SSL context must be set up as soon as possible, before adding any content or

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -292,13 +292,13 @@ namespace Xamarin.Android.Net
 						throw new InvalidOperationException ("Request redirected but no new URI specified");
 					request.Method = redirectState.Method;
 				} catch (Java.Net.SocketTimeoutException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.Timeout, null);
+					throw new WebException (ex.Message, ex, WebExceptionStatus.Timeout, null);
 				} catch (Java.Net.UnknownServiceException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
+					throw new WebException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
 				} catch (Java.Lang.SecurityException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.SecureChannelFailure, null);
+					throw new WebException (ex.Message, ex, WebExceptionStatus.SecureChannelFailure, null);
 				} catch (Java.IO.IOException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-					throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.UnknownError, null);
+					throw new WebException (ex.Message, ex, WebExceptionStatus.UnknownError, null);
 				}
 			}
 		}
@@ -833,7 +833,7 @@ namespace Xamarin.Android.Net
 			try {
 				httpConnection.RequestMethod = request.Method.ToString ();
 			} catch (Java.Net.ProtocolException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
-				throw new HttpRequestException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
+				throw new WebException (ex.Message, ex, WebExceptionStatus.ProtocolError, null);
 			}
 
 			// SSL context must be set up as soon as possible, before adding any content or


### PR DESCRIPTION
Context: 60363ef45cd6994a322adac1b73d4271b0658c1e

This commit is, in a way, a follow-up to 60363ef4 in that it causes less
Java exceptions to "leak" to applications which use code shared between
platforms that might not be able to check for Java exception types
directly (because they don't link against `Mono.Android.dll`).  However,
instead of making the behavior optional, as implemented in 60363ef4,
this commit unconditionally wraps `Java.IO.Exception` and some of its
derivatives in the standard .NET `WebException`.  This makes the handler
to behave in a manner that's closer to how other `HttpClient` custom
handlers behave.