### PR TITLE
Bump mono

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@e795bcef375bc77da0bbe995fc9e57560ed5ddc0
-mono/mono:2020-02@8c085a99b32e99ae2f0a6b3de61541fefb4d3389
+mono/mono:2020-02@87ef5557017a8d822ae31587846a54fcd66daf1b


### PR DESCRIPTION
Context: 9d0457133ffbbd8f366c7896e68b0ea1b343261d
Context: mono/mono@87ef5557017a8d822ae31587846a54fcd66daf1b

Changes: https://github.com/mono/mono/compare/8c085a99b32e99ae2f0a6b3de61541fefb4d3389..87ef5557017a8d822ae31587846a54fcd66daf1b

  * mono/mono@87ef5557017 Emit DWARF debug_abbrev offset for compile units as a label instead of 0 (#19794)

9d045713 bumped mono to mono/mono@8c085a99, however that Mono revision
failed to create a Mono archive for Linux.  Since it is not easy for
Mono to rebuild archives for past revisions, we need to bump it again in
order to be able to bootstrap Xamarin.Android build on Linux machines.