### PR TITLE
LOC CHECKIN | xamarin/xamarin-android d16-6 | 20200424

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -87,6 +87,7 @@ ms.date: 01/24/2020
 + XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
 + XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
 + XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.
++ XA1018: Specified AndroidManifest file does not exist: {file}.
 
 ## XA2xxx: Linker
 
@@ -122,6 +123,7 @@ ms.date: 01/24/2020
 + XA4224: Malformed full class name '{name}'. Missing class name.
 + XA4225: Widget '{widget}' in layout '{layout}' has multiple instances with different types. The property type will be set to: {type}
 + XA4226: Resource item '{file}' does not have the required metadata item '{metadataName}'.
++ XA4228: Unable to find specified //activity-alias/@android:targetActivity: '{targetActivity}'
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -83,6 +83,9 @@ ms.date: 01/24/2020
 + [XA1011](xa1011.md): Using ProGuard with the D8 DEX compiler is no longer supported. Please update \`$(AndroidLinkTool)\` to \`r8\`.
 + XA1012: Included layout root element override ID '{id}' is not valid.
 + XA1013: Failed to parse ID of node '{name}' in the layout file '{file}'.
++ XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
++ XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
++ XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.
 
 ## XA2xxx: Linker
 
@@ -127,6 +130,7 @@ ms.date: 01/24/2020
 + [XA4308](xa4308.md): Failed to generate type maps
 + [XA4309](xa4309.md): 'MultiDexMainDexList' file '{file}' does not exist.
 + [XA4310](xa4310.md): \`$(AndroidSigningKeyStore)\` file \`{keystore}\` could not be found.
++ XA4311: The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -83,6 +83,7 @@ ms.date: 01/24/2020
 + [XA1011](xa1011.md): Using ProGuard with the D8 DEX compiler is no longer supported. Please update \`$(AndroidLinkTool)\` to \`r8\`.
 + XA1012: Included layout root element override ID '{id}' is not valid.
 + XA1013: Failed to parse ID of node '{name}' in the layout file '{file}'.
++ XA1014: JAR library references with identical file names but different contents were found: {libraries}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.
 + XA1015: More than one Android Wear project is specified as the paired project. It can be at most one.
 + XA1016: Target Wear application's project '{project}' does not specify required 'AndroidManifest' project property.
 + XA1017: Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -90,6 +90,8 @@ ms.date: 01/24/2020
 ## XA2xxx: Linker
 
 + XA2006: Could not resolve reference to '{member}' (defined in assembly '{assembly}') with scope '{scope}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.
++ XA2007: Exception while loading assemblies: {exception}
++ XA2008: In referenced assembly {assembly}, Java.Interop.DoNotPackageAttribute requires non-null file name.
 
 ## XA3xxx: Unmanaged code compilation
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -448,6 +448,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to More than one Android Wear project is specified as the paired project. It can be at most one..
+        /// </summary>
+        internal static string XA1015 {
+            get {
+                return ResourceManager.GetString("XA1015", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target Wear application&apos;s project &apos;{0}&apos; does not specify required &apos;AndroidManifest&apos; project property..
+        /// </summary>
+        internal static string XA1016 {
+            get {
+                return ResourceManager.GetString("XA1016", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target Wear application&apos;s AndroidManifest.xml does not specify required &apos;package&apos; attribute..
+        /// </summary>
+        internal static string XA1017 {
+            get {
+                return ResourceManager.GetString("XA1017", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {
@@ -849,6 +876,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4310 {
             get {
                 return ResourceManager.GetString("XA4310", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The application won&apos;t contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the &quot;SignAndroidPackage&quot; target..
+        /// </summary>
+        internal static string XA4311 {
+            get {
+                return ResourceManager.GetString("XA4311", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -520,6 +520,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception while loading assemblies: {0}.
+        /// </summary>
+        internal static string XA2007 {
+            get {
+                return ResourceManager.GetString("XA2007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name..
+        /// </summary>
+        internal static string XA2008 {
+            get {
+                return ResourceManager.GetString("XA2008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not AOT the assembly: {0}.
         /// </summary>
         internal static string XA3001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -448,6 +448,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary..
+        /// </summary>
+        internal static string XA1014 {
+            get {
+                return ResourceManager.GetString("XA1014", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to More than one Android Wear project is specified as the paired project. It can be at most one..
         /// </summary>
         internal static string XA1015 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -484,6 +484,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified AndroidManifest file does not exist: {0}..
+        /// </summary>
+        internal static string XA1018 {
+            get {
+                return ResourceManager.GetString("XA1018", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {
@@ -777,6 +786,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4226 {
             get {
                 return ResourceManager.GetString("XA4226", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find specified //activity-alias/@android:targetActivity: &apos;{0}&apos;.
+        /// </summary>
+        internal static string XA4228 {
+            get {
+                return ResourceManager.GetString("XA4228", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -345,6 +345,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
   </data>
+  <data name="XA1018" xml:space="preserve">
+    <value>Specified AndroidManifest file does not exist: {0}.</value>
+    <comment>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
@@ -510,6 +515,11 @@ In this mesage, the term "layout" means an Android UI layout.
     <value>Resource item '{0}' does not have the required metadata item '{1}'.</value>
     <comment>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</comment>
+  </data>
+  <data name="XA4228" xml:space="preserve">
+    <value>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</value>
+    <comment>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</comment>
   </data>
   <data name="XA4300" xml:space="preserve">
     <value>Native library '{0}' will not be bundled because it has an unsupported ABI.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -325,6 +325,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>{0} - The Android resource XML element name
 {1} - The path of the layout file</comment>
   </data>
+  <data name="XA1015" xml:space="preserve">
+    <value>More than one Android Wear project is specified as the paired project. It can be at most one.</value>
+    <comment>The following are literal names and should not be translated: Android Wear</comment>
+  </data>
+  <data name="XA1016" xml:space="preserve">
+    <value>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</value>
+    <comment>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</comment>
+  </data>
+  <data name="XA1017" xml:space="preserve">
+    <value>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</value>
+    <comment>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
@@ -542,6 +557,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
   <data name="XA4310" xml:space="preserve">
     <value>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</value>
     <comment>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</comment>
+  </data>
+  <data name="XA4311" xml:space="preserve">
+    <value>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</value>
+    <comment>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
   </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -365,6 +365,15 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</comment>
   </data>
+  <data name="XA2007" xml:space="preserve">
+    <value>Exception while loading assemblies: {0}</value>
+    <comment>{0} - The exception message of the associated exception</comment>
+  </data>
+  <data name="XA2008" xml:space="preserve">
+    <value>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</value>
+    <comment>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</comment>
+  </data>
   <data name="XA3001" xml:space="preserve">
     <value>Could not AOT the assembly: {0}</value>
     <comment>The abbreviation "AOT" should not be translated.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -325,6 +325,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <comment>{0} - The Android resource XML element name
 {1} - The path of the layout file</comment>
   </data>
+  <data name="XA1014" xml:space="preserve">
+    <value>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</value>
+    <comment>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</comment>
+  </data>
   <data name="XA1015" xml:space="preserve">
     <value>More than one Android Wear project is specified as the paired project. It can be at most one.</value>
     <comment>The following are literal names and should not be translated: Android Wear</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Soubor $(AndroidSigningKeyStore) {0} se nepovedlo najít.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Sestavení se nepovedlo zkompilovat AOT: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Neznámá možnost {0}. Zkontrolujte prosím $(AndroidAapt2CompileExtraArgs) a $(AndroidAapt2LinkExtraArgs), podívejte se, jestli nezahrnují nějaké argumenty příkazového řádku aapt, které už nejsou pro aapt2 platné, a ujistěte se, že všechny ostatní argumenty jsou pro aapt2 platné.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Použití nástroje ProGuard s kompilátorem D8 DEX se už nepodporuje. Aktualizujte prosím nástroj $(AndroidLinkTool) na R8.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">Zahrnuté ID přepisu kořenového prvku rozložení {0} není platné.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Nepodařilo se analyzovat ID uzlu {0} v souboru rozložení {1}.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">Knihovna JAR se odkazuje na totožné názvy souborů, ale našel se jiný obsah: {0}. Odeberte prosím konfliktní knihovny z EmbeddedJar, InputJar a AndroidJavaLibrary.</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Jako spárovaný projekt je zadán více než jeden projekt Android Wear. Může být maximálně jeden.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Projekt {0} cílové aplikace Wear nespecifikuje požadovanou vlastnost projektu AndroidManifest.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Soubor AndroidManifest.xml cílové aplikace Wear nespecifikuje požadovaný atribut package.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">Zadaný soubor AndroidManifest neexistuje: {0}</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">V sestavení {0} se zjistilo, že se používá AppDomain.CreateDomain(). .NET 5 bude podporovat jen jednu doménu AppDomain, proto toto rozhraní API už nebude po vydání rozhraní .NET 5 v Xamarin.Androidu k dispozici.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -297,7 +297,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="translated">Nelze přeložit odkaz: {0}, na který odkazuje {1}. Možná neexistuje v profilu Mono for Android.</target>
+        <target state="translated">Nelze přeložit odkaz {0}, na který odkazuje {1}. Možná neexistuje v profilu Mono for Android.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Výjimka při načítání sestavení: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">V odkazovaném sestavení {0} vyžaduje položka Java.Interop.DoNotPackageAttribute název souboru, který není null.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Nepodařilo se najít generátor vazby pro jazyk {0} nebo {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">Částečná položka třídy {0} nemá přidruženou vazbu pro rozložení {1}.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Nebyly vygenerovány žádné zdrojové soubory pro vazbu rozložení.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Pro rozložení ({0}) se nenašly žádné widgety.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Plný název třídy {0} má chybný formát. Chybí obor názvů.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Plný název třídy {0} má chybný formát. Chybí název třídy.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Widget {0} v rozložení {1} má více instancí s odlišnými typy. Typ vlastnosti se nastaví na: {2}.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">Položka prostředku {0} nemá požadovanou položku metadat {1}.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">Nepovedlo se najít zadané //activity-alias/@android:targetActivity: {0}</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Aplikace nebude obsahovat spárovaný balíček Wear, protože ještě není vytvořen soubor APK pro balíček aplikace Wear. Při sestavování na příkazovém řádku nezapomeňte sestavit cíl SignAndroidPackage.</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">AOT für Assembly nicht möglich: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Unbekannte Option "{0}". Überprüfen Sie "$(AndroidAapt2CompileExtraArgs)" und "$(AndroidAapt2LinkExtraArgs)" auf aapt-Befehlszeilenargumente, die für "aapt2" nicht mehr gültig sind, und stellen Sie sicher, dass alle anderen Argumente für "aapt2" gültig sind.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Die Verwendung von ProGuard mit dem D8 DEX-Compiler wird nicht mehr unterstützt. Aktualisieren Sie "$(AndroidLinkTool)" auf "r8".</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">Die enthaltene Überschreibungs-ID "{0}" des enthaltenen Layoutstammelements ist ungültig.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Fehler beim Analysieren der ID des Knotens "{0}" in der Layoutdatei "{1}".</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Es ist mehr als ein Android Wear-Projekt als gekoppeltes Projekt angegeben. Es darf höchstens Projekt angegeben werden.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Das Projekt "{0}" der Wear-Zielanwendung gibt nicht die erforderliche Projekteigenschaft "AndroidManifest" an.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Die Datei "AndroidManifest.xml" der Wear-Zielanwendung gibt nicht das erforderliche Attribut "package" an.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">In der Assembly "{0}" wurde die Verwendung von "AppDomain.CreateDomain()" festgestellt. .NET 5 unterstützt nur eine einzelne AppDomain, sodass diese API nach dem Release von .NET 5 nicht mehr in Xamarin.Android verfügbar ist.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -297,7 +297,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="translated">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Möglicherweise ist er nicht im Mono für Android-Profil vorhanden.</target>
+        <target state="translated">Der durch "{1}" referenzierte Verweis "{0}" kann nicht aufgelöst werden. Möglicherweise ist er im Mono für Android-Profil nicht vorhanden.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Ausnahme beim Laden von Assemblys: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">In der referenzierten Assembly "{0}" ist für "Java.Interop.DoNotPackageAttribute" ein Dateiname ungleich NULL erforderlich.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Der Bindungsgenerator für die Sprache {0} oder {1} wurde nicht gefunden.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">Das partielle Klassenelement "{0}" besitzt keine zugeordnete Bindung für das Layout "{1}".</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Es wurden keine Bindungsquelldateien für das Layout generiert.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Für das Layout ({0}) wurden keine Widgets gefunden.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Falsch formatierter vollständiger Klassenname "{0}". Namespace fehlt.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Falsch formatierter vollständiger Klassenname "{0}". Klassenname fehlt.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Das Widget "{0}" im Layout "{1}" weist mehrere Instanzen mit unterschiedlichen Typen auf. Der Eigenschaftentyp wird auf "{2}" festgelegt.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">Das Ressourcenelement "{0}" verfügt nicht über das erforderliche Metadatenelement "{1}".</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Die Anwendung enthält nicht das gekoppelte Wear-Paket, weil das Wear-Anwendungspaket "APK" noch nicht erstellt wurde. Stellen Sie bei einer Kompilierung über die Befehlszeile sicher, dass Sie das Ziel "SignAndroidPackage" erstellen.</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">"{0}" wurde nicht im Android SDK gefunden. Legen Sie den Pfad über "/p:LintToolPath" fest.</target>
+        <target state="translated">"{0}" wurde im Android SDK nicht gefunden. Legen Sie den Pfad über "/p:LintToolPath" fest.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Die $(AndroidSigningKeyStore)-Datei "{0}" wurde nicht gefunden.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">No se pudo aplicar AOT al ensamblado: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">No se ha encontrado el archivo "{0}" de "$(AndroidSigningKeyStore)".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Opción "{0}" desconocida. Compruebe "$(AndroidAapt2CompileExtraArgs)" y "$(AndroidAapt2LinkExtraArgs)" para ver si incluyen los argumentos de la línea de comandos "aapt" que ya no son válidos para "aapt2" y asegúrese de que el resto de argumentos sean válidos para "aapt2".</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Ya no se admite el uso de ProGuard con el compilador D8 DEX. Actualice "$(AndroidLinkTool)" a "r8".</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">El identificador de reemplazo del elemento raíz del diseño "{0}" que se ha incluido no es válido.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">No se pudo analizar el identificador del nodo "{0}" en el archivo de diseño "{1}".</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">Se han encontrado referencias de biblioteca JAR con nombres de archivo idénticos pero contenido distinto: {0}. Quite las bibliotecas en conflicto de EmbeddedJar, InputJar y AndroidJavaLibrary.</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Se ha especificado más de un proyecto de Android Wear como proyecto emparejado. Debe ser uno como máximo.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">El proyecto de la aplicación Wear de destino "{0}" no especifica la propiedad del proyecto "AndroidManifest" requerida.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">El archivo AndroidManifest.xml de la aplicación Wear de destino no especifica el atributo "package" requerido.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">El archivo AndroidManifest especificado no existe: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">Se detectó el uso de AppDomain.CreateDomain() en el ensamblado: {0}. En .NET 5 solo se admitirá una instancia de AppDomain, por lo que esta API ya no estará disponible en Xamarin.Android una vez que se haya lanzado .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Excepción al cargar los ensamblados: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">En el ensamblado {0} al que se hace referencia, Java.Interop.DoNotPackageAttribute requiere un nombre de archivo que no sea NULL.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">No se encuentra el generador de enlaces para el lenguaje {0} o {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">El elemento de clase parcial "{0}" no tiene ningún enlace asociado para el diseño "{1}".</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">No se ha generado ningún archivo de origen de enlace del diseño.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">No se ha encontrado ningún widget para el diseño ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">El nombre de clase completo "{0}" tiene un formato incorrecto. Falta el espacio de nombres.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">El nombre de clase completo "{0}" tiene un formato incorrecto. Falta el nombre de la clase.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">El widget "{0}" del diseño "{1}" tiene varias instancias con tipos distintos. El tipo de propiedad se establecerá como {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">El elemento del recurso "{0}" no tiene el elemento de metadatos "{1}" necesario.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">No se encuentra el elemento //activity-alias/@android:targetActivity especificado: "{0}"</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">La aplicación no contendrá el paquete Wear emparejado porque aún no se ha creado el archivo APK del paquete de la aplicación Wear. Si se está compilando en la línea de comandos, asegúrese de compilar el destino "SignAndroidPackage".</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">No se puede encontrar "{0}" en Android SDK. Establezca su ruta de acceso mediante /p:LintToolPath.</target>
+        <target state="translated">No se encuentra "{0}" en Android SDK. Establezca su ruta de acceso mediante /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Le fichier '$(AndroidSigningKeyStore)' '{0}' est introuvable.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Option '{0}' inconnue. Examinez '$(AndroidAapt2CompileExtraArgs)' et '$(AndroidAapt2LinkExtraArgs)' pour voir s'ils comportent des arguments de ligne de commande 'aapt' qui ne sont plus valides pour 'aapt2', et pour vérifier si tous les autres arguments sont valides pour 'aapt2'.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">L'utilisation de ProGuard avec le compilateur D8 DEX n'est plus prise en charge. Mettez à jour '$(AndroidLinkTool)' vers 'r8'.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">L'ID de substitution de l'élément racine de disposition inclus '{0}' n'est pas valide.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">L'analyse de l'ID du nœud '{0}' dans le fichier de disposition '{1}' a échoué.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Plusieurs projets Android Wear sont spécifiés en tant que projets appairés. Il ne doit en exister qu'un seul.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Le projet '{0}' de l'application Wear cible ne spécifie pas la propriété de projet 'AndroidManifest' nécessaire.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Le fichier AndroidManifest.xml de l'application Wear cible ne spécifie pas l'attribut 'package' nécessaire.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">Utilisation de AppDomain.CreateDomain() détectée dans l'assembly {0}. .NET 5 prend uniquement en charge un seul AppDomain. Cette API ne sera donc plus disponible dans Xamarin.Android après la publication de .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Exception durant le chargement des assemblys : {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">Dans l'assembly référencé {0}, Java.Interop.DoNotPackageAttribute nécessite un nom de fichier non null.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Impossible de trouver le générateur de liaisons pour le langage {0} ou {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">L'élément de classe partiel '{0}' n'a pas de liaison associée pour la disposition '{1}'.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Aucun fichier source de liaison de disposition n'a été généré.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Aucun widget trouvé pour la disposition ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Nom de classe complet incorrect : '{0}'. Espace de noms manquant.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Nom de classe complet incorrect : '{0}'. Nom de classe manquant.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Le widget '{0}' dans la disposition '{1}' a plusieurs instances avec des types différents. Le type de propriété aura la valeur suivante : {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">L'élément de ressource '{0}' n'a pas l'élément de métadonnées obligatoire '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">L'application ne contient pas le package Wear appairé, car le fichier APK du package d'application Wear n'est pas encore créé. Si vous effectuez la génération à partir de la ligne de commande, veillez à générer la cible "SignAndroidPackage".</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">'{0}' est introuvable dans le kit Android SDK. Définissez son chemin via /p:LintToolPath.</target>
+        <target state="translated">'{0}' est introuvable dans le kit Android SDK. Définissez son chemin avec /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
@@ -681,12 +681,12 @@ In this message, the term "handheld app" means "app for handheld devices."
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
         <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Le répertoire Android SDK est introuvable. Définissez-le via /p:AndroidSdkDirectory.</target>
+        <target state="translated">Le répertoire Android SDK est introuvable. Définissez-le avec /p:AndroidSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
         <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Le répertoire Java SDK est introuvable. Définissez-le via /p:JavaSdkDirectory.</target>
+        <target state="translated">Le répertoire Java SDK est introuvable. Définissez-le avec /p:JavaSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Impossible d'effectuer une compilation AOT de l'assembly : {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Opzione `{0}` sconosciuta. Controllare `$(AndroidAapt2CompileExtraArgs)` e `$(AndroidAapt2LinkExtraArgs)` per verificare se includono argomenti della riga di comando di `aapt` che non sono più validi per `aapt2` e assicurarsi che tutti gli altri argomenti siano validi per `aapt2`.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">L'utilizzo di ProGuard con il compilatore DEX D8 non è più supportato. Aggiornare `$(AndroidLinkTool)` a `r8`.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">L'ID '{0}' di override dell'elemento radice del layout incluso non è valido.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Non è stato possibile analizzare l'ID del nodo '{0}' nel file di layout '{1}'.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Come progetto associato è stato specificato più di un progetto Android Wear. È possibile specificarne al massimo uno.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Il progetto '{0}' dell'applicazione Wear di destinazione non specifica la proprietà di progetto obbligatoria 'AndroidManifest'.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Il file AndroidManifest.xml dell'applicazione Wear di destinazione non specifica l'attributo obbligatorio 'package'.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">È stato rilevato l'uso di AppDomain.CreateDomain() nell'assembly: {0}. .NET 5 supporterà solo un'unica istanza di AppDomain, di conseguenza questa API non sarà più disponibile in Xamarin.Android dopo il rilascio di .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Si è verificata un'eccezione durante il caricamento degli assembly: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">Nell'assembly di riferimento {0} Java.Interop.DoNotPackageAttribute richiede un nome file diverso da Null.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Non è possibile trovare il generatore di binding per il linguaggio {0} o {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">L'elemento di classe parziale '{0}' non contiene un binding associato per il layout '{1}'.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Non è stato generato alcun file di origine del binding di layout.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Non sono stati trovati widget per il layout ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Il nome della classe completo '{0}' non è valido. Manca lo spazio dei nomi.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Il nome della classe completo '{0}' non è valido. Manca il nome della classe.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Il widget '{0}' nel layout '{1}' contiene più istanze con tipi diversi. Il tipo di proprietà verrà impostato su {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">L'elemento di risorsa '{0}' non contiene l'elemento di metadati richiesto '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">L'applicazione non conterrà il pacchetto Wear associato perché non è ancora stato creato il file APK del pacchetto dell'applicazione Wear. Se si compila dalla riga di comando, assicurarsi di compilare la destinazione "SignAndroidPackage".</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Non è stato possibile eseguire la compilazione AOT dell'assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Non è stato possibile trovare il file `{0}` di `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">オプション '{0}' が不明です。`$(AndroidAapt2CompileExtraArgs)` と `$(AndroidAapt2LinkExtraArgs)` に、`aapt2` で有効ではなくなった `aapt` コマンド ライン引数が含まれていないか確認し、他のすべての引数が `aapt2` で有効であることを確かめてください。</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">D8 DEX コンパイラで ProGuard を使用することはサポートされなくなりました。'$(AndroidLinkTool)' を 'r8' に更新してください。</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">含まれているレイアウトのルート要素のオーバーライド ID '{0}' が有効ではありません。</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">レイアウト ファイル '{1}' のノード '{0}' の ID を解析できませんでした。</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">複数の Android Wear プロジェクトが、ペアリングされたプロジェクトとして指定されています。最大 1 つ指定できます。</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Target Wear アプリケーションのプロジェクト '{0}' は、必須の 'AndroidManifest' プロジェクト プロパティを指定しません。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Target Wear アプリケーションの AndroidManifest.xml は、必須の 'package' 属性を指定しません。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">アセンブリ {0} で AppDomain.CreateDomain() が使用されていることが検出されました。.NET 5 では単一の AppDomain のみがサポートされる予定のため、.NET 5 がリリースされるとこの API は Xamarin.Android では使用できなくなります。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">アセンブリの読み込み中に例外が発生しました。{0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">参照されたアセンブリ {0} では、Java.Interop.DoNotPackageAttribute に Null 以外のファイル名が必要です。</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">言語 {0} または {1} のバインド ジェネレーターが見つかりません。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">部分クラス項目 '{0}' には、レイアウト '{1}' に関連付けられたバインドがありません。</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">レイアウト バインドのソース ファイルが生成されませんでした。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">レイアウトのウィジェットが見つかりません ({0})。</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">完全なクラス名 '{0}' の形式が正しくありません。名前空間がありません。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">完全なクラス名 '{0}' の形式が正しくありません。クラス名がありません。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">レイアウト '{1}' 内のウィジェット '{0}' には、型が異なる複数のインスタンスがあります。プロパティの型は {2} に設定されます</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">リソース項目 '{0}' に、必要なメタデータ項目 '{1}' がありません。</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Wear アプリケーション パッケージ APK がまだ作成されていないため、アプリケーションにはペアリングされた Wear パッケージは含まれません。コマンド ラインでビルドする場合は、"SignAndroidPackage" ターゲットをビルドしてください。</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">アセンブリを AOT できませんでした: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">'$(AndroidSigningKeyStore)' ファイル '{0}' が見つかりませんでした。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">알 수 없는 옵션 `{0}`입니다. `$(AndroidAapt2CompileExtraArgs)` 및 `$(AndroidAapt2LinkExtraArgs)`를 확인하여 `aapt2`에 대해 이제 유효하지 않은 `aapt` 명령줄 인수가 포함되는지 확인하고 `aapt2`에 대해 모든 다른 인수가 유효한지 확인하세요.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">D8 DEX 컴파일러와 함께 ProGuard 사용이 더 이상 지원되지 않습니다. `$(AndroidLinkTool)`을 `r8`로 업데이트하세요.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">포함된 레이아웃 루트 요소 재정의 ID '{0}'이(가) 잘못되었습니다.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">'{1}' 레이아웃 파일에서 '{0}' 노드의 ID를 구문 분석하지 못했습니다.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">파일 이름은 같지만 콘텐츠가 다른 JAR 라이브러리 참조를 찾았습니다. {0}. EmbeddedJar, InputJar 및 AndroidJavaLibrary에서 충돌하는 라이브러리를 제거하세요.</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">두 개 이상의 Android Wear 프로젝트가 페어링된 프로젝트로 지정되었습니다. 최대 한 개를 사용할 수 있습니다.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">대상 Wear 애플리케이션의 프로젝트 '{0}'이(가) 필요한 'AndroidManifest' 프로젝트 속성을 지정하지 않습니다.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">대상 Wear 애플리케이션의 AndroidManifest.xml이 필요한 'package' 특성을 지정하지 않습니다.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">지정한 AndroidManifest 파일이 없습니다. {0}</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">{0} 어셈블리에서 AppDomain.CreateDomain() 사용이 검색되었습니다. .NET 5는 단일 AppDomain만 지원하므로 .NET 5가 릴리스되면 이 API는 Xamarin.Android에서 더는 사용할 수 없습니다.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">어셈블리 로드 중 예외 발생: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">참조된 어셈블리 {0}에서 Java.Interop.DoNotPackageAttribute에 null이 아닌 파일 이름이 필요합니다.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">{0} 또는 {1} 언어에 대한 바인딩 생성기를 찾을 수 없습니다.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">partial 클래스 항목 '{0}'에 레이아웃 '{1}'과(와) 연결된 바인딩이 없습니다.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">레이아웃 바인딩 소스 파일이 생성되지 않았습니다.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">레이아웃({0})에 대한 위젯을 찾을 수 없습니다.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">전체 클래스 이름 '{0}'의 형식이 잘못되었습니다. 네임스페이스가 없습니다.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">전체 클래스 이름 '{0}'의 형식이 잘못되었습니다. 클래스 이름이 없습니다.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">'{1}' 레이아웃의 '{0}' 위젯에 형식이 다른 여러 인스턴스가 있습니다. 속성 형식이 다음으로 설정됩니다. {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">리소스 항목 '{0}'에 필수 메타데이터 항목 '{1}'이(가) 없습니다.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">지정한 //activity-alias/@android:targetActivity를 찾을 수 없음: '{0}'</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Wear 애플리케이션 패키지 APK가 아직 만들어지지 않았기 때문에 애플리케이션에 페어링된 Wear 패키지가 포함되지 않습니다. 명령줄에서 빌드하는 경우 "SignAndroidPackage" 대상을 빌드해야 합니다.</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">어셈블리를 AOT할 수 없음: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">'$(AndroidSigningKeyStore)' 파일 '{0}'을(를) 찾을 수 없습니다.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Nieznana opcja „{0}”. Sprawdź zmienne „$(AndroidAapt2CompileExtraArgs)” i „$(AndroidAapt2LinkExtraArgs)” pod kątem tego, czy zawierają jakiekolwiek argumenty wiersza polecenia „aapt”, które nie są już prawidłowe dla elementu „aapt2”, oraz upewnij się, że wszystkie pozostałe argumenty są prawidłowe dla elementu „aapt2”.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Używanie narzędzie ProGuard z kompilatorem D8 DEX nie jest już obsługiwane. Zaktualizuj narzędzie „$(AndroidLinkTool)” do wersji „R8”.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">Dołączony identyfikator przesłonięcia „{0}” elementu głównego układu jest nieprawidłowy.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Nie można przeanalizować identyfikatora węzła „{0}” w pliku układu „{1}”.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">Znaleziono odwołania do bibliotek JAR z identycznymi nazwami plików, ale różną zawartością: {0}. Usuń wszystkie biblioteki powodujące konflikt z elementów EmbeddedJar, InputJar i AndroidJavaLibrary.</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Jako projekt sparowany określono więcej niż jeden projekt systemu Android Wear. Może być najwyżej jeden taki projekt.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Projekt aplikacji docelowej systemu Wear „{0}” nie określa wymaganej właściwości projektu „AndroidManifest”.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Plik AndroidManifest.xml aplikacji docelowej systemu Wear nie określa wymaganego atrybutu „package”.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">Określony plik AndroidManifest nie istnieje: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">Wykryto użycie metody AppDomain.CreateDomain() w następującym zestawie: {0}. Program .NET 5 obsługuje tylko jeden obiekt AppDomain, dlatego ten interfejs API nie będzie już dostępny w interfejsie Xamarin.Android po wydaniu programu .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Wyjątek podczas ładowania zestawów: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">W przywoływanym zestawie {0} element Java.Interop.DoNotPackageAttribute wymaga nazwy pliku o wartości innej niż null.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Nie można odnaleźć generatora powiązań dla języka {0} ani {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">Element klasy częściowej „{0}” nie ma skojarzonego powiązania dla układu „{1}”.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Nie wygenerowano żadnych plików źródłowych powiązania układu.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Nie odnaleziono żadnych widżetów dla układu ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Źle sformułowana pełna nazwa klasy „{0}”. Brak przestrzeni nazw.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Źle sformułowana pełna nazwa klasy „{0}”. Brak nazwy klasy.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Widżet „{0}” w układzie „{1}” ma wiele wystąpień o różnych typach. Typ właściwości zostanie skonfigurowany na następującą wartość: {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">Element zasobu „{0}” nie ma wymaganego elementu metadanych „{1}”.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">Nie można znaleźć określonego elementu //activity-alias/@android:targetActivity: „{0}”</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Aplikacja nie będzie zawierać sparowanego pakietu systemu Wear, ponieważ plik APK pakietu aplikacji systemu Wear nie został jeszcze utworzony. W przypadku kompilowania z poziomu wiersza polecenia pamiętaj, aby skompilować element docelowy „SignAndroidPackage”.</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Nie można utworzyć widoku AOT zestawu: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Nie można odnaleźć pliku „$(AndroidSigningKeyStore)” („{0}”).</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Não foi possível localizar o arquivo `{0}` de `$(AndroidSigningKeyStore)`.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Opção desconhecida `{0}`. Verifique se '$(AndroidAapt2CompileExtraArgs)' e '$(AndroidAapt2LinkExtraArgs)' incluem argumentos de linha de comando de `aapt` que não sejam mais válidos para `aapt2` e verifique se todos os outros argumentos são válidos para `aapt2`.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Não há mais suporte para o uso do ProGuard com o compilador de DEX do D8. Atualize o `$(AndroidLinkTool)` para `r8`.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">A ID de substituição do elemento raiz do layout incluída '{0}' não é válida.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Falha ao analisar a ID do nó '{0}' no arquivo de layout '{1}'.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">Foram encontradas referências de biblioteca JAR com nomes de arquivo idênticos, mas conteúdos diferentes: {0}. Remova todas as bibliotecas conflitantes de EmbeddedJar, InputJar e AndroidJavaLibrary.</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Mais de um projeto do Android Wear está especificado como o projeto emparelhado. Ele pode ter no máximo um.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">O projeto '{0}' do aplicativo do Wear do destino não especifica a propriedade do projeto 'AndroidManifest' necessária.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">O AndroidManifest.xml do aplicativo do Wear de destino não especifica o atributo 'package' necessário.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">O arquivo AndroidManifest especificado não existe: {0}.</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">O uso de AppDomain.CreateDomain() foi detectado no assembly: {0}. O .NET 5 dá suporte apenas a um único AppDomain, portanto, essa API não estará mais disponível no Xamarin.Android quando o .NET 5 for lançado.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Exceção ao carregar os assemblies: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">No assembly referenciado {0}, Java.Interop.DoNotPackageAttribute exige um nome de arquivo não nulo.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Não é possível encontrar o gerador de associação para a linguagem {0} ou {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">O item de classe parcial '{0}' não tem uma associação associada para o layout '{1}'.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Não foi gerado nenhum arquivo de origem de associação de layout.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Não foi encontrado nenhum widget para o layout ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Nome de classe completo mal formado '{0}'. Namespace ausente.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Nome de classe completo mal formado '{0}'. Nome de classe ausente.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">O widget '{0}' no layout '{1}' tem várias instâncias com tipos diferentes. O tipo de propriedade será definido como: {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">O item de recurso '{0}' não tem o item de metadados necessário '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">Não é possível localizar o //activity-alias/@android:targetActivity especificado: '{0}'</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">O aplicativo não conterá o pacote do Wear emparelhado porque o APK do pacote de aplicativos do Wear ainda não foi criado. Se estiver criando na linha de comando, não se esqueça de criar o destino "SignAndroidPackage".</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -681,12 +681,12 @@ In this message, the term "handheld app" means "app for handheld devices."
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
         <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Não foi possível encontrar o diretório do SDK do Android. Defina por meio de /p:AndroidSdkDirectory.</target>
+        <target state="translated">Não foi possível encontrar o diretório do SDK do Android. Defina-o por meio de /p:AndroidSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
         <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Não foi possível encontrar o diretório do SDK do Java. Defina por meio de /p:JavaSdkDirectory.</target>
+        <target state="translated">Não foi possível encontrar o diretório do SDK do Java. Defina-o por meio de /p:JavaSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Não foi possível fazer AOT no assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Не удалось выполнить AOT для сборки: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">Неизвестный параметр "{0}". Проверьте "$(AndroidAapt2CompileExtraArgs)" и "$(AndroidAapt2LinkExtraArgs)", чтобы проверить, содержат ли они аргументы командной строки "aapt", которые больше не являются допустимыми для "aapt2", и убедитесь, что все остальные аргументы являются допустимыми для "aapt2".</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">Использование ProGuard с компилятором D8 DEX больше не поддерживается. Обновите "$(AndroidLinkTool)" до версии "r8".</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">Включенный идентификатор переопределения корневого элемента макета "{0}" является недопустимым.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">Не удалось проанализировать идентификатор узла "{0}" в файле макета "{1}".</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">В качестве связанного проекта указано несколько проектов Android Wear. Такой проект может быть только один.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">В проекте целевого приложения Wear "{0}" не указано обязательное свойство проекта "AndroidManifest".</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">В файле AndroidManifest.xml целевого приложения Wear не указан обязательный атрибут "package".</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">В сборке обнаружено использование AppDomain.CreateDomain(): {0}. .NET 5 поддерживает только один домен AppDomain, поэтому этот API не будет доступен в Xamarin.Android после выпуска .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -297,7 +297,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="translated">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Возможно, он отсутствует в профиле Mono для Android.</target>
+        <target state="translated">Не удается разрешить ссылку "{0}", на которую ссылается {1}. Возможно, она отсутствует в профиле Mono для Android.</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Исключение при загрузке сборок: {0}.</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">В сборке {0}, на которую указывает ссылка, для Java.Interop.DoNotPackageAttribute требуется имя файла, отличное от NULL.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">Не удается найти генератор привязки для языка {0} или {1}.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">С элементом разделяемого класса "{0}" не связана привязка для макета "{1}".</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Не были созданы исходные файлы привязки макета.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Не найдены мини-приложения для макета ({0}).</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Полное имя класса "{0}" сформировано неправильно. Отсутствует пространство имен.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Полное имя класса "{0}" сформировано неправильно. Отсутствует имя класса.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">Мини-приложение "{0}" в макете "{1}" содержит несколько экземпляров с разными типами. Будет установлен тип свойства {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">Элемент ресурса "{0}" не включает необходимый элемент метаданных "{1}".</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Приложение не будет содержать связанный пакет Wear, так как пакет APK приложения Wear еще не создан. При сборке в командной строке необходимо выполнить сборку целевого объекта "SignAndroidPackage".</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">Не удается найти "{0}" в пакете SDK для Android. Укажите путь к нему, выполнив команду /p:LintToolPath.</target>
+        <target state="translated">Не удается найти "{0}" в пакете SDK для Android. Укажите путь к нему с помощью параметра /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
@@ -681,12 +681,12 @@ In this message, the term "handheld app" means "app for handheld devices."
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
         <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Не удалось найти каталог пакета SDK для Android. Укажите путь к нему, выполнив команду /p:AndroidSdkDirectory.</target>
+        <target state="translated">Не удалось найти каталог пакета SDK для Android. Укажите путь к нему с помощью параметра /p:AndroidSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
         <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Не удалось найти каталог пакета SDK для Java. Укажите путь к нему, выполнив команду /p:JavaSdkDirectory.</target>
+        <target state="translated">Не удалось найти каталог пакета SDK для Java. Укажите путь к нему с помощью параметра /p:JavaSdkDirectory.</target>
         <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">Не удалось найти файл "$(AndroidSigningKeyStore)" с именем "{0}".</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">`{0}` seçeneği bilinmiyor. `aapt2` için artık geçerli olmayan `aapt` komut satırı bağımsız değişkenlerini içerip içermediklerini görmek ve diğer tüm bağımsız değişkenlerin `aapt2` için geçerli olduğundan emin olmak için lütfen `$(AndroidAapt2CompileExtraArgs)` ve `$(AndroidAapt2LinkExtraArgs)` özelliklerini denetleyin.</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">D8 DEX derleyicisi ile ProGuard kullanılması artık desteklenmiyor. Lütfen `$(AndroidLinkTool)` sürümünü `r8` olarak güncelleştirin.</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">Eklenen düzen kök öğesi geçersiz kılma kimliği ('{0}') geçerli değil.</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">'{1}' düzen dosyasındaki '{0}' düğümünün kimliği ayrıştırılamadı.</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">Eşleştirilmiş proje olarak birden fazla Android Wear projesi belirtildi. En fazla bir proje belirtilebilir.</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">Hedef Wear uygulamasının '{0}' projesinde, gerekli 'AndroidManifest' proje özelliği belirtilmiyor.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">Hedef Wear uygulamasının AndroidManifest.xml dosyasında, gerekli 'package' özniteliği belirtilmiyor.</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">Bütünleştirilmiş kodda AppDomain.CreateDomain() metodunun kullanıldığı saptandı: {0}. .NET 5 yalnızca tek bir AppDomain'i destekleyeceğinden bu API, .NET 5 yayımlandıktan sonra artık Xamarin.Android içinde kullanılamayacak.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">Bütünleştirilmiş kodlar yüklenirken özel durum oluştu: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">Başvurulan {0} bütünleştirilmiş kodundaki Java.Interop.DoNotPackageAttribute, null olmayan dosya adı gerektiriyor.</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">{0} veya {1} dili için bağlama oluşturucusu bulunamıyor.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">'{0}' parçalı sınıf öğesi '{1}' düzeni için ilişkili bir bağlamaya sahip değil.</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">Düzen bağlama kaynağı dosyası oluşturulmadı.</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">Düzen ({0}) için pencere öğesi bulunamadı.</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">Tam sınıf adı ('{0}') hatalı biçimlendirilmiş. Ad alanı eksik.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">Tam sınıf adı ('{0}') hatalı biçimlendirilmiş. Sınıf adı eksik.</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">'{1}' düzenindeki '{0}' pencere öğesi farklı türlerde birden çok örneğe sahip. Özellik türü {2} olarak ayarlanacak</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">'{0}' kaynak öğesinde gerekli meta veri öğesi ('{1}') yok.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">Wear uygulama paketi APK'sı henüz oluşturulmadığından uygulama, eşleştirilen Wear paketini içermeyecek. Komut satırında derleme yapıyorsanız, "SignAndroidPackage" hedefini derlediğinizden emin olun.</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">Android SDK içinde `{0}` bulunamıyor. Lütfen yolunu /p:LintToolPath ile ayarlayın.</target>
+        <target state="translated">Android SDK'sında `{0}` bulunamıyor. Lütfen yolunu /p:LintToolPath ile ayarlayın.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">Bütünleştirilmiş koda AOT uygulanamadı: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">`{0}` adlı `$(AndroidSigningKeyStore)` dosyası bulunamadı.</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">未知选项“{0}”。请检查 "$(AndroidAapt2CompileExtraArgs)" 和 "$(AndroidAapt2LinkExtraArgs)"，以查看它们是否包含任何对 "aapt2" 不再有效的 "aapt" 命令行参数，并确保所有其他参数都对 "aapt2" 有效。</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,53 +240,53 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">不再支持将 ProGuard 与 D8 DEX 编译器一起。请将 "$(AndroidLinkTool)" 更新为 "r8"。</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">包含的布局根元素替代 ID“{0}”无效。</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">未能分析布局文件“{1}”中节点“{0}”的 ID。</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
       <trans-unit id="XA1014">
         <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
-        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <target state="translated">发现具有相同文件名内容不同的 JAR 库参考: {0}。请从 EmbeddedJar、InputJar 和 AndroidJavaLibrary 删除任何冲突的库。</target>
         <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
 {0} - Comma-separated list of the conflicting JAR library file names</note>
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">已将多个 Android Wear 项目指定为配对的项目。最多只能有一个。</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">目标 Wear 应用程序的项目“{0}”未指定所需的 "AndroidManifest" 项目属性。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">目标 Wear 应用程序的 AndroidManifest.xml 未指定所需的 "package" 特性。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1018">
         <source>Specified AndroidManifest file does not exist: {0}.</source>
-        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <target state="translated">指定的 AndroidManifest 文件不存在: {0}。</target>
         <note>The following are literal names and should not be translated: AndroidManifest
 {0} - The path of the specified AndroidManifest file</note>
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">在程序集 {0} 中检测到使用了 AppDomain.CreateDomain()。.NET 5 将仅支持一个 AppDomain，因此 .NET 5 发布后，将无法再在 Xamarin.Android 中使用此 API。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -297,7 +297,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="translated">无法解析引用: `{0}`,引用者为 {1}.它可能不存在于 Mono for Android 配置文件中?</target>
+        <target state="translated">无法解析 {1} 引用的引用“{0}”。Mono for Android 配置文件中可能没有该引用。</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">加载程序集时出错: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">在引用的程序集 {0} 中，Java.Interop.DoNotPackageAttribute 需要非 null 的文件名。</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">找不到语言 {0} 或 {1} 的绑定生成器。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">分部类项“{0}”没有布局“{1}”的关联绑定。</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">未生成任何布局绑定源文件。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">找不到布局的小组件({0})。</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">完整类名“{0}”格式错误。缺少命名空间。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">完整类“{0}”格式错误。缺少类名。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">布局“{1}”中的小组件“{0}”包含多个具有不同类型的实例。属性类型将设置为: {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,13 +482,13 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">资源项“{0}”没有所需的元数据项“{1}”。</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
       <trans-unit id="XA4228">
         <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
-        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <target state="translated">找不到指定的 //activity-alias/@android:targetActivity:“{0}”</target>
         <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
 {0} - The specified targetActivity name</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">应用程序不包含配对的 Wear 包，因为尚未创建 Wear 应用程序包 APK。如果在命令行上生成，请确保生成 "SignAndroidPackage" 目标。</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">无法 AOT 程序集: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">找不到“$(AndroidSigningKeyStore)”文件“{0}”。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="APT0001">
         <source>Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</source>
-        <target state="new">Unknown option `{0}`. Please check `$(AndroidAapt2CompileExtraArgs)` and `$(AndroidAapt2LinkExtraArgs)` to see if they include any `aapt` command line arguments that are no longer valid for `aapt2` and ensure that all other arguments are valid for `aapt2`.</target>
+        <target state="translated">未知的選項 `{0}`。請檢查 `$(AndroidAapt2CompileExtraArgs)` 與 `$(AndroidAapt2LinkExtraArgs)`，確認其是否包含任何對 `aapt2` 不再有效的 `aapt` 命令列引數，並確定所有其他引數對 `aapt2` 皆有效。</target>
         <note>The following are literal names and should not be translated: `aapt`, `aapt2`,  `$(AndroidAapt2CompileExtraArgs)`, `$(AndroidAapt2LinkExtraArgs)`
 {0} - The invalid option name</note>
       </trans-unit>
@@ -240,17 +240,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1011">
         <source>Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</source>
-        <target state="new">Using ProGuard with the D8 DEX compiler is no longer supported. Please update `$(AndroidLinkTool)` to `r8`.</target>
+        <target state="translated">已不再支援並用 ProGuard 與 D8 DEX 編譯器。請將 '$(AndroidLinkTool)' 更新為 'r8'。</target>
         <note>The following are literal names and should not be translated: ProGuard, D8, DEX, `$(AndroidLinkTool)`, `r8`</note>
       </trans-unit>
       <trans-unit id="XA1012">
         <source>Included layout root element override ID '{0}' is not valid.</source>
-        <target state="new">Included layout root element override ID '{0}' is not valid.</target>
+        <target state="translated">包含的版面配置根項目覆寫識別碼 '{0}' 無效。</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1013">
         <source>Failed to parse ID of node '{0}' in the layout file '{1}'.</source>
-        <target state="new">Failed to parse ID of node '{0}' in the layout file '{1}'.</target>
+        <target state="translated">無法剖析配置檔案 '{1}' 中節點 '{0}' 的識別碼。</target>
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
@@ -262,19 +262,19 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
-        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <target state="translated">已將一個以上的 Android Wear 專案指定為配對的專案。最多只能指定一個。</target>
         <note>The following are literal names and should not be translated: Android Wear</note>
       </trans-unit>
       <trans-unit id="XA1016">
         <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
-        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <target state="translated">目標 Wear 應用程式的專案 '{0}' 未指定必要的 'AndroidManifest' 專案屬性。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.
 {0} - The project file name</note>
       </trans-unit>
       <trans-unit id="XA1017">
         <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
-        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <target state="translated">目標 Wear 應用程式的 AndroidManifest.xml 未指定必要的 'package' 屬性。</target>
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -286,7 +286,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
+        <target state="translated">在下列組件中偵測到使用 AppDomain.CreateDomain(): {0}。.NET 5 只支援單一 AppDomain，因此在 .NET 5 發行之後，此 API 就無法再於 Xamarin.Android 中使用。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>
@@ -297,7 +297,7 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2002_Framework">
         <source>Can not resolve reference: `{0}`, referenced by {1}. Perhaps it doesn't exist in the Mono for Android profile?</source>
-        <target state="translated">無法解析參考: `{0}`，參考方為 {1}。或許該參考不存在於 Android 的 Mono 設定檔中?</target>
+        <target state="translated">無法解析參考: '{0}'，參考者: {1}。Mono for Android 設定檔中沒有該項參考嗎?</target>
         <note>{0} - The name of the missing assembly
 {1} - The chain of references that causes a reference to the missing assembly, with &gt; as the separator between items. Example: `System.Memory` &gt; `System.Buffers`</note>
       </trans-unit>
@@ -317,12 +317,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA2007">
         <source>Exception while loading assemblies: {0}</source>
-        <target state="new">Exception while loading assemblies: {0}</target>
+        <target state="translated">載入組件時發生例外狀況: {0}</target>
         <note>{0} - The exception message of the associated exception</note>
       </trans-unit>
       <trans-unit id="XA2008">
         <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
-        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <target state="translated">在參考的組件 {0} 中，Java.Interop.DoNotPackageAttribute 需要非 Null 的檔案名稱。</target>
         <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
 {0} - The assembly name</note>
       </trans-unit>
@@ -433,14 +433,14 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
       </trans-unit>
       <trans-unit id="XA4219">
         <source>Cannot find binding generator for language {0} or {1}.</source>
-        <target state="new">Cannot find binding generator for language {0} or {1}.</target>
+        <target state="translated">找不到語言 {0} 或 {1} 的繫結產生器。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 {0} - The target programming language name, which is usually C#
 {1} - The default programming language name, which is also usually C#</note>
       </trans-unit>
       <trans-unit id="XA4220">
         <source>Partial class item '{0}' does not have an associated binding for layout '{1}'.</source>
-        <target state="new">Partial class item '{0}' does not have an associated binding for layout '{1}'.</target>
+        <target state="translated">有部分類別項目 '{0}' 沒有版面配置 '{1}' 相關聯的繫結。</target>
         <note>In this message, the term "partial class item" means a .NET partial class.
 In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
@@ -449,31 +449,31 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4221">
         <source>No layout binding source files were generated.</source>
-        <target state="new">No layout binding source files were generated.</target>
+        <target state="translated">未產生任何版面配置繫結原始程式檔。</target>
         <note>In this message, the term "binding" means a piece of code that makes it easy to access a certain kind of data that is originally stored outside of the target programming language, which is usually C#.
 In this mesage, the term "layout" means an Android UI layout.
 In this message, the term "source files" means files that can be compiled, usually containing C# source code.</note>
       </trans-unit>
       <trans-unit id="XA4222">
         <source>No widgets found for layout ({0}).</source>
-        <target state="new">No widgets found for layout ({0}).</target>
+        <target state="translated">找不到版面配置 ({0}) 的小工具。</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - Semicolon-separated list of paths for the files that define the layout</note>
       </trans-unit>
       <trans-unit id="XA4223">
         <source>Malformed full class name '{0}'. Missing namespace.</source>
-        <target state="new">Malformed full class name '{0}'. Missing namespace.</target>
+        <target state="translated">完整類別名稱 '{0}' 的格式不正確。缺少命名空間。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4224">
         <source>Malformed full class name '{0}'. Missing class name.</source>
-        <target state="new">Malformed full class name '{0}'. Missing class name.</target>
+        <target state="translated">完整類別名稱 '{0}' 的格式不正確。缺少類別名稱。</target>
         <note>{0} - The class name</note>
       </trans-unit>
       <trans-unit id="XA4225">
         <source>Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</source>
-        <target state="new">Widget '{0}' in layout '{1}' has multiple instances with different types. The property type will be set to: {2}</target>
+        <target state="translated">版面配置 '{1}' 的小工具 '{0}' 具有多個不同類型的執行個體。此屬性類型將會設定為 {2}</target>
         <note>In this message, the term "widgets" means Android UI elements.
 In this mesage, the term "layout" means an Android UI layout.
 {0} - The name of the widget
@@ -482,7 +482,7 @@ In this mesage, the term "layout" means an Android UI layout.
       </trans-unit>
       <trans-unit id="XA4226">
         <source>Resource item '{0}' does not have the required metadata item '{1}'.</source>
-        <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
+        <target state="translated">資源項目 '{0}' 不具所需的中繼資料項目 '{1}'。</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
       </trans-unit>
@@ -570,7 +570,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
-        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <target state="translated">因為尚未建立 Wear 應用程式套件 APK，所以該應用程式不會包含配對的 Wear 套件。如果從命令列進行建置，請務必建置 "SignAndroidPackage" 目標。</target>
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
@@ -632,7 +632,7 @@ In this message, the term "bundled" is a short way of saying "included into the 
       </trans-unit>
       <trans-unit id="XA5205_Lint">
         <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
-        <target state="translated">在 Android SDK 中找不到 `{0}`。請透過 /p:LintToolPath 設定其路徑。</target>
+        <target state="translated">在 Android SDK 中找不到 '{0}'。請透過 /p:LintToolPath 設定其路徑。</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
       </trans-unit>
@@ -681,12 +681,12 @@ In this message, the term "handheld app" means "app for handheld devices."
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
         <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">找不到 Android SDK 目錄。請透過 /p:AndroidSdkDirectory 來設定。</target>
+        <target state="translated">找不到 Android SDK 目錄。請透過 /p:AndroidSdkDirectory 進行設定。</target>
         <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
         <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">找不到 Java SDK 目錄。請透過 /p:JavaSdkDirectory 來設定。</target>
+        <target state="translated">找不到 Java SDK 目錄。請透過 /p:JavaSdkDirectory 進行設定。</target>
         <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -254,6 +254,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1014">
+        <source>JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</source>
+        <target state="new">JAR library references with identical file names but different contents were found: {0}. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.</target>
+        <note>The following are literal names and should not be translated: JAR, EmbeddedJar, InputJar and AndroidJavaLibrary
+{0} - Comma-separated list of the conflicting JAR library file names</note>
+      </trans-unit>
       <trans-unit id="XA1015">
         <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
         <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -303,6 +303,17 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 {1} - The assembly name
 {2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
+      <trans-unit id="XA2007">
+        <source>Exception while loading assemblies: {0}</source>
+        <target state="new">Exception while loading assemblies: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA2008">
+        <source>In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</source>
+        <target state="new">In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.</target>
+        <note>The following are literal names and should not be translated: Java.Interop.DoNotPackageAttribute
+{0} - The assembly name</note>
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="translated">無法對組件進行 AOT 編譯: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -254,6 +254,24 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>{0} - The Android resource XML element name
 {1} - The path of the layout file</note>
       </trans-unit>
+      <trans-unit id="XA1015">
+        <source>More than one Android Wear project is specified as the paired project. It can be at most one.</source>
+        <target state="new">More than one Android Wear project is specified as the paired project. It can be at most one.</target>
+        <note>The following are literal names and should not be translated: Android Wear</note>
+      </trans-unit>
+      <trans-unit id="XA1016">
+        <source>Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</source>
+        <target state="new">Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.
+{0} - The project file name</note>
+      </trans-unit>
+      <trans-unit id="XA1017">
+        <source>Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</source>
+        <target state="new">Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.</target>
+        <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -520,6 +538,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
         <target state="translated">找不到 `$(AndroidSigningKeyStore)` 檔案 `{0}`。</target>
         <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+      </trans-unit>
+      <trans-unit id="XA4311">
+        <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>
+        <target state="new">The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</target>
+        <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
+"Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -278,6 +278,12 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <note>The following are literal names and should not be translated: Wear, AndroidManifest.xml, 'package'
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1018">
+        <source>Specified AndroidManifest file does not exist: {0}.</source>
+        <target state="new">Specified AndroidManifest file does not exist: {0}.</target>
+        <note>The following are literal names and should not be translated: AndroidManifest
+{0} - The path of the specified AndroidManifest file</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="new">Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</target>
@@ -479,6 +485,12 @@ In this mesage, the term "layout" means an Android UI layout.
         <target state="new">Resource item '{0}' does not have the required metadata item '{1}'.</target>
         <note>{0} - The name of the Android layout resource file
 {1} - The name of the metadata item</note>
+      </trans-unit>
+      <trans-unit id="XA4228">
+        <source>Unable to find specified //activity-alias/@android:targetActivity: '{0}'</source>
+        <target state="new">Unable to find specified //activity-alias/@android:targetActivity: '{0}'</target>
+        <note>The following are literal names and should not be translated: //activity-alias/@android:targetActivity
+{0} - The specified targetActivity name</note>
       </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Android.Tasks
 			var jars = MonoAndroidHelper.DistinctFilesByContent (jarFilePaths).ToArray ();
 			var dups = MonoAndroidHelper.GetDuplicateFileNames (jars, new string [] {"classes.jar"});
 			if (dups.Any ()) {
-				Log.LogError ("You have Jar libraries, {0}, that have the identical name with inconsistent file contents. Please make sure to remove any conflicting libraries in EmbeddedJar, InputJar and AndroidJavaLibrary.", String.Join (", ", dups.ToArray ()));
+				Log.LogCodedError ("XA1014", Properties.Resources.XA1014, String.Join (", ", dups.ToArray ()));
 				return false;
 			}
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			// Look for targetSdkVersion in the user's AndroidManifest.xml
 			if (!string.IsNullOrWhiteSpace (AndroidManifest)) {
 				if (!File.Exists (AndroidManifest)) {
-					Log.LogError ("Specified AndroidManifest.xml file does not exist: {0}.", AndroidManifest);
+					Log.LogCodedError ("XA1018", Properties.Resources.XA1018, AndroidManifest);
 					return false;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
@@ -25,13 +25,13 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			if (ProjectFiles.Length != 1)
-				Log.LogError ("More than one Android Wear project is specified as the paired project. It can be at most one.");
+				Log.LogCodedError ("XA1015", Properties.Resources.XA1015);
 			
 			var wearProj = ProjectFiles.First ();
 			var manifestXml = XDocument.Load (wearProj.ItemSpec)
 				.Root.Elements (msbuildNS + "PropertyGroup").Elements (msbuildNS + "AndroidManifest").Select (e => e.Value).FirstOrDefault ();
 			if (string.IsNullOrEmpty (manifestXml))
-				Log.LogError ("Target Wear application's project '{0}' does not specify required 'AndroidManifest' project property.", wearProj);
+				Log.LogCodedError ("XA1016", Properties.Resources.XA1016, wearProj);
 			manifestXml = Path.Combine (Path.GetDirectoryName (wearProj.ItemSpec), manifestXml.Replace ('\\', Path.DirectorySeparatorChar));
 
 			ApplicationManifestFile = manifestXml;
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Tasks
 
 			ApplicationPackageName = AndroidAppManifest.CanonicalizePackageName (XDocument.Load (manifestXml).Root.Attributes ("package").Select (a => a.Value).FirstOrDefault ());
 			if (string.IsNullOrEmpty (ApplicationPackageName))
-				Log.LogError ("Target Wear application's AndroidManifest.xml does not specify required 'package' attribute.");
+				Log.LogCodedError ("XA1017", Properties.Resources.XA1017);
 			
 			Log.LogDebugMessage ("  [Output] ApplicationPackageName: " + ApplicationPackageName);
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Tasks
 				Log.LogCodedError ("XA5211", Properties.Resources.XA5211, wearPackageName, PackageName);
 
 			if (!File.Exists (WearApplicationApkPath)) {
-				Log.LogWarning ("This application won't contain the paired Wear package because the Wear application package .apk is not created yet. If you are using MSBuild or XBuild, you have to invoke \"SignAndroidPackage\" target.");
+				Log.LogCodedWarning ("XA4311", Properties.Resources.XA4311);
 				return true;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -100,14 +100,14 @@ namespace Xamarin.Android.Tasks
 					assemblies [assemblyName] = taskItem;
 				}
 			} catch (Exception ex) {
-				LogError ("Exception while loading assemblies: {0}", ex);
+				LogCodedError ("XA2007", Properties.Resources.XA2007, ex);
 				return;
 			}
 			try {
 				foreach (var assembly in topAssemblyReferences)
 					AddAssemblyReferences (resolver, assemblies, assembly, null);
 			} catch (Exception ex) {
-				LogError ("Exception while loading assemblies: {0}", ex);
+				LogCodedError ("XA2007", Properties.Resources.XA2007, ex);
 				return;
 			}
 
@@ -293,7 +293,7 @@ namespace Xamarin.Android.Tasks
 							if (arguments.FixedArguments.Length > 0) {
 								string file = arguments.FixedArguments [0].Value?.ToString ();
 								if (string.IsNullOrWhiteSpace (file))
-									LogError ("In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.", assembly.GetAssemblyName ().FullName);
+									LogCodedError ("XA2008", Properties.Resources.XA2008, assembly.GetAssemblyName ().FullName);
 								do_not_package_atts.Add (Path.GetFileName (file));
 							}
 						}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4180,6 +4180,22 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void XA1018 ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidManifest", "DoesNotExist");
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				string error = builder.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA1018:"));
+				Assert.IsNotNull (error, "Build should have failed with XA1018.");
+				StringAssert.Contains ("DoesNotExist", error, "Error should include the name of the nonexistent file");
+			}
+		}
+
+		[Test]
 		public void XA4310 ([Values ("apk", "aab")] string packageFormat)
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckDuplicateJavaLibrariesTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	[Category ("Node-2")]
+	[Parallelizable (ParallelScope.Self)]
+	public class CheckDuplicateJavaLibrariesTests : BaseTest {
+		List<BuildErrorEventArgs> errors;
+		List<BuildWarningEventArgs> warnings;
+		List<BuildMessageEventArgs> messages;
+		MockBuildEngine engine;
+		string path;
+
+		[SetUp]
+		public void Setup ()
+		{
+			engine = new MockBuildEngine (TestContext.Out,
+				errors: errors = new List<BuildErrorEventArgs> (),
+				warnings: warnings = new List<BuildWarningEventArgs> (),
+				messages: messages = new List<BuildMessageEventArgs> ());
+
+			path = Path.Combine (Root, "temp", TestName);
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = path;
+		}
+
+		[Test]
+		public void XA1014ConflictingJarNames ()
+		{
+			Directory.CreateDirectory (path);
+			string jar1 = Path.Combine (path, "library.jar");
+			File.WriteAllText (jar1, "jar1");
+
+			Directory.CreateDirectory (Path.Combine (path, "jar2"));
+			string jar2 = Path.Combine (path, "jar2", "library.jar");
+			File.WriteAllText (jar2, "jar2");
+
+			var task = new CheckDuplicateJavaLibraries {
+				BuildEngine = engine,
+				JavaSourceFiles = new ITaskItem [] { new TaskItem (jar1), new TaskItem (jar2) }
+			};
+
+			Assert.IsFalse (task.Execute (), "Task should fail!");
+			BuildErrorEventArgs error = errors [0];
+			Assert.AreEqual ("XA1014", error.Code);
+			StringAssert.Contains ("library.jar", error.Message);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Android.Tasks {
 					alias.Remove ();
 					activity.AddAfterSelf (alias);
 				} else {
-					log.LogWarning ("unable to find target activity for activity alias: " + attr.Value);
+					log.LogCodedWarning ("XA4228", Properties.Resources.XA4228, attr.Value);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -697,7 +697,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="$(ProjectDir)$(AndroidManifest)" Condition="'$(AndroidManifest)' != ''">
 		<Output TaskParameter="Value" PropertyName="_AndroidManifestAbs"/>
 	</CreateProperty>
-	<Error Text="AndroidManifest file does not exist" Condition="'$(_AndroidManifestAbs)'!='' And !Exists ('$(_AndroidManifestAbs)')"/>
+	<AndroidError Code="XA1018"
+		ResourceName="XA1018"
+		FormatArguments="$(_AndroidManifestAbs)"
+		Condition="'$(_AndroidManifestAbs)'!='' And !Exists ('$(_AndroidManifestAbs)')" />
 
 	<GetAndroidPackageName ManifestFile="$(_AndroidManifestAbs)" AssemblyName="$(AssemblyName)">
 		<Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />


### PR DESCRIPTION
Add all of the latest `.xlf` file changes from the 20200424 localization drop except for the changes related to XA0031 because those are for https://github.com/xamarin/xamarin-android/commit/231bf2a4381af4996c795e27fa65b15d63e3fc0b, which is only present on master.

Cherry-pick all of the corresponding `.resx` file changes from master.

This leaves two `.resx` file changes on master that are not yet cherry-picked because they do not yet have any corresponding translations in the `.xlf` files: 3fee2438 and ef12d24e.

