### PR TITLE
[Xamarin.Android.Build.Tasks] update API level warning messages

### DIFF
--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -7,13 +7,13 @@ ms.date: 02/28/2019
 
 ## Issue
 
-As of August 1st 2018, new applications and application updates uploaded
-to the Google Play store need to target v8.0 (API 26) or above.
+As of August 1st 2019, new applications and application updates uploaded
+to the Google Play store need to target v9.0 (API 28) or above.
 
 ## Solution
 
 If you are seeing this warning, you should update the
-`$(TargetFrameworkVersion)` of your projects to be v8.0 or above.
+`$(TargetFrameworkVersion)` of your projects to be v9.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
 warnings, you can make use of the `/warnasmessage:XA0113` command line

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -229,8 +229,8 @@ In this message, the phrase "should not be reached" means that this error messag
     <comment>The following are literal names and should not be translated: `aapt2`</comment>
   </data>
   <data name="XA0113" xml:space="preserve">
-    <value>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</value>
-    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+    <value>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</value>
+    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</comment>
   </data>
@@ -240,8 +240,8 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</comment>
   </data>
   <data name="XA0117" xml:space="preserve">
-    <value>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</value>
-    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+    <value>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</value>
+    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</comment>
   </data>
   <data name="XA0118_Parse" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play vyžaduje, aby nové aplikace a aktualizace používaly TargetFrameworkVersion verze 8.0 (rozhraní API úrovně 26) nebo vyšší. Aktuálně cílíte na verzi {0} (rozhraní API úrovně {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play vyžaduje, aby nové aplikace a aktualizace používaly TargetFrameworkVersion verze 8.0 (rozhraní API úrovně 26) nebo vyšší. Aktuálně cílíte na verzi {0} (rozhraní API úrovně {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">Hodnota {0} pro TargetFrameworkVersion je zastaralá. Aktualizujte prosím tuto hodnotu na 4.4 nebo vyšší.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">Hodnota {0} pro TargetFrameworkVersion je zastaralá. Aktualizujte prosím tuto hodnotu na 4.4 nebo vyšší.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play erfordert, dass neue Anwendungen und Updates die TargetFrameworkVersion v8.0 (API-Ebene 26) oder höher verwenden müssen. Sie verwenden als Ziel aktuell Version {0} (API-Ebene {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play erfordert, dass neue Anwendungen und Updates die TargetFrameworkVersion v8.0 (API-Ebene 26) oder höher verwenden müssen. Sie verwenden als Ziel aktuell Version {0} (API-Ebene {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">Die TargetFrameworkVersion {0} ist veraltet. Führen Sie eine Aktualisierung auf Version 4.4 oder höher durch.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">Die TargetFrameworkVersion {0} ist veraltet. Führen Sie eine Aktualisierung auf Version 4.4 oder höher durch.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play requiere que las nuevas aplicaciones y actualizaciones usen un valor de TargetFrameworkVersion de v8.0 (nivel de API 26) o superior. Actualmente se dirige a {0} (nivel de API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play requiere que las nuevas aplicaciones y actualizaciones usen un valor de TargetFrameworkVersion de v8.0 (nivel de API 26) o superior. Actualmente se dirige a {0} (nivel de API {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">El valor de TargetFrameworkVersion {0} está en desuso. Actualícelo a v 4.4 o superior.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">El valor de TargetFrameworkVersion {0} está en desuso. Actualícelo a v 4.4 o superior.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play impose aux nouvelles applications et aux mises à jour d'utiliser le TargetFrameworkVersion version 8.0 (niveau d'API 26) ou une version ultérieure. Vous ciblez {0} (niveau d'API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play impose aux nouvelles applications et aux mises à jour d'utiliser le TargetFrameworkVersion version 8.0 (niveau d'API 26) ou une version ultérieure. Vous ciblez {0} (niveau d'API {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">Le TargetFrameworkVersion {0} est déprécié. Mettez-le à jour vers la version 4.4 ou une version ultérieure.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">Le TargetFrameworkVersion {0} est déprécié. Mettez-le à jour vers la version 4.4 ou une version ultérieure.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Con Google Play le nuove applicazioni e gli aggiornamenti devono usare TargetFrameworkVersion 8.0 (livello API 26) o versione successiva. La versione di destinazione impostata attualmente è {0} (livello API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Con Google Play le nuove applicazioni e gli aggiornamenti devono usare TargetFrameworkVersion 8.0 (livello API 26) o versione successiva. La versione di destinazione impostata attualmente è {0} (livello API {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0} è deprecato. Aggiornarlo alla versione 4.4 o successiva.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0} è deprecato. Aggiornarlo alla versione 4.4 o successiva.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play では、新しいアプリケーションと更新プログラムでバージョン 8.0 (API レベル 26) 以上の TargetFrameworkVersion を使用する必要があります。現在は、{0} (API レベル {1}) をターゲットにしています。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play では、新しいアプリケーションと更新プログラムでバージョン 8.0 (API レベル 26) 以上の TargetFrameworkVersion を使用する必要があります。現在は、{0} (API レベル {1}) をターゲットにしています。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0} は非推奨です。v4.4 以上に更新してください。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0} は非推奨です。v4.4 以上に更新してください。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play에서는 새 애플리케이션 및 업데이트가 v8.0(API 레벨 26) 이상의 TargetFrameworkVersion을 사용하도록 요구합니다. 현재 {0}(API 레벨 {1})을(를) 대상으로 하고 있습니다.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play에서는 새 애플리케이션 및 업데이트가 v8.0(API 레벨 26) 이상의 TargetFrameworkVersion을 사용하도록 요구합니다. 현재 {0}(API 레벨 {1})을(를) 대상으로 하고 있습니다.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0}은(는) 사용되지 않습니다. v4.4 이상으로 업데이트하세요.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0}은(는) 사용되지 않습니다. v4.4 이상으로 업데이트하세요.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Sklep Google Play wymaga, aby nowe aplikacje i aktualizacje używały elementu TargetFrameworkVersion o wartości v8.0 (poziom 26 lub nowszy interfejsu API). Obecna wersja docelowa to {0} (poziom interfejsu API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Sklep Google Play wymaga, aby nowe aplikacje i aktualizacje używały elementu TargetFrameworkVersion o wartości v8.0 (poziom 26 lub nowszy interfejsu API). Obecna wersja docelowa to {0} (poziom interfejsu API {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">Wartość {0} dla elementu TargetFrameworkVersion jest przestarzała. Zaktualizuj ją na wartość v4.4 lub wyższą.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">Wartość {0} dla elementu TargetFrameworkVersion jest przestarzała. Zaktualizuj ją na wartość v4.4 lub wyższą.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">O Google Play exige que novos aplicativos e atualizações usem a TargetFrameworkVersion v8.0 (nível 26 da API) ou superior. No momento, você está direcionando à {0} (nível {1} da API).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">O Google Play exige que novos aplicativos e atualizações usem a TargetFrameworkVersion v8.0 (nível 26 da API) ou superior. No momento, você está direcionando à {0} (nível {1} da API).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">A TargetFrameworkVersion {0} foi preterida. Atualize para a v4.4 ou superior.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">A TargetFrameworkVersion {0} foi preterida. Atualize para a v4.4 ou superior.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play требует, чтобы новые приложения и обновления использовали TargetFrameworkVersion версии 8.0 (уровень API 26) или выше. Сейчас целевая версия — {0} (уровень API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play требует, чтобы новые приложения и обновления использовали TargetFrameworkVersion версии 8.0 (уровень API 26) или выше. Сейчас целевая версия — {0} (уровень API {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">Версия TargetFrameworkVersion {0} устарела. Обновите ее до версии 4.4 или более поздней.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">Версия TargetFrameworkVersion {0} устарела. Обновите ее до версии 4.4 или более поздней.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play, yeni uygulamaların ve güncelleştirmelerin v8.0 (API düzeyi 26) veya üzeri bir TargetFrameworkVersion kullanmasını gerektiriyor. Şu anda hedeflediğiniz: {0} (API düzeyi {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play, yeni uygulamaların ve güncelleştirmelerin v8.0 (API düzeyi 26) veya üzeri bir TargetFrameworkVersion kullanmasını gerektiriyor. Şu anda hedeflediğiniz: {0} (API düzeyi {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0} kullanım dışı. Lütfen bu sürümü v4.4 veya üzeri olacak şekilde güncelleştirin.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0} kullanım dışı. Lütfen bu sürümü v4.4 veya üzeri olacak şekilde güncelleştirin.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play 要求新应用程序和更新使用 TargetFrameworkVersion v8.0 (API 级别 26)或更高版本。当前目标是 {0} (API 级别 {1})。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play 要求新应用程序和更新使用 TargetFrameworkVersion v8.0 (API 级别 26)或更高版本。当前目标是 {0} (API 级别 {1})。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0} 已弃用。请将其更新到 v4.4 或更高版本。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0} 已弃用。请将其更新到 v4.4 或更高版本。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -139,9 +139,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: `aapt2`</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play 要求新的應用程式和更新必須使用 v8.0 (API 層級 26) 以上的 TargetFrameworkVersion。您目前的目標為 {0} (API 層級 {1})。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="needs-review-translation">Google Play 要求新的應用程式和更新必須使用 v8.0 (API 層級 26) 以上的 TargetFrameworkVersion。您目前的目標為 {0} (API 層級 {1})。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
 {0} - The current value of TargetFrameworkVersion
 {1} - The corresponding API level number</note>
       </trans-unit>
@@ -152,9 +152,9 @@ In this message, the phrase "should not be reached" means that this error messag
 {0} - The name of the missing resource</note>
       </trans-unit>
       <trans-unit id="XA0117">
-        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
-        <target state="translated">TargetFrameworkVersion {0} 已淘汰。請將其更新為 v4.4 或更高版本。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v5.0 or higher.</source>
+        <target state="needs-review-translation">TargetFrameworkVersion {0} 已淘汰。請將其更新為 v4.4 或更高版本。</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v5.0
 {0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0118_Parse">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
@@ -44,9 +44,9 @@ namespace Xamarin.Android.Tasks.Legacy
 
 			int apiLevel;
 			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
-				if (apiLevel < 26)
+				if (apiLevel < 28)
 					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, TargetFrameworkVersion, AndroidApiLevel);
-				if (apiLevel < 19)
+				if (apiLevel < 21)
 					Log.LogCodedWarning ("XA0117", Properties.Resources.XA0117, TargetFrameworkVersion);
 			}
 


### PR DESCRIPTION
Context: https://support.google.com/googleplay/android-developer/answer/113469#targetsdk

As of August 1, 2019, Google Play requires API level 28. The `XA0113` warning was checking for API 26, so it needed to be updated.

The `XA0117` warning also needs to be updated as API 21 is Xamarin.Android's new supported minimum API level.