### PR TITLE
[Xamarin.Android.Build.Tasks]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -43,7 +43,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <AndroidUseLatestPlatformSdk Condition="'$(AndroidUseLatestPlatformSdk)' == ''">False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v4.4</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v5.0</TargetFrameworkVersion>
     <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
     <UseShortFileNames Condition="'$(UseShortFileNames)' == ''">True</UseShortFileNames>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -27,7 +27,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
+        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
         <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -25,7 +25,7 @@ Copyright (C) 2012 Xamarin. All rights reserved.
             Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
+        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
@@ -25,7 +25,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
             Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
     <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
     <UseHostCompilerIfAvailable>false</UseHostCompilerIfAvailable>
     <NoStdLib>true</NoStdLib>


### PR DESCRIPTION
Context: a64898132e746d4425d54cfc4c52f6fc7892ef9c
Context: https://github.com/xamarin/xamarin-android/pull/4567
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3745247&view=logs&j=43d78dc4-ec1e-5245-95fd-87585dd83b08&t=6c172c00-c01b-5149-b118-044152099deb

Ever since a6489813, API-21 has been the minimum supported API-level
for applications, which in turn means that the minimum
`$(TargetFrameworkVersion)` value is v5.0.

What happens if an `.csproj` file doesn't explicitly provide a
`$(TargetFrameworkVersion)` value?  Then the project "inherits" the
default value specified in e.g. `Xamarin.Android.CSharp.targets`:

	<TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>

v4.4 is API-19, which is less than v5.0/API-21.

Which means if a `.csproj` doesn't explicitly provide a
`$(TargetFrameworkVersion)` value, it defaults to an *invalid* value,
and is promptly greeted with a build error:

	error XA0001: Unsupported or invalid $(TargetFrameworkVersion) value of 'v4.4'. Please update your Project Options.

This is the scenario that the `tests/CodeBehind` tests was
encountering:
`tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj` attempts to
import `Configuration.props` to use `$(AndroidFrameworkVersion)`
as the default value for `$(TargetFrameworkVersion)`, but when those
tests execute, they don't run from that directory.  Consequently,
`..\..\..\Configuration.props` *does not exist*:

	Project "../../../Configuration.props" was not imported by "…/bin/TestRelease/temp/CodeBehind/FailedBuildFew_ConflictingButton/Release/project/CodeBehindBuildTests.csproj" at (21,3), due to false condition; (Exists('..\..\..\Configuration.props')) was evaluated as (Exists('..\..\..\Configuration.props')).

which means `$(TargetFrameworkVersion)` isn't set, the default is
used, and as the default is wrong, things break.

Fix this scenario by properly updating the default
`$(TargetFrameworkVersion)` values within
`Xamarin.Android.Bindings.targets`, `Xamarin.Android.CSharp.targets`,
`Xamarin.Android.FSharp.targets`, and
`Xamarin.Android.VisualBasic.targets` so that `v5.0` is the new
default value.