### PR TITLE
[Xamarin.Android.Build.Tasks] warning message that DX is deprecated

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -93,6 +93,7 @@ ms.date: 01/24/2020
 + XA1020: At least one Java library is required for binding. Check that a Java library is included in the project and has the appropriate build action: 'LibraryProjectZip' (for AAR or ZIP), 'EmbeddedJar', 'InputJar' (for JAR), or 'LibraryProjectProperties' (project.properties).
 + XA1021: Specified source Java library not found: {file}
 + XA1022: Specified reference Java library not found: {file}
++ [XA1023](xa1023.md): Using the DX DEX Compiler is deprecated.
 
 ## XA2xxx: Linker
 

--- a/Documentation/guides/messages/xa1023.md
+++ b/Documentation/guides/messages/xa1023.md
@@ -1,0 +1,29 @@
+---
+title: Xamarin.Android warning XA1023
+description: XA1023 warning code
+ms.date: 05/18/2020
+---
+# Xamarin.Android warning XA1023
+
+## Example messages
+
+```
+warning XA1023: Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.
+```
+
+## Issue
+
+Google has deprecated the DX DEX Compiler in favor of the [D8 DEX
+Compiler][d8]. On [February 1, 2021][dx], DX will no longer be a part
+of Android SDK or Android Studio.
+
+[d8]: https://developer.android.com/studio/command-line/d8
+[dx]: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html
+
+## Solution
+
+Update the `$(AndroidDexTool)` MSBuild property to `d8` to select the
+D8 DEX Compiler. This property corresponds to the **Dex compiler**
+setting in the Visual Studio project properties pages. Alternatively,
+remove `<AndroidDexTool>` from the _.csproj_ file to let the build
+select the default value `d8`.

--- a/Documentation/release-notes/dx-deprecation.md
+++ b/Documentation/release-notes/dx-deprecation.md
@@ -1,0 +1,6 @@
+  * warning XA1023: Using the DX Dex Compiler is deprecated ... Google
+    has deprecated the DX Dex Compiler. DX will be [completely
+    removed][dx] in a future release of the Android SDK and Android
+    Studio.
+
+[dx]: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -547,6 +547,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using the DX Dex Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`..
+        /// </summary>
+        internal static string XA1023 {
+            get {
+                return ResourceManager.GetString("XA1023", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -381,6 +381,10 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</comment>
   </data>
+  <data name="XA1023" xml:space="preserve">
+    <value>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</value>
+    <comment>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">V sestavení {0} se zjistilo, že se používá AppDomain.CreateDomain(). .NET 5 bude podporovat jen jednu doménu AppDomain, proto toto rozhraní API už nebude po vydání rozhraní .NET 5 v Xamarin.Androidu k dispozici.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">In der Assembly "{0}" wurde die Verwendung von "AppDomain.CreateDomain()" festgestellt. .NET 5 unterstützt nur eine einzelne AppDomain, sodass diese API nach dem Release von .NET 5 nicht mehr in Xamarin.Android verfügbar ist.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Se detectó el uso de AppDomain.CreateDomain() en el ensamblado: {0}. En .NET 5 solo se admitirá una instancia de AppDomain, por lo que esta API ya no estará disponible en Xamarin.Android una vez que se haya lanzado .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Utilisation de AppDomain.CreateDomain() détectée dans l'assembly {0}. .NET 5 prend uniquement en charge un seul AppDomain. Cette API ne sera donc plus disponible dans Xamarin.Android après la publication de .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">È stato rilevato l'uso di AppDomain.CreateDomain() nell'assembly: {0}. .NET 5 supporterà solo un'unica istanza di AppDomain, di conseguenza questa API non sarà più disponibile in Xamarin.Android dopo il rilascio di .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">アセンブリ {0} で AppDomain.CreateDomain() が使用されていることが検出されました。.NET 5 では単一の AppDomain のみがサポートされる予定のため、.NET 5 がリリースされるとこの API は Xamarin.Android では使用できなくなります。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">{0} 어셈블리에서 AppDomain.CreateDomain() 사용이 검색되었습니다. .NET 5는 단일 AppDomain만 지원하므로 .NET 5가 릴리스되면 이 API는 Xamarin.Android에서 더는 사용할 수 없습니다.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Wykryto użycie metody AppDomain.CreateDomain() w następującym zestawie: {0}. Program .NET 5 obsługuje tylko jeden obiekt AppDomain, dlatego ten interfejs API nie będzie już dostępny w interfejsie Xamarin.Android po wydaniu programu .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">O uso de AppDomain.CreateDomain() foi detectado no assembly: {0}. O .NET 5 dá suporte apenas a um único AppDomain, portanto, essa API não estará mais disponível no Xamarin.Android quando o .NET 5 for lançado.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">В сборке обнаружено использование AppDomain.CreateDomain(): {0}. .NET 5 поддерживает только один домен AppDomain, поэтому этот API не будет доступен в Xamarin.Android после выпуска .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Bütünleştirilmiş kodda AppDomain.CreateDomain() metodunun kullanıldığı saptandı: {0}. .NET 5 yalnızca tek bir AppDomain'i destekleyeceğinden bu API, .NET 5 yayımlandıktan sonra artık Xamarin.Android içinde kullanılamayacak.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">在程序集 {0} 中检测到使用了 AppDomain.CreateDomain()。.NET 5 将仅支持一个 AppDomain，因此 .NET 5 发布后，将无法再在 Xamarin.Android 中使用此 API。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -322,6 +322,11 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>In this message, the term "reference Java library" refers to a library that is included as a reference so that types from the library can be resolved during the build process.
 {0} - The file name of the library</note>
       </trans-unit>
+      <trans-unit id="XA1023">
+        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
+        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">在下列組件中偵測到使用 AppDomain.CreateDomain(): {0}。.NET 5 只支援單一 AppDomain，因此在 .NET 5 發行之後，此 API 就無法再於 Xamarin.Android 中使用。</target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -523,6 +523,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		ResourceName="XA1011"
 		Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "
 	/>
+	<AndroidWarning Code="XA1023"
+		ResourceName="XA1023"
+		Condition=" '$(AndroidDexTool)' == 'dx' "
+	/>
 </Target>
 
 <Target Name="UpdateGeneratedFiles"


### PR DESCRIPTION
Context: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

On February 1, 2021 DX will be removed from the Android SDK and
Android Studio. We should start emitting a warning in Xamarin.Android
*now*, so that developers can migrate to D8.