### PR TITLE
[build] install .NET 5 preview 4 nightly build

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -48,9 +48,9 @@ variables:
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
-  DotNetCoreVersion: 3.x
-  # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
-  DotNetCorePreviewVersion: 5.0.100-preview.1.20155.7
+  DotNetCoreVersion: 3.1.201
+  # Version number from: https://github.com/dotnet/installer#installers-and-binaries
+  DotNetCorePreviewVersion: 5.0.100-preview.4.20227.14
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
@@ -99,14 +99,12 @@ stages:
     - script: echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/Library/Android/jdk"
       displayName: set JAVA_HOME
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCorePreviewVersion)
-      inputs:
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
         version: $(DotNetCorePreviewVersion)
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCoreVersion)
-      inputs:
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
 
     # Prepare and build everything
@@ -235,14 +233,12 @@ stages:
 
     - template: yaml-templates\clean.yaml
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCorePreviewVersion)
-      inputs:
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
         version: $(DotNetCorePreviewVersion)
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCoreVersion)
-      inputs:
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
 
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -11,14 +11,12 @@ steps:
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
-- task: UseDotNet@2
-  displayName: install .NET Core $(DotNetCorePreviewVersion)
-  inputs:
+- template: use-dot-net.yaml
+  parameters:
     version: $(DotNetCorePreviewVersion)
 
-- task: UseDotNet@2
-  displayName: install .NET Core $(DotNetCoreVersion)
-  inputs:
+- template: use-dot-net.yaml
+  parameters:
     version: $(DotNetCoreVersion)
 
 - script: |

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -1,0 +1,27 @@
+# This template enables installing master/nighly builds of .NET 5.
+# We can eventually switch back to the UseDotNet task.
+
+parameters:
+  version: ''
+
+steps:
+
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+      $ProgressPreference = 'SilentlyContinue'
+      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+      & dotnet --list-sdks
+    displayName: install .NET Core ${{ parameters.version }}
+    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
+  - bash: >
+      DOTNET_ROOT=~/.dotnet/ &&
+      PATH="$DOTNET_ROOT:$PATH" &&
+      curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
+      sh dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&
+      dotnet --list-sdks &&
+      echo "##vso[task.setvariable variable=DOTNET_ROOT]$DOTNET_ROOT" &&
+      echo "##vso[task.setvariable variable=PATH]$PATH"
+    displayName: install .NET Core ${{ parameters.version }}
+    condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -2,7 +2,7 @@
 # We can eventually switch back to the UseDotNet task.
 
 parameters:
-  version: ''
+  version: $(DotNetCoreVersion)
 
 steps:
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -72,10 +72,6 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuild (string runtimeIdentifier, bool isRelease)
 		{
 			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (runtimeIdentifier);
-			//TODO: re-enable these when we have a public .NET 5 Preview 4 build
-			if (abi == "x86" || abi == "x86_64")
-				Assert.Ignore ($"Ignoring RID {runtimeIdentifier} until a new .NET 5 build is available.");
-
 			var proj = new XASdkProject (SdkVersion) {
 				IsRelease = isRelease
 			};

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Build.Tests
 			.Select (attr => attr.Value)
 			.FirstOrDefault () ?? "0.0.1";
 
-		[Test, Ignore ("Re-enable when we can install .NET 5 preview 4+ on CI.")]
+		[Test]
 		public void DotNetInstallAndRun ([Values (false, true)] bool isRelease)
 		{
 			if (!HasDevices)


### PR DESCRIPTION
Context: https://github.com/xamarin/net5-samples/blob/7607d1cde77f0bef676cb7e1a4290e3150501c56/azure-pipelines.yml
Context: https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer

Currently, on CI we've been doing:

    - task: UseDotNet@2
      inputs:
        version: 5.0.100-preview.1.20155.7

This `UseDotNet` Azure DevOps task works for any public release of
.NET 5 found here:

https://dotnet.microsoft.com/download/dotnet/5.0

However, we need .NET 5 Preview 4, which is not on this public
downloads page yet...

Luckily, we can use these install scripts *instead*:

https://docs.microsoft.com/dotnet/core/tools/dotnet-install-script

The main drawback is the powershell script *only* works on Windows, so
we have to conditionally use bash on macOS.

This allows us to download any build found here:

https://github.com/dotnet/installer#installers-and-binaries

Now we can get .NET 5 Preview 4 on CI *right now*. This will be
important for us to start using changes that may have only landed in
dotnet/installer/master down the road.

On macOS, we also have to set `$PATH` and `$DOTNET_ROOT` for the
remainder of the build using:

    echo "##vso[task.setvariable variable=DOTNET_ROOT]$DOTNET_ROOT" &&
    echo "##vso[task.setvariable variable=PATH]$PATH"

When using just `export`, future steps on Azure DevOps did not have the
new environment variables set.

At some point we can switch back to the `UseDotNet` task when .NET
public builds are available.