### PR TITLE
[Xamarin.Android.Build.Tasks] fix for utf8 chars and custom views

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Android.Tasks
 			var managedConflicts = new Dictionary<string, List<string>> (0, StringComparer.Ordinal);
 			var javaConflicts    = new Dictionary<string, List<string>> (0, StringComparer.Ordinal);
 
-			using (var acw_map = MemoryStreamPool.Shared.CreateStreamWriter (Encoding.Default)) {
+			using (var acw_map = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				foreach (TypeDefinition type in javaTypes) {
 					string managedKey = type.FullName.Replace ('/', '.');
 					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2583,11 +2583,17 @@ public class Test
 		[Category ("SmokeTests")]
 		public void BuildApplicationWithSpacesInPath ([Values (true, false)] bool enableMultiDex, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
+			var folderName = $"BuildReleaseApp AndÜmläüts({enableMultiDex}{dexTool}{linkTool})";
+			var lib = new XamarinAndroidLibraryProject {
+				IsRelease = true,
+				ProjectName = "Library1"
+			};
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				AotAssemblies = true,
 				DexTool = dexTool,
 				LinkTool = linkTool,
+				References = { new BuildItem ("ProjectReference", $"..\\{folderName}Library1\\Library1.csproj") }
 			};
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "Hello (World).jar") { BinaryContent = () => Convert.FromBase64String (@"
 UEsDBBQACAgIAMl8lUsAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
@@ -2617,7 +2623,9 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 </Project>
 ",
 			});
-			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InItAndÜmläüts({enableMultiDex}{dexTool}{linkTool})"))) {
+			using (var libb = CreateDllBuilder (Path.Combine ("temp", $"{folderName}Library1")))
+			using (var b = CreateApkBuilder (Path.Combine ("temp", folderName))) {
+				libb.Build (lib);
 				if (dexTool == "d8" && linkTool == "proguard") {
 					b.ThrowOnBuildFailure = false;
 					Assert.IsFalse (b.Build (proj), "Build should have failed.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -580,7 +580,7 @@ namespace Lib2
 				}
 			};
 			// Use a custom view
-			app.LayoutMain = app.LayoutMain.Replace ("</LinearLayout>", "<MyApp.CustomTextView android:id=\"@+id/myText\" /></LinearLayout>");
+			app.LayoutMain = app.LayoutMain.Replace ("</LinearLayout>", "<MyApp.CustomTextView android:id=\"@+id/myText\" android:text=\"à请\" /></LinearLayout>");
 			app.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 
 			int count = 0;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -600,7 +600,7 @@ namespace Xamarin.Android.Tasks
 		public static bool SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)
 		{
 			engine?.RegisterTaskObject (mapFile, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
-			using (var writer = MemoryStreamPool.Shared.CreateStreamWriter (Encoding.Default)) {
+			using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				foreach (var i in map.OrderBy (x => x.Key)) {
 					foreach (var v in i.Value.OrderBy (x => x))
 						writer.WriteLine ($"{i.Key};{v}");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tasks
 
 		public static bool SaveIfChanged (this XDocument document, string fileName)
 		{
-			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter (Encoding.Default))
+			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ())
 			using (var xw = new Monodroid.LinePreservedXmlWriter (sw)) {
 				xw.WriteNode (document.CreateNavigator (), false);
 				xw.Flush ();


### PR DESCRIPTION
Fixes: https://feedback.devdiv.io/955972

Android layout files with utf8 characters and custom views fail to
build with:

    error APT2258: not well-formed (invalid token).

In be47b3ec, I inadvertently changed the `<ConvertCustomView/>`
MSBuild task to save changes using `Encoding.Default`.
`XDocumentExtensions.SaveIfChanged` should just use
`MonoAndroidHelper.UTF8withoutBOM` by default.

The other places that use this method, will not be affected by using
UTF-8 without a BOM. I also fixed two other places in the build that
use `Encoding.Default`.

I updated two tests to reproduce this issue.