### PR TITLE
[Xamarin.Android.Build.Tasks] Update NDK dependency check

### DIFF
--- a/Documentation/release-notes/fix-4675.md
+++ b/Documentation/release-notes/fix-4675.md
@@ -1,0 +1,6 @@
+#### IDE compatibility
+
+- [GitHub 4675](https://github.com/xamarin/xamarin-android/issues/4675):
+  _The project ... is missing Android SDKs required for building._ prevented
+  building without the Android NDK installed for projects with **Enable Startup
+  Tracing** or **AOT Compilation** enabled.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3285,10 +3285,14 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "GetAndroidDependencies";
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				IEnumerable<string> taskOutput = builder.LastBuildOutput
+					.SkipWhile (x => !x.StartsWith ("Task \"CalculateProjectDependencies\""))
+					.SkipWhile (x => !x.StartsWith ("  Output Item(s):"))
+					.TakeWhile (x => !x.StartsWith ("Done executing task \"CalculateProjectDependencies\""));
 				if (ndkRequired)
-					StringAssertEx.Contains ("ndk-bundle", builder.LastBuildOutput, "ndk-bundle should be a dependency.");
+					StringAssertEx.Contains ("ndk-bundle", taskOutput, "ndk-bundle should be a dependency.");
 				else
-					StringAssertEx.DoesNotContain ("ndk-bundle", builder.LastBuildOutput, "ndk-bundle should not be a dependency.");
+					StringAssertEx.DoesNotContain ("ndk-bundle", taskOutput, "ndk-bundle should not be a dependency.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3273,6 +3273,26 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[TestCase ("AotAssemblies", false)]
+		[TestCase ("AndroidEnableProfiledAot", false)]
+		[TestCase ("EnableLLVM", true)]
+		[TestCase ("BundleAssemblies", true)]
+		public void GetDependencyNdkRequiredConditions (string property, bool ndkRequired)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AotAssemblies = true;
+			proj.SetProperty (property, "true");
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "GetAndroidDependencies";
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				if (ndkRequired)
+					StringAssertEx.Contains ("ndk-bundle", builder.LastBuildOutput, "ndk-bundle should be a dependency.");
+				else
+					StringAssertEx.DoesNotContain ("ndk-bundle", builder.LastBuildOutput, "ndk-bundle should not be a dependency.");
+			}
+		}
+
+		[Test]
 		public void GetDependencyWhenBuildToolsAreMissingTest ()
 		{
 			var apis = new ApiInfo [] {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2808,7 +2808,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="GetAndroidDependencies" DependsOnTargets="_BeforeGetAndroidDependencies;_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
-    <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(AotAssemblies)' == 'True'">true</_NdkRequired>
+    <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(EnableLLVM)' == 'True'">true</_NdkRequired>
     <_NdkRequired Condition="'$(_NdkRequired)' == ''">false</_NdkRequired>
   </PropertyGroup>
   <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>


### PR DESCRIPTION
Context: f0b1e8a53054c5620b256b7f5613ef5b3610146c
Fixes: https://github.com/xamarin/xamarin-android/issues/4675

Thanks to commit f0b1e8a5, Xamarin.Android 10.0 and higher no longer
require the NDK when `$(AotAssemblies)`=`true` or
`$(AndroidEnableProfiledAot)`=`true`.  The NDK is now only required when
`$(EnableLLVM)`=`true` or when `$(BundleAssemblies)`=`true`.

Update `GetAndroidDependencies` to account for this new behavior.  This
allows users who have `$(AotAssemblies)`=`true` or
`$(AndroidEnableProfiledAot)`=`true` to build successfully from within
Visual Studio without being forced to install the NDK.  Previously, this
scenario was blocked by an error:

	The project AndroidApp1 is missing Android SDKs required for building. Double-click on this message and follow the prompts to install them.

This error provided the following additional information in the Output
window:

	Project 'AndroidApp1' requires the following components installed on your machine:
	NDK

	In order to resolve this, please go to the Error List window, make sure "Build + IntelliSense" is selected and double-click on the error above.
	Build has been canceled.