### PR TITLE
[monodroid] Set cmake path to include build type

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -291,15 +291,8 @@ if(UNIX)
 endif()
 
 set(XAMARIN_APP_STUB_SOURCES ${SOURCES_DIR}/application_dso_stub.cc)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${XA_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE})
 add_library(xamarin-app SHARED ${XAMARIN_APP_STUB_SOURCES})
-if (ENABLE_NDK)
-  # Only Android builds need to go in separate directories, desktop builds have the same ABI
-  set_target_properties(
-    xamarin-app
-    PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${XA_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}"
-    )
-endif()
 
 if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
   set(XAMARIN_DEBUG_APP_HELPER_SOURCES


### PR DESCRIPTION
The `CMAKE_LIBRARY_OUTPUT_DIRECTORY` value was same for Debug and
Release build types (which is not the same as Configuration, we build
both types in each configuration). And because we configure these
in parallel, it might result in concurent file writes.

I think this is causing these errors on build bots:

    error : CMake Error at C:/Users/dlab14/android-toolchain/sdk/cmake/3.10.2.4988404/share/cmake-3.10/Modules/CheckCXXSourceCompiles.cmake:91 (file): [C:\A\vs2019xam00000E-1\_work\2\s\src\monodroid\monodroid.csproj]
    error :   file failed to open for writing (Permission denied): [C:\A\vs2019xam00000E-1\_work\2\s\src\monodroid\monodroid.csproj]
    error :     C:/A/vs2019xam00000E-1/_work/2/s/src/monodroid/obj/Release/x86_64-Release/CMakeFiles/CMakeTmp/src.cxx [C:\A\vs2019xam00000E-1\_work\2\s\src\monodroid\monodroid.csproj]