### PR TITLE
[apkdiff] Remove apkdiff from installers

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -477,6 +477,17 @@ stages:
         configuration: $(ApkTestConfiguration)
 
     - task: MSBuild@1
+      displayName: build apkdiff.csproj
+      inputs:
+        solution: tools/apkdiff/apkdiff.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /restore
+          /t:Build
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-apkdiff.binlog
+      continueOnError: true
+
+    - task: MSBuild@1
       displayName: build check-boot-times.csproj
       inputs:
         solution: build-tools/check-boot-times/check-boot-times.csproj

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -115,20 +115,6 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.exe" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.exe.config" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Mono.Options.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll.config" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Newtonsoft.Json.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Newtonsoft.Json-LICENSE.md" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Buffers.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Collections.Immutable.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Memory.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Numerics.Vectors.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Reflection.Metadata.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\System.Runtime.CompilerServices.Unsafe.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.exe" />
@@ -269,8 +255,6 @@
   <ItemGroup>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libzip.dll" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\apkdiff\libzip.dll" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\apkdiff\lib64\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libwinpthread-1.dll" />
@@ -319,7 +303,6 @@
     <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
     <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
     <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\apkdiff" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" />
@@ -336,7 +319,6 @@
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)"          Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)"           Condition=" '$(PackageId)' != 'Xamarin.Android.Sdk' " />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\libzip.$(LibExtension)" />
-    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\apkdiff\libzip.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
   </ItemGroup>
   <!-- Allow us to exclude mono bundle files for PR builds -->

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -323,10 +323,10 @@
   </Target>
   <Target Name="CheckAndRecordApkSizes">
     <PropertyGroup>
-      <ApkDiffExtension Condition=" '$(HostOS)' == 'Windows' ">.exe</ApkDiffExtension>
-      <ApkDiffPath Condition=" '$(HostOS)' == 'Windows' ">$(XAInstallPrefix)xbuild\Xamarin\Android\apkdiff\apkdiff$(ApkDiffExtension)</ApkDiffPath>
-      <ApkDiffPath Condition=" !Exists('$(ApkDiffPath)') ">$(XAInstallPrefix)xbuild\Xamarin\Android\$(HostOS)\apkdiff$(ApkDiffExtension)</ApkDiffPath>
-      <ApkDiffPath Condition=" !Exists('$(ApkDiffPath)') ">$(MonoAndroidBinDirectory)\apkdiff$(ApkDiffExtension)</ApkDiffPath>
+      <ApkDiffHostExtension Condition=" '$(HostOS)' == 'Windows' ">.exe</ApkDiffHostExtension>
+      <ApkDiffPath Condition=" '$(ApkDiffPath)' == '' ">$(XAInstallPrefix)xbuild\Xamarin\Android\apkdiff\apkdiff.exe</ApkDiffPath>
+      <ApkDiffPath Condition=" !Exists('$(ApkDiffPath)') ">$(XAInstallPrefix)xbuild\Xamarin\Android\$(HostOS)\apkdiff$(ApkDiffHostExtension)</ApkDiffPath>
+      <ApkDiffPath Condition=" !Exists('$(ApkDiffPath)') ">$(MonoAndroidBinDirectory)\apkdiff$(ApkDiffHostExtension)</ApkDiffPath>
     </PropertyGroup>
     <ApkDiffCheckRegression
         Condition="Exists('$(_ApkSizesReferenceDirectory)\$([System.IO.Path]::GetFileNameWithoutExtension(%(_AllArchives.Identity)))-$(Configuration)$(TestsFlavor)$([System.IO.Path]::GetExtension(%(_AllArchives.Identity)))desc')"


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1109699
Context: https://xamarinhq.slack.com/archives/C03CEGRUW/p1587737392083500

Remove `apkdiff` (2e28f2ea) from the macOS `.pkg` and Windows `.vsix`
installers.  After internal discussion, we felt that it didn't make
sense to include `apkdiff` within the Xamarin.Android installers, and
it would instead make more sense to package it for use with
`dotnet tool`.  See also:

  * [`dotnet tool install` documentation][0]
  * [Tutorial: Install and use a .NET Core global tool using the .NET Core CLI][1]

[0]: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install
[1]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-use