### PR TITLE
[typemaps] Don't create `System.Type` instance for generic types

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -210,6 +210,14 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
 	const char *managed_type_name = entry->to;
 	log_debug (LOG_DEFAULT, "typemap: Java type '%s' corresponds to managed type '%s'", java_type_name, managed_type_name);
 
+	const char *ch = managed_type_name;
+	while (ch != nullptr && *ch != '\0') {
+		if (*ch++ == '`') {
+			log_debug (LOG_DEFAULT, "typemap: managed type '%s' is a generic one, will create Type instance in managed code", managed_type_name);
+			return nullptr;
+		}
+	}
+
 	MonoType *type = mono_reflection_type_from_name (const_cast<char*>(managed_type_name), nullptr);
 	if (XA_UNLIKELY (type == nullptr)) {
 		log_warn (LOG_ASSEMBLY, "typemap: managed type '%s' (mapped from Java type '%s') could not be loaded", managed_type_name, java_type_name);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4596
Context: 7117414ca27d88a71b4a272705a0207f772423bd

7117414c made string lookup return into our type map support, for Debug
builds only, and with them the old problem of duplicate type names
returned as well - it is possible that a single Java type name will map
to a number of managed types and vice versa.  This is not a problem in
most cases, but whenever a Java type name maps to a generic managed
type (for instance "Android.Runtime.JavaList`1, Mono.Android"), the
code added in 7117414c runs into trouble:

    System.MemberAccessException : Cannot create an instance of Android.Runtime.JavaList`1[T] because Type.ContainsGenericParameters is true.
       at System.Reflection.RuntimeConstructorInfo.DoInvoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
       at System.Reflection.RuntimeConstructorInfo.Invoke (System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
       at System.Reflection.ConstructorInfo.Invoke (System.Object[] parameters)
       at Java.Interop.TypeManager.CreateProxy (System.Type type, System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
       at Java.Interop.TypeManager.CreateInstance (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type targetType)
       at Java.Lang.Object.GetObject (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type type)
       at Java.Lang.Object._GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
       at Java.Lang.Object.GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
       at Android.OS.Bundle.Get (System.String key)
       at Xamarin.Android.RuntimeTests.BundleTest.TestBundleIntegerArrayList2 ()
       at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
       at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)

The reason this happens is due to the way the native code processes the
managed type name it obtained from the `Java -> managed` map.  Namely,
it uses Mono embedding API to return a `MonoType` instance corresponding
to the managed type name, then that `MonoType` instance is converted
into `MonoReflectionType*` which is returned to the managed code (it
corresponds to the `System.Type` instance there) and then an attempt to
instantiate this type is made in the usual way.  It works for
non-generic types, but whenever a generic type is processed in this way
it will result in us returning a `MonoReflectionType*` corresponding to
an **open** generic type which then results in the exception shown
above.

Given just the type name, the native runtime is unable to "close" the
generic type without information regarding the types of the generic
parameters needed to do it.  The solution, a workaround really, for now
is to look at the type name and return `null` to the managed code
whenever we see that the type name contains the "`" character, marking
it as a generic type.  The managed code will then proceed to look up the
type and instantiate it in the correct way.

In the future we need to find a better solution for this issue, but
doing so would require quite extensive changes to our current code.  The
solution implemented here is sufficient for now.