### PR TITLE
[Xamarin.Android.Build.Tasks] refactor common logic for binding projects

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -221,7 +221,9 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.CSharp.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.D8.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Designer.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DesignTime.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DX.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.EmbeddedResource.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.FSharp.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Legacy.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.props" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Build.Tests
 				"_ExtractJavaDocJars",
 				"ExportJarToXml",
 				"GenerateBindings",
-				"ResolveLibraryProjects",
+				"_CreateBindingResourceArchive",
 				"BuildDocumentation",
 				"_ResolveLibraryProjectImports",
 				"CoreCompile",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -18,19 +18,12 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <UsingTask TaskName="Xamarin.Android.Tasks.ApiXmlAnalyzer" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.BindingsGenerator" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GetApiLevelFromFramework" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.GetImportedLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.JarToXml" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ClassParse" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.CollectLibraryInputJars" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.CreateLibraryResourceArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.CreateTemporaryDirectory" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.JavaDoc" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.RemoveDirFixed" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ImportJavaDoc" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.MDoc" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.Unzip" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -84,8 +77,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 
-  <!-- Do not resolve from the GAC under any circumstances in Mobile -->
   <PropertyGroup>
+    <_AndroidStampDirectory>$(IntermediateOutputPath)stamp\</_AndroidStampDirectory>
+    <!-- Do not resolve from the GAC under any circumstances in Mobile -->
     <AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
     <AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
   </PropertyGroup>
@@ -105,16 +99,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <ApiOutputFile Condition="'$(ApiOutputFile)' == ''">$(IntermediateOutputPath)api.xml</ApiOutputFile>
     <_GeneratorStampFile>$(IntermediateOutputPath)generator.stamp</_GeneratorStampFile>
     <AndroidSequencePointsMode Condition=" '$(AndroidSequencePointsMode)' == ''">None</AndroidSequencePointsMode>
-	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">jl</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">nl</_NativeLibraryImportsDirectoryName>
-
-	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'==''">library_project_imports</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'==''">native_library_imports</_NativeLibraryImportsDirectoryName>
-	<_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
-	<_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
-	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'True' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
-	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
-	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
 		
 	<!-- Prevent warnings about assembly version conflicts -->
 	<AutoUnifyAssemblyReferences>True</AutoUnifyAssemblyReferences>
@@ -125,14 +109,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	     Disable generation to avoid "bizarre" build errors. -->
 	<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
-
-<Target Name="_GetReferenceAssemblyPaths">
-	<GetReferenceAssemblyPaths
-			TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"
-			RootPath="$(TargetFrameworkRootPath)">
-		<Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_XATargetFrameworkDirectories" />
-	</GetReferenceAssemblyPaths>
-</Target>
 
   <!-- Warn about deprecated configurations.
        Do it here because we want them to appear on every build,
@@ -196,63 +172,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </CreateProperty>
 
   </Target>
-
-  <Target Name="_SetupDesignTimeBuildForBuild">
-    <PropertyGroup>
-      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
-    </PropertyGroup>
-  </Target>
-  
-  <Target Name="_SetupDesignTimeBuildForCompile">
-    <PropertyGroup>
-      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
-    </PropertyGroup>
-  </Target>
-
-<Target Name="_ResolveLibraryProjectImports"
-		Inputs="$(MSBuildProjectFullPath);$(_AndroidBuildPropertiesCache)"
-		Outputs="$(_AndroidLibraryProjectImportsCache)">
-	<ResolveLibraryProjectImports
-		ContinueOnError="$(DesignTimeBuild)"
-		CacheFile="$(_AndroidLibraryProjectImportsCache)"
-		DesignTimeBuild="$(DesignTimeBuild)"
-		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
-		AarLibraries="@(AndroidAarLibrary)"
-		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
-		UseShortFileNames="$(UseShortFileNames)"
-		OutputDirectory="$(IntermediateOutputPath)"
-		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
-		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)">
-	</ResolveLibraryProjectImports>
-</Target>
-
-
-<Target Name="_ExtractLibraryProjectImports" DependsOnTargets="_ResolveLibraryProjectImports">
-	<ReadLibraryProjectImportsCache
-			CacheFile="$(_AndroidLibraryProjectImportsCache)">
-		<Output TaskParameter="Jars" PropertyName="ZippedLibraryProjectJars" />
-	</ReadLibraryProjectImportsCache>
-</Target>
-
-<Target Name="_BuildLibraryImportsCache"
-		Inputs="$(MSBuildProjectFullPath)"
-		Outputs="$(_AndroidLibraryImportsCache)">
-	<GetImportedLibraries TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
-			CacheFile="$(_AndroidLibraryImportsCache)">
-		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
-	</GetImportedLibraries>
-  <ItemGroup>
-    <ReferenceJar Include="@(ZippedLibraryProjectJars);@(ExtractedJarImports)" />
-  </ItemGroup>
-</Target>
-
-<Target Name="_GetLibraryImports" DependsOnTargets="_BuildLibraryImportsCache">
-	<ReadImportedLibrariesCache
-			CacheFile="$(_AndroidLibraryImportsCache)">
-		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
-	</ReadImportedLibrariesCache>
-</Target>
 
 <PropertyGroup>
 	<ExportJarToXmlDependsOnTargets>
@@ -415,24 +334,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="AddLibraryProjectsToCompile" DependsOnTargets="ResolveLibraryProjects">
-    <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
-      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-  
-  <Target Name="ResolveLibraryProjects"
-      Inputs="@(LibraryProjectProperties);@(LibraryProjectZip)"
-      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-    <CreateLibraryResourceArchive
-      OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-      OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
-      OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
-      LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
-      LibraryProjectZipFiles="@(LibraryProjectZip)" />
-  </Target>
+  <Target Name="ResolveLibraryProjects" DependsOnTargets="_CreateBindingResourceArchive" />
 
   <Target Name="AddLibraryJarsToBind" DependsOnTargets="ResolveLibraryProjects">
     <ItemGroup>
@@ -490,6 +392,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <Delete Files="$(_GeneratorStampFile)" />
 
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />
+    <RemoveDirFixed Directories="$(_AndroidStampDirectory)" Condition="Exists ('$(_AndroidStampDirectory)')" />
 
     <Delete Files="@(IntermediateAssembly->'$(OutputPath)%(filename).xml')" />
     <Delete Files="@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')" />
@@ -519,23 +422,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <RemoveDirFixed Directories="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)" Condition="Exists ('$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)')" />
   </Target>
 
-  <Target Name="_CreateNativeLibraryArchive"
-          Condition="@(EmbeddedNativeLibrary) != ''" 
-          Inputs="@(EmbeddedNativeLibrary)"
-          Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-    <CreateNativeLibraryArchive
-      OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
-      EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)" />
-  </Target>
-
-  <Target Name="_AddNativeLibraryArchiveToCompile" DependsOnTargets="_CreateNativeLibraryArchive">
-    <ItemGroup Condition="Exists('$(IntermediateOutputPath)__AndroidNativeLibraries__.zip')">
-      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-        <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Legacy.targets" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -111,7 +111,13 @@
     <None Include="Xamarin.Android.D8.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Android.DesignTime.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Android.DX.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Xamarin.Android.EmbeddedResource.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Xamarin.Android.FSharp.targets">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -51,8 +51,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.ConvertCustomView" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyIfChanged" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyResource" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateResgenManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateTemporaryDirectory" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateAdditionalLibraryResourceCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -70,7 +68,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.GetConvertedJavaLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetFilesThatExist" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetJavaPlatformJar" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.GetImportedLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetMonoPlatformJar" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Javac" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Dx" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -88,13 +85,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveDirFixed" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveRegisterAttribute" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadAndroidManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetExtraPackages" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyGeneratedJavaResourceClasses" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadJavaStubsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ScanAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.SplitProperty" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckProjectItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -270,20 +264,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Obsolete -->
 	<AndroidGdbDebugServer>None</AndroidGdbDebugServer>
 
-	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">jl</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">nl</_NativeLibraryImportsDirectoryName>
-
-	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'==''">library_project_imports</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'==''">native_library_imports</_NativeLibraryImportsDirectoryName>
 	<_AndroidLayoutBindingsDependencyCache>$(IntermediateOutputPath)layout-binding-deps.cache</_AndroidLayoutBindingsDependencyCache>
-	<_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
-	<_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
-	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'True' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
-	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
-	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
 	<_AndroidProguardInputJarFilter>(!META-INF/MANIFEST.MF)</_AndroidProguardInputJarFilter>
 	<_AndroidAapt2VersionFile>$(IntermediateOutputPath)aapt2.version</_AndroidAapt2VersionFile>
-	<_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
 	<_AndroidLibraryFlatArchivesDirectory>$(IntermediateOutputPath)flata\</_AndroidLibraryFlatArchivesDirectory>
 	<_AndroidLibraryFlatFilesDirectory>$(IntermediateOutputPath)flat\</_AndroidLibraryFlatFilesDirectory>
 	<_AndroidStampDirectory>$(IntermediateOutputPath)stamp\</_AndroidStampDirectory>
@@ -343,7 +326,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
 	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
 	<_AdbPropertiesCache>$(IntermediateOutputPath)adb.props</_AdbPropertiesCache>
-	<_AndroidDesignTimeBuildPropertiesCache>$(_AndroidIntermediateDesignTimeBuildDirectory)build.props</_AndroidDesignTimeBuildPropertiesCache>
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
 
@@ -406,6 +388,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" Condition=" '$(AndroidDexTool)' == 'dx' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Legacy.targets" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
@@ -472,25 +456,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		.exe.mdb
 	</AllowedReferenceRelatedFileExtensions>
 </PropertyGroup>
-
-<Target Name="_SetupDesignTimeBuildForBuild">
-	<PropertyGroup>
-		<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
-	</PropertyGroup>
-</Target>
-  
-<Target Name="_SetupDesignTimeBuildForCompile">
-	<PropertyGroup>
-		<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
-		<ManagedDesignTimeBuild Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'True' And '$(DesignTimeBuild)' == 'True' And '$(BuildingInsideVisualStudio)' == 'True' ">True</ManagedDesignTimeBuild>
-		<ManagedDesignTimeBuild Condition=" '$(ManagedDesignTimeBuild)' == '' ">False</ManagedDesignTimeBuild>
-		<_AndroidLibraryImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryImportsCache)') ">$(_AndroidLibraryImportsDesignTimeCache)</_AndroidLibraryImportsCache>
-		<_AndroidLibraryProjectImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryProjectImportsCache)') ">$(_AndroidLibraryProjectImportsDesignTimeCache)</_AndroidLibraryProjectImportsCache>
-		<_AndroidBuildPropertiesCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeBuildPropertiesCache)</_AndroidBuildPropertiesCache>
-	</PropertyGroup>
-	<MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
-	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" Condition=" !Exists ('$(_AndroidIntermediateDesignTimeBuildDirectory)') " />
-</Target>
 
 <ItemGroup>
 	<AndroidCustomMetaDataForReferences Include="@(_AndroidAssemblySkipCases)" />
@@ -927,9 +892,6 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidResourceDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' != 'True' ">$(AndroidResgenFile)</_AndroidResourceDesignerFile>
 	<_AndroidStaticResourcesFlag>$(IntermediateOutputPath)static.flag</_AndroidStaticResourcesFlag>
 	<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</AndroidUseManagedDesignTimeResourceGenerator>
-	<_AndroidLibraryImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryimports.cache</_AndroidLibraryImportsDesignTimeCache>
-	<_AndroidLibraryProjectImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryprojectimports.cache</_AndroidLibraryProjectImportsDesignTimeCache>
-	<_AndroidManagedResourceDesignerFile>$(_AndroidIntermediateDesignTimeBuildDirectory)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
 
 <Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion;_ResolveMonoAndroidSdks">
@@ -973,7 +935,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
 		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
 	</ItemGroup>
-	<MakeDir Directories="$(_AndroidStampDirectory)" Condition="!Exists('$(_AndroidStampDirectory)')" />
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"
 			Lines="@(_PropertyCacheItems->ToLowerInvariant())"
@@ -1104,90 +1065,12 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
-<Target Name="_ResolveLibraryProjectImports"
-		DependsOnTargets="$(CoreResolveReferencesDependsOn)"
-		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
-		Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
-	<ResolveLibraryProjectImports
-		ContinueOnError="$(DesignTimeBuild)"
-		CacheFile="$(_AndroidLibraryProjectImportsCache)"
-		DesignTimeBuild="$(DesignTimeBuild)"
-		Assemblies="@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths)"
-		AarLibraries="@(AndroidAarLibrary)"
-		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
-		UseShortFileNames="$(UseShortFileNames)"
-		OutputDirectory="$(IntermediateOutputPath)"
-		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
-		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
-	>
-	</ResolveLibraryProjectImports>
-	<Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="True" />
-</Target>
-
-<Target Name="_ExtractLibraryProjectImports" DependsOnTargets="_ResolveLibraryProjectImports">
-	<ReadLibraryProjectImportsCache
-		CacheFile="$(_AndroidLibraryProjectImportsCache)">
-		<Output TaskParameter="ResolvedResourceDirectories" ItemName="LibraryResourceDirectories" />
-		<Output TaskParameter="ResolvedAssetDirectories" ItemName="LibraryAssetDirectories" />
-		<Output TaskParameter="ResolvedEnvironmentFiles" ItemName="LibraryEnvironments" />
-		<Output TaskParameter="ResolvedResourceDirectoryStamps" ItemName="_LibraryResourceDirectoryStamps" />
-	</ReadLibraryProjectImportsCache>
-</Target>
-
 <Target Name="_AddMultiDexDependencyJars">
   <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != '' ">
     <AndroidJavaLibrary Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == '' ">
     <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
-  </ItemGroup>
-</Target>
-
-<PropertyGroup>
-	<_GetLibraryImportsDependsOnTargets>
-		_ExtractLibraryProjectImports;
-		_AddMultiDexDependencyJars
-		;_BuildLibraryImportsCache
-	</_GetLibraryImportsDependsOnTargets>
-</PropertyGroup>
-
-<Target Name="_BuildLibraryImportsCache"
-		Inputs="$(_AndroidLibraryProjectImportsCache)"
-		Outputs="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp">
-	<GetImportedLibraries
-			TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
-			CacheFile="$(_AndroidLibraryImportsCache)">
-	</GetImportedLibraries>
-	<Touch Files="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp" />
-	</ItemGroup>
-</Target>
-
-<Target Name="_GetLibraryImports" DependsOnTargets="$(_GetLibraryImportsDependsOnTargets)">
-  <ReadImportedLibrariesCache CacheFile="$(_AndroidLibraryImportsCache)">
-    <Output TaskParameter="Jars"              ItemName="ExtractedJarImports" />
-    <Output TaskParameter="NativeLibraries"   ItemName="ExtractedNativeLibraryImports" />
-    <Output TaskParameter="NativeLibraries"   ItemName="AndroidNativeLibrary" />
-    <Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
-  </ReadImportedLibrariesCache>
-</Target>
-  
-<Target Name="_CreateNativeLibraryArchive"
-        Condition=" '$(AndroidApplication)' != 'True' And '@(EmbeddedNativeLibrary)' != '' " 
-        DependsOnTargets="ResolveReferences"
-        Inputs="@(EmbeddedNativeLibrary)"
-        Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-  <CreateNativeLibraryArchive
-      OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
-      EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)" />
-  <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
-  <ItemGroup>
-    <FileWrites Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
-    <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-      <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
-    </EmbeddedResource>
   </ItemGroup>
 </Target>
 
@@ -1376,32 +1259,6 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <FileWrites Include="$(_AndroidResgenFlagFile)" />
   </ItemGroup>
-</Target>
-
-<Target Name="_CreateManagedLibraryResourceArchive"
-		Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
-		Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"
-		Condition=" '$(AndroidApplication)' != 'True' "
-	>
-	<!-- embed managed resources into dll as a zip archive, like AndroidLibraryProjectZip -->
-	<CreateManagedLibraryResourceArchive
-		OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-		ResourceDirectory="$(MonoAndroidResDirIntermediate)"
-		AndroidAssets="@(AndroidAsset)"
-		MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
-		AndroidJavaSources="@(AndroidJavaSource)"
-		AndroidJavaLibraries="@(AndroidJavaLibrary)"
-		AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
-		FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
-		RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
-	/>
-	<Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
-	<ItemGroup>
-		<FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
-		<EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-			<LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
-		</EmbeddedResource>
-	</ItemGroup>
 </Target>
 
 <!-- AIDL Build -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
@@ -1,0 +1,50 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.DesignTime.targets
+
+This file contains MSBuild targets related to design-time builds.
+
+This file is used by all project types, including binding projects.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
+    <_AndroidDesignTimeBuildPropertiesCache>$(_AndroidIntermediateDesignTimeBuildDirectory)build.props</_AndroidDesignTimeBuildPropertiesCache>
+    <_AndroidLibraryImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryimports.cache</_AndroidLibraryImportsDesignTimeCache>
+    <_AndroidLibraryProjectImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryprojectimports.cache</_AndroidLibraryProjectImportsDesignTimeCache>
+    <_AndroidManagedResourceDesignerFile>$(_AndroidIntermediateDesignTimeBuildDirectory)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
+  </PropertyGroup>
+
+  <Target Name="_CreateStampDirectory">
+    <MakeDir
+      Condition=" '$(_AndroidStampDirectory)' != '' And !Exists('$(_AndroidStampDirectory)')"
+      Directories="$(_AndroidStampDirectory)"
+    />
+  </Target>
+
+  <Target Name="_SetupDesignTimeBuildForBuild" DependsOnTargets="_CreateStampDirectory">
+    <PropertyGroup>
+      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
+    </PropertyGroup>
+  </Target>
+  
+  <Target Name="_SetupDesignTimeBuildForCompile" DependsOnTargets="_CreateStampDirectory">
+    <PropertyGroup>
+      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
+      <ManagedDesignTimeBuild Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'true' And '$(DesignTimeBuild)' == 'true' And '$(BuildingInsideVisualStudio)' == 'true' ">true</ManagedDesignTimeBuild>
+      <ManagedDesignTimeBuild Condition=" '$(ManagedDesignTimeBuild)' == '' ">False</ManagedDesignTimeBuild>
+      <_AndroidLibraryImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryImportsCache)') ">$(_AndroidLibraryImportsDesignTimeCache)</_AndroidLibraryImportsCache>
+      <_AndroidLibraryProjectImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryProjectImportsCache)') ">$(_AndroidLibraryProjectImportsDesignTimeCache)</_AndroidLibraryProjectImportsCache>
+      <_AndroidBuildPropertiesCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeBuildPropertiesCache)</_AndroidBuildPropertiesCache>
+    </PropertyGroup>
+    <MakeDir
+        Condition=" '$(_AndroidIsBindingProject)' != 'true' And !Exists ('$(_AndroidIntermediateDesignTimeBuildDirectory)') "
+        Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)"
+    />
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
@@ -21,8 +21,8 @@ This file is used by all project types, including binding projects.
 
   <Target Name="_CreateStampDirectory">
     <MakeDir
-      Condition=" '$(_AndroidStampDirectory)' != '' And !Exists('$(_AndroidStampDirectory)')"
-      Directories="$(_AndroidStampDirectory)"
+        Condition=" '$(_AndroidStampDirectory)' != '' And !Exists('$(_AndroidStampDirectory)') "
+        Directories="$(_AndroidStampDirectory)"
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -38,17 +38,17 @@ This file is used by all project types, including binding projects.
       Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
       Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
     <ResolveLibraryProjectImports
-      ContinueOnError="$(DesignTimeBuild)"
-      CacheFile="$(_AndroidLibraryProjectImportsCache)"
-      DesignTimeBuild="$(DesignTimeBuild)"
-      Assemblies="@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths)"
-      AarLibraries="@(AndroidAarLibrary)"
-      ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-      NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
-      UseShortFileNames="$(UseShortFileNames)"
-      OutputDirectory="$(IntermediateOutputPath)"
-      AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
-      OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
+        ContinueOnError="$(DesignTimeBuild)"
+        CacheFile="$(_AndroidLibraryProjectImportsCache)"
+        DesignTimeBuild="$(DesignTimeBuild)"
+        Assemblies="@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths)"
+        AarLibraries="@(AndroidAarLibrary)"
+        ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
+        NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
+        UseShortFileNames="$(UseShortFileNames)"
+        OutputDirectory="$(IntermediateOutputPath)"
+        AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+        OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
     />
     <Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="true" />
   </Target>
@@ -119,15 +119,15 @@ This file is used by all project types, including binding projects.
       Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
       Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
     <CreateManagedLibraryResourceArchive
-      OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-      ResourceDirectory="$(MonoAndroidResDirIntermediate)"
-      AndroidAssets="@(AndroidAsset)"
-      MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
-      AndroidJavaSources="@(AndroidJavaSource)"
-      AndroidJavaLibraries="@(AndroidJavaLibrary)"
-      AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
-      FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
-      RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
+        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+        ResourceDirectory="$(MonoAndroidResDirIntermediate)"
+        AndroidAssets="@(AndroidAsset)"
+        MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
+        AndroidJavaSources="@(AndroidJavaSource)"
+        AndroidJavaLibraries="@(AndroidJavaLibrary)"
+        AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
+        FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
+        RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
     />
     <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
     <ItemGroup>
@@ -143,11 +143,11 @@ This file is used by all project types, including binding projects.
       Inputs="@(LibraryProjectProperties);@(LibraryProjectZip)"
       Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
     <CreateLibraryResourceArchive
-      OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-      OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
-      OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
-      LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
-      LibraryProjectZipFiles="@(LibraryProjectZip)"
+        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+        OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
+        OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
+        LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
+        LibraryProjectZipFiles="@(LibraryProjectZip)"
     />
     <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
       <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -1,0 +1,160 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.EmbeddedResource.targets
+
+This file contains MSBuild targets related to the creation or extraction
+of `__AndroidLibraryProjects__.zip` or `__AndroidNativeLibraries__.zip`.
+These are packaged as `EmbeddedResource` files in Xamarin.Android assemblies.
+
+This file is used by all project types, including binding projects.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateLibraryResourceArchive"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.GetImportedLibraries"                AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache"      AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+  <PropertyGroup>
+    <_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)' == '' And '$(UseShortFileNames)' == 'true' ">jl</_LibraryProjectImportsDirectoryName>
+    <_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)' == '' ">library_project_imports</_LibraryProjectImportsDirectoryName>
+    <_NativeLibraryImportsDirectoryName  Condition=" '$(_NativeLibraryImportsDirectoryName)' == '' And '$(UseShortFileNames)' == 'true' ">nl</_NativeLibraryImportsDirectoryName>
+    <_NativeLibraryImportsDirectoryName  Condition=" '$(_NativeLibraryImportsDirectoryName)' == '' ">native_library_imports</_NativeLibraryImportsDirectoryName>
+    <_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
+    <_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
+    <_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'true' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
+    <_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
+    <_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
+  </PropertyGroup>
+
+  <Target Name="_ResolveLibraryProjectImports"
+      DependsOnTargets="$(CoreResolveReferencesDependsOn)"
+      Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
+      Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
+    <ResolveLibraryProjectImports
+      ContinueOnError="$(DesignTimeBuild)"
+      CacheFile="$(_AndroidLibraryProjectImportsCache)"
+      DesignTimeBuild="$(DesignTimeBuild)"
+      Assemblies="@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths)"
+      AarLibraries="@(AndroidAarLibrary)"
+      ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
+      NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
+      UseShortFileNames="$(UseShortFileNames)"
+      OutputDirectory="$(IntermediateOutputPath)"
+      AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+      OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
+    />
+    <Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="_ExtractLibraryProjectImports" DependsOnTargets="_ResolveLibraryProjectImports">
+    <ReadLibraryProjectImportsCache
+        CacheFile="$(_AndroidLibraryProjectImportsCache)">
+      <Output TaskParameter="ResolvedResourceDirectories" ItemName="LibraryResourceDirectories" />
+      <Output TaskParameter="ResolvedAssetDirectories" ItemName="LibraryAssetDirectories" />
+      <Output TaskParameter="ResolvedEnvironmentFiles" ItemName="LibraryEnvironments" />
+      <Output TaskParameter="ResolvedResourceDirectoryStamps" ItemName="_LibraryResourceDirectoryStamps" />
+    </ReadLibraryProjectImportsCache>
+  </Target>
+
+  <Target Name="_BuildLibraryImportsCache"
+      Inputs="$(_AndroidLibraryProjectImportsCache)"
+      Outputs="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp">
+    <GetImportedLibraries
+        TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
+        CacheFile="$(_AndroidLibraryImportsCache)"
+    />
+    <Touch Files="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidStampDirectory)_BuildLibraryImportsCache.stamp" />
+    </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' == 'true' ">
+      _ExtractLibraryProjectImports;
+      _BuildLibraryImportsCache;
+    </_GetLibraryImportsDependsOnTargets>
+    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' != 'true' ">
+      _ExtractLibraryProjectImports;
+      _AddMultiDexDependencyJars;
+      _BuildLibraryImportsCache;
+    </_GetLibraryImportsDependsOnTargets>
+  </PropertyGroup>
+
+  <Target Name="_GetLibraryImports" DependsOnTargets="$(_GetLibraryImportsDependsOnTargets)">
+    <ReadImportedLibrariesCache CacheFile="$(_AndroidLibraryImportsCache)">
+      <Output TaskParameter="Jars"              ItemName="ExtractedJarImports" />
+      <Output TaskParameter="NativeLibraries"   ItemName="ExtractedNativeLibraryImports" />
+      <Output TaskParameter="NativeLibraries"   ItemName="AndroidNativeLibrary" />
+      <Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
+    </ReadImportedLibrariesCache>
+  </Target>
+    
+  <Target Name="_CreateNativeLibraryArchive"
+      Condition=" '$(AndroidApplication)' != 'true' And '@(EmbeddedNativeLibrary)' != '' "
+      Inputs="@(EmbeddedNativeLibrary)"
+      Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
+    <CreateNativeLibraryArchive
+        OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
+        EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)"
+    />
+    <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
+        <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateManagedLibraryResourceArchive"
+      Condition=" '$(AndroidApplication)' != 'true' And '$(_AndroidIsBindingProject)' != 'true' "
+      Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
+      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+    <CreateManagedLibraryResourceArchive
+      OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+      ResourceDirectory="$(MonoAndroidResDirIntermediate)"
+      AndroidAssets="@(AndroidAsset)"
+      MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
+      AndroidJavaSources="@(AndroidJavaSource)"
+      AndroidJavaLibraries="@(AndroidJavaLibrary)"
+      AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
+      FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
+      RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
+    />
+    <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateBindingResourceArchive"
+      Condition=" '$(_AndroidIsBindingProject)' == 'true' "
+      Inputs="@(LibraryProjectProperties);@(LibraryProjectZip)"
+      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+    <CreateLibraryResourceArchive
+      OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+      OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
+      OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
+      LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
+      LibraryProjectZipFiles="@(LibraryProjectZip)"
+    />
+    <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -135,8 +135,7 @@ projects. .NET 5 projects will not import this file.
       AddBindingsToCompile;
       AddEmbeddedJarsAsResources;
       AddEmbeddedReferenceJarsAsResources;
-      AddLibraryProjectsToCompile;
-      _AddNativeLibraryArchiveToCompile
+      _CreateNativeLibraryArchive;
     </ResolveReferencesDependsOn>
 
     <CleanDependsOn>


### PR DESCRIPTION
For .NET 5, I am looking into getting binding projects working.

There may not need to be a concept of a "binding project" *at all*, if
we can get the item groups to work in a regular .NET 5 Android
application or library.

My first thought was to just try something like this in
`Microsoft.Android.Sdk.targets`:

    <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.targets" />
    <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />

However, there is a lot of duplicate MSBuild targets in
`Xamarin.Android.Bindings.targets`. There are targets with the same
name that do slightly different things.

To try to consolidate this, I've created two new files:

* `Xamarin.Android.DesignTime.targets` - for design-time build things
* `Xamarin.Android.EmbeddedResource.targets` - for creation/extraction
  of `__AndroidLibraryProjects__.zip` or `__AndroidNativeLibraries__.zip`.

Now Xamarin.Android class libraries and binding projects will share
the same targets in these files.

This will bring binding projects closer to working in .NET 5. If we
get `Xamarin.Android.Binding.targets` as short as it can be, it will
be much easier to get working.

Other changes:

* A duplicate `_GetReferenceAssemblyPaths` target could be removed. It
  is already present in `Xamarin.Android.Legacy.targets`.
* I left the `ResolveLibraryProjects` target intact, as it seems to
  have a very public-looking name. I changed it to depend on a private
  `_CreateBindingResourceArchive` target.