### PR TITLE
[build] fix /t:CreateAllPacks on macOS Catalina

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -27,10 +27,10 @@
   </PropertyGroup>
   <ItemGroup>
     <_MsxDocAssembly Include="Mono.Android">
-      <SourceDir>$(_AndroidApiDocsPath)docs\%(Identity)\en\</SourceDir>
+      <SourceDir>$(_AndroidApiDocsPath)docs\%(Identity)\en</SourceDir>
     </_MsxDocAssembly>
     <_MonoDocAssembly Include="@(_MsxDocAssembly);OpenTK-1.0;Xamarin.Android.NUnitLite">
-      <SourceDir>$(_AndroidApiDocsPath)docs\%(Identity)\en\</SourceDir>
+      <SourceDir>$(_AndroidApiDocsPath)docs\%(Identity)\en</SourceDir>
     </_MonoDocAssembly>
     <_BclDocsAssembly Include="mscorlib;System.Core;System.ComponentModel.Composition;System.ComponentModel.DataAnnotations;System.Data;System" />
     <_BclDocsAssembly Include="System.EnterpriseServices;System.Json;System.Numerics;System.Runtime.Serialization;System.ServiceModel" />
@@ -45,15 +45,15 @@
   </Target>
   <Target Name="_FindDocSourceFiles">
     <ItemGroup>
-      <_MsxDocSourceFile Include="%(_MsxDocAssembly.SourceDir)**" />
-      <_MonoDocSourceFile Include="%(_MonoDocAssembly.SourceDir)**" />
+      <_MsxDocSourceFile Include="%(_MsxDocAssembly.SourceDir)\**" />
+      <_MonoDocSourceFile Include="%(_MonoDocAssembly.SourceDir)\**" />
     </ItemGroup>
   </Target>
   <Target Name="_GenerateMsxDocXmls"
       DependsOnTargets="_FindFrameworkDirs;_FindDocSourceFiles"
       Inputs="@(_MsxDocSourceFile)"
       Outputs="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml')">
-    <Exec Command="$(ManagedRuntime) &quot;$(MSBuildSrcDir)mdoc.exe&quot; --debug export-msxdoc -o &quot;$(_LatestStableFrameworkDir)%(_MsxDocAssembly.Identity).xml&quot; &quot;%(_MsxDocAssembly.SourceDir)\&quot;" />
+    <Exec Command="$(ManagedRuntime) &quot;$(MSBuildSrcDir)mdoc.exe&quot; --debug export-msxdoc -o &quot;$(_LatestStableFrameworkDir)%(_MsxDocAssembly.Identity).xml&quot; &quot;%(_MsxDocAssembly.SourceDir)&quot;" />
   </Target>
   <Target Name="_GenerateMsxDocXmlRedirects"
       DependsOnTargets="_FindFrameworkDirs"
@@ -69,7 +69,7 @@
       Inputs="@(_MonoDocSourceFile)"
       Outputs="$(_MonoDocOutputPath)MonoAndroid-lib.zip;$(_MonoDocOutputPath)MonoAndroid-lib.tree">
     <MakeDir Directories="$(_MonoDocOutputPath)"/>
-    <Exec Command="$(ManagedRuntime) &quot;$(MSBuildSrcDir)mdoc.exe&quot; --debug assemble -o &quot;$(_MonoDocOutputPath)MonoAndroid-lib&quot; @(_MonoDocAssembly->'&quot;%(SourceDir)\&quot;', ' ')" />
+    <Exec Command="$(ManagedRuntime) &quot;$(MSBuildSrcDir)mdoc.exe&quot; --debug assemble -o &quot;$(_MonoDocOutputPath)MonoAndroid-lib&quot; @(_MonoDocAssembly->'&quot;%(SourceDir)&quot;', ' ')" />
   </Target>
   <Target Name="_GenerateBclAssemblyDocXmlRedirects"
       Inputs="$(XamarinAndroidSourcePath)build-tools\scripts\redirect-BCL.xml.in"


### PR DESCRIPTION
Running this command on macOS was failing for me:

    $ msbuild /t:CreateAllPacks build-tools/create-packs/Microsoft.Android.Sdk.proj

With:

    build-tools/installers/create-installers.targets(72,5): error MSB3073:
    The command "mono "bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/mdoc.exe" --debug assemble -o "bin/Debug/lib/monodoc/MonoAndroid-lib" "external/android-api-docs/docs/Mono.Android/en/\" "external/android-api-docs/docs/OpenTK-1.0/en/\" "external/android-api-docs/docs/Xamarin.Android.NUnitLite/en/\"" exited with code 1. [build-tools/create-packs/Microsoft.Android.Sdk.proj] [build-tools/create-packs/Microsoft.Android.Sdk.proj]
    build-tools/create-packs/Directory.Build.targets(61,5): error MSB3073:
    The command "dotnet pack -p:Configuration=Debug "build-tools/create-packs/Microsoft.Android.Sdk.proj"" exited with code 1. [build-tools/create-packs/Microsoft.Android.Sdk.proj]

Take note of the path:

    "external/android-api-docs/docs/Mono.Android/en/\"

Reviewing `create-installers.targets`:

    &quot;%(_MsxDocAssembly.SourceDir)\&quot;

`%(SourceDir)` already had a trailing slash, and the addition of an
extra one is breaking the `mdoc.exe` command.

I am not sure why we didn't hit an issue on CI, but I am running macOS
Catalina locally.