### PR TITLE
Bump Mono

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@e795bcef375bc77da0bbe995fc9e57560ed5ddc0
-mono/mono:2020-02@075c3f06197e3b969f4234d0f56a2e10ee6ee305
+mono/mono:2020-02@8c085a99b32e99ae2f0a6b3de61541fefb4d3389

--- a/Documentation/release-notes/4725.md
+++ b/Documentation/release-notes/4725.md
@@ -1,0 +1,9 @@
+#### Application Mono Framework behavior on device and emulator
+
+- [GitHub 4713](https://github.com/xamarin/xamarin-android/issues/4713):
+  Starting in Xamarin.Android 10.3, SIGSEGV during
+  `monodroid_typemap_java_to_managed` could cause apps to abort if the
+  application was built with the `$(AndroidEnablePreloadAssemblies)`
+  set to `False`, that is assembly preload at application startup
+  would be turned off and the application happened to use a managed
+  type which resides in an assembly not yet loaded by the runtime.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4713
Context: mono/mono@10795da1c065c
Context: mono/mono@8c085a99b32e9

Whenever Xamarin.Android runtime needs to instantiate a managed type, it
first looks it up by calling the following function:

    MonoType *type = mono_reflection_type_from_name ("MyType, Assembly", nullptr);

The `nullptr` pointer refers to an instance of the Mono `MonoImage`
structure and if `null`, it should cause Mono to find the correct image
containing the type and load it, if not already loaded.

The pointer is propagated down the call chain inside Mono and due to one
of the functions called not properly validating its arguments, the
`null` pointer was dereferenced, leading to a crash similar to:

    libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x4c0 in tid 11029 (ompanyname.app3), pid 11029 (ompanyname.app3)
    crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
    /system/bin/tombstoned: received crash request for pid 11029
    crash_dump64: performing dump of process 11029 (target tid = 11029)
    DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
    DEBUG   : Build fingerprint: 'google/sdk_gphone_x86_64/generic_x86_64:10/QSR1.190920.001/5891938:user/release-keys'
    DEBUG   : Revision: '0'
    DEBUG   : ABI: 'x86_64'
    DEBUG   : Timestamp: 2020-05-25 14:45:29+0200
    DEBUG   : pid: 11029, tid: 11029, name: ompanyname.app3  >>> com.companyname.app3 <<<
    DEBUG   : uid: 10134
    DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x4c0
    DEBUG   : Cause: null pointer dereference
    DEBUG   :     rax 000000000000002f  rbx 0000000000000001  rcx 0000000000000000  rdx 0000000000000030
    DEBUG   :     r8  0000000000000003  r9  000000000013e2e2  r10 0173eed800000000  r11 0000000000000206
    DEBUG   :     r12 0000000000000000  r13 00007478530343c0  r14 00007478075eda33  r15 000074780763efb0
    DEBUG   :     rdi 0000000000000000  rsi 00007478e2cb14d0
    DEBUG   :     rbp 00007ffef3a35680  rsp 00007ffef3a355d0  rip 0000747807a4066a
    DEBUG   :
    DEBUG   : backtrace:
    DEBUG   :       #00 pc 00000000003ba66a  /data/app/com.companyname.app3-aQUF6Ge6_v-WaLb5i8Q7vw==/lib/x86_64/libmonosgen-2.0.so (_mono_reflection_get_type_from_info+474)
    DEBUG   :       #01 pc 00000000003ba3d1  /data/app/com.companyname.app3-aQUF6Ge6_v-WaLb5i8Q7vw==/lib/x86_64/libmonosgen-2.0.so (mono_reflection_type_from_name_checked+321)
    DEBUG   :       #02 pc 00000000003ba26d  /data/app/com.companyname.app3-aQUF6Ge6_v-WaLb5i8Q7vw==/lib/x86_64/libmonosgen-2.0.so (mono_reflection_type_from_name+125)
    DEBUG   :       #03 pc 000000000000ddb5  /data/app/com.companyname.app3-aQUF6Ge6_v-WaLb5i8Q7vw==/lib/x86_64/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::typemap_java_to_managed(char const*)+389) (BuildId: 9952f1cfe0d910ae631abc73479f88eef34fd71d)
    DEBUG   :       #04 pc 000000000000def3  /data/app/com.companyname.app3-aQUF6Ge6_v-WaLb5i8Q7vw==/lib/x86_64/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::typemap_java_to_managed(_MonoString*)+99) (BuildId: 9952f1cfe0d910ae631abc73479f88eef34fd71d)
    DEBUG   :       #05 pc 0000000000069532  <anonymous:5ad25000>

Mono commit mono/mono@10795da1c06 fixes this issue.

Other changes:

 * mono/mono@89d772a3abb Always include Unicode charinfo, so tar made in csc mode works in mcs mode (#19813)
 * mono/mono@e9d3af508e4 Bump bockbuild to get https://github.com/mono/bockbuild/pull/159
 * mono/mono@d6f0c25d34d [2020-02] Bump msbuild to track mono-2019-12 (#19661)