### PR TITLE
[Xamarin.Android.Build.Tasks] fix .resx files for IDE builds

### DIFF
--- a/Documentation/release-notes/4724.md
+++ b/Documentation/release-notes/4724.md
@@ -1,0 +1,8 @@
+#### Application behavior on device and emulator
+
+  - [Developer Community 1030901](https://developercommunity.visualstudio.com/content/problem/1030901/localization-in-android-doesnt-work-4.html),
+    [GitHub 4664](https://github.com/xamarin/xamarin-android/issues/4664):
+    Starting in Xamarin.Android 10.3, localized resources from _.resx_ files were
+    no longer deployed when building and deploying from within Visual Studio to
+    an attached device or emulator.  (In contrast, clean builds started via the
+    **Build > Archive** command or on the command line worked as expected.)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -725,5 +725,42 @@ namespace App1
 				}
 			}
 		}
+
+		[Test]
+		public void MissingSatelliteAssembly ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidLibraryProject {
+				ProjectName = "Localization",
+				OtherBuildItems = {
+					new BuildItem ("EmbeddedResource", "Foo.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+					},
+					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+					}
+				}
+			};
+
+			var app = new XamarinFormsMapsApplicationProject {
+				IsRelease = true,
+			};
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
+
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (libBuilder.Build (lib), "Library Build should have succeeded.");
+				appBuilder.Target = "Build";
+				Assert.IsTrue (appBuilder.Build (app), "App Build should have succeeded.");
+				appBuilder.Target = "SignAndroidPackage";
+				Assert.IsTrue (appBuilder.Build (app), "App SignAndroidPackage should have succeeded.");
+
+				var apk = Path.Combine (Root, appBuilder.ProjectDirectory,
+					app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+					Assert.IsTrue (zip.ContainsEntry ("assemblies/es/Localization.resources.dll"), "Apk should contain satellite assemblies!");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,22 +19,6 @@ namespace Xamarin.Android.Build.Tests
 		string intermediate;
 		string bin;
 
-		const string Resx = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<root>
-	<resheader name=""resmimetype"">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name=""version"">
-		<value>2.0</value>
-	</resheader>
-	<resheader name=""reader"">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name=""writer"">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<!--contents-->
-</root>";
 		// Disable split by language
 		const string BuildConfig = @"{
 	""optimizations"": {
@@ -58,10 +42,10 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				OtherBuildItems = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {
-						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
 					},
 					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
-						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
 					}
 				}
 			};
@@ -97,11 +81,6 @@ namespace Xamarin.Android.Build.Tests
 			var projectDir = Path.Combine (Root, appBuilder.ProjectDirectory);
 			intermediate = Path.Combine (projectDir, app.IntermediateOutputPath);
 			bin = Path.Combine (projectDir, app.OutputPath);
-		}
-
-		string ResxWithContents (string contents)
-		{
-			return Resx.Replace ("<!--contents-->", contents);
 		}
 
 		[TearDown]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
@@ -62,5 +62,27 @@ AAAAAAE1FVEEtSU5GL/7KAABQSwECFAAUAAgICADvhD9Mlldz8EQAAABFAAAAFAAAAAAAAAAAAAAAAAA
 TkYvTUFOSUZFU1QuTUZQSwECFAAUAAgICACzhD9MNzBZxakBAAC1AgAAPAAAAAAAAAAAAAAAAADDAAAAY29tL3hhbWFya
 W4vYW5kcm9pZC90ZXN0L21zYnVpbGR0ZXN0L0phdmFTb3VyY2VKYXJUZXN0LmNsYXNzUEsFBgAAAAADAAMA5wAAANYCAA
 AAAA==";
+
+		const string Resx = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+	<resheader name=""resmimetype"">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name=""version"">
+		<value>2.0</value>
+	</resheader>
+	<resheader name=""reader"">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name=""writer"">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<!--contents-->
+</root>";
+
+		public static string ResxWithContents (string contents)
+		{
+			return Resx.Replace ("<!--contents-->", contents);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2562,6 +2562,7 @@ because xbuild doesn't support framework reference assemblies.
   </SignAndroidPackageDependsOn>
   <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
   <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'True' ">
+    BuildOnlySettings;
     _CreatePropertiesCache;
     ResolveReferences;
     _CopyPackage;


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4664
Fixes: https://feedback.devdiv.io/1030901

It turns out that building *inside* Visual Studio is causing `.resx`
files to stop working. Satellite assemblies are missing from the APK
and/or were not deployed with Fast Deployment.

In 65a917a9, I removed a direct call to `<ResolveAssemblyReference/>`
for performance reasons. This appears to have caused this problem.

This is due to:

https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2101
https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2059

`<ResolveAssemblyReference/>` by default only finds satellite
assemblies when `$(BuildingProject)` is set. This does *not* happen
when `$(BuildingInsideVisualStudio)` is `true` during design-time
builds.

So inside the IDE:

* `Build` runs, `$(BuildingProject)` is `true` and everything works.
* `Install` runs, `$(BuildingProject)` is `false`. This is the part
  where everything falls apart.

I could reproduce this in a test by running `Build` then
`SignAndroidPackage` in two steps. Our MSBuild tests are already set
`$(BuildingInsideVisualStudio)` to `true` by default.

The fix for this is to make `SignAndroidPackage` depend on
`BuildOnlySettings`:

https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1081-L1086

This makes `$(BuildingProject)` always `true` if `SignAndroidPackage`
or `Install` runs in the IDE.