### PR TITLE
[ProGuard] bump to 6.2.2 and use Github source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,8 +28,9 @@
     branch = master
 [submodule "external/proguard"]
     path = external/proguard
-    url = https://github.com/xamarin/proguard.git
+    url = https://github.com/Guardsquare/proguard.git
     branch = master
+    ignore = dirty
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git

--- a/Documentation/release-notes/4683.md
+++ b/Documentation/release-notes/4683.md
@@ -1,0 +1,12 @@
+### ProGuard version update to 6.2.2
+
+The version of ProGuard included in Xamarin.Android has been updated
+from 5.3.2 to [6.2.2][proguard], bringing in a number of improvements
+and bug fixes.
+
+> [!NOTE]
+> ProGuard is only relevant for projects configured to use the older
+> DX DEX compiler.  Project authors are recommended to update to the
+> newer D8 DEX compiler at their earliest convenience.
+
+[proguard]: https://www.guardsquare.com/products/proguard/manual/versions

--- a/build-tools/automation/CredScanSuppressions.json
+++ b/build-tools/automation/CredScanSuppressions.json
@@ -32,6 +32,14 @@
         {
             "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Crypto.Interfaces\\IPBEKey.xml",
             "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\proguard\\examples\\android\\debug.keystore",
+            "_justification": "Dummy keystore file from a proguard example."
+        },
+        {
+            "file": "external\\proguard\\examples\\android-plugin\\debug.keystore",
+            "_justification": "Dummy keystore file from a proguard example."
         }
     ]
 }

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -196,7 +196,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\pdb2mdb.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\pdb2mdb.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\lib\proguard.jar"/>
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.html" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.md" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup-xf.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\r8.jar" />

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/proguard.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/proguard.cs
@@ -7,10 +7,10 @@ namespace Xamarin.Android.Prepare
 	[TPN]
 	class proguard_xamarin_proguard_TPN : ThirdPartyNotice
 	{
-		static readonly Uri    url         = new Uri ("https://github.com/xamarin/proguard/");
+		static readonly Uri    url         = new Uri ("https://github.com/Guardsquare/proguard");
 
 		public override string LicenseFile => CommonLicenses.GPLv2Path;
-		public override string Name        => "xamarin/proguard";
+		public override string Name        => "Guardsquare/proguard";
 		public override Uri    SourceUrl   => url;
 		public override string LicenseText => String.Empty;
 

--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -3,22 +3,22 @@
     <_OutputJar>$(OutputPath)lib\proguard.jar</_OutputJar>
     <_OutputBat>$(OutputPath)bin\proguard.bat</_OutputBat>
     <_OutputSh>$(OutputPath)bin\proguard.sh</_OutputSh>
-    <_OutputLicense>$(OutputPath)license.html</_OutputLicense>
+    <_OutputLicense>$(OutputPath)license.md</_OutputLicense>
   </PropertyGroup>
   <ItemGroup>
     <_Outputs Include="$(_OutputJar);$(_OutputBat);$(_OutputSh);$(_OutputLicense)" />
   </ItemGroup>
   <Target Name="_BuildProGuard"
-      Inputs="$(MSBuildThisFile);$(ProGuardSourceFullPath)\buildscripts\build.xml"
+      Inputs="$(MSBuildThisFile)"
       Outputs="@(_Outputs)">
     <Exec
-        Command="&quot;$(GradleWPath)&quot; proguardJar $(GradleArgs)"
+        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
-        WorkingDirectory="$(ProGuardSourceFullPath)\buildscripts"
+        WorkingDirectory="$(ProGuardSourceFullPath)\core"
     />
     <MakeDir Directories="$(OutputPath)" />
     <Copy
-        SourceFiles="..\..\external\proguard\lib\proguard.jar"
+        SourceFiles="..\..\external\proguard\core\build\libs\core.jar"
         DestinationFiles="$(_OutputJar)"
     />
     <Copy
@@ -30,7 +30,7 @@
         DestinationFiles="$(_OutputSh)"
     />
     <Copy
-        SourceFiles="..\..\external\proguard\docs\license.html"
+        SourceFiles="..\..\external\proguard\docs\license.md"
         DestinationFiles="$(_OutputLicense)"
     />
     <Touch Files="@(_Outputs)" />
@@ -40,7 +40,7 @@
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
-        WorkingDirectory="$(ProGuardSourceFullPath)\buildscripts"
+        WorkingDirectory="$(ProGuardSourceFullPath)\core"
     />
   </Target>
   <Target Name="CoreCompile" />


### PR DESCRIPTION
Changes: https://github.com/Guardsquare/proguard/compare/9d4660e5...ebe9000c

This updates our submodule from:

    https://github.com/xamarin/proguard

To the official ProGuard source on Github:

    https://github.com/Guardsquare/proguard/

To build only `proguard.jar` and no other optional components, I was
able to build `:core` and copy `core.jar` to the proper location.

I also added `ignore = dirty` setting, since we lost control of the
`.gitignore` setup in the `external/proguard` git submodule. Otherwise
we will always show changes to `external/proguard` after a build.