### PR TITLE
[.NET 5] $(AndroidBoundExceptionType)=System

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -35,6 +35,13 @@ In .NET 5 the behavior of the following MSBuild tasks will change, but
 
 `$(AndroidUseIntermediateDesignerFile)` will be `True` by default.
 
+`$(AndroidBoundExceptionType)` will be `System` by default.  This will
+[alter the types of exceptions thrown from various methods][abet-sys] to
+better align with existing .NET 5 semantics, at the cost of compatibility with
+previous Xamarin.Android releases.
+
+[abet-sys]: https://github.com/xamarin/xamarin-android/issues/4127
+
 ## Default file inclusion
 
 Default Android related file globbing behavior is defined in `Microsoft.Android.Sdk.DefaultItems.props`.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -11,6 +11,7 @@
     <DisableImplicitAndroidFrameworkReference Condition=" '$(DisableImplicitAndroidFrameworkReference)' == '' ">false</DisableImplicitAndroidFrameworkReference>
     <EnableDefaultAndroidResourceItems Condition=" '$(EnableDefaultAndroidResourceItems)' == '' ">true</EnableDefaultAndroidResourceItems>
     <EnableDefaultAndroidAssetItems Condition=" '$(EnableDefaultAndroidAssetItems)' == '' ">true</EnableDefaultAndroidAssetItems>
+    <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     <_AndroidResourceDesigner>Resource.designer.cs</_AndroidResourceDesigner>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -265,9 +265,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidDebugKeyValidity Condition=" '$(AndroidDebugKeyValidity)' == '' ">10950</AndroidDebugKeyValidity>
 	<AndroidDebugStoreType Condition=" '$(AndroidDebugStoreType)' == '' ">pkcs12</AndroidDebugStoreType>
 
-  <!-- Backward compatibility options -->
-  <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">Java</AndroidBoundExceptionType>
-
 	<!-- Obsolete -->
 	<AndroidGdbDebugServer>None</AndroidGdbDebugServer>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -10,6 +10,10 @@ projects. .NET 5 projects will not import this file.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">Java</AndroidBoundExceptionType>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(AndroidBuildApplicationPackage)' == 'True' And '$(AndroidApplication)' == 'True' ">
     <_PostBuildTargets>
       _CopyPackage;


### PR DESCRIPTION
Commit 60363ef4 added support for the `$(AndroidBoundExceptionType)`
MSBuild property, which controls whether or not Java exception types
are wrapped in appropriate .NET exception types from ".NET methods"
such as `IList.Add()` via `Android.Runtime.JavaList`/etc.

By default `$(AndroidBoundExceptionType)`=Java, meaning "don't wrap",
and `System` can be used to enable exception wrapping.

Commit 60363ef4 mentioned:

> [When .NET 5 is released with Xamarin.Android support][1], the
> default value will be `System`.

Do it!  Within .NET 5, `$(AndroidBoundExceptionType)`=System,
by default.