### PR TITLE
[CI] Avoid use of `script: |` blocks

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -32,12 +32,12 @@ jobs:
     inputs:
       versionSpec: 5.x
 
-  - script: |
-      sudo apt-get install -y gnupg ca-certificates
-      sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-      echo "deb https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list
-      sudo apt-get update
-      sudo apt-get install -y mono-devel
+  - script: >
+      sudo apt-get install -y gnupg ca-certificates &&
+      sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
+      (echo "deb https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list) &&
+      sudo apt-get update &&
+      sudo apt-get install -y mono-devel &&
       sudo apt-get install -y ca-certificates-mono
     displayName: install mono preview
 
@@ -47,11 +47,11 @@ jobs:
   - script: make package-deb V=1 CONFIGURATION=$(OSSBuildConfiguration)
     displayName: make package-deb
 
-  - script: |
-      mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
-      cp $(System.DefaultWorkingDirectory)/*xamarin.android*.tar.bz2 $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
-      cp $(System.DefaultWorkingDirectory)/*.changes $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
-      cp $(System.DefaultWorkingDirectory)/*.dsc $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
+  - script: >
+      mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
+      cp $(System.DefaultWorkingDirectory)/*xamarin.android*.tar.bz2 $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
+      cp $(System.DefaultWorkingDirectory)/*.changes $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
+      cp $(System.DefaultWorkingDirectory)/*.dsc $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
       cp $(System.DefaultWorkingDirectory)/*.deb $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
     displayName: copy linux artifacts
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -141,8 +141,8 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make all-tests
 
-    - script: |
-        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests
+    - script: >
+        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
         cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy bcl-tests assemblies
@@ -166,15 +166,15 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make create-installers
 
-    - script: |
-        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+    - script: >
+        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
         cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy unsigned installers
 
-    - script: |
-        VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
+    - script: >
+        VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct` &&
         echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: create updateinfo file
@@ -402,10 +402,10 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
-    - script: |
-        cd $(System.DefaultWorkingDirectory)/release-scripts
-        git checkout $(ReleaseScriptsBranch)
-        sudo xcode-select -s /Applications/$(NotarizationXcode)
+    - script: >
+        cd $(System.DefaultWorkingDirectory)/release-scripts &&
+        git checkout $(ReleaseScriptsBranch) &&
+        sudo xcode-select -s /Applications/$(NotarizationXcode) &&
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG
 

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -24,10 +24,10 @@ steps:
   condition: ${{ parameters.condition }}
   continueOnError: true
 
-- script: |
-    SOURCE=$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/${{ parameters.artifactName }}
-    DEST=$(Build.ArtifactStagingDirectory)/${{ parameters.artifactFolder }}/
-    mkdir -p "$DEST"
+- script: >
+    SOURCE="$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/${{ parameters.artifactName }}" &&
+    DEST="$(Build.ArtifactStagingDirectory)/${{ parameters.artifactFolder }}/" &&
+    mkdir -p "$DEST" &&
     cp "$SOURCE" "$DEST"
   displayName: copy apk/aab
   condition: ${{ parameters.condition }}

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -39,15 +39,15 @@ steps:
     configuration: ${{ parameters.configuration }}
     msbuildArguments: /restore
 
-- script: |
-    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
-    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+- script: >
+    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
+    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
-- script: |
-    $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI
+- script: >
+    $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI &&
     $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))


### PR DESCRIPTION
Context: https://github.com/MicrosoftDocs/azure-devops-docs/issues/3265
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3679916&view=logs&j=8556562a-ae5f-5bd1-7c4d-bf1af4b6f1e1&t=5076e147-fc66-561e-6c69-3aa777afefc5

We sometimes observe experiencing "weird issue" on AzDO CI in which
the **Test** > **APK Instrumentation** step fails:

	…/external/Java.Interop/src/Java.Interop/Java.Interop.targets(37,5): error MSB3073: The command """ -source 1.6 -target 1.6 -bootclasspath "" -d "obj/Release/ji-classes" java/com/xamarin/java_interop/internal/JavaProxyObject.java java/com/xamarin/java_interop/internal/JavaProxyThrowable.java java/com/xamarin/java_interop/GCUserPeerable.java java/com/xamarin/java_interop/ManagedPeer.java" exited with code 127.

The cause of the issue is that `make -C external/Java.Interop prepare`
is never executed, which is *bizarre*, because `xaprepare -s=Required`
is responsible for calling it; see 130905e16.

Checking the build logs, and we see that the
**install test dependencies** job *appears* to run it:

	##[debug]script=mono build-tools/xaprepare/xaprepare/bin/Release/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
	mono build-tools/xaprepare/xaprepare/bin/Release/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
	mono build-tools/xaprepare/xaprepare/bin/Release/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI

…but it doesn't actually *successfully* run *all* those commands!
Instead, only `xaprepare -s=AndroidToolchain` finishes:

	% grep 'Running scenario' prepare-*
	prepare-20200427T203230.log:[00:00:21.6506301] Running scenario: Install Android SDK, NDK and Corretto JDK.

Compare to:

	% grep 'Initializing scenario' prepare-*
	prepare-20200427T203008.log:[00:00:00.2793986] Initializing scenario UpdateMono
	prepare-20200427T203116.log:[00:00:00.4118305] Initializing scenario Required
	prepare-20200427T203230.log:[00:00:00.2998047] Initializing scenario AndroidToolchain

It appears that at present Azure DevOps `script` blocks don't run via
[`bash -e`][0] -- which would cause a failure if any command exits
with a failre -- which means that the errors emitted from
`xaprepare -s=UpdateMono` and `xaprepare -s=Required` are *ignored*.

***We do not want to ignore errors.***

As such, @jonpryor now regards *all* `script: |` YAML as potentially
wrong or buggy.

Replace all `script: |` blocks with `script: >` blocks.  `script: >`
blocks replace newlines with a space, turning the block into a
*single command*.  This in turn requires inserting `&&` between
intermediate commands, so that subsequent commands only execute if the
previous commands exited successfully.

Thus, turn this:

	- script: |
	  command1
	  command2

into:

	- script: >
	  command1 &&
	  command2

*Hopefully*, the DevOps `script` handler doesn't ignore *all* errors,
and the above transformation means that the `script` block itself will
exit with a failure if any command within the pipeline fails.

[0]: https://stackoverflow.com/a/9952249