### PR TITLE
[tests] mark hanging test [NonParallelizable]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Build.Tests {
 
 	[TestFixture]
 	[Category ("Node-2")]
-	[Parallelizable (ParallelScope.Self)]
+	[NonParallelizable] // NOTE: This test was hanging without this
 	public class ResolveSdksTaskTests : BaseTest {
 #pragma warning disable 414
 


### PR DESCRIPTION
Hanging test prints:

    [TESTLOG] Test CheckClassIsReplacedWithMd5 Outcome=Passed

This started happening since 835c59bc, but I don't see how the commit
would cause it.

Working build (https://build.azdo.io/3669040) prints this after
`CheckClassIsReplacedWithMd5`:

    => Xamarin.Android.Build.Tests.ResolveSdksTaskTests.LatestTFV_OldTargetSdkVersion

After adding logging, etc. I couldn't figure out if this was a bug in
NUnit or our tests. Adding `[NonParallelizable]` for the entire
`ResolveSdksTaskTests` class seems to solve the hang, so I think we
should just go with this for now.