### PR TITLE
[CI/OSS] Use new Ubuntu VM scale set agents

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -16,9 +16,6 @@ pr:
 # Global variables
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 variables:
-  EnableMacStage: true
-  EnableLinuxStage: true
-
   XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Android-OSS
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public
 
@@ -31,9 +28,6 @@ variables:
   # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
   DotNetCorePreviewVersion: 5.0.100-preview.4.20227.14
 
-  BUILD_TESTS: true
-  RUN_TESTS: false
-
 stages:
 - stage: mac_stage
   displayName: Mac
@@ -42,7 +36,7 @@ stages:
   - job: mac_build
     displayName: Mac Build
     pool:
-      name: $(XA.Build.MacOSSPool)  # The variable is defined on the pipeline definition
+      name: $(XA.Build.MacOSSPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -98,7 +92,6 @@ stages:
         make all-tests CONFIGURATION=$(XA.Build.Configuration) V=1
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make all-tests
-      condition: and(succeeded(), eq(variables['BUILD_TESTS'], 'true'))
 
     - script: >
         echo "make package-build-status CONFIGURATION=$(XA.Build.Configuration) V=1" &&
@@ -124,7 +117,7 @@ stages:
         make run-performance-tests CONFIGURATION=$(XA.Build.Configuration) V=1
       workingDirectory: $(Build.SourcesDirectory)
       displayName: run performance tests
-      condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+      condition: and(succeeded(), eq(variables['EnableTestExecution'], 'true'))   # The variable is defined on the pipeline definition
 
     - template: yaml-templates/upload-results.yaml
       parameters:
@@ -137,7 +130,7 @@ stages:
   jobs:
   - job: linux_build_package
     displayName: Linux Build
-    pool: $(XA.Build.LinuxOSSPool)                        # The variable is defined on the pipeline definition
+    pool: $(XA.Build.LinuxOSSPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -15,6 +15,7 @@ pr:
 
 # Global variables
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+# https://dev.azure.com/xamarin/public/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=48&view=Tab_Variables
 variables:
   XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Android-OSS
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -17,7 +17,7 @@ pr:
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 variables:
   EnableMacStage: true
-  EnableLinuxStage: false
+  EnableLinuxStage: true
 
   XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Android-OSS
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public
@@ -159,6 +159,12 @@ stages:
         sudo apt-get install -y mono-devel &&
         sudo apt-get install -y ca-certificates-mono
       displayName: install mono preview
+
+    - script: echo "##vso[task.setvariable variable=HOME]$(Agent.HomeDirectory)"
+      displayName: set HOME to agent directory
+
+    - script: echo "##vso[task.setvariable variable=PATH]$PATH:$(Agent.HomeDirectory)/android-toolchain/jdk/bin"
+      displayName: append jdk tools to PATH
 
     - script: make jenkins V=1 PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make jenkins

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -166,11 +166,11 @@ stages:
       displayName: make package-deb
 
     - script: >
-        mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
-        cp $(System.DefaultWorkingDirectory)/*xamarin.android*.tar.bz2 $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
-        cp $(System.DefaultWorkingDirectory)/*.changes $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
-        cp $(System.DefaultWorkingDirectory)/*.dsc $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts &&
-        cp $(System.DefaultWorkingDirectory)/*.deb $(System.DefaultWorkingDirectory)/bin/Build$(OSSBuildConfiguration)/linux-artifacts
+        mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
+        cp $(System.DefaultWorkingDirectory)/*xamarin.android*.tar.bz2 $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
+        cp $(System.DefaultWorkingDirectory)/*.changes $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
+        cp $(System.DefaultWorkingDirectory)/*.dsc $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
+        cp $(System.DefaultWorkingDirectory)/*.deb $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts
       displayName: copy linux artifacts
 
     - task: PublishPipelineArtifact@1

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -98,8 +98,12 @@
         Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/monodoc/MonoAndroid-lib.zip&quot; ."
     />
   </Target>
+  <!-- See pipeline variable settings
+        https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=12278&view=Tab_Variables
+        https://dev.azure.com/xamarin/public/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=48&view=Tab_Variables
+  -->
   <Target Name="_PrepareForNotarization"
-      Condition=" '$(HostOS)' == 'Darwin' And '$(RunningOnCI)' == 'true' "
+      Condition=" '$(HostOS)' == 'Darwin' And '$(RunningOnCI)' == 'true' And '$(XAOSSBuild)' != 'true' "
       DependsOnTargets="_CreateSymbolicLinks" >
     <Exec Command="dd if=&quot;%(CopiedMSBuildItemsUnix.Identity)&quot; of=&quot;%(CopiedMSBuildItemsUnix.Identity).swab&quot; conv=swab"
         Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />

--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -23,6 +23,8 @@ override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libwinpthread-1.dll
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.so
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/apkdiff/libzip.dll
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/apkdiff/libzip.so
 
 	dh_install
 


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=18233&view=results

Our OSS Linux builds have been failing because they are running out of
disk space.  I've set up a new [virtual machine scale set agent pool][0]
to try to use for our Ubuntu builds.  These VMs are configured with more
disk space than the ~10 GB allowed by the hosted agents.

The virtual machine scale set resource can be found in the azure portal
here:

https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/64e11c84-c922-4ffd-bea9-67ab39354edd/resourceGroups/XAMARIN-PUBLIC-PIPELINES/providers/Microsoft.Compute/virtualMachineScaleSets/android-public-ubuntu-vmss/overview

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops