### PR TITLE
[Xamarin.Android.Build.Tasks] simplify d8/r8 multi-dex support

### DIFF
--- a/Documentation/release-notes/4654.md
+++ b/Documentation/release-notes/4654.md
@@ -1,0 +1,31 @@
+### Multidex now handled automatically for projects using D8
+
+Because the minimum compatible Android version is now Android 5.0 Lollipop (API
+level 21), multidex configuration is now handled automatically for all
+Xamarin.Android projects that are configured to use the D8 DEX compiler.
+
+Any projects that have transitioned to D8 and are using the
+**MultiDexMainDexList** build action or the **Enable Multi-Dex** setting in the
+Visual Studio project property pages can now discard those settings.  These
+correspond to the `MultiDexMainDexList` MSBuild item type and the
+`AndroidEnableMultiDex` MSBuild property:
+
+```xml
+<ItemGroup>
+  <MultiDexMainDexList Include="multidex-config.txt" />
+</ItemGroup>
+<PropertyGroup>
+  <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+</PropertyGroup>
+```
+
+#### Background information
+
+Android 5.0 Lollipop (API level 21) and higher use the ART runtime, which
+pre-compiles DEX files during app installation a single _.oat_ file, so the
+Android build process automatically enables and configures multidex for apps
+that have a `minSdkVersion` of Android 5.0 (API level 21) or higher.
+
+See the [multidex documentation][multidex] for additional details.
+
+[multidex]: https://developer.android.com/studio/build/multidex#mdex-on-l

--- a/Documentation/release-notes/r8-multidex-config.md
+++ b/Documentation/release-notes/r8-multidex-config.md
@@ -1,9 +1,0 @@
-### R8 now uses ProguardConfiguration items when code shrinking is disabled
-
-In previous versions, Xamarin.Android did not yet pass `ProguardConfiguration`
-items to the R8 tool when the **Code shrinker** setting, corresponding to the
-`AndroidLinkTool` MSBuild property, was disabled.
-
-Project authors who added a `--pg-conf` option to the `AndroidR8ExtraArguments`
-MSBuild property to work around this limitation in the past can now transition
-to the standard `ProguardConfiguration` mechanism.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -104,6 +104,23 @@ namespace Xamarin.Android.Tasks
 						}
 					}
 				}
+				if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
+					var configs = ProguardConfigurationFiles
+						.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
+						.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
+						.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
+						.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
+						.Replace ("{project}", string.Empty) // current directory anyways.
+						.Split (';')
+						.Select (s => s.Trim ())
+						.Where (s => !string.IsNullOrWhiteSpace (s));
+					foreach (var file in configs) {
+						if (File.Exists (file))
+							cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
+						else
+							Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
+					}
+				}
 			} else {
 				//NOTE: we may be calling r8 *only* for multi-dex, and all shrinking is disabled
 				cmd.AppendSwitch ("--no-tree-shaking");
@@ -121,23 +138,6 @@ namespace Xamarin.Android.Tasks
 				File.WriteAllLines (temp, lines);
 				tempFiles.Add (temp);
 				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);
-			}
-			if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
-				var configs = ProguardConfigurationFiles
-					.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
-					.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
-					.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
-					.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
-					.Replace ("{project}", string.Empty) // current directory anyways.
-					.Split (';')
-					.Select (s => s.Trim ())
-					.Where (s => !string.IsNullOrWhiteSpace (s));
-				foreach (var file in configs) {
-					if (File.Exists (file))
-						cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
-					else
-						Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
-				}
 			}
 
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -20,13 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidSdkDirectory { get; set; }
 
-		// multidex
-		public bool EnableMultiDex { get; set; }
-		public ITaskItem [] CustomMainDexListFiles { get; set; }
-		public string MultiDexMainDexListFile { get; set; }
-
 		// proguard-like configuration settings
-		public bool EnableShrinking { get; set; } = true;
 		public bool IgnoreWarnings { get; set; }
 		public string AcwMapFile { get; set; }
 		public string ProguardGeneratedReferenceConfiguration { get; set; }
@@ -53,91 +47,44 @@ namespace Xamarin.Android.Tasks
 		{
 			var cmd = base.GetCommandLineBuilder ();
 
-			if (EnableMultiDex) {
-				if (MinSdkVersion >= 21) {
-					if (CustomMainDexListFiles?.Length > 0) {
-						Log.LogCodedWarning ("XA4306", Properties.Resources.XA4306);
-					}
-				} else if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
-					Log.LogCodedWarning ("XA4305", Properties.Resources.XA4305);
-				} else {
-					var content = new List<string> ();
-					var temp = Path.GetTempFileName ();
-					tempFiles.Add (temp);
-					if (CustomMainDexListFiles != null) {
-						foreach (var file in CustomMainDexListFiles) {
-							if (File.Exists (file.ItemSpec)) {
-								content.Add (File.ReadAllText (file.ItemSpec));
-							} else {
-								Log.LogCodedWarning ("XA4309", file.ItemSpec, 0, Properties.Resources.XA4309, file.ItemSpec);
-							}
+			if (!string.IsNullOrEmpty (AcwMapFile)) {
+				var acwLines = File.ReadAllLines (AcwMapFile);
+				using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration)) {
+					for (int i = 0; i + 2 < acwLines.Length; i += 3) {
+						try {
+							var line = acwLines [i + 2];
+							var java = line.Substring (line.IndexOf (';') + 1);
+							appcfg.WriteLine ("-keep class " + java + " { *; }");
+						} catch {
+							// skip invalid lines
 						}
 					}
-					File.WriteAllText (temp, string.Concat (content));
-
-					cmd.AppendSwitchIfNotNull ("--main-dex-list ", temp);
-					cmd.AppendSwitchIfNotNull ("--main-dex-rules ", Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules"));
-					cmd.AppendSwitchIfNotNull ("--main-dex-list-output ", MultiDexMainDexListFile);
 				}
 			}
-
-			if (EnableShrinking) {
-				if (!string.IsNullOrEmpty (AcwMapFile)) {
-					var acwLines = File.ReadAllLines (AcwMapFile);
-					using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration)) {
-						for (int i = 0; i + 2 < acwLines.Length; i += 3) {
-							try {
-								var line = acwLines [i + 2];
-								var java = line.Substring (line.IndexOf (';') + 1);
-								appcfg.WriteLine ("-keep class " + java + " { *; }");
-							} catch {
-								// skip invalid lines
-							}
-						}
+			if (!string.IsNullOrWhiteSpace (ProguardCommonXamarinConfiguration)) {
+				using (var xamcfg = File.CreateText (ProguardCommonXamarinConfiguration)) {
+					GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg.BaseStream);
+					if (IgnoreWarnings) {
+						xamcfg.WriteLine ("-ignorewarnings");
 					}
 				}
-				if (!string.IsNullOrWhiteSpace (ProguardCommonXamarinConfiguration)) {
-					using (var xamcfg = File.CreateText (ProguardCommonXamarinConfiguration)) {
-						GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg.BaseStream);
-						if (IgnoreWarnings) {
-							xamcfg.WriteLine ("-ignorewarnings");
-						}
-					}
+			}
+			if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
+				var configs = ProguardConfigurationFiles
+					.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
+					.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
+					.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
+					.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
+					.Replace ("{project}", string.Empty) // current directory anyways.
+					.Split (';')
+					.Select (s => s.Trim ())
+					.Where (s => !string.IsNullOrWhiteSpace (s));
+				foreach (var file in configs) {
+					if (File.Exists (file))
+						cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
+					else
+						Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
 				}
-				if (!string.IsNullOrEmpty (ProguardConfigurationFiles)) {
-					var configs = ProguardConfigurationFiles
-						.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
-						.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
-						.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
-						.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)
-						.Replace ("{project}", string.Empty) // current directory anyways.
-						.Split (';')
-						.Select (s => s.Trim ())
-						.Where (s => !string.IsNullOrWhiteSpace (s));
-					foreach (var file in configs) {
-						if (File.Exists (file))
-							cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
-						else
-							Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
-					}
-				}
-			} else {
-				//NOTE: we may be calling r8 *only* for multi-dex, and all shrinking is disabled
-				cmd.AppendSwitch ("--no-tree-shaking");
-				cmd.AppendSwitch ("--no-minification");
-				// Rules to turn off optimizations
-				var temp = Path.GetTempFileName ();
-				var lines = new List<string> {
-					"-dontoptimize",
-					"-dontpreverify",
-					"-keepattributes **"
-				};
-				if (IgnoreWarnings) {
-					lines.Add ("-ignorewarnings");
-				}
-				File.WriteAllLines (temp, lines);
-				tempFiles.Add (temp);
-				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);
 			}
 
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1348,56 +1348,6 @@ namespace UnnamedProject {
 		}
 
 		[Test]
-		public void MultiDexR8ConfigWithNoCodeShrinking ([Values (true, false)] bool useConfig)
-		{
-			var proj = new XamarinAndroidApplicationProject () {
-				IsRelease = true,
-				DexTool = "d8",
-			};
-			proj.SetProperty ("AndroidEnableMultiDex", "True");
-			/* The source for the library is a single class:
-			*
-			abstract class ExtendsClassValue extends ClassValue<Boolean> {}
-			*
-			* The reason `ClassValue` is used for this test is precisely that it
-			* does not exist in `android.jar`.  This means the library cannot be
-			* compiled using `@(AndroidJavaSource)`.  It was instead compiled
-			* using `javac ExtendsClassValue.java` and then manually archived
-			* using `jar cvf ExtendsClassValue.jar
-			* ExtendsClassValue.class`.
-			*/
-			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "ExtendsClassValue.jar") { BinaryContent = () => Convert.FromBase64String (@"
-UEsDBBQACAgIAChzjVAAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
-AAAAFBLAwQUAAgICAAoc41QAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My
-0xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqBAlY6BnoGpkqaPhmJhflF+enlWjycvFyAQBQS
-wcIv1FGtTsAAAA7AAAAUEsDBBQACAgIABxzjVAAAAAAAAAAAAAAAAAXAAAARXh0ZW5kc0NsYXNzV
-mFsdWUuY2xhc3NtT7sKwkAQnNWYaHwExVaw9AHa2CkWilZi46M/9ZCT8wJ5iL9lJVj4AX6UuEmjh
-Qu7M8wwu+zr/XgCGMBzkUXJQdlBhWCPlFHRmJBttbcEa+ofJMFbKCOX8Xkng7XYaVYKK3U0IooD5
-t3FSVxEXwtz7E+1CMOt0LEc/agT39dSmOF4SHBXfhzs5Vwla2qbUH4jvSRRgoUcoTq7RtIcwq9Lq
-P+7YzWR4Q+SIm4OM9rMGoyJkuvcQbfUdnjaqUgcyjNmUICbYvEDUEsHCB4E1g/HAAAAEgEAAFBLA
-QIUABQACAgIAChzjVAAAAAAAgAAAAAAAAAJAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi/+ygAAU
-EsBAhQAFAAICAgAKHONUL9RRrU7AAAAOwAAABQAAAAAAAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BT
-klGRVNULk1GUEsBAhQAFAAICAgAHHONUB4E1g/HAAAAEgEAABcAAAAAAAAAAAAAAAAAugAAAEV4d
-GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
-				") });
-			if (useConfig)
-				proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
-					TextContent = () => "-dontwarn java.lang.ClassValue"
-				});
-			using (var builder = CreateApkBuilder ()) {
-				Assert.True (builder.Build (proj), "Build should have succeeded.");
-				string warning = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build succeeded."))
-						.FirstOrDefault (x => x.Contains ("R8 : warning : Missing class: java.lang.ClassValue"));
-				if (useConfig) {
-					Assert.IsNull (warning, "Build should have completed without an R8 warning for `java.lang.ClassValue`.");
-					return;
-				}
-				Assert.IsNotNull (warning, "Build should have completed with an R8 warning for `java.lang.ClassValue`.");
-			}
-		}
-
-		[Test]
 		public void BasicApplicationRepetitiveBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -299,18 +299,14 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
 	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
 
-	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == '' And '$(AndroidLinkTool)' != ''">
+	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == ''">
 		{sdk.dir}tools\proguard\proguard-android.txt;
 		{intermediate.common.xamarin};
 		{intermediate.references};
 		{intermediate.application};
 		@(ProguardConfiguration);
 	</ProguardConfigFiles>
-	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == '' And '$(AndroidLinkTool)' == ''">
-		{sdk.dir}tools\proguard\proguard-android.txt;
-		@(ProguardConfiguration);
-	</ProguardConfigFiles>
-
+	
 	<_AndroidMainDexListFile>$(IntermediateOutputPath)multidex.keep</_AndroidMainDexListFile>
 	
 	<AndroidManifestPlaceholders Condition="'$(AndroidManifestPlaceholders)' == ''"></AndroidManifestPlaceholders>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -768,8 +768,8 @@ because xbuild doesn't support framework reference assemblies.
 
 	<!-- Setup $(AndroidApplicationJavaClass) -->
 	<PropertyGroup>
-		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == '' And $(AndroidEnableMultiDex)">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
-		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == ''">android.app.Application</AndroidApplicationJavaClass>
+		<AndroidApplicationJavaClass Condition=" '$(AndroidApplicationJavaClass)' == '' And '$(AndroidEnableMultiDex)' == 'true' And '$(AndroidDexTool)' == 'dx' ">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
+		<AndroidApplicationJavaClass Condition=" '$(AndroidApplicationJavaClass)' == '' ">android.app.Application</AndroidApplicationJavaClass>
 	</PropertyGroup>
 	<Message Text="Application Java class: $(AndroidApplicationJavaClass)" />
 </Target>
@@ -1060,15 +1060,6 @@ because xbuild doesn't support framework reference assemblies.
 	<ItemGroup>
 		<FileWrites Include="$(_AndroidResFlagFile)" />
 	</ItemGroup>
-</Target>
-
-<Target Name="_AddMultiDexDependencyJars">
-  <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != '' ">
-    <AndroidJavaLibrary Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == '' ">
-    <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_AddAndroidEnvironmentToCompile">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -22,11 +22,8 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <!-- Target-level properties to simplify conditions-->
     <PropertyGroup>
       <!--Flag indicating if using d8 or r8-->
-      <_UseR8 Condition=" ('$(AndroidLinkTool)' == 'r8' And '$(_ProguardProjectConfiguration)' != '') Or '$(AndroidEnableMultiDex)' == 'True' ">True</_UseR8>
+      <_UseR8 Condition=" '$(AndroidLinkTool)' == 'r8' And '$(_ProguardProjectConfiguration)' != '' ">True</_UseR8>
       <_UseR8 Condition=" '$(_UseR8)' == '' ">False</_UseR8>
-      <!--Flag indicating if r8 should have EnableShrinking-->
-      <_R8EnableShrinking Condition=" '$(AndroidLinkTool)' == 'r8' ">True</_R8EnableShrinking>
-      <_R8EnableShrinking Condition=" '$(_R8EnableShrinking)' == '' ">False</_R8EnableShrinking>
     </PropertyGroup>
 
     <Error
@@ -66,10 +63,6 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
         ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
         ProguardConfigurationFiles="$(ProguardConfigFiles)"
-        EnableShrinking="$(_R8EnableShrinking)"
-        EnableMultiDex="$(AndroidEnableMultiDex)"
-        MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-        CustomMainDexListFiles="@(MultiDexMainDexList)"
         IgnoreWarnings="$(AndroidR8IgnoreWarnings)"
         ExtraArguments="$(AndroidR8ExtraArguments)"
     />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -14,6 +14,15 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Target Name="_AddMultiDexDependencyJars">
+    <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'true' And '$(AndroidMultiDexSupportJar)' != '' ">
+      <AndroidJavaLibrary Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'true' And '$(AndroidMultiDexSupportJar)' == '' ">
+      <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_CompileToDalvik"
       DependsOnTargets="$(_BeforeCompileToDalvik);$(_CompileToDalvikDependsOnTargets)"
       Inputs="$(_CompileToDalvikInputs)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -77,11 +77,11 @@ This file is used by all project types, including binding projects.
   </Target>
 
   <PropertyGroup>
-    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' == 'true' ">
+    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' == 'true' Or '$(AndroidDexTool)' != 'dx' ">
       _ExtractLibraryProjectImports;
       _BuildLibraryImportsCache;
     </_GetLibraryImportsDependsOnTargets>
-    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' != 'true' ">
+    <_GetLibraryImportsDependsOnTargets Condition=" '$(_AndroidIsBindingProject)' != 'true' And '$(AndroidDexTool)' == 'dx' ">
       _ExtractLibraryProjectImports;
       _AddMultiDexDependencyJars;
       _BuildLibraryImportsCache;


### PR DESCRIPTION
Context: https://developer.android.com/studio/build/multidex#mdex-gradle

When `android:minSdkVersion` is 21 or higher, d8 can automatically
support multi-dex. It will merely generate multiple `classes.dex`
files as needed, and we won't have a need for an
`$(AndroidEnableMultiDex)` MSBuild property.

Changes when `$(AndroidDexTool)` is set to `d8`:

* We no longer use `android-support-multidex.jar`.
* We no longer use `android.support.multidex.MultiDexApplication`.
* `$(AndroidEnableMultiDex)` is not used for anything.

These changes are not made when `AndroidDexTool=dx`

This makes the `<R8/>` MSBuild task much simpler, as many of the
incoming values are no longer needed. `<R8/>` will now only be needed
when `AndroidLinkTool=r8` and developers are opting into code
shrinking.