### PR TITLE
[Mono.Android] API-R Developer Preview 4.

### DIFF
--- a/Documentation/release-notes/4653.md
+++ b/Documentation/release-notes/4653.md
@@ -1,0 +1,17 @@
+### Preview bindings for Android 11 Developer Preview 4
+
+This version includes preview bindings for the [fourth Developer Preview of
+Android 11][android-11-preview-4] from Google.  See the [Android 11 Developer
+Preview documentation][android-11-upstream] for additional information about the
+behavior and API changes in this new Android version.  To try the bindings for
+the new APIs in a Xamarin.Android project, set **Compile using Android version:
+(Target Framework)** to **Android 10.0.99 (R)** under the **Application** tab of
+the Visual Studio project property pages.  This sets the
+`TargetFrameworkVersion` property to `v10.0.99` in the _.csproj_ file:
+
+```xml
+<TargetFrameworkVersion>v10.0.99</TargetFrameworkVersion>
+```
+
+[android-11-preview-4]: https://android-developers.googleblog.com/2020/05/android-11-beta-plans.html
+[android-11-upstream]: https://developer.android.com/preview

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-27_r03",   apiLevel: "27", pkgRevision: "3"),
 				new AndroidPlatformComponent ("platform-28_r04",   apiLevel: "28", pkgRevision: "4"),
 				new AndroidPlatformComponent ("platform-29_r01",   apiLevel: "29", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-R_r02",    apiLevel: "R",  pkgRevision: "2"),
+				new AndroidPlatformComponent ("platform-R_r03",    apiLevel: "R",  pkgRevision: "3"),
 
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1"),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-27_r03",   apiLevel: "27", pkgRevision: "3"),
 				new AndroidPlatformComponent ("platform-28_r04",   apiLevel: "28", pkgRevision: "4"),
 				new AndroidPlatformComponent ("platform-29_r01",   apiLevel: "29", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-R_r03",    apiLevel: "R",  pkgRevision: "3"),
+				new AndroidPlatformComponent ("platform-R_r04",    apiLevel: "R",  pkgRevision: "4"),
 
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1"),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0"),

--- a/src/Mono.Android/Mono.Android.slnf
+++ b/src/Mono.Android/Mono.Android.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "..\\..\\Xamarin.Android.sln",
+    "projects": [
+      "build-tools\\api-merge\\api-merge.csproj",
+      "build-tools\\api-xml-adjuster\\api-xml-adjuster.csproj",
+      "build-tools\\jnienv-gen\\jnienv-gen.csproj",
+      "external\\Java.Interop\\src\\Java.Interop.NamingCustomAttributes\\Java.Interop.NamingCustomAttributes.shproj",
+      "external\\Java.Interop\\tools\\generator\\generator.csproj",
+      "external\\Java.Interop\\tools\\jcw-gen\\jcw-gen.csproj",
+      "src\\Mono.Android\\Mono.Android.csproj",
+      "src\\java-runtime\\java-runtime.csproj"
+    ]
+  }
+}

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1555,6 +1555,8 @@
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationStart' and count(parameter)=2]" />
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationEnd' and count(parameter)=2]" />
 
+  <attr path="/api/package[@name='android.widget.inline']/class[@name='InlineContentView']/method[@name='onLayout' and count(parameter)=5 and parameter[1][@type='boolean'] and parameter[2][@type='int'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='int']]" name="visibility">protected</attr>
+  
   <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.
        To preserve backwards compatibility, we need to "un-nest" anything added before API-30 -->
   

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1555,6 +1555,7 @@
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationStart' and count(parameter)=2]" />
   <remove-node api-since="30" path="/api/package[@name='android.animation']/interface[@name='Animator.AnimatorListener']/method[@name='onAnimationEnd' and count(parameter)=2]" />
 
+  <!-- Needs to match 'protected' visibility of 'View.onLayout' it overrides -->
   <attr path="/api/package[@name='android.widget.inline']/class[@name='InlineContentView']/method[@name='onLayout' and count(parameter)=5 and parameter[1][@type='boolean'] and parameter[2][@type='int'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='int']]" name="visibility">protected</attr>
   
   <!-- Starting with API added in API-30, we are going to allow interfaces to contain nested types.


### PR DESCRIPTION
Bumps our API-R preview from DP2 to DP4.  This only required one `metadata` to make a method match its base visibility.

Note this does not include additional enumification.  The current plan is to have enumification complete for 16.7 (10.4) P3.