### PR TITLE
[build] bump to dotnet 5.0.100-preview.3.20216.6

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -50,7 +50,7 @@ variables:
   NUnitConsoleVersion: 3.9.0
   DotNetCoreVersion: 3.x
   # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
-  DotNetCorePreviewVersion: 5.0.100-preview.1.20155.7
+  DotNetCorePreviewVersion: 5.0.100-preview.3.20216.6
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019


### PR DESCRIPTION
This doesn't give us any new functionality, but I've noticed the
MSBuild `Node-2` tests are hanging. These are the ones that run the
`XASdkTests`, which I think is suspicious.

It's worth updating anyway, since preview 1 is from March 16.