### PR TITLE
[.NET 5] use $(OutputType) Exe for application vs library

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -3,15 +3,20 @@
 _NOTE: this document is very likely to change, as the requirements for
 .NET 5 are better understood._
 
-A .NET 5 project for Xamarin.Android will look something like:
+A .NET 5 project for a Xamarin.Android application will look something
+like:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>
 ```
+
+For a "library" project, you would omit the `$(OutputType)` property
+completely or specify `Library`.
 
 See the [Target Framework Names in .NET 5][net5spec] spec for details.
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -22,10 +22,6 @@
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
     <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
     <AndroidResgenFile Condition=" '$(AndroidResgenFile)' == '' ">$(MonoAndroidResourcePrefix)\$(_AndroidResourceDesigner)</AndroidResgenFile>
-    <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidApplication Condition=" '$(AndroidApplication)' == '' And Exists('$(AndroidManifest)') ">true</AndroidApplication>
-    <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
-    <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -5,6 +5,15 @@
     <_XamarinAndroidBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
+    <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' And '$(AndroidApplication)' == 'true' ">Properties\AndroidManifest.xml</AndroidManifest>
+    <!-- We don't ever need a `static void Main` method, so switch to Library here-->
+    <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
+  </PropertyGroup>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.targets
@@ -23,6 +23,14 @@
     <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)' == 'monoandroid'">MonoAndroid</TargetFrameworkIdentifier>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' And ('$(OutputType)' == 'Exe' or Exists('$(AndroidManifest)')) ">true</AndroidApplication>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
+    <!-- We don't ever need a `static void Main` method, so switch to Library here-->
+    <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Common.targets"/>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -29,6 +29,7 @@ namespace Xamarin.ProjectTools
 
 		public const string OutputPath = "OutputPath";
 		public const string IntermediateOutputPath = "IntermediateOutputPath";
+		public const string OutputType = "OutputType";
 		public const string AndroidFastDeploymentType = "AndroidFastDeploymentType";
 		public const string AndroidClassParser = "AndroidClassParser";
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -24,7 +24,7 @@ namespace Xamarin.ProjectTools
 		public string PackageName { get; set; }
 		public string JavaPackageName { get; set; }
 
-		public XASdkProject (string sdkVersion = "")
+		public XASdkProject (string sdkVersion = "", string outputType = "Exe")
 		{
 			Sdk = string.IsNullOrEmpty (sdkVersion) ? "Microsoft.Android.Sdk" : $"Microsoft.Android.Sdk/{sdkVersion}";
 			TargetFramework = "netcoreapp5.0";
@@ -33,6 +33,7 @@ namespace Xamarin.ProjectTools
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
 			ExtraNuGetConfigSources = new List<string> { Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs") };
 			GlobalPackagesFolder = Path.Combine (XABuildPaths.TopDirectory, "packages");
+			SetProperty (KnownProperties.OutputType, outputType);
 
 			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.AndroidManifest.xml")))
 				default_android_manifest = sr.ReadToEnd ();
@@ -46,9 +47,11 @@ namespace Xamarin.ProjectTools
 			}
 
 			// Add relevant Android content to our project without writing it to the .csproj file
-			Sources.Add (new BuildItem.Source ("Properties\\AndroidManifest.xml") {
-				TextContent = () => default_android_manifest.Replace ("${PROJECT_NAME}", ProjectName).Replace ("${PACKAGENAME}", string.Format ("{0}.{0}", ProjectName))
-			});
+			if (outputType == "Exe") {
+				Sources.Add (new BuildItem.Source ("Properties\\AndroidManifest.xml") {
+					TextContent = () => default_android_manifest.Replace ("${PROJECT_NAME}", ProjectName).Replace ("${PACKAGENAME}", string.Format ("{0}.{0}", ProjectName))
+				});
+			}
 			Sources.Add (new BuildItem.Source ($"MainActivity{Language.DefaultExtension}") { TextContent = () => ProcessSourceTemplate (default_main_activity_cs) });
 			Sources.Add (new BuildItem.Source ("Resources\\layout\\Main.axml") { TextContent = () => default_layout_main });
 			Sources.Add (new BuildItem.Source ("Resources\\values\\Strings.xml") { TextContent = () => default_strings_xml.Replace ("${PROJECT_NAME}", ProjectName) });

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -21,7 +21,7 @@ namespace Xamarin.ProjectTools
 			SetProperty ("ProjectTypeGuids", () => "{" + Language.ProjectTypeGuid + "};{" + ProjectTypeGuid + "}");
 			SetProperty ("ProjectGuid", () => "{" + ProjectGuid + "}");
 
-			SetProperty ("OutputType", "Library");
+			SetProperty (KnownProperties.OutputType, "Library");
 			SetProperty ("MonoAndroidAssetsPrefix", "Assets");
 			SetProperty ("MonoAndroidResourcePrefix", "Resources");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinPCLProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinPCLProject.cs
@@ -12,7 +12,7 @@ namespace Xamarin.ProjectTools
 			SetProperty ("ProjectGuid", () => "{" + ProjectGuid + "}");
 			SetProperty ("TargetFrameworkProfile", "Profile78");
 			SetProperty ("TargetFrameworkVersion", "v4.5");
-			SetProperty ("OutputType", "Library");
+			SetProperty (KnownProperties.OutputType, "Library");
 		}
 
 		public override string ProjectTypeGuid {


### PR DESCRIPTION
In .NET 5, Xamarin.iOS is already using `<OutputType>Exe<OutputType>`
to distinguish an iOS application vs an iOS class library.

Xamarin.Android, however, is checking the existence of
`Properties/AndroidManifest.xml`.

This brings up some issues:

* When using a multi-targeted project in .NET, we should be using the
  same convention to distinguish library vs applications on both iOS
  and Android.
* Xamarin.iOS apps have a `static void Main` method. `OutputType=Exe`
  makes sense, as it tells Roslyn to expect a `Main` method.

To consolidate this, I propose:

* Use `$(OutputType)` of `Exe` to set `$(AndroidApplication)` to
  `true`. No longer look for `AndroidManifest.xml` for this default.
* Immediately set `$(OutputType)` to `Library`, since we *never* want a
  `Main` method on Android.

To make this work, I had to move these defaults from
`Xamarin.Android.Sdk.props` to `Xamarin.Android.Sdk.targets`. This
allows these properties to be evaluated *after* the values set in the
user's project.

I added a test that builds a library, checking that the
`__AndroidLibraryProjects__.zip` `EmbeddedResource` has the correct
contents.