### PR TITLE
[tests] cleanup and fix failing MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
@@ -54,14 +54,6 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */  true,
 			},
 		};
-		// useJackAndJill, useLatestSdk
-		static object [] JackFlagAndFxVersion () => new object [] {
-			new Object [] { false, "v7.1" },
-			// Disabled because Jack DOESN'T work
-			// re-enable once it does.
-			//new Object [] { true, false },
-			//new Object [] { true, true },
-		};
 
 		static object [] RuntimeChecks () => new object [] {
 			new object[] {


### PR DESCRIPTION
Since a6489813, we have a few MSBuild tests failing related to
multi-dex.

`BuildApplicationRequiresMultiDex("d8")` - for now I've just ignored
this test when running with `AndroidDexTool=d8`. It appears when API
21 is the minimum, `d8` is able to setup multi-dex automatically and
the build won't fail. I will need to revisit this in the future to
decide what Xamarin.Android should do about multi-dex going forward.

`BuildHasNoWarnings(False,True,True,"apk")` - one case we were
asserting there was 1 warning. Now there are 0 warnings.

`BuildMultiDexApplication(False,"v7.1")` - this test needed to be
parameterized for `AndroidDexTool` of `dx` and `d8`. I also generally
cleaned it up, removing `useJackAndJill` and simplifying assertions.