### PR TITLE
Add resources at end of APK

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -125,6 +125,15 @@ namespace Xamarin.Android.Tasks
 
 			using (var notice = Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"))
 			using (var apk = new ZipArchiveEx (apkOutputPath, File.Exists (apkOutputPath) ? FileMode.Open : FileMode.Create )) {
+				bool apkInputPathExists = apkInputPath != null && File.Exists (apkInputPath);
+
+				DateTime lastWriteOutput = DateTime.MinValue;
+				DateTime lastWriteInput = DateTime.MinValue;
+				if (apkInputPathExists) {
+					lastWriteOutput = File.Exists (apkOutputPath) ? File.GetLastWriteTimeUtc (apkOutputPath) : DateTime.MinValue;
+					lastWriteInput = File.GetLastWriteTimeUtc (apkInputPath);
+				}
+
 				for (long i = 0; i < apk.Archive.EntryCount; i++) {
 					ZipEntry e = apk.Archive.ReadEntry ((ulong) i);
 					Log.LogDebugMessage ($"Registering item {e.FullName}");
@@ -218,9 +227,7 @@ namespace Xamarin.Android.Tasks
 				}
 
 				HashSet<ulong> deletedEntries = new HashSet<ulong> ();
-				if (apkInputPath != null && File.Exists (apkInputPath)) {
-					var lastWriteOutput = File.Exists (apkOutputPath) ? File.GetLastWriteTimeUtc (apkOutputPath) : DateTime.MinValue;
-					var lastWriteInput = File.GetLastWriteTimeUtc (apkInputPath);
+				if (apkInputPathExists) {
 					using (var packaged = new ZipArchiveEx (apkInputPath, FileMode.Open)) {
 						foreach (var entry in packaged.Archive) {
 							Log.LogDebugMessage ($"Deregistering item {entry.FullName}");


### PR DESCRIPTION
Update the BuildApk logic so that:
- Resources are added last, not first. That way when an APK is first built, all the resources are at the end, after native libraries, etc.
- Modified resources are moved from their current position in the zip to the end of the APK. We make libzip do that by deleting the entry before we re-add it, so that it doesn't overwrite it's current index.

For a typical dev inner loop scenario, assemblies are outside the APK (with fast deploy) and the APK contains just native libraries and resources. Of these, the native libraries tend not to change, while resources can change frequently as the customer updates their UI. By keeping frequently changing parts of the APK at the end, we minimize the amount of bytes that need to get updated by delta install. Delta install (and Apply Changes) updates any changed item in the APK and everything after that item (since the offsets of everything after change too when the item changed in size).

Android Studio follows a similar approach, where updated parts of the APK are moved to the end. Though Android Studio does that somewhat differently, using zipflinger, which unlike us allows gaps in the APK, so it minimizes items moving around even more. Perhaps one day we'll use zipflinger too, with that exact same algorithm, but for now we approximate it with the above, while sticking with libzip.