### PR TITLE
[tests] improve PerformanceTest accuracy

### DIFF
--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -1,15 +1,16 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildReferenceVersion>15.1.0.0</MSBuildReferenceVersion>
+    <MSBuildPackageReferenceVersion>16.5</MSBuildPackageReferenceVersion>
   </PropertyGroup>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <ItemGroup>
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
     <!-- Only use these on Windows as it causes problems with running unit tests in the IDE's on MacOS -->
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build"                Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,15 +2,15 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,10500
-Build_No_Changes,3250
-Build_CSharp_Change,4450
-Build_AndroidResource_Change,4150
-Build_AndroidManifest_Change,4500
-Build_Designer_Change,3600
-Build_JLO_Change,9500
-Build_CSProj_Change,9950
-Build_XAML_Change,9400
-Build_XAML_Change_RefAssembly,6000
-Install_CSharp_Change,5000
-Install_XAML_Change,6500
+Build_From_Clean_DontIncludeRestore,9500
+Build_No_Changes,2000
+Build_CSharp_Change,3250
+Build_AndroidResource_Change,3000
+Build_AndroidManifest_Change,3250
+Build_Designer_Change,2500
+Build_JLO_Change,8500
+Build_CSProj_Change,9000
+Build_XAML_Change,7000
+Build_XAML_Change_RefAssembly,4000
+Install_CSharp_Change,4000
+Install_XAML_Change,5000


### PR DESCRIPTION
Context: https://msbuildlog.com
Context: https://github.com/microsoft/msbuild/blob/ba9a1d64a7abf15a8505827c00413156a3eb7f62/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs

I've noticed that we have been including some MSBuild overhead in our
timings in `PerformanceTest`. If you use the MSBuild binlog viewer,
you can see the "project build time" can be *seconds* shorter than the
overall build time. This extra time is spent for MSBuild startup,
shutdown, and writing log files, etc. We can exclude this time for
these tests.

We can get this number by parsing the `.binlog` file directly, using a
`BuildEventArgsReader` MSBuild API. I just had to update our
`<PackageReference/>` to `Microsoft.Build.*` to a newer version.

Keeping a `Stack` of "project started" event, you can sum them as
"project finished" events occur. These events occur in a tree-like
fashion for project dependencies, so a `Stack` is needed to calculate
the values properly.

I also turned off the other log files, to improve the accuracy
further.

Builds in `PerformanceTest` will be running:

    msbuild /noconsolelogger /bl

This is should be optimal for what we need here.

I was able to drop each timing by a decent amount. I think this will
be more accurate for catching regressions and reduce random failures.