### PR TITLE
[typemaps] Fix a log statement which may lead to segfault when used

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -210,7 +210,7 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
 
 	const char *managed_type_name = entry->to;
 	if (managed_type_name == nullptr) {
-		log_debug (LOG_ASSEMBLY, "typemap: Java type '%s' maps either to an open generic type or an interface type.");
+		log_debug (LOG_ASSEMBLY, "typemap: Java type '%s' maps either to an open generic type or an interface type.", java_type_name);
 		return nullptr;
 	}
 	log_debug (LOG_DEFAULT, "typemap: Java type '%s' corresponds to managed type '%s'", java_type_name, managed_type_name);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4596
Context: a017561b1e44c51a9af79fae0baaa50fe01c4123
Context: https://gist.github.com/pjcollins/87762e81f1f3c7e8b821356e4612eecf

A missing parameter in a call to `log_debug` added in a017561b may lead
to a segfault when `assembly` log category and `debug` log level are
enabled:

		F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x3 in tid 922 (DrawableTinting), pid 922 (DrawableTinting)
		I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
		I /system/bin/tombstoned: received crash request for pid 922
		I crash_dump64: performing dump of process 922 (target tid = 922)
		F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
		F DEBUG   : Build fingerprint: 'Android/sdk_phone_x86_64/generic_x86_64:9/PSR1.180720.012/4923214:userdebug/test-keys'
		F DEBUG   : Revision: '0'
		F DEBUG   : ABI: 'x86_64'
		F DEBUG   : pid: 922, tid: 922, name: DrawableTinting  >>> com.xamarin.DrawableTinting <<<
		F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x3
		F DEBUG   : Cause: null pointer dereference
		F DEBUG   :     rax 0000000000000000  rbx 00007ffed3c283c0  rcx 0000000000000003  rdx 0000000000000002
		F DEBUG   :     r8  00007ffed3c283c0  r9  00000000ffffffff  r10 00007ffed3c283d0  r11 00007ffed3c28824
		F DEBUG   :     r12 00007c88774a2f17  r13 00000000ffffffff  r14 0000000000000000  r15 00007ffed3c283d0
		F DEBUG   :     rdi 0000000000000003  rsi 00007ffed3c283bb
		F DEBUG   :     rbp 00007ffed3c28f18  rsp 00007ffed3c28288  rip 00007c890f860761
		F DEBUG   :
		F DEBUG   : backtrace:
		F DEBUG   :     #00 pc 0000000000020761  /system/lib64/libc.so (strlen+17)
		F DEBUG   :     #01 pc 000000000006e761  /system/lib64/libc.so (__vfprintf+5953)
		F DEBUG   :     #02 pc 000000000008df5d  /system/lib64/libc.so (vsnprintf+189)
		F DEBUG   :     #03 pc 0000000000007b60  /system/lib64/liblog.so (__android_log_vprint+64)
		F DEBUG   :     #04 pc 000000000001350c  /data/app/com.xamarin.DrawableTinting-zvchh4ya_DW11GfpEPFICw==/lib/x86_64/libmonodroid.so (log_debug_nocheck(_LogCategories, char const*, ...)+204)
		F DEBUG   :     #05 pc 000000000000de6a  /data/app/com.xamarin.DrawableTinting-zvchh4ya_DW11GfpEPFICw==/lib/x86_64/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::typemap_java_to_managed(char const*)+538)
		F DEBUG   :     #06 pc 000000000000df13  /data/app/com.xamarin.DrawableTinting-zvchh4ya_DW11GfpEPFICw==/lib/x86_64/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::typemap_java_to_managed(_MonoString*)+99)
		F DEBUG   :     #07 pc 00000000000d57f8  <anonymous:0000000042d04000>

Add the missing parameter to prevent the `SIGSEGV` from happening.