### PR TITLE
[Xamarin.Android.Build.Tests] Print build tool and args

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1130,7 +1130,7 @@ namespace Lib1 {
 				if (useAapt2) {
 					StringAssertEx.DoesNotContain ("APT0000", builder.LastBuildOutput, "Build output should not contain an APT0000 warning");
 				} else {
-					var expected = builder.RunningMSBuild ? "warning APT1146: max res 26, skipping values-v27" : "warning APT1146: warning : max res 26, skipping values-v27";
+					var expected = "warning APT1146: max res 26, skipping values-v27";
 					StringAssertEx.Contains (expected, builder.LastBuildOutput, "Build output should contain an APT1146 warning about 'max res 26, skipping values-v27'");
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2351,7 +2351,6 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric_1_4_3);
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				builder.RequiresMSBuild = true;
 				builder.Target = "Restore";
 				Assert.IsTrue (builder.Build (proj), "Restore should have succeeded.");
 				builder.Target = "Build";
@@ -3010,7 +3009,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				},
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				b.RequiresMSBuild = true;
 				b.Target = "Restore";
 				Assert.IsTrue (b.Build (proj), "Restore should have succeeded.");
 				b.Target = "Build";
@@ -3042,7 +3040,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				},
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				b.RequiresMSBuild = true;
 				b.Target = "Restore";
 				Assert.IsTrue (b.Build (proj), "Restore should have succeeded.");
 				b.Target = "Build";
@@ -3519,7 +3516,7 @@ namespace UnnamedProject {
 		[Test]
 		public void RunXABuildInParallel ()
 		{
-			var xabuild = new ProjectBuilder ("temp/RunXABuildInParallel").XABuildExe;
+			var xabuild = new ProjectBuilder ("temp/RunXABuildInParallel").BuildTool;
 			var psi     = new ProcessStartInfo (xabuild, "/version") {
 				CreateNoWindow         = true,
 				RedirectStandardOutput = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -606,8 +606,6 @@ namespace App1
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
-					builder.RequiresMSBuild =
-						ab.RequiresMSBuild = true;
 					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
 					Assert.IsTrue (ab.Build (app), "App should have built.");
 					var apk = Path.Combine (Root, ab.ProjectDirectory,


### PR DESCRIPTION
The Builder.BuildInternal function has been updated to print the build
tool being used and the arguments being passed to it.  Some additional
cleanup has been made around legacy code which previously would allow
`xbuild` to be used as a build tool on macOS.

Sample "before" output:


    => Xamarin.Android.Build.Tests.BuildTest.DuplicateManagedNames
    [TESTLOG] Test DuplicateManagedNames Starting
    Using msbuild
    Using msbuild
    Using msbuild
    Using msbuild
    Found Time Elapsed 00:00:11.4900000

Sample "after" output:

    => Xamarin.Android.Build.Tests.IncrementalBuildTest.ConvertCustomView(False)
    [TESTLOG] Test ConvertCustomViewFalse Starting
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\MyLibrary.csproj /t:Build /noconsolelogger "/flp1:LogFile=C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\build.log;Encoding=UTF-8;Verbosity=diagnostic" /restore @"C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\project.rsp"
    Found Time Elapsed 00:00:02.9700000
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\MyApp.csproj /t:Build,SignAndroidPackage /noconsolelogger "/flp1:LogFile=C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\build.log;Encoding=UTF-8;Verbosity=diagnostic" @"C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\project.rsp"
    Found Time Elapsed 00:00:16.9700000
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\MyLibrary.csproj /t:Build /noconsolelogger "/flp1:LogFile=C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\build2.log;Encoding=UTF-8;Verbosity=diagnostic" /restore @"C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyLibrary\project.rsp"
    Found Time Elapsed 00:00:02.1400000
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\MyApp.csproj /t:Build,SignAndroidPackage /noconsolelogger "/flp1:LogFile=C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\build2.log;Encoding=UTF-8;Verbosity=diagnostic" @"C:\A\vs2019xam00000N-1\_work\2\s\bin\TestRelease\temp\ConvertCustomViewFalse\MyApp\project.rsp"
    Found Time Elapsed 00:00:08.6500000
    [TESTLOG] Test ConvertCustomViewFalse Complete
    [TESTLOG] Test ConvertCustomViewFalse Outcome=Passed