### PR TITLE
[XA.Build.Tasks] Use 'android-R' instead of 'android-30' to properly find preview bindings.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -14,7 +14,7 @@
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
-    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\monoandroid10\android-$(AndroidLatestStableApiLevel)\mcw</AndroidGeneratedClassDirectory>
+    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\monoandroid10\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4356

In order to build preview bindings on Windows, we set the following properties in `Configuration.props`:
```
<AndroidLatestStableApiLevel Condition="'$(AndroidLatestStableApiLevel)' == ''">30</AndroidLatestStableApiLevel>
<AndroidLatestStablePlatformId Condition="'$(AndroidLatestStablePlatformId)' == ''">R</AndroidLatestStablePlatformId>
<AndroidLatestStableFrameworkVersion Condition="'$(AndroidLatestStableFrameworkVersion)'==''">v10.0.99</AndroidLatestStableFrameworkVersion>
```

This writes the generated files to `src\Mono.Android\obj\$(Configuration)\monoandroid10\android-R\mcw`, however `Xamarin.Android.Build.Tasks.csproj` is looking in `src\Mono.Android\obj\$(Configuration)\monoandroid10\android-30\mcw`, because it is using `$(AndroidLatestStableApiLevel)` instead of `$(AndroidLatestStablePlatformId)`.  Fixing this allows `msbuild Xamarin.Android.sln` to succeed on Windows.
