### PR TITLE
Bump to xamarin/monodroid/master@e50ff9a4

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@9242fa4fe5df2413faf12689c522825404b90755
+xamarin/monodroid:master@5849ea1078827543cad9c966d27e4ab9915e572d
 mono/mono:2020-02@075c3f06197e3b969f4234d0f56a2e10ee6ee305


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/9242fa4fe5df2413faf12689c522825404b90755...e50ff9a43a56293cb3c9112344f250eebc002ec8

  * xamarin/monodroid@e50ff9a43: Bump to xamarin/androidtools/master@ff35fa96 (#1092)
  * xamarin/monodroid@3d4f171a0: Bump to xamarin/xamarin-android/master@a01756 (#1087)
  * xamarin/monodroid@5560daf55: [tools/RuntimeService] base versionCode off xamarin-android (#1088)