### PR TITLE
Bump to r8 1.6.82

### DIFF
--- a/Documentation/release-notes/4670.md
+++ b/Documentation/release-notes/4670.md
@@ -1,0 +1,4 @@
+### D8/R8 version update to 1.6.82
+
+The version of the [D8 dexer and R8 shrinker](https://r8.googlesource.com/r8)
+included in Xamarin.Android has been updated from 1.5.68 to 1.6.82.

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -1,19 +1,17 @@
-plugins {
-    id 'java'
-}
+apply plugin: 'java'
+apply plugin: 'idea'
 
-// See: https://r8.googlesource.com/r8/+/refs/tags/1.5.67/build.gradle#53
+// See: https://r8.googlesource.com/r8/+/refs/tags/1.6.82/build.gradle#55
 repositories {
     maven {
        url 'http://storage.googleapis.com/r8-deps/maven_mirror/'
     }
-    maven { url 'https://maven.google.com' }
+    google()
     mavenCentral()
-    maven { url 'https://kotlin.bintray.com/kotlinx' }
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '1.5.68'
+    compile group: 'com.android.tools', name: 'r8', version: '1.6.82'
 }
 
 jar {


### PR DESCRIPTION
Context: https://r8.googlesource.com/r8/+/refs/tags/1.6.82/
Context: https://mvnrepository.com/artifact/com.android.tools/r8/1.6.82