### PR TITLE
[.NET 5] add a `Run` MSBuild target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -20,4 +20,7 @@
     <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
   </ItemGroup>
 
+  <!-- NOTE: We have to replace the Run target after Microsoft.NET.Sdk.targets are imported -->
+  <Target Name="Run" DependsOnTargets="Publish;Install;StartAndroidActivity" />
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -85,6 +85,13 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
+		public bool Run ()
+		{
+			//TODO: this should eventually run `dotnet run --project foo.csproj`
+			var arguments = GetDefaultCommandLineArgs ("publish", "Run");
+			return Execute (arguments.ToArray ());
+		}
+
 		public IEnumerable<string> LastBuildOutput {
 			get {
 				if (!string.IsNullOrEmpty (BuildLogFile) && File.Exists (BuildLogFile)) {

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -36,8 +36,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.CopyNuGetConfig (relativeProjDir);
 			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
 
-			Assert.IsTrue (dotnet.Publish ("Install"), "`dotnet publish /t:Install` should succeed");
-			AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+			Assert.IsTrue (dotnet.Run (), "`dotnet run` should succeed");
 			bool didLaunch = WaitForActivityToStart (proj.PackageName, "MainActivity",
 				Path.Combine (fullProjDir, "logcat.log"), 30);
 			RunAdbCommand ($"uninstall {proj.PackageName}");


### PR DESCRIPTION
Currently with .NET 5, you can build, deploy, and run an app with:

    dotnet publish foo.csproj -t:Install -t:StartAndroidActivity

This doesn't match the behavior of other platforms that use `dotnet
run` to launch.

Unfortunately `dotnet run` won't work in its current state:

    Unable to run your project.
    Ensure you have a runnable project type and ensure 'dotnet run' supports this project.
    A runnable project should target a runnable TFM (for instance, netcoreapp2.0) and have OutputType 'Exe'.
    The current OutputType is 'Library'.

But we can supply a `Run` target to start Android applications:

https://github.com/dotnet/sdk/blob/645919b8e850771a73f2f7a31b97038d6bdf1092/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L755-L758

This at least allows this command to work:

    dotnet publish foo.csproj -t:Run

I updated a test to use this command as well.