### PR TITLE
[tests] fix failing NuGet restore on TimeZone tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -67,6 +67,8 @@ namespace Xamarin.ProjectTools
 			Sources.Add (new BuildItem.Source ($"Resources\\Resource.designer{Language.DefaultExtension}") { TextContent = () => string.Empty });
 		}
 
+		protected override bool SetExtraNuGetConfigSources => true;
+
 		public string Configuration => IsRelease ? "Release" : "Debug";
 
 		public string OutputPath => Path.Combine ("bin", Configuration, TargetFramework.ToLowerInvariant ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -31,10 +31,7 @@ namespace Xamarin.ProjectTools
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
 		public string GlobalPackagesFolder { get; set; } = Path.Combine (XABuildPaths.TopDirectory, "packages");
-		public IList<string> ExtraNuGetConfigSources { get; set; } = new List<string> {
-			Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
-			"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
-		};
+		public IList<string> ExtraNuGetConfigSources { get; set; }
 
 		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;
 		/// <summary>
@@ -77,7 +74,16 @@ namespace Xamarin.ProjectTools
 			Packages = new List<Package> ();
 			Imports = new List<Import> ();
 
+			// Feeds only needed for .NET 5+
+			if (SetExtraNuGetConfigSources) {
+				ExtraNuGetConfigSources = new List<string> {
+					Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
+					"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
+				};
+			}
 		}
+
+		protected virtual bool SetExtraNuGetConfigSources => Builder.UseDotNet;
 
 		public string GetProperty (string name)
 		{


### PR DESCRIPTION
TimeZone tests fail to build with `/restore`:

    NuGet.targets(124,5): The local source '/Users/runner/runners/2.168.2/work/1/s/bin/BuildRelease/nupkgs' doesn't exist.

In 10d814f2, I added support for running our MSBuild test suite under
.NET 5. This inadvertently added the local source to the
`NuGet.config` for the TimeZone tests.

To fix this, I made the change so the `NuGet.config` will only contain
the extra sources if:

* `XASdkProject` is used.
* `Builder.UseDotNet` is set via `nunit3-console --params dotnet=true`.