### PR TITLE
[monodroid] Return first entry in binary_search

### DIFF
--- a/Documentation/release-notes/4645.md
+++ b/Documentation/release-notes/4645.md
@@ -1,0 +1,5 @@
+#### Application behavior on device and emulator
+
+  * [GitHub 4596](https://github.com/xamarin/xamarin-android/issues/4596):
+    Ensure that Java-to-managed type mappings lookup the correct non-generic
+    binding type, avoiding a *System.MemberAccessException*.

--- a/src/Mono.Android/Test/Android.OS/BundleTest.cs
+++ b/src/Mono.Android/Test/Android.OS/BundleTest.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Android.RuntimeTests {
 			b.PutIntegerArrayList ("key", new List<Java.Lang.Integer> () { Java.Lang.Integer.ValueOf (1) });
 			var obj = b.Get ("key");
 			Assert.NotNull (obj, "Missing 'key' in bundle");
+			Assert.IsTrue (obj is global::Android.Runtime.JavaList, "`obj` should be a JavaList!");
 			try {
 				var list = b.GetIntegerArrayList ("key");
 				Assert.NotNull (list, "'key' doesn't refer to a list of integers");

--- a/src/Mono.Android/Test/Environment.txt
+++ b/src/Mono.Android/Test/Environment.txt
@@ -1,0 +1,2 @@
+debug.mono.debug=1
+debug.mono.log=timing,default

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -79,6 +79,9 @@
     <AndroidBoundLayout Include="Resources\layout\Main.axml" />
   </ItemGroup>
   <ItemGroup>
+    <AndroidEnvironment Include="Environment.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <AndroidAsset Include="Assets\asset1.txt" />
     <AndroidAsset Include="Assets\subfolder\asset2.txt" />
   </ItemGroup>

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -331,6 +331,8 @@ EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
 
+		simple_pointer_guard<char[], false> type_name (mono_type_get_name_full (mono_reflection_type_get_type (ret), MONO_TYPE_NAME_FORMAT_FULL_NAME));
+		log_info_nocheck (LOG_TIMING, "Typemap.java_to_managed: `%s` -> %s", java_type_name.get (), type_name.get ());
 		Timing::info (total_time, "Typemap.java_to_managed: end, total time");
 	}
 
@@ -513,6 +515,8 @@ EmbeddedAssemblies::typemap_managed_to_java (MonoReflectionType *reflection_type
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
 
+		simple_pointer_guard<char[], false> type_name (mono_type_get_name_full (type, MONO_TYPE_NAME_FORMAT_FULL_NAME));
+		log_info_nocheck (LOG_TIMING, "Typemap.managed_to_java: `%s` -> %s", type_name.get (), ret);
 		Timing::info (total_time, "Typemap.managed_to_java: end, total time");
 	}
 

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -170,14 +170,12 @@ EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nme
 		} else {
 			break;
 		}
+		ret = nullptr;
 	}
 
 	if (ret == nullptr) {
 		return ret;
 	}
-
-	const Entry *orig_ret = ret;
-	log_info (LOG_DEFAULT, "# jonp: binary_search: found ret=%p; trying previous entries!", orig_ret);
 
 	// `base` may contain duplicate keys.  Return the *first* entry for a given key.
 	while (ret > base) {
@@ -193,7 +191,6 @@ EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nme
 		}
 		ret = prev_ret;
 	}
-	log_info (LOG_DEFAULT, "# jonp: binary_search: new ret=%p; distance=%ul", ret, ((unsigned long) (orig_ret - ret))/sizeof(Entry));
 	return ret;
 }
 
@@ -245,15 +242,15 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
 		TypeMap *module;
 		for (size_t i = 0; i < type_map_count; i++) {
 			module = &type_maps[i];
-			entry = linear_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, module->java_to_managed, module->entry_count);
+			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, module->java_to_managed, module->entry_count);
 			if (entry != nullptr) {
-				entry2 = binary_search<const char, TypeMapEntry, compare_type_name, false>(java_type_name, module->java_to_managed, module->entry_count);
+				entry2 = linear_search<const char, TypeMapEntry, compare_type_name, false>(java_type_name, module->java_to_managed, module->entry_count);
 				break;
 			}
 		}
 	} else {
-		entry = linear_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, type_map.java_to_managed, type_map.entry_count);
-		entry2 = binary_search<const char, TypeMapEntry, compare_type_name, false>(java_type_name, type_map.java_to_managed, type_map.entry_count);
+		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, type_map.java_to_managed, type_map.entry_count);
+		entry2 = linear_search<const char, TypeMapEntry, compare_type_name, false>(java_type_name, type_map.java_to_managed, type_map.entry_count);
 	}
 
 	if (entry != entry2) {
@@ -395,15 +392,15 @@ EmbeddedAssemblies::typemap_managed_to_java (const char *managed_type_name)
 		TypeMap *module;
 		for (size_t i = 0; i < type_map_count; i++) {
 			module = &type_maps[i];
-			entry = linear_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, module->managed_to_java, module->entry_count);
+			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, module->managed_to_java, module->entry_count);
 			if (entry != nullptr) {
-				entry2 = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, module->managed_to_java, module->entry_count);
+				entry2 = linear_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, module->managed_to_java, module->entry_count);
 				break;
 			}
 		}
 	} else {
-		entry = linear_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, type_map.managed_to_java, type_map.entry_count);
-		entry2 = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, type_map.managed_to_java, type_map.entry_count);
+		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, type_map.managed_to_java, type_map.entry_count);
+		entry2 = linear_search<const char, TypeMapEntry, compare_type_name, false> (managed_type_name, type_map.managed_to_java, type_map.entry_count);
 	}
 
 	if (entry != entry2) {

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -108,6 +108,9 @@ namespace xamarin::android::internal {
 		template<typename Key, typename Entry, int (*compare)(const Key*, const Entry*), bool use_extra_size = false>
 		const Entry* binary_search (const Key *key, const Entry *base, size_t nmemb, size_t extra_size = 0);
 
+		template<typename Key, typename Entry, int (*compare)(const Key*, const Entry*), bool use_extra_size = false>
+		const Entry* linear_search (const Key *key, const Entry *base, size_t nmemb, size_t extra_size = 0);
+
 #if defined (DEBUG) || !defined (ANDROID)
 		static int compare_type_name (const char *type_name, const TypeMapEntry *entry);
 #else


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4596

Context: https://github.com/xamarin/monodroid/commit/192b1f1b71c98650d04bf0a4e52ee337a054ff4c
Context: https://github.com/xamarin/java.interop/blob/fc18c54b2ccf14f444fadac0a1e7e81f837cc470/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs#L149-L186

In some environments, `BundleTest.TestBundleIntegerArrayList2()` fails
when  using the commercial shared runtime:

	Test 'Xamarin.Android.RuntimeTests.BundleTest.TestBundleIntegerArrayList2' failed: System.MemberAccessException : Cannot create an instance of Android.Runtime.JavaList`1[T] because Type.ContainsGenericParameters is true.
	  at System.Reflection.RuntimeConstructorInfo.DoInvoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
	  at System.Reflection.RuntimeConstructorInfo.Invoke (System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
	  at System.Reflection.ConstructorInfo.Invoke (System.Object[] parameters)
	  at Java.Interop.TypeManager.CreateProxy (System.Type type, System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
	  at Java.Interop.TypeManager.CreateInstance (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type targetType)
	  at Java.Lang.Object.GetObject (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.Type type)
	  at Java.Lang.Object._GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
	  at Java.Lang.Object.GetObject[T] (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer)
	  at Android.OS.Bundle.Get (System.String key)
	  at Xamarin.Android.RuntimeTests.BundleTest.TestBundleIntegerArrayList2 ()
	  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
	  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)

The problem appears to be rooted in ce2bc689.  In a pre-ce2bc689 world,
there were two separate sets of "typemap" files that the application
could use:

  * Java-to-managed mappings, in `typemap.jm`
  * Managed-to-Java mappings, in `typemap.mj`.

These files did *not* need to have the same number of entries!

	% unzip /Library/Frameworks/Xamarin.Android.framework/Versions/10.2.0.100/lib/xamarin.android/xbuild/Xamarin/Android/Mono.Android.DebugRuntime-debug.apk typemap.jm
	% unzip /Library/Frameworks/Xamarin.Android.framework/Versions/10.2.0.100/lib/xamarin.android/xbuild/Xamarin/Android/Mono.Android.DebugRuntime-debug.apk typemap.mj
	% strings typemap.jm | wc -l
	   10318
	% strings typemap.mj | wc -l
	   11956

The reason why they have a different number of entries is *aliasing*:
there can be *multiple* bindings for a given Java type.  The
managed-to-Java mappings can contain *all* of them; the
Java-to-managed mapping *must* pick Only One.

For example, [`java.util.ArrayList`][0] contains (at least?) *three* bindings:

  * [`Android.Runtime.JavaList`][1]
  * [`Android.Runtime.JavaList<T>`][2]
  * `Java.Util.ArrayList` (generated at build time)

In a pre-ce2bc689 world, this was "fine": we'd binary search each file
*separately* to find type mappings.

This changed in ce2bc689, as the typemap information was merged into a
*single* array in order to de-duplicate information.  This reduced
`.apk` size.

An unanticipated result of this is that the Java-to-managed mappings
can now contain *duplicate* keys, "as if" the original `typemap.jm`
had the contents:

  java/util/ArrayList
  Android.Runtime.JavaList, Mono.Android
  java/util/ArrayList
  Android.Runtime.JavaList`1, Mono.Android
  java/util/ArrayList
  Java.Util.ArrayLlist, Mono.Android

Whereas pre-ce2bc689 there would have only been the first entry.

"Sometimes" this duplication is "fine": the typemap search
"Just happens" to return the first entry, or the 3rd entry, and apps
continue to work as intended.

"Sometimes" it isn't: the typemap binary search finds the 2nd entry,
which is a generic type.  This results in attempting to instantiate a
generic type *without appropriate type parameters*, which results in
the aforementioned `MemberAccessException`.

Update `EmbeddedAssemblies::binary_search()` so that instead of
returning the "first" entry that the binary search happens to land on,
probe *previous* entries in the type mappings to see if they *also*
contain the same key.  `binary_search()` can instead return the
*first entry* within the mapping, not just the first it happens to
land upon while binary searching.

This should allow for more *consistent* behaviors, ensuring that
Java-to-managed typemap lookup obtains a *non*-generic type, thus
avoiding the `MemberAccessException`.

Additionally, update `TestBundleIntegerArrayList2()` so that it asserts
the runtime *type* of `obj` returned, asserting that it is in fact a
`JavaList` and not e.g. `Java.Util.ArrayList` or something.
(The linker could otherwise "change" things, and this assertion will
ensure that `JavaList` won't be linked away…)

[0]: https://developer.android.com/reference/java/util/ArrayList
[1]: https://github.com/xamarin/xamarin-android/blob/61f09bf2ef0c8f09550e2d77eb97f417432b315b/src/Mono.Android/Android.Runtime/JavaList.cs#L11-L13
[2]: https://github.com/xamarin/xamarin-android/blob/61f09bf2ef0c8f09550e2d77eb97f417432b315b/src/Mono.Android/Android.Runtime/JavaList.cs#L667-L668