### PR TITLE
[d16-7] [Xamarin.Android.Build.Tasks] fix .resx files for IDE builds

### DIFF
--- a/Documentation/release-notes/4724.md
+++ b/Documentation/release-notes/4724.md
@@ -1,0 +1,8 @@
+#### Application behavior on device and emulator
+
+  - [Developer Community 1030901](https://developercommunity.visualstudio.com/content/problem/1030901/localization-in-android-doesnt-work-4.html),
+    [GitHub 4664](https://github.com/xamarin/xamarin-android/issues/4664):
+    Starting in Xamarin.Android 10.3, localized resources from _.resx_ files were
+    no longer deployed when building and deploying from within Visual Studio to
+    an attached device or emulator.  (In contrast, clean builds started via the
+    **Build > Archive** command or on the command line worked as expected.)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -725,5 +725,42 @@ namespace App1
 				}
 			}
 		}
+
+		[Test]
+		public void MissingSatelliteAssembly ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidLibraryProject {
+				ProjectName = "Localization",
+				OtherBuildItems = {
+					new BuildItem ("EmbeddedResource", "Foo.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+					},
+					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+					}
+				}
+			};
+
+			var app = new XamarinFormsMapsApplicationProject {
+				IsRelease = true,
+			};
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
+
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (libBuilder.Build (lib), "Library Build should have succeeded.");
+				appBuilder.Target = "Build";
+				Assert.IsTrue (appBuilder.Build (app), "App Build should have succeeded.");
+				appBuilder.Target = "SignAndroidPackage";
+				Assert.IsTrue (appBuilder.Build (app), "App SignAndroidPackage should have succeeded.");
+
+				var apk = Path.Combine (Root, appBuilder.ProjectDirectory,
+					app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+					Assert.IsTrue (zip.ContainsEntry ("assemblies/es/Localization.resources.dll"), "Apk should contain satellite assemblies!");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,22 +19,6 @@ namespace Xamarin.Android.Build.Tests
 		string intermediate;
 		string bin;
 
-		const string Resx = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<root>
-	<resheader name=""resmimetype"">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name=""version"">
-		<value>2.0</value>
-	</resheader>
-	<resheader name=""reader"">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name=""writer"">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<!--contents-->
-</root>";
 		// Disable split by language
 		const string BuildConfig = @"{
 	""optimizations"": {
@@ -58,10 +42,10 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				OtherBuildItems = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {
-						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
 					},
 					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
-						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
 					}
 				}
 			};
@@ -97,11 +81,6 @@ namespace Xamarin.Android.Build.Tests
 			var projectDir = Path.Combine (Root, appBuilder.ProjectDirectory);
 			intermediate = Path.Combine (projectDir, app.IntermediateOutputPath);
 			bin = Path.Combine (projectDir, app.OutputPath);
-		}
-
-		string ResxWithContents (string contents)
-		{
-			return Resx.Replace ("<!--contents-->", contents);
 		}
 
 		[TearDown]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	static class InlineData
+	{
+#if false // Java source with javadoc
+		package com.xamarin.android.test.msbuildtest;
+
+		public class JavaSourceJarTest
+		{
+			/**
+			 * Returns greeting message.
+			 * <p>
+			 * Returns "Morning, ", "Hello, " or "Evening, " with name argument,
+			 * depending on the argument hour.
+			 * </p>
+			 * @param name name to display.
+			 * @param date time to determine the greeting message.
+			 * @return the resulting message.
+			 */
+			public String greet (String name, java.util.Date date)
+			{
+				String head = date.getHours () < 11 ? "Morning, " : date.getHours () < 17 ? "Hello, " : "Evening, ";
+				return head + name;
+			}
+		}
+#endif
+
+		public const string JavaSourcesJarBase64 = @"
+UEsDBBQACAgIAC2gP0wAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAAAAAAFBLAwQUAAgIC
+AAtoD9MAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLE
+lN0XWqBAlY6BnEG5oaKmj4FyUm56QqOOcXFeQXJZYA1WvycvFyAQBQSwcIlldz8EQAAABFAAAAUEsDBBQACAgIACqgP0w
+AAAAAAAAAAAAAAAA7AAAAY29tL3hhbWFyaW4vYW5kcm9pZC90ZXN0L21zYnVpbGR0ZXN0L0phdmFTb3VyY2VKYXJUZXN0
+LmphdmF1kc1uwjAMx+99CosTsCqI0yRgG4dNQki7jL2Aaaw2Wz4qJ2WbJt59SSgfQsyq4kb+2X/babH6xJqgckZ8o0FWV
+qCV7JQUgXwQxm87pWX6nxdF2221qqDS6D2scYcb13FFa+T3CBS/BUSbjMfZwxjeKHRsPdRMFJStwZD3UU8cgUX7eM0OXh
+3byJYwiN+KtHbRg2MYvOyoj8CXCg1YNATIdWfIhvJYSFJLViY1ZyE0ZwKa2O1ZenLWXrbIaA718hEcSOVbjT/iipEYYlj
+1DAVioyxlnX+nXHKeLUNMvtO3qEn2/YY3gROSK8Kwv6XOSviIaxddUFo8p1ZSP6Oceth+sp5vCCU8ZELUFFZxeg/DESxg
+OoWny0XD7JSb7FbGfco4vcbs8jHmp+R+zix8l/s9xPbFvvgDUEsHCDlC8jY2AQAAawIAAFBLAQIUABQACAgIAC2gP0wAA
+AAAAgAAAAAAAAAJAAQAAAAAAAAAAAAAAAAAAABNRVRBLUlORi/+ygAAUEsBAhQAFAAICAgALaA/TJZXc/BEAAAARQAAAB
+QAAAAAAAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAKqA/TDlC8jY2AQAAawIAADsAAAA
+AAAAAAAAAAAAAwwAAAGNvbS94YW1hcmluL2FuZHJvaWQvdGVzdC9tc2J1aWxkdGVzdC9KYXZhU291cmNlSmFyVGVzdC5q
+YXZhUEsFBgAAAAADAAMA5gAAAGICAAAAAA==";
+
+		public const string JavaClassesJarBase64 = @"
+UEsDBBQACAgIAO+EP0wAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAAAAAAFBLAwQUAAgIC
+ADvhD9MAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLE
+lN0XWqBAlY6BnEG5oaKmj4FyUm56QqOOcXFeQXJZYA1WvycvFyAQBQSwcIlldz8EQAAABFAAAAUEsDBBQACAgIALOEP0w
+AAAAAAAAAAAAAAAA8AAAAY29tL3hhbWFyaW4vYW5kcm9pZC90ZXN0L21zYnVpbGR0ZXN0L0phdmFTb3VyY2VKYXJUZXN0
+LmNsYXNzbVHZSsNAFD1j2yStaW3rvlvX1i0g4osiuKLi8lARfHPaDCWaJiWdit/ji6/6UkHBD/CjxDupIloDucuZO+fMn
+Hn/eHkDsIpCAp3oS6AfAwYGDQwZGNYxkoCmUA2jKozpGNcxwaBtOJ4jNxki+cIFQ3THtwVD17HjidNGtSSCc15yCYlVAi
+Ekw1r++JrfcsvlXsUqysDxKustpCEd19rlUqwX2kcYkkXJyzcnvBYS6sgxJIp+IyiLfUcJ9B3RnhZwxINzUZfLisWEiaS
+OSRNTmGaIn/iBR4SLdHT9QLiur6r43q34Rvv/am83HNcWgYkZzJqYQ54uUfar1h2vclq3uGcHvmNbkiStar2kxsO67UAM
+6R/ys9K1KP+GWnoMqd9+MBgVIQ+IqR7afEiu81pNeDbD0j92ttv3dQVy0ZD+t0pP/h+fkYN6fvV1gCnvKKaoG6XMKMfmn
+8GeqKBHpqiFYIRiGpmv0SvaGqW8sthER7rzHkY28oDusMuoLvqAWDZ2+grt8hn6UhPGAv1NxB9DWcWbIk4QYxeyGEc3Rc
+BAJJXc0qmjw4eTvZ9QSwcINzBZxakBAAC1AgAAUEsBAhQAFAAICAgA74Q/TAAAAAACAAAAAAAAAAkABAAAAAAAAAAAAAA
+AAAAAAE1FVEEtSU5GL/7KAABQSwECFAAUAAgICADvhD9Mlldz8EQAAABFAAAAFAAAAAAAAAAAAAAAAAA9AAAATUVUQS1J
+TkYvTUFOSUZFU1QuTUZQSwECFAAUAAgICACzhD9MNzBZxakBAAC1AgAAPAAAAAAAAAAAAAAAAADDAAAAY29tL3hhbWFya
+W4vYW5kcm9pZC90ZXN0L21zYnVpbGR0ZXN0L0phdmFTb3VyY2VKYXJUZXN0LmNsYXNzUEsFBgAAAAADAAMA5wAAANYCAA
+AAAA==";
+
+		const string Resx = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+	<resheader name=""resmimetype"">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name=""version"">
+		<value>2.0</value>
+	</resheader>
+	<resheader name=""reader"">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name=""writer"">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<!--contents-->
+</root>";
+
+		public static string ResxWithContents (string contents)
+		{
+			return Resx.Replace ("<!--contents-->", contents);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2747,6 +2747,7 @@ because xbuild doesn't support framework reference assemblies.
   </SignAndroidPackageDependsOn>
   <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
   <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'True' ">
+    BuildOnlySettings;
     _CreatePropertiesCache;
     ResolveReferences;
     _CopyPackage;


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4664
Fixes: https://feedback.devdiv.io/1030901

It turns out that building *inside* Visual Studio is causing `.resx`
files to stop working.  Satellite assemblies are missing from the
`.apk` and/or were not deployed with Fast Deployment.

In 65a917a9, I removed a direct call to `<ResolveAssemblyReference/>`
for performance reasons. This appears to have caused this problem.

This is due to:

  * https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2101
  * https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2059

`<ResolveAssemblyReference/>` by default only finds satellite
assemblies when `$(BuildingProject)` is set.  This does *not* happen
when `$(BuildingInsideVisualStudio)` is `true` during design-time
builds.

Thus, inside the IDE:

  * `Build` runs, `$(BuildingProject)` is `true` and everything works.
  * `Install` runs, `$(BuildingProject)` is `false`.  This is the part
    where everything falls apart.

I could reproduce this in a test by running `Build` then
`SignAndroidPackage` in two steps.  Our MSBuild tests already set
`$(BuildingInsideVisualStudio)` to `true` by default.

The fix for this is to make `SignAndroidPackage` depend on
`BuildOnlySettings`:

  * https://github.com/microsoft/msbuild/blob/dc485bce3427e9d2b020ce61c2400e7b5a76062c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1081-L1086

This makes `$(BuildingProject)` always `true` if `SignAndroidPackage`
or `Install` runs in the IDE.