### PR TITLE
Fix build break on newly reimaged bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,7 @@ prepare-help: prepare-build
 
 .PHONY: prepare-update-mono
 prepare-update-mono: prepare-build
-	# Ensure VBCSCompiler.exe process isn't running during the mono update
-	# pgrep -lfi VBCSCompiler.exe
+	# Ensure the VBCSCompiler.exe process isn't running during the mono update
 	$(eval pid=$(shell sh -c "pgrep VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 ifneq ($(pid),)
 	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to mono update ..."

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ shutdown-compiler-server:
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
 	if [[ -n "$(pid)" ]]; then \
-		echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono" ;\
+		echo "Terminating the VBCSCompiler.exe '$(pid)' process prior to updating mono" ;\
 		pgrep -lfi VBCSCompiler.exe ;\
 		kill -HUP $(pid) 2>/dev/null ;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ prepare-update-mono: prepare-build
 	# Ensure VBCSCompiler.exe process isn't running during the mono update
 	# pgrep -lfi VBCSCompiler.exe
 	$(eval pid=$(shell sh -c "pgrep VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
-ifeq ($(pid),)
+ifneq ($(pid),)
 	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to mono update ..."
 	kill -HUP $(pid)
 endif

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ shutdown-compiler-server:
 	if [[ -n "$(pid)" ]]; then \
 		echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono" ;\
 		pgrep -lfi VBCSCompiler.exe ;\
-		kill -HUP $(pid) ;\
+		kill -HUP $(pid) 2>/dev/null ;\
 	fi
 
 .PHONY: prepare-update-mono

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,9 @@ shutdown-compiler-server:
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
 	if [[ -n "$(pid)" ]]; then \
-		echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono"; \
-		pgrep -lfi VBCSCompiler.exe; \
-		kill -HUP $(pid); \
+		echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono" ;\
+		pgrep -lfi VBCSCompiler.exe ;\
+		kill -HUP $(pid) ;\
 	fi
 
 .PHONY: prepare-update-mono

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ prepare-update-mono: prepare-build
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
 	$(eval pid=$(shell sh -c "pgrep VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 ifneq ($(pid),)
-	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to mono update ..."
+	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to updating mono"
 	kill -HUP $(pid)
 endif
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:UpdateMono

--- a/Makefile
+++ b/Makefile
@@ -212,12 +212,12 @@ prepare-help: prepare-build
 shutdown-compiler-server:
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
 	pgrep -lfi VBCSCompiler.exe 2>/dev/null || true
-	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
-	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
-	if [[ -n "$(pid)" ]]; then \
-		echo "Terminating the VBCSCompiler '$(pid)' server process prior to updating mono" ;\
+	@pid=`pgrep -lfi VBCSCompiler.exe 2>/dev/null | awk '{ print $$1 }'` ; \
+	echo "VBCSCompiler process ID (if running): $$pid" ;\
+	if [[ -n "$$pid" ]]; then \
+		echo "Terminating the VBCSCompiler '$$pid' server process prior to updating mono" ; \
 		exitCode=0 ;\
-		kill -HUP $(pid) 2>/dev/null || exitCode=$$? ;\
+		kill -HUP $$pid 2>/dev/null || exitCode=$$? ;\
 		if [[ $$exitCode -eq 0 ]]; then \
 			sleep 2 ;\
 			pgrep -lfi VBCSCompiler.exe 2>/dev/null&&echo "ERROR: VBCSCompiler server still exists" || echo "Verified that the VBCSCompiler server process no longer exists" ;\

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ prepare-update-mono: prepare-build
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 ifneq ($(pid),)
 	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to updating mono"
+	pgrep -lfi VBCSCompiler.exe
 	kill -HUP $(pid)
 endif
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:UpdateMono

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,9 @@ shutdown-compiler-server:
 	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
 	if [[ -n "$(pid)" ]]; then \
 		echo "Terminating the VBCSCompiler '$(pid)' server process prior to updating mono" ;\
-		pgrep -lfi VBCSCompiler.exe ;\
 		kill -HUP $(pid) 2>/dev/null ;\
+		echo "VBCSCompiler server process should no longer exist" ;\
+		pgrep -lfi VBCSCompiler.exe 2>/dev/null || true ;\
 	fi
 
 .PHONY: prepare-update-mono

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ prepare-update-mono: prepare-build
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 ifneq ($(pid),)
-	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to updating mono"
+	@echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono"
 	pgrep -lfi VBCSCompiler.exe
 	kill -HUP $(pid)
 endif

--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,14 @@ prepare-help: prepare-build
 
 .PHONY: prepare-update-mono
 prepare-update-mono: prepare-build
-	pgrep -lfi VBCSCompiler.exe
+	# Ensure VBCSCompiler.exe process isn't running during the mono update
+	# pgrep -lfi VBCSCompiler.exe
+	$(eval pid=$(shell sh -c "pgrep VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
+ifeq ($(pid),)
+	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to mono update ..."
+	kill -HUP $(pid)
+endif
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:UpdateMono
-	pgrep -lfi VBCSCompiler.exe
 
 prepare-external-git-dependencies: prepare-build
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:PrepareExternalGitDependencies

--- a/Makefile
+++ b/Makefile
@@ -208,17 +208,20 @@ prepare: prepare-build
 prepare-help: prepare-build
 	mono --debug $(PREPARE_EXE) -h
 
-.PHONY: prepare-update-mono
-prepare-update-mono: prepare-build
+.PHONY: shutdown-compiler-server
+shutdown-compiler-server:
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
 	pgrep -lfi VBCSCompiler.exe 2>/dev/null || true
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
-	@echo "VBCSCompiler process ID (if running): $(pid)"
-ifneq ($(pid),)
-	@echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono"
-	pgrep -lfi VBCSCompiler.exe
-	kill -HUP $(pid)
-endif
+	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
+	if [[ -n "$(pid)" ]]; then \
+		echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono"; \
+		pgrep -lfi VBCSCompiler.exe; \
+		kill -HUP $(pid); \
+	fi
+
+.PHONY: prepare-update-mono
+prepare-update-mono: prepare-build shutdown-compiler-server
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:UpdateMono
 
 prepare-external-git-dependencies: prepare-build

--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,14 @@ shutdown-compiler-server:
 	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
 	if [[ -n "$(pid)" ]]; then \
 		echo "Terminating the VBCSCompiler '$(pid)' server process prior to updating mono" ;\
-		kill -HUP $(pid) 2>/dev/null ;\
-		echo "VBCSCompiler server process should no longer exist" ;\
-		pgrep -lfi VBCSCompiler.exe 2>/dev/null || true ;\
+		exitCode=0 ;\
+		kill -HUP $(pid) 2>/dev/null || exitCode=$$? ;\
+		if [[ $$exitCode -eq 0 ]]; then \
+			sleep 2 ;\
+			pgrep -lfi VBCSCompiler.exe 2>/dev/null&&echo "ERROR: VBCSCompiler server still exists" || echo "Verified that the VBCSCompiler server process no longer exists" ;\
+		else \
+			echo "ERROR: Kill command failed with exit code $$exitCode" ;\
+		fi \
 	fi
 
 .PHONY: prepare-update-mono

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,9 @@ prepare-help: prepare-build
 .PHONY: prepare-update-mono
 prepare-update-mono: prepare-build
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
+	pgrep -lfi VBCSCompiler.exe 2>/dev/null || true
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
+	@echo "VBCSCompiler process ID (if running): $(pid)"
 ifneq ($(pid),)
 	@echo "VBCSCompiler.exe process '$(pid)' is running. Destroying process prior to updating mono"
 	pgrep -lfi VBCSCompiler.exe

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ prepare-help: prepare-build
 .PHONY: prepare-update-mono
 prepare-update-mono: prepare-build
 	# Ensure the VBCSCompiler.exe process isn't running during the mono update
-	$(eval pid=$(shell sh -c "pgrep VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
+	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 ifneq ($(pid),)
 	@echo "VBCSCompiler.exe process '$(pid)' is running. Killing process prior to updating mono"
 	kill -HUP $(pid)

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ shutdown-compiler-server:
 	$(eval pid=$(shell sh -c "pgrep -lfi VBCSCompiler.exe 2>/dev/null" | awk '{ print $$1 }'))
 	@echo "VBCSCompiler process ID (if running): $(pid)" ;\
 	if [[ -n "$(pid)" ]]; then \
-		echo "Terminating the VBCSCompiler.exe '$(pid)' process prior to updating mono" ;\
+		echo "Terminating the VBCSCompiler '$(pid)' server process prior to updating mono" ;\
 		pgrep -lfi VBCSCompiler.exe ;\
 		kill -HUP $(pid) 2>/dev/null ;\
 	fi

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -87,10 +87,7 @@ stages:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
     displayName: Build
-    # UNDONE: Test if build workflow still works against a newly re-imaged agent (bot)
-    # pool: $(MacMojaveBuildPool)
-    # pool: VSEng-Xamarin-RedmondMac-Android-Untrusted
-    pool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Test
+    pool: $(MacMojaveBuildPool)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -87,7 +87,10 @@ stages:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
     displayName: Build
-    pool: $(MacMojaveBuildPool)
+    # UNDONE: Test if build workflow still works against a newly re-imaged agent (bot)
+    # pool: $(MacMojaveBuildPool)
+    # pool: VSEng-Xamarin-RedmondMac-Android-Untrusted
+    pool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Test
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:


### PR DESCRIPTION
In the process of creating a new Mac OSS PR workflow, I encountered an issue where the build would consistently break when executing the `prepare-update-mono` target.  The break occurred on the following command on _a newly reimaged agent (bot)_:
```bash
pgrep -lfi VBCSCompiler.exe
```
The command returns 0 if the managed compiler server `VBCSCompiler.exe` is running; otherwise, it returns 1 if the process is not running.  When executing the build pipeline on the newly re-imaged machine, the process is not running, the `pgrep` command returns 1 and the build fails with the following error: 

```
pgrep -lfi VBCSCompiler.exe
make: *** [prepare-update-mono] Error 1
```

Turns out that on established build machines in the pool, `VBCSCompiler.exe` is consistently found to be running at this stage of the build.  If you inspect a build log, you will see that the `pgrep` command logged that `VBCSCompiler.exe` is running.  Here's an example from a recent build log:

```
pgrep -lfi VBCSCompiler.exe
36187 /Library/Frameworks/Mono.framework/Versions/6.10.0/bin/mono-sgen64 /Library/Frameworks/Mono.framework/Versions/6.10.0/lib/mono/msbuild/Current/bin/Roslyn/VBCSCompiler.exe -pipename:sX2CFXy8VTADY0R+V+y_1o2brmCa+1ch6aJTNiSJU4w
```

In discussing the issue with @directhex, the intent of the command is quite the opposite. The intent is to ensure that `VBCSCompiler.exe` is not running at this point of time. Based on the purpose of the target to perform a mono update, we should ensure that processes associated with the `mono` toolset are shutdown and not running prior to the update.  Since `VBCSCompiler.exe` is part of the `mono` toolset it seems to make more logical sense to ensure that it is not running.  In other words, ensure that the next invocation of `MSBuild` starts the compiler server from the new location if `mono` is updated.

**Note:** The original change was introduced to `master` on 2020-03-13 via this commit: 8599d63d2. That change was verified and continued to run, as with most changes, on a well established build agent (bot).

**Build validation**
Log output from the most recent [PR build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3670578&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=967deba6-588a-5db9-6e70-909908c847bd) indicates that the `VBCSCompiler` process was successfully terminated

```
pgrep -lfi VBCSCompiler.exe 2>/dev/null || true
/Library/Frameworks/Mono.framework/Versions/6.12.0/bin/mono-sgen64 /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Roslyn/VBCSCompiler.exe -pipename:9+YB2btX0dwaCLheWLK88CakD6Q4tWAcacUOQ2hCxbI
VBCSCompiler process ID (if running): 72723
Terminating the VBCSCompiler '72723' server process prior to updating mono
Verified that the VBCSCompiler server process no longer exists
```