### PR TITLE
[.NET 5] NuGet workarounds for Xamarin.Forms projects

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -102,6 +102,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project>
   <PropertyGroup>
     <AndroidNETSdkVersion>$(AndroidPackVersionLong)</AndroidNETSdkVersion>
+    <XamarinAndroidVersion>$(AndroidPackVersionLong)</XamarinAndroidVersion>
   </PropertyGroup>
   <ItemGroup>
     <KnownFrameworkReference Include="Microsoft.Android"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
@@ -1,0 +1,46 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.NuGet.targets
+
+This file contains *temporary* workarounds for NuGet in .NET 5.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.FixupNuGetReferences" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
+  <PropertyGroup>
+    <!-- Clear $(AssetTargetFallback), so only $(PackageTargetFallback) is used. -->
+    <AssetTargetFallback></AssetTargetFallback>
+    <!--
+      Use $(PackageTargetFallback), even though it is deprecated.
+      It doesn't suffer from: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955
+    -->
+    <PackageTargetFallback>
+      monoandroid10.0;
+      monoandroid90;
+      monoandroid81;
+      monoandroid80;
+      monoandroid70;
+      monoandroid60;
+      monoandroid50;
+      $(PackageTargetFallback);
+    </PackageTargetFallback>
+  </PropertyGroup>
+
+  <Target Name="_FixupNuGetReferences" AfterTargets="ResolvePackageAssets">
+    <FixupNuGetReferences
+        PackageTargetFallback="$(PackageTargetFallback)"
+        CopyLocalItems="@(RuntimeCopyLocalItems)">
+      <Output TaskParameter="AssembliesToRemove" ItemName="_AssembliesToRemove" />
+      <Output TaskParameter="AssembliesToAdd"    ItemName="Reference" />
+    </FixupNuGetReferences>
+    <ItemGroup>
+      <RuntimeCopyLocalItems          Remove="@(_AssembliesToRemove)" />
+      <ResolvedCompileFileDefinitions Remove="@(_AssembliesToRemove)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -9,6 +9,7 @@
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
     <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
+    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' And '$(AndroidApplication)' == 'true' ">android.21-x86</RuntimeIdentifier>
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' And '$(AndroidApplication)' == 'true' ">Properties\AndroidManifest.xml</AndroidManifest>
     <!-- We don't ever need a `static void Main` method, so switch to Library here-->
     <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
@@ -20,6 +21,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.AssemblyResolution.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.NuGet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Tooling.targets" />
 
   <!-- Automatically supply project capabilities for IDE use -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// This task contains *temporary* workarounds for NuGet in .NET 5.
+	/// </summary>
+	public class FixupNuGetReferences : AndroidTask
+	{
+		public override string TaskPrefix => "FNR";
+
+		[Required]
+		public string [] PackageTargetFallback { get; set; }
+
+		public ITaskItem [] CopyLocalItems { get; set; }
+
+		[Output]
+		public string [] AssembliesToAdd { get; set; }
+
+		[Output]
+		public ITaskItem [] AssembliesToRemove { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (CopyLocalItems == null || CopyLocalItems.Length == 0)
+				return true;
+
+			var assembliesToAdd     = new Dictionary<string, string> ();
+			var assembliesToRemove  = new List<ITaskItem> ();
+			var fallbackDirectories = new HashSet<string> ();
+
+			foreach (var item in CopyLocalItems) {
+				var directory = Path.GetDirectoryName (item.ItemSpec);
+				var directoryName = Path.GetFileName (directory);
+				Log.LogDebugMessage ($"{directoryName} -> {item.ItemSpec}");
+				if (directoryName == "netstandard2.0") {
+					var parent = Directory.GetParent (directory);
+					foreach (var nugetDirectory in parent.EnumerateDirectories ()) {
+						var name = Path.GetFileName (nugetDirectory.Name);
+						foreach (var fallback in PackageTargetFallback) {
+							if (!string.Equals (name, fallback, StringComparison.OrdinalIgnoreCase))
+								continue;
+							var fallbackDirectory = Path.Combine (parent.FullName, fallback);
+							fallbackDirectories.Add (fallbackDirectory);
+
+							// Remove the netstandard assembly, if there is a platform-specific one
+							var path = Path.Combine (fallbackDirectory, Path.GetFileName (item.ItemSpec));
+							if (File.Exists (path)) {
+								Log.LogDebugMessage ($"Removing: {item.ItemSpec}");
+								assembliesToRemove.Add (item);
+							}
+						}
+					}
+				}
+			}
+
+			// Look for any platform-specific assemblies
+			foreach (var directory in fallbackDirectories) {
+				foreach (var assembly in Directory.GetFiles (directory, "*.dll")) {
+					var assemblyName = Path.GetFileName (assembly);
+					if (!assembliesToAdd.ContainsKey (assemblyName)) {
+						Log.LogDebugMessage ($"Adding: {assembly}");
+						assembliesToAdd.Add (assemblyName, assembly);
+					}
+				}
+			}
+
+			AssembliesToAdd = assembliesToAdd.Values.ToArray ();
+			AssembliesToRemove = assembliesToRemove.ToArray ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -90,6 +90,16 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
+		public void DotNetBuildXamarinForms ()
+		{
+			var proj = new XamarinFormsXASdkProject (SdkVersion);
+			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
+			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+		}
+
+		[Test]
 		public void BuildWithLiteSdk ()
 		{
 			var proj = new XASdkProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -208,6 +208,11 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+		public static Package XamarinForms_4_5_0_617 = new Package {
+			Id = "Xamarin.Forms",
+			Version = "4.5.0.617",
+			TargetFramework = "MonoAndroid10.0",
+		};
 		public static Package XamarinFormsMaps_4_0_0_425677 = new Package {
 			Id = "Xamarin.Forms.Maps",
 			Version = "4.0.0.425677",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.ProjectTools
+{
+	public class XamarinFormsXASdkProject : XASdkProject
+	{
+		static readonly string default_main_activity_cs;
+		static readonly string colors_xml;
+		static readonly string styles_xml;
+		static readonly string Tabbar_xml;
+		static readonly string Toolbar_xml;
+		static readonly string MainPage_xaml;
+		static readonly string MainPage_xaml_cs;
+		static readonly string App_xaml;
+		static readonly string App_xaml_cs;
+
+		static XamarinFormsXASdkProject ()
+		{
+			var assembly = typeof (XamarinFormsXASdkProject).Assembly;
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainActivity.cs")))
+				default_main_activity_cs = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.colors.xml")))
+				colors_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.styles.xml")))
+				styles_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.AndroidX.Tabbar.xml")))
+				Tabbar_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.AndroidX.Toolbar.xml")))
+				Toolbar_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainPage.xaml")))
+				MainPage_xaml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainPage.xaml.cs")))
+				MainPage_xaml_cs = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.App.xaml")))
+				App_xaml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.App.xaml.cs")))
+				App_xaml_cs = sr.ReadToEnd ();
+		}
+
+
+		public XamarinFormsXASdkProject (string sdkVersion = "", string outputType = "Exe")
+			: base (sdkVersion, outputType)
+		{
+			PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
+
+			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
+			Imports.Add (new Import (() => "Directory.Build.targets") {
+				TextContent = () =>
+					@"<Project>
+						<PropertyGroup>
+							<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
+						</PropertyGroup>
+					</Project>"
+			});
+
+			Sources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
+				TextContent = () => colors_xml,
+			});
+			Sources.Add (new AndroidItem.AndroidResource ("Resources\\values\\styles.xml") {
+				TextContent = () => styles_xml,
+			});
+			Sources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\Tabbar.xml") {
+				TextContent = () => Tabbar_xml,
+			});
+			Sources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\Toolbar.xml") {
+				TextContent = () => Toolbar_xml,
+			});
+			Sources.Add (new BuildItem ("EmbeddedResource", "MainPage.xaml") {
+				TextContent = MainPageXaml,
+			});
+			Sources.Add (new BuildItem.Source ("MainPage.xaml.cs") {
+				TextContent = () => ProcessSourceTemplate (MainPage_xaml_cs),
+			});
+			Sources.Add (new BuildItem ("EmbeddedResource", "App.xaml") {
+				TextContent = () => ProcessSourceTemplate (App_xaml),
+			});
+			Sources.Add (new BuildItem.Source ("App.xaml.cs") {
+				TextContent = () => ProcessSourceTemplate (App_xaml_cs),
+			});
+
+			MainActivity = default_main_activity_cs;
+		}
+
+		protected virtual string MainPageXaml () => ProcessSourceTemplate (MainPage_xaml);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -82,6 +82,11 @@ namespace Xamarin.ProjectTools
 				}
 				sb.AppendLine ("\t</ItemGroup>");
 			}
+			foreach (var import in Imports) {
+				var project = import.Project ();
+				if (project != "Directory.Build.props" && project != "Directory.Build.targets")
+					sb.AppendLine ($"\t<Import Project=\"{project}\" />");
+			}
 			return $"<Project Sdk=\"{Sdk}\">\r\n{sb.ToString ()}\r\n</Project>";
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/AndroidX/Tabbar.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/AndroidX/Tabbar.xml
@@ -1,0 +1,10 @@
+<androidx.design.widget.TabLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/sliding_tabs"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary"
+    app:tabIndicatorColor="@android:color/white"
+    app:tabGravity="fill"
+    app:tabMode="fixed" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/AndroidX/Toolbar.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/AndroidX/Toolbar.xml
@@ -1,0 +1,6 @@
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -9,6 +9,12 @@
   <Import Project="..\..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
   <ItemGroup>
     <Compile Remove="Resources\**\*.cs" />
+    <EmbeddedResource Include="Resources\AndroidX\Tabbar.xml">
+      <LogicalName>Xamarin.ProjectTools.Resources.AndroidX.Tabbar.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\AndroidX\Toolbar.xml">
+      <LogicalName>Xamarin.ProjectTools.Resources.AndroidX.Toolbar.xml</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\Wear\LayoutMain.axml">
       <LogicalName>Xamarin.ProjectTools.Resources.Wear.LayoutMain.axml</LogicalName>
     </EmbeddedResource>

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -17,14 +17,21 @@ namespace Xamarin.Android.Build.Tests
 			.FirstOrDefault () ?? "0.0.1";
 
 		[Test]
-		public void DotNetInstallAndRun ([Values (false, true)] bool isRelease)
+		public void DotNetInstallAndRun ([Values (false, true)] bool isRelease, [Values (false, true)] bool xamarinForms)
 		{
 			if (!HasDevices)
 				Assert.Ignore ("Skipping Test. No devices available.");
 
-			var proj = new XASdkProject (SdkVersion) {
-				IsRelease = isRelease
-			};
+			XASdkProject proj;
+			if (xamarinForms) {
+				proj = new XamarinFormsXASdkProject (SdkVersion) {
+					IsRelease = isRelease
+				};
+			} else {
+				proj = new XASdkProject (SdkVersion) {
+					IsRelease = isRelease
+				};
+			}
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, DeviceAbi);
 			proj.SetRuntimeIdentifier (DeviceAbi);
 


### PR DESCRIPTION
Context: https://github.com/xamarin/net5-samples/blob/d525d8a2d60700f52f86372c47e83d646d800aa4/Directory.Android.targets

Currently, .NET 5 will not restore *existing* Xamarin.Android NuGet
packages. It does not know to map `netcoreapp5.0` to
`MonoAndroid10.0`, `MonoAndroid9` etc.

We'll need to work around this until this lands:

* https://github.com/NuGet/NuGet.Client/pull/3339

To get a Xamarin.Forms project building & running *at all* in
`xamarin/net5-samples`, I had to:

1. Change `$(AssetTargetFallback)`
2. Write an MSBuild target to replace any instances of
   `netstandard2.0\Xamarin.Forms.Platform.dll` with
   `MonoAndroid10.0\Xamarin.Forms.Platform.dll`.
3. Add additional platform-specific assemblies in
   `$(PkgXamarin_Forms)\lib\MonoAndroid10.0\`

There are still some issues with this:

1. You get a lot of `NU1701` warnings due to `$(AssetTargetFallback)`.
2. Due to: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955
   You have to manually list *every* transitive dependency, which
   totals around ~36 packages for AndroidX.

These drawbacks make it completely impractical to run some subset of
our existing MSBuild tests on .NET 5. We would have to list the entire
tree of `<PackageReference/>` for every test.

Since we might be waiting a bit of time for this, I have been able to
come up with some workarounds to solve these problems for now:

1. Add a `Microsoft.Android.Sdk.NuGet.targets` with workarounds that
   we will completely remove down the road (I hope!).
2. Use `$(PackageTargetFallback)` instead of `$(AssetTargetFallback)`.
   It does not emit `NU1701` warnings, and transitive dependencies
   work! It is a deprecated MSBuild property, but should be fine as a
   workaround.
3. Write a `_FixupNuGetReferences` MSBuild target that runs after
   `ResolvePackageAssets`. A `<FixupNuGetReferences/>` MSBuild task
   will remove any `netstandard2.0` assemblies where platform-specific
   ones exist. It also needs to add platform-specific assemblies that
   are missing.

With this in place, a Xamarin.Forms `.csproj` with no hacks works!

```xml
 <Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
    <TargetFramework>netcoreapp5.0</TargetFramework>
    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
   </ItemGroup>
 </Project>
```

I created a new `XamarinFormsXASdkProject` class for use in our
existing .NET 5 MSBuild tests.

Other changes:

* `$(XamarinAndroidVersion)` needs to be filled out for the AndroidX
  MSBuild targets:
  https://github.com/xamarin/XamarinAndroidXMigration/blob/ea130ca0d0e9b3e20edccec02364f36da11ada6b/source/Xamarin.AndroidX.Migration/BuildTasks/Xamarin.AndroidX.Migration.targets#L107
* `$(RuntimeIdentifier)` should have a default value for application
  projects.
* Some tweaks to make `XASdkProject` more flexible.
* `Xamarin.ProjectTools.DotNetStandard` projects now support
  `<Import/>`.
* Added AndroidX-compatible `Tabbar.xml` and `Toolbar.xml`