### PR TITLE
Include Mono.Posix.NETStandard as it is required by LibZipsharp and SDK Manager

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -176,6 +176,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.pdb" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Posix.NETStandard.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.exe" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />

--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -32,6 +32,9 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" GeneratePathProperty="true">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -277,7 +277,7 @@
       <FileWrites Include="$(_GeneratedProfileClass)" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="_CopyExtractedMultiDexJar"
     Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk);$(_SupportLicense)"
     Outputs="$(OutputPath)android-support-multidex.jar;$(OutputPath)MULTIDEX_JAR_LICENSE">
@@ -376,10 +376,10 @@
 
   <!-- Copy package ref symbols for our installers. '$(Pkg*)' props are set during NuGet restore when GeneratePathProperty="true" -->
   <Target Name="_CopyExtraPackageContent"
-      Inputs="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb"
+      Inputs="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb;$(PkgMono_Posix_NETStandard)\ref\$(TargetFrameworkNETStandard)\Mono.Posix.NETStandard.dll"
       Outputs="$(OutputPath)\libZipSharp.pdb;$(OutputPath)\Xamarin.Build.AsyncTask.pdb" >
     <Copy
-        SourceFiles="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb"
+        SourceFiles="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb;$(PkgMono_Posix_NETStandard)\ref\$(TargetFrameworkNETStandard)\Mono.Posix.NETStandard.dll"
         DestinationFolder="$(OutputPath)"
     />
   </Target>


### PR DESCRIPTION
When running `InstallAndroidDependenciesTest` locally it fails with the following error.

```
[ERROR] FATAL UNHANDLED EXCEPTION: System.IO.FileNotFoundException: Could not load file or assembly 'Mono.Posix.NETStandard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies.
File name: 'Mono.Posix.NETStandard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
  at Xamarin.Installer.AndroidSDK.Manager.Helper.Unzip (System.String baseDirectory, System.String archivePath, System.String fileOwnerName, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x002d9] in <4587721623424dba847f5b558050d27a>:0 
  at Xamarin.Installer.AndroidSDK.Common.BasePackage.InstallArchive (System.String description, System.String archivePath, System.String targetDirectory, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x0008c] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.Common.BasePackage.DoInstall (System.String archivePath, System.String androidSDKRoot, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x00077] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.Common.BasePackage.Install (System.String archivePath, System.String androidSDKRoot, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x0000a] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.Repository.InstallComponent (Xamarin.Installer.AndroidSDK.Common.IAndroidComponent component, System.String archivePath, System.String androidSDKRoot, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x000a7] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.Repository.Install (Xamarin.Installer.AndroidSDK.Common.IAndroidComponent component, System.String archivePath, System.String androidSDKRoot, Xamarin.Installer.Common.InstallationProgressEventArgs+InstallationProgressActionDelegate progressCallback) [0x00064] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.AndroidSDKInstaller.InstallComponent (Xamarin.Installer.AndroidSDK.Common.IAndroidComponent c, Xamarin.Installer.AndroidSDK.AndroidSdkInstance instance, Xamarin.Installer.AndroidSDK.Manager.IProgressMonitor monitor) [0x00247] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.AndroidSDK.AndroidSDKInstaller.Install (Xamarin.Installer.AndroidSDK.AndroidSdkInstance instance, System.Collections.Generic.IList`1[T] componentsToInstall, System.Boolean throwIfInvalidComponentsFound, Xamarin.Installer.AndroidSDK.Manager.IProgressMonitor monitor) [0x0015d] in <ab8f5d80e51e408981b80ff8e71c6bd4>:0 
  at Xamarin.Installer.Build.Tasks.InstallAndroidDependencies.Install () [0x004c5] in <4587721623424dba847f5b558050d27a>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_1 (System.Object state) [0x00000] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context (System.Object state) [0x00007] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00021] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <fa1c70bff5424f0bbf617c0b03a3a060>:0 
```
The following commit xamarin/android-sdk-installer@d9276b4
introduced the `Mono.Posix.NETStandard` dependency. It is used by `ICSharpCode.SharpZipLib.Zip` during
the unzip process. We should make sure we include `Mono.Posix.NETStandard` in our installer so that
user can run the `InstallAndroidDependencies` target.