### PR TITLE
[tests] ignore .NET 5 tests for x86/x64

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -57,6 +57,11 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (DotNetPublishSource))]
 		public void DotNetPublish (string runtimeIdentifier, bool isRelease)
 		{
+			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (runtimeIdentifier);
+			//TODO: re-enable these when we have a public .NET 5 Preview 4 build
+			if (abi == "x86" || abi == "x86_64")
+				Assert.Ignore ($"Ignoring RID {runtimeIdentifier} until a new .NET 5 build is available.");
+
 			var proj = new XASdkProject (SdkVersion) {
 				IsRelease = isRelease
 			};
@@ -68,7 +73,6 @@ namespace Xamarin.Android.Build.Tests
 			var apk = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath,
 				runtimeIdentifier, "UnnamedProject.UnnamedProject.apk");
 			FileAssert.Exists (apk);
-			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (runtimeIdentifier);
 			using (var zip = ZipHelper.OpenZip (apk)) {
 				Assert.IsTrue (zip.ContainsEntry ($"lib/{abi}/libmonodroid.so"), "libmonodroid.so should exist.");
 			}


### PR DESCRIPTION
Some of our tests are failing on CI with:

    dotnet\sdk\5.0.100-preview.2.20176.6\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(329,5):
    error NETSDK1082: There was no runtime pack for Microsoft.NETCore.App available for the specified RuntimeIdentifier 'android.21-x86'.

These tests work fine if you install a master build of .NET 5. We will
need a build of .NET 5 Preview 4 for these tests to work.

Let's ignore them for now, so our CI will be more greenish.