### PR TITLE
[.NET 5] Update NuGet package version scheme

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -12,7 +12,6 @@
       Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
-    <ProductVersion>10.4.99</ProductVersion>
     <!-- TFV for all projects, try v4.7.2 but fallback if needed -->
     <_StandardLibraryPath Condition=" '$(TargetFrameworkVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductVersion>10.4.99</ProductVersion>
+    <ProductVersion>10.4.100</ProductVersion>
     <!-- NuGet package version numbers. See Documentation/guides/DotNet5.md.
          Rules:
          * Reset patch version (third number) to 100 every time either major or minor version is bumped.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,4 +12,15 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ProductVersion>10.4.99</ProductVersion>
+    <!-- NuGet package version numbers. See Documentation/guides/DotNet5.md.
+         Rules:
+         * Reset patch version (third number) to 100 every time either major or minor version is bumped.
+         * Bump last two digits of the patch version for service releases.
+         * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
+    -->
+    <AndroidPackVersion>10.0.100</AndroidPackVersion>
+  </PropertyGroup>
+
 </Project>

--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -145,11 +145,11 @@ This is the package version scheme: `OS-Major.OS-Minor.InternalRelease[-prerelea
     * If we have a particular feature we want people to subscribe to (such as
       an Android preview release), we publish previews with a custom pre-release
       identifier:
-        * Example: `10.1.100-android_r.beta.1`
+        * Example: `10.1.100-android-r.beta.1`
         * This way people can sign up for only official previews, by
-          referencing `*-android_r.beta.*`
-        * It's still possible to sign up for all `android_r` builds, by
-          referencing `*-ci.android_r.*`
+          referencing `*-android-r.beta.*`
+        * It's still possible to sign up for all `android-r` builds, by
+          referencing `*-ci.android-r.*`
 * Build metadata: Required Hash
     * This is `sha.` + the short commit hash.
         * Use the short hash because the long hash is quite long and
@@ -162,8 +162,8 @@ This is the package version scheme: `OS-Major.OS-Minor.InternalRelease[-prerelea
       version string refers to a stable version or not.
         * Example: `10.0.100`: incomplete version
         * Example: `10.0.100+sha.1a2b3c`: stable
-        * Example: `10.0.100-ci.d17_0.1234+sha.1a2b3c`: CI build
-        * Example: `10.0.100-android_r.beta.1+sha.1a2b3c`: official
+        * Example: `10.0.100-ci.d17-0.1234+sha.1a2b3c`: CI build
+        * Example: `10.0.100-android-r.beta.1+sha.1a2b3c`: official
           preview
             * Technically it's possible to remove the prerelease part, but
               we’d still be able to figure out it’s not a stable version by

--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -106,7 +106,7 @@ The following instructions can be used for early preview testing.
     packages you want to use:
 
 ```xml
-<Project Sdk="Microsoft.Android.Sdk/10.4.99.24">
+<Project Sdk="Microsoft.Android.Sdk/10.0.100">
   <PropertyGroup>
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
@@ -120,4 +120,58 @@ The following instructions can be used for early preview testing.
 dotnet publish -t:Install *.csproj
 ```
 
-[0]:  https://github.com/dotnet/installer#installers-and-binaries
+## Package Versioning Scheme
+
+Our NuGet packages are versioned using [Semver 2.0.0][2].
+
+This is the scheme: `OS-Major.OS-Minor.InternalRelease[-prereleaseX]+sha.1b2c3d4`.
+
+* Major: The major OS version.
+* Minor: The minor OS version.
+* Patch: Our internal release version based on `100` as a starting point.
+    * Service releases will bump the last two digits of the patch version
+    * Feature releases will round the patch version up to the nearest 100
+      (this is the same as bumping the first digit of the patch version, and
+      resetting the last two digits to 0).
+    * This follows [how the dotnet SDK does it][1].
+* Pre-release: Optional (e.g.: Android previews, CI, etc.)
+    * For CI we use a `ci` prefix + the branch name (cleaned up to only be
+      alphanumeric) + the commit distance (number of commits since any of the
+      major.minor.patch versions changed).
+        * Example: `Android 10.0.100-ci.master.1234`
+        * Alphanumeric means `a-zA-Z0-9-`: any character not in this range
+          will be replaced with a `-`.
+    * Pull requests have `pr` prefix, followed by `gh`+ PR number + commit
+      distance.
+        * Example: `Android 10.1.200-ci.pr.gh3333.1234`
+    * If we have a particular feature we want people to subscribe to (such as
+      an Android preview release), we publish previews with a custom pre-release
+      identifier:
+        * Example: `Android 10.1.100-android_q.beta.1`
+        * This way people can sign up for only official previews, by
+          referencing `Android *-android_q.beta.*`
+        * It's still possible to sign up for all `android_q` builds, by
+          referencing `Android *-ci.android_q.*`
+* Build metadata: Required Hash
+    * This is `sha.` + the short commit hash.
+        * Use the short hash because the long hash is quite long and
+          cumbersome. This leaves the complete version open for duplication,
+          but this is extremely unlikely.
+    * Example: `Android 10.0.100+sha.1a2b3c`
+    * Example (CI build): `Android 10.0.100-ci.master.1234+sha.1a2b3c`
+    * Since the build metadata is required for all builds, we're able to
+      recognize incomplete version numbers and determine if a particular
+      version string refers to a stable version or not.
+        * Example: `Android 10.0.100`: incomplete version
+        * Example: `Android 10.0.100+sha.1a2b3c`: stable
+        * Example: `Android 10.0.100-ci.d17_0.1234+sha.1a2b3c`: CI build
+        * Example: `Android 10.0.100-android_q.beta.1+sha.1a2b3c`: official
+          preview
+            * Technically it's possible to remove the prerelease part, but
+              we’d still be able to figure out it’s not a stable version by
+              using the commit hash.
+
+
+[0]: https://github.com/dotnet/installer#installers-and-binaries
+[1]: https://github.com/dotnet/designs/blob/master/accepted/2018/sdk-version-scheme.md
+[2]: https://semver.org

--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -122,9 +122,7 @@ dotnet publish -t:Install *.csproj
 
 ## Package Versioning Scheme
 
-Our NuGet packages are versioned using [Semver 2.0.0][2].
-
-This is the scheme: `OS-Major.OS-Minor.InternalRelease[-prereleaseX]+sha.1b2c3d4`.
+This is the package version scheme: `OS-Major.OS-Minor.InternalRelease[-prereleaseX]+sha.1b2c3d4`.
 
 * Major: The major OS version.
 * Minor: The minor OS version.
@@ -138,34 +136,34 @@ This is the scheme: `OS-Major.OS-Minor.InternalRelease[-prereleaseX]+sha.1b2c3d4
     * For CI we use a `ci` prefix + the branch name (cleaned up to only be
       alphanumeric) + the commit distance (number of commits since any of the
       major.minor.patch versions changed).
-        * Example: `Android 10.0.100-ci.master.1234`
+        * Example: `10.0.100-ci.master.1234`
         * Alphanumeric means `a-zA-Z0-9-`: any character not in this range
           will be replaced with a `-`.
     * Pull requests have `pr` prefix, followed by `gh`+ PR number + commit
       distance.
-        * Example: `Android 10.1.200-ci.pr.gh3333.1234`
+        * Example: `10.1.200-ci.pr.gh3333.1234`
     * If we have a particular feature we want people to subscribe to (such as
       an Android preview release), we publish previews with a custom pre-release
       identifier:
-        * Example: `Android 10.1.100-android_q.beta.1`
+        * Example: `10.1.100-android_r.beta.1`
         * This way people can sign up for only official previews, by
-          referencing `Android *-android_q.beta.*`
-        * It's still possible to sign up for all `android_q` builds, by
-          referencing `Android *-ci.android_q.*`
+          referencing `*-android_r.beta.*`
+        * It's still possible to sign up for all `android_r` builds, by
+          referencing `*-ci.android_r.*`
 * Build metadata: Required Hash
     * This is `sha.` + the short commit hash.
         * Use the short hash because the long hash is quite long and
           cumbersome. This leaves the complete version open for duplication,
           but this is extremely unlikely.
-    * Example: `Android 10.0.100+sha.1a2b3c`
-    * Example (CI build): `Android 10.0.100-ci.master.1234+sha.1a2b3c`
+    * Example: `10.0.100+sha.1a2b3c`
+    * Example (CI build): `10.0.100-ci.master.1234+sha.1a2b3c`
     * Since the build metadata is required for all builds, we're able to
       recognize incomplete version numbers and determine if a particular
       version string refers to a stable version or not.
-        * Example: `Android 10.0.100`: incomplete version
-        * Example: `Android 10.0.100+sha.1a2b3c`: stable
-        * Example: `Android 10.0.100-ci.d17_0.1234+sha.1a2b3c`: CI build
-        * Example: `Android 10.0.100-android_q.beta.1+sha.1a2b3c`: official
+        * Example: `10.0.100`: incomplete version
+        * Example: `10.0.100+sha.1a2b3c`: stable
+        * Example: `10.0.100-ci.d17_0.1234+sha.1a2b3c`: CI build
+        * Example: `10.0.100-android_r.beta.1+sha.1a2b3c`: official
           preview
             * Technically it's possible to remove the prerelease part, but
               we’d still be able to figure out it’s not a stable version by
@@ -174,4 +172,3 @@ This is the scheme: `OS-Major.OS-Minor.InternalRelease[-prereleaseX]+sha.1b2c3d4
 
 [0]: https://github.com/dotnet/installer#installers-and-binaries
 [1]: https://github.com/dotnet/designs/blob/master/accepted/2018/sdk-version-scheme.md
-[2]: https://semver.org

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -199,7 +199,7 @@ stages:
         packagesToPush: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: xamarin-impl public feed
-      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
+      condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['PushXAPackages'], 'true')))
 
     - task: PublishPipelineArtifact@1
       displayName: upload nupkgs

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -44,7 +44,7 @@
   <Target Name="_GetDefaultPackageVersion"
       DependsOnTargets="GetXAVersionInfo" >
     <PropertyGroup>
-      <PackageVersion>$(ProductVersion).$(XAVersionCommitCount)</PackageVersion>
+      <PackageVersion>$(AndroidPackVersionLong)</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -44,7 +44,7 @@
   <Target Name="_GetDefaultPackageVersion"
       DependsOnTargets="GetXAVersionInfo" >
     <PropertyGroup>
-      <PackageVersion>$(AndroidPackVersionLong)</PackageVersion>
+      <PackageVersion>$(AndroidPackVersionLong)+sha.$(XAVersionHash)</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -35,7 +35,6 @@ the new entry point for short-form style Android projets in .NET 5.
   <Target Name="_GenerateXASdkContent"
       DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions" >
     <PropertyGroup>
-      <PackageVersion>$(_AndroidNETSdkVersion)</PackageVersion>
       <ToolsSourceDir>$(XamarinAndroidSourcePath)bin\Build$(Configuration)\packs\tools\</ToolsSourceDir>
     </PropertyGroup>
     <ItemGroup>
@@ -65,13 +64,9 @@ the new entry point for short-form style Android projets in .NET 5.
         SkipUnchangedFiles="True"
         Condition="$([MSBuild]::IsOSPlatform('osx'))"
     />
-    <Copy
-        SourceFiles="@(VersionFiles)"
-        DestinationFolder="$(ToolsSourceDir)"
-        SkipUnchangedFiles="True"
-    />
     <ItemGroup>
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />
+      <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\Version*" PackagePath="tools" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" PackagePath="Sdk" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\**"
           Exclude="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\**\*.Lite.*"
@@ -83,10 +78,8 @@ the new entry point for short-form style Android projets in .NET 5.
        https://github.com/dotnet/installer/blob/d98f5f18bce44014aeacd2f99923b4779d89459d/src/redist/targets/GenerateBundledVersions.targets
        -->
   <Target Name="_GenerateBundledVersions"
-      DependsOnTargets="GetXAVersionInfo" >
+      DependsOnTargets="_GetDefaultPackageVersion" >
     <PropertyGroup>
-      <_AndroidNETSdkVersion>$(ProductVersion).$(XAVersionCommitCount)</_AndroidNETSdkVersion>
-      <_AndroidNETAppPackageVersion>$(ProductVersion).$(XAVersionCommitCount)</_AndroidNETAppPackageVersion>
       <_AndroidNETAppTargetFramework>netcoreapp5.0</_AndroidNETAppTargetFramework>
       <BundledVersionsPropsFileName>Microsoft.Android.Sdk.BundledVersions.props</BundledVersionsPropsFileName>
     </PropertyGroup>
@@ -108,16 +101,16 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 -->
 <Project>
   <PropertyGroup>
-    <AndroidNETSdkVersion>$(_AndroidNETSdkVersion)</AndroidNETSdkVersion>
+    <AndroidNETSdkVersion>$(AndroidPackVersionLong)</AndroidNETSdkVersion>
   </PropertyGroup>
   <ItemGroup>
     <KnownFrameworkReference Include="Microsoft.Android"
                               TargetFramework="$(_AndroidNETAppTargetFramework)"
                               RuntimeFrameworkName="Microsoft.Android"
-                              DefaultRuntimeFrameworkVersion="$(_AndroidNETAppPackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(_AndroidNETAppPackageVersion)"
+                              DefaultRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
+                              LatestRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
                               TargetingPackName="Microsoft.Android.Ref"
-                              TargetingPackVersion="$(_AndroidNETAppPackageVersion)"
+                              TargetingPackVersion="$(AndroidPackVersionLong)"
                               RuntimePackNamePatterns="Microsoft.Android.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
                               Profile="Android"

--- a/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
+++ b/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
@@ -35,13 +35,4 @@ temporary MSBuild project SDK that redirects to a Xamarin.Android installation o
     </BeforePack>
   </PropertyGroup>
 
-  <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\XAVersionInfo.targets" />
-
-  <Target Name="_GetDefaultPackageVersion"
-      DependsOnTargets="GetXAVersionInfo" >
-    <PropertyGroup>
-      <PackageVersion>$(ProductVersion).$(XAVersionCommitCount)</PackageVersion>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -83,11 +83,10 @@
     </GitBranch>
     <PropertyGroup>
       <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">xamarin-android</XARepositoryName>
-      <_AndroidPackMetadata>sha.$(XAVersionHash)</_AndroidPackMetadata>
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(XAVersionBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)+$(_AndroidPackMetadata)</AndroidPackVersionLong>
+      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -85,7 +85,8 @@
       <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">xamarin-android</XARepositoryName>
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(XAVersionBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
+      <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
+      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
       <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
     </PropertyGroup>
   </Target>

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -40,7 +40,7 @@
   <Target Name="GetXAVersionInfo"
       DependsOnTargets="_GetSubmodulesVersionInfo">
     <GitBlame
-        FileName="Configuration.props"
+        FileName="Directory.Build.props"
         LineFilter="&lt;ProductVersion&gt;"
         WorkingDirectory="$(XamarinAndroidSourcePath)"
         ToolPath="$(GitToolPath)"
@@ -53,6 +53,21 @@
         ToolPath="$(GitToolPath)"
         ToolExe="$(GitToolExe)">
       <Output TaskParameter="CommitCount"             PropertyName="XAVersionCommitCount"   Condition=" '$(XAVersionCommitCount)' == '' " />
+    </GitCommitsInRange>
+    <GitBlame
+        FileName="Directory.Build.props"
+        LineFilter="&lt;AndroidPackVersion&gt;"
+        WorkingDirectory="$(XamarinAndroidSourcePath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Commits"                 ItemName="_PackVersionCommit" />
+    </GitBlame>
+    <GitCommitsInRange
+        StartCommit="%(_PackVersionCommit.CommitHash)"
+        WorkingDirectory="$(XamarinAndroidSourcePath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="CommitCount"             PropertyName="PackVersionCommitCount"   Condition=" '$(PackVersionCommitCount)' == '' " />
     </GitCommitsInRange>
     <GitCommitHash
         WorkingDirectory="$(XamarinAndroidSourcePath)"
@@ -68,6 +83,11 @@
     </GitBranch>
     <PropertyGroup>
       <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">xamarin-android</XARepositoryName>
+      <_AndroidPackMetadata>sha.$(XAVersionHash)</_AndroidPackMetadata>
+      <!-- See Azure Pipelines predefined variables. -->
+      <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
+      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(XAVersionBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
+      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)+$(_AndroidPackMetadata)</AndroidPackVersionLong>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -6,6 +6,7 @@
       AfterTargets="Build">
     <PropertyGroup>
       <_XAPrefix>$(XAInstallPrefix)xbuild\Xamarin\Android</_XAPrefix>
+      <_PackVersionPathPrefix>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\</_PackVersionPathPrefix>
       <_VersionFile>..\..\bin\$(Configuration)\Version</_VersionFile>
       <_VersionCommitFile>..\..\bin\$(Configuration)\Version.commit</_VersionCommitFile>
       <_VersionRevFile>..\..\bin\$(Configuration)\Version.rev</_VersionRevFile>
@@ -13,6 +14,9 @@
       <_XAVersionTxtFile>$(_XAPrefix)\Version.txt</_XAVersionTxtFile>
       <_XAVersionCommitFile>$(_XAPrefix)\Version.commit</_XAVersionCommitFile>
       <_XAVersionRevFile>$(_XAPrefix)\Version.rev</_XAVersionRevFile>
+      <_PackVersionTxtFile>$(_PackVersionPathPrefix)Version.txt</_PackVersionTxtFile>
+      <_PackVersionCommitFile>$(_PackVersionPathPrefix)Version.commit</_PackVersionCommitFile>
+      <_PackVersionRevFile>$(_PackVersionPathPrefix)Version.rev</_PackVersionRevFile>
     </PropertyGroup>
     <MakeDir Directories="$(_XAPrefix)" />
     <WriteLinesToFile
@@ -31,12 +35,22 @@
         Overwrite="True"
     />
     <WriteLinesToFile
+        File="$(_PackVersionTxtFile)"
+        Lines="$(AndroidPackVersion)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
         File="$(_VersionCommitFile)"
         Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
         Overwrite="True"
     />
     <WriteLinesToFile
         File="$(_XAVersionCommitFile)"
+        Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
+        File="$(_PackVersionCommitFile)"
         Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
         Overwrite="True"
     />
@@ -48,6 +62,11 @@
     <WriteLinesToFile
         File="$(_XAVersionRevFile)"
         Lines="$(XAVersionCommitCount)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
+        File="$(_PackVersionRevFile)"
+        Lines="$(PackVersionCommitCount)"
         Overwrite="True"
     />
   </Target>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -39,10 +39,18 @@
       Condition="!Exists ('$(IntermediateOutputPath)AssemblyInfo.cs')"
       Inputs="Properties\AssemblyInfo.cs.in"
       Outputs="$(IntermediateOutputPath)AssemblyInfo.cs">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
+      <_PackageVersion>$(ProductVersion)</_PackageVersion>
+      <_PackageVersionBuild>$(XAVersionCommitCount)</_PackageVersionBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+      <_PackageVersion>$(AndroidPackVersion)</_PackageVersion>
+      <_PackageVersionBuild>$(PackVersionCommitCount)</_PackageVersionBuild>
+    </PropertyGroup>
     <ReplaceFileContents
         SourceFile="Properties\AssemblyInfo.cs.in"
         DestinationFile="$(IntermediateOutputPath)AssemblyInfo.cs"
-        Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch)">
+        Replacements="@PACKAGE_VERSION@=$(_PackageVersion);@PACKAGE_VERSION_BUILD@=$(_PackageVersionBuild);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch)">
     </ReplaceFileContents>
   </Target>
   <Target Name="_BuildJNIEnv"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Directory.Build.targets
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Directory.Build.targets
@@ -17,7 +17,7 @@
       <Compile Remove="$(GeneratedSdkVersionFile)" />
       <_SdkVersionInfo Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>SdkVersion</_Parameter1>
-        <_Parameter2>$(ProductVersion).$(XAVersionCommitCount)</_Parameter2>
+        <_Parameter2>$(AndroidPackVersionLong)</_Parameter2>
       </_SdkVersionInfo>
     </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<XamarinAndroidVersion>@PACKAGE_VERSION@-@PACKAGE_VERSION_BUILD@</XamarinAndroidVersion>
+		<XamarinAndroidVersion Condition=" '$(UsingAndroidNETSdk)' != 'true' ">@PACKAGE_VERSION@-@PACKAGE_VERSION_BUILD@</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<Debugger Condition=" '$(Debugger)' == '' ">Xamarin</Debugger>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -961,7 +961,8 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidNdkPath=$(_AndroidNdkDirectory)" />
 		<_PropertyCacheItems Include="JavaSdkPath=$(_JavaSdkDirectory)" />
 		<_PropertyCacheItems Include="AndroidSequencePointsMode=$(_AndroidSequencePointsMode)" />
-		<_PropertyCacheItems Include="XamarinAndroidVersion=$(XamarinAndroidVersion)" />
+		<_PropertyCacheItems Include="XamarinAndroidVersion=$(XamarinAndroidVersion)" Condition=" '$(UsingAndroidNETSdk)' != 'true' " />
+		<_PropertyCacheItems Include="AndroidNETSdkVersion=$(AndroidNETSdkVersion)"   Condition=" '$(UsingAndroidNETSdk)' == 'true' " />
 		<_PropertyCacheItems Include="MonoSymbolArchive=$(MonoSymbolArchive)" />
 		<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
 		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />


### PR DESCRIPTION
Updates the version for all .nupkg files we are generating for .NET 5 to
follow the dotnet [SDK versioning scheme][0].  For more information, see
Documentation/guides/DotNet5.md.

Versioning for release candidates has not yet been automated.  This
commit only introduces the following two package version types:

    * 10.0.100-ci.branchname.commitdistance+sha.1b2c3d4e
    * 10.0.100-ci.pr.gh1234.commitdistance+sha.1b2c3d4f

Version file generation has been updated to generate new files for our
nupkgs.  Mono.Android assembly info generation has also been updated to
include different version information depending on $(TargetFramework).

[0]: https://github.com/dotnet/designs/blob/master/accepted/2018/sdk-version-scheme.md