### PR TITLE
[xaprepare] Install essential utilities in the `Required` scenario

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
+++ b/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Prepare
 
 		public void Init (Context context)
 		{
-			bool require = context.CheckCondition (KnownConditions.AllowProgramInstallation);
+			bool require = !context.CheckCondition (KnownConditions.EnsureEssential) && context.CheckCondition (KnownConditions.AllowProgramInstallation);
 
 			Log.StatusLine ();
 			Log.StatusLine ("Locating essential tool binaries", ConsoleColor.DarkGreen);

--- a/build-tools/xaprepare/xaprepare/Application/KnownConditions.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownConditions.cs
@@ -24,5 +24,11 @@ namespace Xamarin.Android.Prepare
 		///   the top of the repository. Default: unset
 		/// </summary>
 		IncludeCommercial,
+
+		/// <summary>
+		///   If this condition is set, the current scenario will take care of missing essential (<see
+		///   cref="EssentialTools"/>) programs should they be missing.
+		/// </summary>
+		EnsureEssential,
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Android.Prepare
 			if (context == null)
 				throw new ArgumentNullException (nameof (context));
 
+			// Install essential tools, should they be missing
+			context.SetCondition (KnownConditions.EnsureEssential, true);
+
 			Steps.Add (new Step_GenerateFiles (atBuildStart: true, onlyRequired: true));
 			Steps.Add (new Step_PrepareExternalJavaInterop ());
 		}


### PR DESCRIPTION
Context: a5748347da50ea002ea7288821c8813fb82be4fa

a5748347 made `xaprepare` ignore "essential" tools if they are missing
from the system, so that certain scenarios (currently `UpdateMono`) can
complete their task even without the essentials being
installed (provided the scenario doesn't actually need the tool, of
course).  However, what was missing is the part to actually install the
tools, since they're not going to magically appear on the host we're
currently running on.  This, however, requires a task that can both
ignore missing essential tools *and* install them (the idea behind
essential tools is that the scenarios may blindly assume the tools
exist, thus making the code simpler).  One such task is the `Required`
scenario which ensures that all necessary bits are there.  However, even
with a5748347 the scenario would fail as it would expect the essentials
to be there:

    Required program '7za' could not be found
    System.InvalidOperationException: Required program '7za' could not be found
      at Xamarin.Android.Prepare.OS.Which (System.String programPath, System.Boolean required)
      at Xamarin.Android.Prepare.EssentialTools.Init (Xamarin.Android.Prepare.Context context)
      at Xamarin.Android.Prepare.Context+<Init>d__201.MoveNext ()
    --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task)
      at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult ()
      at Xamarin.Android.Prepare.App+<Run>d__3.MoveNext ()

This commit fixes the problem by making the `Required` scenario capable
of installing the essentials that are missing (applies to `7zip` and
`git` as other programs like `pkgutil` and `brew` are real prerequisites
which must exist before `xaprepare` runs)