### PR TITLE
Try a build with no changes

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -20,15 +20,27 @@ steps:
 
 - script: |
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+  displayName: install test dependencies- Mono
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- script: |
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+  displayName: install test dependencies- Required
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- script: |
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
-  displayName: install test dependencies
+  displayName: install test dependencies- Android Toolchain
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: |
     $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI
+  displayName: install test dependencies- Required
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
+- script: |
     $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
-  displayName: install test dependencies
+  displayName: install test dependencies- Android Toolchain
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - task: UseDotNet@2


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4622

PR #4622 is consistently failing in the **APK Instrumentation** step
because `javac` wasn't found (?!).  Is this specific to PR #4622?
Or is d16-6 just "broken in general"?