### PR TITLE
[tests] One .NET MSBuild test infrastructure

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -77,6 +77,9 @@ will not be supported.
 `$(AndroidCodegenTarget)` will be `XAJavaInterop1` by default.
 `XamarinAndroid` will not be supported.
 
+`$(MonoSymbolArchive)` will be `False`, since `mono-symbolicate` is
+not yet supported.
+
 If Java binding is enabled with `@(InputJar)`, `@(EmbeddedJar)`,
 `@(LibraryProjectZip)`, etc. then `$(AllowUnsafeBlocks)` will default
 to `True`.

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -64,6 +64,13 @@ jobs:
           nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
           testResultsFile: TestResult-MSBuildTests-macOS-NoNode-$(XA.Build.Configuration).xml
 
+      - template: run-nunit-tests.yaml
+        parameters:
+          testRunTitle: Xamarin.Android.Build.Tests - macOS - One .NET
+          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
+          nunitConsoleExtraArgs: --where "cat == dotnet" --params dotnet=true
+          testResultsFile: TestResult-MSBuildTests-macOS-dotnet-$(XA.Build.Configuration).xml
+
     - template: upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild - Mac-${{ parameters.node_id }}

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -55,6 +55,13 @@ jobs:
           nunitConsoleExtraArgs: --workers=4 --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
           testResultsFile: TestResult-MSBuildTests-Windows-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
 
+      - template: run-nunit-tests.yaml
+        parameters:
+          testRunTitle: Xamarin.Android.Build.Tests - Windows - One .NET
+          testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
+          nunitConsoleExtraArgs: --workers=4 --where "cat == dotnet" --params dotnet=true
+          testResultsFile: TestResult-MSBuildTests-Windows-dotnet-$(XA.Build.Configuration).xml
+
     - template: upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild - Windows-${{ parameters.node_id }}

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -28,6 +28,8 @@
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
     <!-- jar2xml is not supported -->
     <AndroidClassParser>class-parse</AndroidClassParser>
+    <!-- mono-symbolicate is not supported -->
+    <MonoSymbolArchive>false</MonoSymbolArchive>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Build.Tests
 
 		static object [] RuntimeChecks () => new object [] {
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "Full",
 				/* optimize */         true ,
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "release",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "Full",
 				/* optimize */         true ,
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   CommercialBuildAvailable ? "debug" : "release",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "Full",
 				/* optimize */         false ,
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "debug",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "Full",
 				/* optimize */         false ,
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "debug",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "",
 				/* optimize */         true ,
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "release",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "",
 				/* optimize */         true ,
@@ -105,7 +105,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   CommercialBuildAvailable ? "debug" : "release",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "",
 				/* optimize */         false ,
@@ -113,7 +113,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "debug",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     true ,
 				/* debugType */        "",
 				/* optimize */         false ,
@@ -121,7 +121,7 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */   "debug",
 			},
 			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* supportedAbi */     "armeabi-v7a",
 				/* debugSymbols */     false ,
 				/* debugType */        "",
 				/* optimize */         null ,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -386,7 +386,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void CheckAppBundle ([Values (true, false)] bool isRelease)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -40,6 +40,8 @@ namespace Xamarin.Android.Build.Tests
 
 			static SetUp ()
 			{
+				Builder.UseDotNet = string.Equals (TestContext.Parameters ["dotnet"], bool.TrueString, StringComparison.OrdinalIgnoreCase);
+
 				using (var builder = new Builder ()) {
 					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 					AndroidMSBuildDirectory = builder.AndroidMSBuildDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -15,17 +15,11 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2")]
 	public class XASdkTests : BaseTest
 	{
-		static readonly string SdkVersion = Assembly.GetExecutingAssembly ()
-			.GetCustomAttributes<AssemblyMetadataAttribute> ()
-			.Where (attr => attr.Key == "SdkVersion")
-			.Select (attr => attr.Value)
-			.FirstOrDefault () ?? "0.0.1";
-
 		[Test]
 		[Category ("SmokeTests")]
 		public void DotNetBuildLibrary ([Values (false, true)] bool isRelease)
 		{
-			var proj = new XASdkProject (SdkVersion, outputType: "Library") {
+			var proj = new XASdkProject (outputType: "Library") {
 				IsRelease = isRelease
 			};
 			var dotnet = CreateDotNetBuilder (proj);
@@ -48,7 +42,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		public void DotNetBuildBinding ()
 		{
-			var proj = new XASdkProject (SdkVersion, outputType: "Library");
+			var proj = new XASdkProject (outputType: "Library");
 			proj.OtherBuildItems.Add (new AndroidItem.EmbeddedJar ("javaclasses.jar") {
 				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64)
 			});
@@ -97,7 +91,7 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuild (string runtimeIdentifier, bool isRelease)
 		{
 			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (runtimeIdentifier);
-			var proj = new XASdkProject (SdkVersion) {
+			var proj = new XASdkProject {
 				IsRelease = isRelease
 			};
 			proj.OtherBuildItems.Add (new AndroidItem.InputJar ("javaclasses.jar") {
@@ -134,7 +128,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		public void DotNetBuildXamarinForms ()
 		{
-			var proj = new XamarinFormsXASdkProject (SdkVersion);
+			var proj = new XamarinFormsXASdkProject ();
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
@@ -144,7 +138,7 @@ namespace Xamarin.Android.Build.Tests
 		public void BuildWithLiteSdk ()
 		{
 			var proj = new XASdkProject () {
-				Sdk = $"Xamarin.Android.Sdk.Lite/{SdkVersion}",
+				Sdk = $"Xamarin.Android.Sdk.Lite/{XASdkProject.SdkVersion}",
 				TargetFramework = "monoandroid10.0"
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -1,11 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace Xamarin.ProjectTools
 {
 	public class XASdkProject : DotNetStandard
 	{
+		public static readonly string SdkVersion = typeof (XASdkProject).Assembly
+			.GetCustomAttributes<AssemblyMetadataAttribute> ()
+			.Where (attr => attr.Key == "SdkVersion")
+			.Select (attr => attr.Value)
+			.FirstOrDefault () ?? "0.0.1";
+
 		const string default_strings_xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<string name=""hello"">Hello World, Click Me!</string>
@@ -36,17 +44,13 @@ namespace Xamarin.ProjectTools
 		public string PackageName { get; set; }
 		public string JavaPackageName { get; set; }
 
-		public XASdkProject (string sdkVersion = "", string outputType = "Exe")
+		public XASdkProject (string outputType = "Exe")
 		{
-			Sdk = string.IsNullOrEmpty (sdkVersion) ? "Microsoft.Android.Sdk" : $"Microsoft.Android.Sdk/{sdkVersion}";
+			Sdk = $"Microsoft.Android.Sdk/{SdkVersion}";
 			TargetFramework = "net5.0";
 
 			PackageName = PackageName ?? string.Format ("{0}.{0}", ProjectName);
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
-			ExtraNuGetConfigSources = new List<string> {
-				Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
-				"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
-			};
 			GlobalPackagesFolder = Path.Combine (XABuildPaths.TopDirectory, "packages");
 			SetProperty (KnownProperties.OutputType, outputType);
 
@@ -80,22 +84,5 @@ namespace Xamarin.ProjectTools
 				.Replace ("${PACKAGENAME}", PackageName)
 				.Replace ("${JAVA_PACKAGENAME}", JavaPackageName);
 		}
-
-		public void SetRuntimeIdentifier (string androidAbi)
-		{
-			if (androidAbi == "armeabi-v7a") {
-				SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm");
-			}
-			else if (androidAbi == "arm64-v8a") {
-				SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm64");
-			}
-			else if (androidAbi == "x86") {
-				SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x86");
-			}
-			else if (androidAbi == "x86_64") {
-				SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x64");
-			}
-		}
-
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -36,15 +36,29 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			SetProperty ("AndroidApplication", "True");
+			if (Builder.UseDotNet) {
+				SetProperty (KnownProperties.OutputType, "Exe");
+				SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
 
-			SetProperty ("AndroidResgenClass", "Resource");
-			SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);
-			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
-			SetProperty (DebugProperties, "AndroidLinkMode", "None");
-			SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");
-			SetProperty (DebugProperties, KnownProperties.EmbedAssembliesIntoApk, "False", "'$(EmbedAssembliesIntoApk)' == ''");
-			SetProperty (ReleaseProperties, KnownProperties.EmbedAssembliesIntoApk, "True", "'$(EmbedAssembliesIntoApk)' == ''");
+				// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
+				Imports.Add (new Import (() => "Directory.Build.targets") {
+					TextContent = () =>
+						@"<Project>
+							<PropertyGroup>
+								<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
+							</PropertyGroup>
+						</Project>"
+				});
+			} else {
+				SetProperty ("AndroidApplication", "True");
+				SetProperty ("AndroidResgenClass", "Resource");
+				SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);
+				SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
+				SetProperty (DebugProperties, "AndroidLinkMode", "None");
+				SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");
+				SetProperty (DebugProperties, KnownProperties.EmbedAssembliesIntoApk, "False", "'$(EmbedAssembliesIntoApk)' == ''");
+				SetProperty (ReleaseProperties, KnownProperties.EmbedAssembliesIntoApk, "True", "'$(EmbedAssembliesIntoApk)' == ''");
+			}
 
 			AndroidManifest = default_android_manifest;
 			LayoutMain = default_layout_main;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
@@ -48,8 +48,11 @@ namespace Xamarin.ProjectTools
 		{
 			var root = base.Construct ();
 			root.AddImport (XamarinAndroidLanguage.BindingProjectImport);
-			foreach (var import in Imports)
-				root.AddImport (import.Project ());
+			foreach (var import in Imports) {
+				var projectName = import.Project ();
+				if (projectName != "Directory.Build.props" && projectName != "Directory.Build.targets")
+					root.AddImport (import.Project ());
+			}
 			return root;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Xml;
-using Microsoft.Build.Construction;
 
 namespace Xamarin.ProjectTools
 {
@@ -18,8 +14,10 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidLibraryProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			SetProperty ("AndroidApplication", "False");
-			SetProperty ("AndroidResgenFile", Path.Combine ("Resources", "Resource.designer.cs"));
+			if (!Builder.UseDotNet) {
+				SetProperty ("AndroidApplication", "False");
+				SetProperty ("AndroidResgenFile", Path.Combine ("Resources", "Resource.designer.cs"));
+			}
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\Strings.xml") { TextContent = () => StringsXml.Replace ("${PROJECT_NAME}", ProjectName) });
 			StringsXml = default_strings_xml;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -13,22 +13,22 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			Language = XamarinAndroidProjectLanguage.CSharp;
-			TargetFrameworkVersion = Versions.Android10;
-			UseLatestPlatformSdk = true;
-			AddReferences ("System.Core", "System.Xml", "Mono.Android");
-			ProjectGuid = Guid.NewGuid ().ToString ();
 
-			SetProperty ("ProjectTypeGuids", () => "{" + Language.ProjectTypeGuid + "};{" + ProjectTypeGuid + "}");
-			SetProperty ("ProjectGuid", () => "{" + ProjectGuid + "}");
+			if (!Builder.UseDotNet) {
+				TargetFrameworkVersion = Versions.Android10;
+				UseLatestPlatformSdk = true;
+				AddReferences ("System.Core", "System.Xml", "Mono.Android");
+				ProjectGuid = Guid.NewGuid ().ToString ();
+				SetProperty ("ProjectTypeGuids", () => "{" + Language.ProjectTypeGuid + "};{" + ProjectTypeGuid + "}");
+				SetProperty ("ProjectGuid", () => "{" + ProjectGuid + "}");
+				SetProperty ("MonoAndroidAssetsPrefix", "Assets");
+				SetProperty ("MonoAndroidResourcePrefix", "Resources");
+				SetProperty (KnownProperties.AndroidUseLatestPlatformSdk, () => UseLatestPlatformSdk ? "True" : "False");
+				SetProperty (KnownProperties.TargetFrameworkVersion, () => TargetFrameworkVersion);
+				SetProperty (ReleaseProperties, KnownProperties.AndroidUseSharedRuntime, "False");
+			}
 
 			SetProperty (KnownProperties.OutputType, "Library");
-			SetProperty ("MonoAndroidAssetsPrefix", "Assets");
-			SetProperty ("MonoAndroidResourcePrefix", "Resources");
-
-			SetProperty (KnownProperties.AndroidUseLatestPlatformSdk, () => UseLatestPlatformSdk ? "True" : "False");
-			SetProperty (KnownProperties.TargetFrameworkVersion, () => TargetFrameworkVersion);
-
-			SetProperty (ReleaseProperties, KnownProperties.AndroidUseSharedRuntime, "False");
 		}
 
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
@@ -40,9 +40,8 @@ namespace Xamarin.ProjectTools
 				App_xaml_cs = sr.ReadToEnd ();
 		}
 
-
-		public XamarinFormsXASdkProject (string sdkVersion = "", string outputType = "Exe")
-			: base (sdkVersion, outputType)
+		public XamarinFormsXASdkProject (string outputType = "Exe")
+			: base (outputType)
 		{
 			PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml.XPath;
 using System.Xml.Linq;
-using Xamarin.Android.Tools.VSWhere;
 
 namespace Xamarin.ProjectTools
 {
@@ -17,6 +16,11 @@ namespace Xamarin.ProjectTools
 	{
 		const string SigSegvError = "Got a SIGSEGV while executing native code";
 		const string ConsoleLoggerError = "[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative";
+
+		/// <summary>
+		/// If true, use `dotnet build` and IShortFormProject throughout the tests
+		/// </summary>
+		public static bool UseDotNet { get; set; }
 
 		string root;
 		string buildLogFullPath;
@@ -282,11 +286,13 @@ namespace Xamarin.ProjectTools
 
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
-			var psi   = new ProcessStartInfo (XABuildExe);
+			var psi   = new ProcessStartInfo (UseDotNet ? "dotnet" : XABuildExe);
 			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "project.rsp");
+			if (UseDotNet)
+				args.Append ("build ");
 			args.AppendFormat ("{0} /t:{1} {2}",
 					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
-			if (AutomaticNuGetRestore && restore) {
+			if (AutomaticNuGetRestore && restore && !UseDotNet) {
 				args.Append (" /restore");
 			}
 			args.Append ($" @\"{responseFile}\"");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Construction;
 
 namespace Xamarin.ProjectTools
 {
-	public abstract class DotNetXamarinProject : XamarinProject
+	public abstract class DotNetXamarinProject : XamarinProject, IShortFormProject
 	{
 		protected DotNetXamarinProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
@@ -22,38 +22,42 @@ namespace Xamarin.ProjectTools
 			ItemGroupList.Add (OtherBuildItems);
 			ItemGroupList.Add (Sources);
 
-			AddReferences ("System"); // default
-
 			SetProperty (KnownProperties.Configuration, debugConfigurationName, "'$(Configuration)' == ''");
-			SetProperty ("Platform", "AnyCPU", "'$(Platform)' == ''");
-			SetProperty ("ErrorReport", "prompt");
-			SetProperty ("WarningLevel", "4");
-			SetProperty ("ConsolePause", "false");
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
-			SetProperty ("BaseIntermediateOutputPath", "obj\\", " '$(BaseIntermediateOutputPath)' == '' ");
 
-			SetProperty (DebugProperties, "DebugSymbols", "true");
-			SetProperty (DebugProperties, "DebugType", "full");
-			SetProperty (DebugProperties, "Optimize", "false");
-			SetProperty (DebugProperties, KnownProperties.OutputPath, Path.Combine ("bin", debugConfigurationName));
-			SetProperty (DebugProperties, "DefineConstants", "DEBUG;");
-			SetProperty (DebugProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", debugConfigurationName));
+			if (Builder.UseDotNet) {
+				SetProperty ("TargetFramework", "net5.0");
+				SetProperty ("EnableDefaultItems", "false");
+				SetProperty ("AppendTargetFrameworkToOutputPath", "false");
+				SetProperty ("AppendRuntimeIdentifierToOutputPath", "false");
+			} else {
+				AddReferences ("System"); // default
+				SetProperty ("Platform", "AnyCPU", "'$(Platform)' == ''");
+				SetProperty ("ErrorReport", "prompt");
+				SetProperty ("WarningLevel", "4");
+				SetProperty ("ConsolePause", "false");
 
-			SetProperty (ReleaseProperties, "Optimize", "true");
-			SetProperty (ReleaseProperties, "ErrorReport", "prompt");
-			SetProperty (ReleaseProperties, "WarningLevel", "4");
-			SetProperty (ReleaseProperties, "ConsolePause", "false");
-			SetProperty (ReleaseProperties, KnownProperties.OutputPath, Path.Combine ("bin", releaseConfigurationName));
+				SetProperty ("BaseIntermediateOutputPath", "obj\\", " '$(BaseIntermediateOutputPath)' == '' ");
+
+				SetProperty (DebugProperties, "DebugSymbols", "true");
+				SetProperty (DebugProperties, "DebugType", "full");
+				SetProperty (DebugProperties, "Optimize", "false");
+				SetProperty (DebugProperties, "DefineConstants", "DEBUG;");
+
+				SetProperty (ReleaseProperties, "Optimize", "true");
+				SetProperty (ReleaseProperties, "ErrorReport", "prompt");
+				SetProperty (ReleaseProperties, "WarningLevel", "4");
+				SetProperty (ReleaseProperties, "ConsolePause", "false");
+			}
+
+			// These are always set, so the OutputPath and IntermediateOutputPath properties work
+			SetProperty (DebugProperties,   KnownProperties.OutputPath,             Path.Combine ("bin", debugConfigurationName));
+			SetProperty (DebugProperties,   KnownProperties.IntermediateOutputPath, Path.Combine ("obj", debugConfigurationName));
+			SetProperty (ReleaseProperties, KnownProperties.OutputPath,             Path.Combine ("bin", releaseConfigurationName));
 			SetProperty (ReleaseProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", releaseConfigurationName));
 
 			Sources.Add (new BuildItem.Source (() => "Properties\\AssemblyInfo" + Language.DefaultExtension) { TextContent = () => ProcessSourceTemplate (AssemblyInfo ?? Language.DefaultAssemblyInfo) });
-		}
-
-		void AddProperties (IList<Property> list, string condition, KeyValuePair<string, string> [] props)
-		{
-			foreach (var p in props)
-				list.Add (new Property (condition, p.Key, p.Value));
 		}
 
 		public IList<BuildItem> OtherBuildItems { get; private set; }
@@ -72,6 +76,10 @@ namespace Xamarin.ProjectTools
 			get { return GetProperty (ActiveConfigurationProperties, KnownProperties.IntermediateOutputPath); }
 			set { SetProperty (ActiveConfigurationProperties, KnownProperties.IntermediateOutputPath, value); }
 		}
+
+		public string Sdk { get; set; } = $"Microsoft.Android.Sdk/{XASdkProject.SdkVersion}";
+
+		public bool EnableDefaultItems => false;
 
 		public void AddReferences (params string [] references)
 		{
@@ -114,6 +122,9 @@ namespace Xamarin.ProjectTools
 
 		public override string SaveProject ()
 		{
+			if (Builder.UseDotNet) {
+				return XmlUtils.ToXml (this);
+			}
 			XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
 			var encoding = Encoding.UTF8;
 			var root = Construct ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/IShortFormProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/IShortFormProject.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.ProjectTools
+{
+	public interface IShortFormProject
+	{
+		/// <summary>
+		/// If true, uses the default MSBuild wildcards for short-form projects.
+		/// </summary>
+		bool EnableDefaultItems { get; }
+		string Sdk { get; set; }
+		IList<PropertyGroup> PropertyGroups { get; }
+		IList<Package> PackageReferences { get; }
+		IList<BuildItem> OtherBuildItems { get; }
+		IList<IList<BuildItem>> ItemGroupList { get; }
+		IList<Import> Imports { get; }
+		void SetProperty (string name, string value, string condition = null);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -31,7 +31,10 @@ namespace Xamarin.ProjectTools
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
 		public string GlobalPackagesFolder { get; set; } = Path.Combine (XABuildPaths.TopDirectory, "packages");
-		public IList<string> ExtraNuGetConfigSources { get; set; }
+		public IList<string> ExtraNuGetConfigSources { get; set; } = new List<string> {
+			Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
+			"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
+		};
 
 		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;
 		/// <summary>
@@ -58,9 +61,14 @@ namespace Xamarin.ProjectTools
 			CommonProperties = new List<Property> ();
 			common = new PropertyGroup (null, CommonProperties);
 			DebugProperties = new List<Property> ();
-			debug = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{debugConfigurationName}|AnyCPU'", DebugProperties);
 			ReleaseProperties = new List<Property> ();
-			release = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{releaseConfigurationName}|AnyCPU'", ReleaseProperties);
+			if (Builder.UseDotNet) {
+				debug = new PropertyGroup ($"'$(Configuration)' == '{debugConfigurationName}'", DebugProperties);
+				release = new PropertyGroup ($"'$(Configuration)' == '{releaseConfigurationName}'", ReleaseProperties);
+			} else {
+				debug = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{debugConfigurationName}|AnyCPU'", DebugProperties);
+				release = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{releaseConfigurationName}|AnyCPU'", ReleaseProperties);
+			}
 
 			PropertyGroups.Add (common);
 			PropertyGroups.Add (debug);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Xamarin.ProjectTools
+{
+	public static class ProjectExtensions
+	{
+		public static void SetRuntimeIdentifier (this IShortFormProject project, string androidAbi)
+		{
+			if (androidAbi == "armeabi-v7a") {
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm");
+			} else if (androidAbi == "arm64-v8a") {
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm64");
+			} else if (androidAbi == "x86") {
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x86");
+			} else if (androidAbi == "x86_64") {
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x64");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.ProjectTools
+{
+	static class XmlUtils
+	{
+		public static string ToXml (IShortFormProject project)
+		{
+			var sb = new StringBuilder ();
+			foreach (var pg in project.PropertyGroups) {
+				if (pg.Properties.Count == 0)
+					continue;
+				if (string.IsNullOrEmpty (pg.Condition)) {
+					sb.AppendLine ("\t<PropertyGroup>");
+				} else {
+					sb.AppendLine ($"\t<PropertyGroup Condition=\"{pg.Condition}\">");
+				}
+				foreach (var p in pg.Properties) {
+					var conditon = string.IsNullOrEmpty (p.Condition) ? "" : $" Condition=\"{p.Condition}\"";
+					sb.AppendLine ($"\t\t<{p.Name}{conditon}>{p.Value ()}</{p.Name}>");
+				}
+				sb.AppendLine ("\t</PropertyGroup>");
+			}
+			if (project.PackageReferences.Count > 0) {
+				sb.AppendLine ("\t<ItemGroup>");
+				foreach (var pr in project.PackageReferences) {
+					sb.AppendLine ($"\t\t<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
+				}
+				sb.AppendLine ("\t</ItemGroup>");
+			}
+			if (project.EnableDefaultItems) {
+				// If $(EnableDefaultItems), then only OtherBuildItems are added
+				if (project.OtherBuildItems.Count > 0) {
+					sb.AppendLine ("\t<ItemGroup>");
+					foreach (var bi in project.OtherBuildItems) {
+						AppendBuildItem (sb, bi);
+					}
+					sb.AppendLine ("\t</ItemGroup>");
+				}
+			} else if (project.ItemGroupList.Count > 0) {
+				foreach (var itemGroup in project.ItemGroupList) {
+					if (itemGroup.Count == 0)
+						continue;
+					sb.AppendLine ("\t<ItemGroup>");
+					foreach (var bi in itemGroup) {
+						AppendBuildItem (sb, bi);
+					}
+					sb.AppendLine ("\t</ItemGroup>");
+				}
+			}
+			foreach (var import in project.Imports) {
+				var projectName = import.Project ();
+				if (projectName != "Directory.Build.props" && projectName != "Directory.Build.targets")
+					sb.AppendLine ($"\t<Import Project=\"{projectName}\" />");
+			}
+			return $"<Project Sdk=\"{project.Sdk}\">\r\n{sb}\r\n</Project>";
+		}
+
+		static void AppendBuildItem (StringBuilder sb, BuildItem bi)
+		{
+			sb.Append ($"\t\t<{bi.BuildAction} ");
+			if (bi.Include != null) sb.Append ($"Include=\"{bi.Include ()}\" ");
+			if (bi.Update != null) sb.Append ($"Update=\"{bi.Update ()}\" ");
+			if (bi.Remove != null) sb.Append ($"Remove=\"{bi.Remove ()}\" ");
+			if (bi.Generator != null) sb.Append ($"Generator=\"{bi.Generator ()}\" ");
+			if (bi.DependentUpon != null) sb.Append ($"DependentUpon=\"{bi.DependentUpon ()}\" ");
+			if (bi.Version != null) sb.Append ($"Version=\"{bi.Version ()}\" ");
+			if (bi.SubType != null) sb.Append ($"SubType=\"{bi.SubType ()}\" ");
+			if (!bi.Metadata.Any ()) {
+				sb.AppendLine ($"\t\t/>");
+			} else {
+				sb.AppendLine ($">");
+				foreach (var kvp in bi.Metadata) {
+					sb.AppendLine ($"\t\t\t<{kvp.Key}>{kvp.Value}</{kvp.Key}>");
+				}
+				sb.AppendLine ($"\t\t</{bi.BuildAction}>");
+			}
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -10,12 +10,6 @@ namespace Xamarin.Android.Build.Tests
 	[NonParallelizable]
 	public class XASdkDeployTests : DeviceTest
 	{
-		static readonly string SdkVersion = Assembly.GetAssembly (typeof(XASdkProject))
-			.GetCustomAttributes<AssemblyMetadataAttribute> ()
-			.Where (attr => attr.Key == "SdkVersion")
-			.Select (attr => attr.Value)
-			.FirstOrDefault () ?? "0.0.1";
-
 		[Test]
 		public void DotNetInstallAndRun ([Values (false, true)] bool isRelease, [Values (false, true)] bool xamarinForms)
 		{
@@ -24,11 +18,11 @@ namespace Xamarin.Android.Build.Tests
 
 			XASdkProject proj;
 			if (xamarinForms) {
-				proj = new XamarinFormsXASdkProject (SdkVersion) {
+				proj = new XamarinFormsXASdkProject {
 					IsRelease = isRelease
 				};
 			} else {
-				proj = new XASdkProject (SdkVersion) {
+				proj = new XASdkProject {
 					IsRelease = isRelease
 				};
 			}


### PR DESCRIPTION
As we transition to One .NET, we need a way to run our existing
MSBuild tests with `dotnet build` instead of `msbuild`.

To do this:

* Add a new `dotnet` category, on a subset of tests. Eventually, we
  may be able to run all tests, but not quite yet.
* Add a `--params dotnet=true` parameter to the `nunit3-console`
  invocation.
* `Xamarin.ProjectTools` does not have a reference to NUnit, so create
  a `Builder.UseDotNet` static property that is set in `BaseTest`.
* `Builder.UseDotNet` is used throughout `Xamarin.ProjectTools` to
  change the contents of generated projects.

For now, this enables 35 passing tests. We will fix issues and enable
more of them moving forward.

Workarounds:

* We have to set `$(XamarinAndroidSupportSkipVerifyVersions)` for
  existing support libraries to be used.
* We have to use a `Directory.Build.targets` and
  `$(VectorDrawableCheckBuildToolsVersionTaskBeforeTargets)` for
  existing support libraries.

Other fixes:

* Cleaned up `BuildBasicApplication`, so it is parameterized.
* Cleaned up `CheckWhichRuntimeIsIncluded`, `supportedAbi` does not
  need to be a `string[]`.
* `$(MonoSymbolArchive)` should default to `false`, since
  `mono-symbolicate` is not yet available for .NET 5. This fixed a few
  tests around `Release` builds.