### PR TITLE
[Xamarin.Android.Build.Tasks] Honour Manifest `tools:node="remove"` items.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputManifestFile { get; set; }
 
+		public string [] ManifestOverlayFiles { get; set; }
 		public string [] LibraryManifestFiles { get; set; }
 
 		public string [] ManifestPlaceholders { get; set; }
@@ -42,7 +43,7 @@ namespace Xamarin.Android.Tasks
 				var m = new ManifestDocument (tempFile);
 				var ms = MemoryStreamPool.Shared.Rent ();
 				try {
-					m.Save (Log, ms);
+					m.Save (Log, ms, removeNodes: true);
 					MonoAndroidHelper.CopyIfStreamChanged (ms, OutputManifestFile);
 					return result;
 				} finally {
@@ -76,6 +77,10 @@ namespace Xamarin.Android.Tasks
 			StringBuilder sb = new StringBuilder ();
 			sb.AppendLine ("--main");
 			sb.AppendLine (AndroidManifest);
+			if (ManifestOverlayFiles != null) {
+				sb.AppendLine ("--overlays");
+				sb.AppendLine ($"{string.Join ($"{Path.PathSeparator}", ManifestOverlayFiles)}");
+			}
 			if (LibraryManifestFiles != null) {
 				sb.AppendLine ("--libs");
 				sb.AppendLine ($"{string.Join ($"{Path.PathSeparator}", LibraryManifestFiles)}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -148,6 +148,31 @@ namespace Bug12935
 		}
 
 		[Test]
+		public void RemovePermissionTest ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				PackageReferences = {
+					KnownPackages.ZXing_Net_Mobile,
+				},
+				ManifestMerger = "manifestmerger.jar",
+			};
+			proj.AndroidManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" xmlns:tools=""http://schemas.android.com/tools"" android:versionCode=""1"" android:versionName=""1.0"" package=""foo.foo"">
+	<uses-sdk android:targetSdkVersion=""29""/>
+	<uses-permission android:name=""android.permission.CAMERA"" tools:node=""remove"" />
+	<application android:label=""foo"">
+	</application>
+</manifest>";
+			using (var b = CreateApkBuilder ("temp/RemovePermissionTest", cleanupAfterSuccessfulBuild: true, cleanupOnDispose: false)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var manifestFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				var text = File.ReadAllText (manifestFile);
+				StringAssert.DoesNotContain ("android.permission.CAMERA", text, $"{manifestFile} should not contain 'android.permission.CAMERA'");
+			}
+		}
+
+		[Test]
 		public void IntentFilterData ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -309,7 +309,7 @@ namespace Xamarin.ProjectTools
 			}
 		};
 		public static Package CocosSharp_PCL_Shared_1_5_0_0 = new Package {
-			Id = "CocosSharp.PCL.Shared", 
+			Id = "CocosSharp.PCL.Shared",
 			Version = "1.5.0.0",
 			TargetFramework ="MonoAndroid10",
 			References =  {
@@ -325,7 +325,7 @@ namespace Xamarin.ProjectTools
 			}
 		};
 		public static Package MonoGame_Framework_Android_3_4_0_459 = new Package {
-			Id = "MonoGame.Framework.Android", 
+			Id = "MonoGame.Framework.Android",
 			Version = "3.4.0.459",
 			TargetFramework = "MonoAndroid10",
 			References = {
@@ -335,7 +335,7 @@ namespace Xamarin.ProjectTools
 			}
 		};
 		public static Package Xamarin_Android_Support_v8_RenderScript_28_0_0_3 = new Package {
-			Id = "Xamarin.Android.Support.v8.RenderScript", 
+			Id = "Xamarin.Android.Support.v8.RenderScript",
 			Version = "28.0.0.3",
 			TargetFramework = "MonoAndroid90",
 			References = {
@@ -564,6 +564,12 @@ namespace Xamarin.ProjectTools
 			Id = "akavache",
 			Version = "6.0.30",
 			TargetFramework = "netstandard2.0",
+		};
+
+		public static Package ZXing_Net_Mobile = new Package {
+			Id = "ZXing.Net.Mobile",
+			Version = "2.4.1",
+			TargetFramework = "MonoAndroid10",
 		};
 	}
 }


### PR DESCRIPTION
Fixes #4662

The `manifestmerger.jar` did not work in the way we expeected.
Its primary purpose is to allow users to remove/modify manifest
items from `LIBRARY` projects. What it doesn't do it process
items in the main manifest itself.

As part of our build system we sometimes auto generate manifest
items based on C# attributes within a referenced assembly. A good
example of this is the `ZXing.Net.Mobile` packages. This will
inplicitly add a `uses-permission` element for `android.permission.CAMERA`.

In #4662 the user expectation was that if they add the `tools:node="remove"`
to the `uses-permission` element in their own manifest, this would stop
the permission from being added. Unfortunately this did NOT happen.
The `manifestmerger.jar` completely ignored this entry and it ended up
in the final manifest. This is because the permission itself is NOT coming
from a library manifest file, but is being injected directly into the
main manifest file by our own code.

To work around this limitation and to get the expected user behaviour
this PR modifies the `ManifestDocument` class to strip out all the
elements which contain a `tools:node="remove"` attribute. These new
functionality will ONLY be called by the `ManifestMerger` class. This
is because that is the only configuration where `tools:node="remeove"`
will be used.

This fixes the inital issue and will allow our system to behave as
the user expected.