### PR TITLE
[Microsoft.Android.Sdk] change dotnet publish/build behavior

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -22,6 +22,10 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CheckForContent;
       _ValidateAndroidPackageProperties;
       $(BuildDependsOn);
+      _CompileDex;
+      $(_AfterCompileDex);
+      _CopyPackage;
+      _Sign;
     </BuildDependsOn>
   </PropertyGroup>
 
@@ -77,22 +81,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CleanMonoAndroidIntermediateDir;
       _CleanAndroidBuildPropertiesCache;
     </CleanDependsOn>
-  </PropertyGroup>
-
-  <!--
-    TODO: currently using a private property for hooking into `dotnet publish`
-
-    Revise after this lands: https://github.com/dotnet/sdk/pull/11073
-  -->
-
-  <PropertyGroup>
-    <_CorePublishTargets>
-      $(_CorePublishTargets);
-      _CompileDex;
-      $(_AfterCompileDex);
-      Package;
-      _Sign;
-    </_CorePublishTargets>
   </PropertyGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -30,6 +30,6 @@
   </ItemGroup>
 
   <!-- NOTE: We have to replace the Run target after Microsoft.NET.Sdk.targets are imported -->
-  <Target Name="Run" DependsOnTargets="Publish;Install;StartAndroidActivity" />
+  <Target Name="Run" DependsOnTargets="Install;StartAndroidActivity" />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -22,17 +22,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void DotNetBuild ([Values (false, true)] bool isRelease)
-		{
-			var proj = new XASdkProject (SdkVersion) {
-				IsRelease = isRelease
-			};
-			var dotnet = CreateDotNetBuilder (proj);
-			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
-		}
-
-		[Test]
-		[Category ("SmokeTests")]
 		public void DotNetBuildLibrary ([Values (false, true)] bool isRelease)
 		{
 			var proj = new XASdkProject (SdkVersion, outputType: "Library") {
@@ -54,7 +43,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		static readonly object [] DotNetPublishSource = new object [] {
+		static readonly object [] DotNetBuildSource = new object [] {
 			new object [] {
 				/* runtimeIdentifier */  "android.21-arm",
 				/* isRelease */          false,
@@ -79,8 +68,8 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		[TestCaseSource (nameof (DotNetPublishSource))]
-		public void DotNetPublish (string runtimeIdentifier, bool isRelease)
+		[TestCaseSource (nameof (DotNetBuildSource))]
+		public void DotNetBuild (string runtimeIdentifier, bool isRelease)
 		{
 			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (runtimeIdentifier);
 			//TODO: re-enable these when we have a public .NET 5 Preview 4 build
@@ -93,7 +82,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
 
 			var dotnet = CreateDotNetBuilder (proj);
-			Assert.IsTrue (dotnet.Publish (), "`dotnet publish` should succeed");
+			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
 
 			var apk = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -88,7 +88,7 @@ namespace Xamarin.ProjectTools
 		public bool Run ()
 		{
 			//TODO: this should eventually run `dotnet run --project foo.csproj`
-			var arguments = GetDefaultCommandLineArgs ("publish", "Run");
+			var arguments = GetDefaultCommandLineArgs ("build", "Run");
 			return Execute (arguments.ToArray ());
 		}
 


### PR DESCRIPTION
Currently, we are producing `.apk` files with .NET 5 with:

    dotnet publish foo.csproj

The problem with this is that `dotnet build` needs to produce
something that is "runnable". `dotnet build` is the developer loop,
while `dotnet publish` is something you run for a release.

Ideally, to produce an `.apk` you would instead do:

    dotnet build foo.csproj

`dotnet publish` would be used for distribution to Google Play. Our
first implementation would likely support re-signing the app and
copying the output to a local `publish` directory.

For now, I've removed our usage of `$(_CorePublishTargets)` and moved
these targets to `$(BuildDependsOn)`. The benefit here, is we are no
longer using any private MSBuild properties for .NET 5.

I updated our tests in these areas. I dropped the tests running
`dotnet publish`, as they are no longer valid.

Down the road:

* Make `dotnet publish` do *something*. Once we know what it should do.
* Implement `dotnet run`.