### PR TITLE
[.NET 5] Update TargetFramework to net5.0

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -156,7 +156,7 @@ The following instructions can be used for early preview testing.
 ```xml
 <Project Sdk="Microsoft.Android.Sdk/10.0.100">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -27,7 +27,7 @@ variables:
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
-  DotNetCorePreviewVersion: 5.0.100-preview.4.20227.14
+  DotNetCorePreviewVersion: 5.0.100-preview.6.20265.2
 
 stages:
 - stage: mac_stage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -50,7 +50,7 @@ variables:
   NUnitConsoleVersion: 3.9.0
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-preview.4.20227.14
+  DotNetCorePreviewVersion: 5.0.100-preview.6.20265.2
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -15,7 +15,7 @@ by projects that use the Microsoft.Android framework in .NET 5.
     <Authors>Microsoft</Authors>
     <Description>Microsoft.Android reference assemblies. Please do not reference directly.</Description>
     <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
-    <_AndroidRefPackAssemblyPath>ref\netcoreapp5.0</_AndroidRefPackAssemblyPath>
+    <_AndroidRefPackAssemblyPath>ref\net5.0</_AndroidRefPackAssemblyPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -17,7 +17,7 @@ projects that use the Microsoft.Android framework in .NET 5.
     <Authors>Microsoft</Authors>
     <Description>Microsoft.Android runtime components. Please do not reference directly.</Description>
     <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
-    <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\netcoreapp5.0</_AndroidRuntimePackAssemblyPath>
+    <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\net5.0</_AndroidRuntimePackAssemblyPath>
     <_AndroidRuntimePackNativePath>runtimes\$(AndroidRID)\native</_AndroidRuntimePackNativePath>
   </PropertyGroup>
 

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -85,7 +85,7 @@ the new entry point for short-form style Android projets in .NET 5.
   <Target Name="_GenerateBundledVersions"
       DependsOnTargets="_GetDefaultPackageVersion" >
     <PropertyGroup>
-      <_AndroidNETAppTargetFramework>netcoreapp5.0</_AndroidNETAppTargetFramework>
+      <_AndroidNETAppTargetFramework>net5.0</_AndroidNETAppTargetFramework>
       <BundledVersionsPropsFileName>Microsoft.Android.Sdk.BundledVersions.props</BundledVersionsPropsFileName>
     </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -39,11 +39,14 @@ namespace Xamarin.ProjectTools
 		public XASdkProject (string sdkVersion = "", string outputType = "Exe")
 		{
 			Sdk = string.IsNullOrEmpty (sdkVersion) ? "Microsoft.Android.Sdk" : $"Microsoft.Android.Sdk/{sdkVersion}";
-			TargetFramework = "netcoreapp5.0";
+			TargetFramework = "net5.0";
 
 			PackageName = PackageName ?? string.Format ("{0}.{0}", ProjectName);
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
-			ExtraNuGetConfigSources = new List<string> { Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs") };
+			ExtraNuGetConfigSources = new List<string> {
+				Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
+				"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
+			};
 			GlobalPackagesFolder = Path.Combine (XABuildPaths.TopDirectory, "packages");
 			SetProperty (KnownProperties.OutputType, outputType);
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -50,12 +50,17 @@ projects.
   </PropertyGroup>
 
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
+    <!-- When using .NET 5, provide a list of paths to the Android and NETCore targeting pack directories, e.g.
+          `packages\microsoft.android.ref\10.0.100-ci.master.22\ref\net5.0\` and
+          `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.6.20264.1\ref\net5.0\`
+         See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
+    -->
+    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
+      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(ResolvedTargetingPack->'%(Path)\ref\%(TargetFramework)')" Condition=" '@(ResolvedTargetingPack)' == '@(FrameworkReference)' and '%(Identity)' != '' " />
+    </ItemGroup>
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-      <!-- When using .NET 5, provide the path to Mono.Android.dll e.g.
-            `packages\microsoft.android.ref\10.0.100-ci.master.22\ref\net5.0\`
-      -->
-      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' And '%(FileName)%(Extension)' == 'Mono.Android.dll'  ">@(Reference->'%(RootDir)%(Directory)')</_XATargetFrameworkDirectories>
+      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(_ResolveSdksFrameworkRefAssemblyPaths)</_XATargetFrameworkDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -43,7 +43,7 @@ projects.
   </Target>
 
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
-    <_ResolveSdksDependsOnTargets>ResolveFrameworkReferences</_ResolveSdksDependsOnTargets>
+    <_ResolveSdksDependsOnTargets>ResolveTargetingPackAssets</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
     <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
@@ -52,11 +52,10 @@ projects.
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-      <!-- When using .NET 5, provide a list of paths to all framework reference directories, e.g.
-            `packages\xamarin.android.app.ref\10.3.99.160\ref\netcoreapp5.0\` and
-            `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.2.20160.6\ref\netcoreapp5.0\`
+      <!-- When using .NET 5, provide the path to Mono.Android.dll e.g.
+            `packages\microsoft.android.ref\10.0.100-ci.master.22\ref\net5.0\`
       -->
-      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(ResolvedFrameworkReference->'%(TargetingPackPath)\ref\$(TargetFramework)')</_XATargetFrameworkDirectories>
+      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' And '%(FileName)%(Extension)' == 'Mono.Android.dll'  ">@(Reference->'%(RootDir)%(Directory)')</_XATargetFrameworkDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"


### PR DESCRIPTION
The latest .NET 5 previews now have support for a $(TargetFramework) of
`net5.0`, which allows us to replace our usage of `netcoreapp5.0` with
`net5.0`.

The .NET 5 version of `_ResolveSdks` has also been updated to avoid
usage of the projects $(TargetFramework) value when setting the path
to `Mono.Android.dll`.  This fixes an issue that was occurring when
using the latest .NET 5 nightly preview, which was the result of Android
projects using targeting packs with different $(TargetFramework) values.

    /Users/peter/.nuget/packages/microsoft.android.sdk/10.0.100-ci.net5-fix-tf.22/tools/Xamarin.Android.Tooling.targets(61,5): error XARSD7004: System.ArgumentException: `/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/5.0.0-preview.6.20264.1/ref/netcoreapp5.0` must be a directory! (Parameter 'frameworkDirectories')
    /Users/peter/.nuget/packages/microsoft.android.sdk/10.0.100-ci.net5-fix-tf.22/tools/Xamarin.Android.Tooling.targets(61,5): error XARSD7004:    at Xamarin.Android.Tools.AndroidVersions..ctor(IEnumerable`1 frameworkDirectories) in /Users/peter/source/pj/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs:line 30
    /Users/peter/.nuget/packages/microsoft.android.sdk/10.0.100-ci.net5-fix-tf.22/tools/Xamarin.Android.Tooling.targets(61,5): error XARSD7004:    at Xamarin.Android.Tasks.MonoAndroidHelper.RefreshSupportedVersions(String[] referenceAssemblyPaths)
    /Users/peter/.nuget/packages/microsoft.android.sdk/10.0.100-ci.net5-fix-tf.22/tools/Xamarin.Android.Tooling.targets(61,5): error XARSD7004:    at Xamarin.Android.Tasks.ResolveSdks.RunTask()
    /Users/peter/.nuget/packages/microsoft.android.sdk/10.0.100-ci.net5-fix-tf.22/tools/Xamarin.Android.Tooling.targets(61,5): error XARSD7004:    at Xamarin.Android.Tasks.AndroidTask.Execute()