### PR TITLE
[tests] fix PerformanceTest

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -32,8 +32,16 @@ namespace Xamarin.Android.Build.Tests
 				RunAdbCommand ($"pull {remote} \"{local}\"");
 				RunAdbCommand ($"shell rm {remote}");
 				RunAdbCommand ($"logcat -d > {deviceLog}");
-				TestContext.AddTestAttachment (local);
-				TestContext.AddTestAttachment (deviceLog);
+				if (File.Exists (local)) {
+					TestContext.AddTestAttachment (local);
+				} else {
+					TestContext.WriteLine ($"{local} did not exist!");
+				}
+				if (File.Exists (deviceLog)) {
+					TestContext.AddTestAttachment (deviceLog);
+				} else {
+					TestContext.WriteLine ($"{deviceLog} did not exist!");
+				}
 			}
 
 			base.CleanupTest ();

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,14 +2,14 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,10250
+Build_From_Clean_DontIncludeRestore,10500
 Build_No_Changes,3250
 Build_CSharp_Change,4450
 Build_AndroidResource_Change,4150
 Build_AndroidManifest_Change,4500
 Build_Designer_Change,3600
 Build_JLO_Change,9500
-Build_CSProj_Change,9800
+Build_CSProj_Change,9950
 Build_XAML_Change,9400
 Build_XAML_Change_RefAssembly,6000
 Install_CSharp_Change,5000


### PR DESCRIPTION
Context: https://build.azdo.io/3744248

Some of the MSBuild performance timings have started failing.

It seems like it is a change on the build machines, as I've not seen
anything in the logs pointing out a regression. I merely bumped a few
of the times here.

I also fixed the failure related to missing test attachments:

    TearDown : System.IO.FileNotFoundException : Test attachment file path could not be found.

If one of the files was missing in `DeviceTest.cs`, then it would fail
getting any subsequent attachments due to the thrown exception.