### PR TITLE
[Xamarin.Android.Build.Tasks] Catch Exception when setting Console.InputEncoding

### DIFF
--- a/Documentation/release-notes/4722.md
+++ b/Documentation/release-notes/4722.md
@@ -1,0 +1,24 @@
+#### Visual Studio Crashes when changing an AndroidResource file.
+
+- [Developer Community 1038779](https://developercommunity.visualstudio.com/content/problem/1038779/visual-studio-crash-down.html):
+- [GitHub 4734](https://github.com/xamarin/xamarin-android/issues/4734):
+
+In 16.7 Preview 1 we encountered a problem were Visual Studio world
+crash uneexpectedly. Further investigation lead to an Unhandled `IOException`
+in the new `aapt2` deamon code causing the problem. This only seems to
+happen when `AndroidUseManagedDesignTimeResourceGenerator` is set to
+`False` in the csproj. As to why it happens that is still unknown. The
+problem occurs when we are trying to set the `InputEncoding` of the `Console`.
+This is to make sure `aapt2` can handle non-ASCII characters in paths. However
+when running in a design time build the `IOException` of `invalid handle` is thrown.
+This does not occur during a normal build.
+
+The workarond is to remove the `AndroidUseManagedDesignTimeResourceGenerator` from
+the csproj. The fix is to catch the `IOException` and allow `aapt2` to run. This will
+stop Visual Studio from crashing.
+
+### Known issues
+
+  If the `IOException` is thrown and caught, `aapt2` will not be able to accept non-ASCII
+  characters for paths as its input. You might see `aapt2` build failures if you have
+  non-ASCII characters in your paths.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -18,7 +18,7 @@ using ThreadingTasks = System.Threading.Tasks;
 using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks {
-	
+
 	public abstract class Aapt2 : AndroidAsyncTask {
 
 		private static readonly int DefaultMaxAapt2Daemons = 6;
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tasks {
 		protected virtual int GetRequiredDaemonInstances ()
 		{
 			return 1;
-		} 
+		}
 
 		Aapt2Daemon daemon;
 
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tasks {
 		public override bool Execute ()
 		{
 			// Must register on the UI thread!
-			// We don't want to use up ALL the available cores especially when 
+			// We don't want to use up ALL the available cores especially when
 			// running in the IDE. So lets cap it at DefaultMaxAapt2Daemons (6).
 			int maxInstances = Math.Min (Environment.ProcessorCount-1, DefaultMaxAapt2Daemons);
 			if (DaemonMaxInstanceCount == 0)
@@ -74,6 +74,9 @@ namespace Xamarin.Android.Tasks {
 				DaemonMaxInstanceCount = Math.Min (DaemonMaxInstanceCount, maxInstances);
 			daemon  = Aapt2Daemon.GetInstance (BuildEngine4, GenerateFullPathToTool (),
 				DaemonMaxInstanceCount, GetRequiredDaemonInstances (), registerInDomain: DaemonKeepInDomain);
+			while (daemon.StartupWarnings.Count > 0) {
+				LogCodedWarning ("APT2000", daemon.StartupWarnings.Dequeue ());
+			}
 			return base.Execute ();
 		}
 
@@ -97,7 +100,7 @@ namespace Xamarin.Android.Tasks {
 					}
 				}
 			}
-		} 
+		}
 
 		protected bool LogAapt2EventsFromOutput (string singleLine, MessageImportance messageImportance, bool apptResult)
 		{
@@ -122,7 +125,7 @@ namespace Xamarin.Android.Tasks {
 					return true;
 				}
 				if (message.StartsWith ("unknown option", StringComparison.OrdinalIgnoreCase)) {
-					// we need to filter out the remailing help lines somehow. 
+					// we need to filter out the remailing help lines somehow.
 					LogCodedError ("APT0001", Properties.Resources.APT0001, message.Substring ("unknown option '".Length).TrimEnd ('.', '\''));
 					return false;
 				}


### PR DESCRIPTION
Context https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1130414

For some unknown reason the setting of `Console.InputEncoding`
on a customers machine is throwing an IOException. This then
causes Visual Studio to completely crash.

```
Description: The process was terminated due to an unhandled exception.
Exception Info: System.IO.IOException
   at System.IO.__Error.WinIOError(Int32, System.String)
   at System.IO.__Error.WinIOError()
   at System.Console.set_InputEncoding(System.Text.Encoding)
   at Xamarin.Android.Tasks.Aapt2Daemon.Aapt2DaemonStart()
   at System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.ThreadHelper.ThreadStart()
```

At this time we are still unsure as to what is causing the problem.
But we should at least catch the exception to that Visual Studio does
not crash.

We need to figure out a way of reporting this issue somehow in the
exception handler so we can get more data.

Note: Not sure what is going on with the line ending changes :/