### PR TITLE
Remove the LaunchProfiles capability for the CPS integration

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -27,6 +27,10 @@
     <ProjectCapability Include="Mobile" />
     <ProjectCapability Include="Android" />
     <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
+    
+    // See https://work.azdo.io/1112733
+    <!-- Conflicts with our targets generator in VS+CPS -->
+    <ProjectCapability Remove="LaunchProfiles" />
   </ItemGroup>
 
   <!-- NOTE: We have to replace the Run target after Microsoft.NET.Sdk.targets are imported -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -28,8 +28,7 @@
     <ProjectCapability Include="Android" />
     <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
     
-    // See https://work.azdo.io/1112733
-    <!-- Conflicts with our targets generator in VS+CPS -->
+    <!-- Conflicts with our targets generator in VS+CPS: See https://work.azdo.io/1112733 -->
     <ProjectCapability Remove="LaunchProfiles" />
   </ItemGroup>
 


### PR DESCRIPTION
Implements https://work.azdo.io/1112733 as a workaround for the conflicts between 
the built-in launchsettings.json-based .NET Core debugger and our Mono debugger.