### PR TITLE
Set the adb port forwarding

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -59,6 +59,7 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
   </Target>
   <Target Name="FinishAotProfiling"
       DependsOnTargets="_ResolveSdks">
-    <Exec Command="&quot;$(MonoAndroidBinDirectory)aprofutil&quot; $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o &quot;$(AndroidAotCustomProfilePath)&quot;" />
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) forward tcp:$(AndroidAotProfilerPort) tcp:$(AndroidAotProfilerPort)" />
+    <Exec Command="&quot;$(MonoAndroidBinDirectory)aprofutil&quot; $(AProfUtilExtraOptions) -s -v -p $(AndroidAotProfilerPort) -o &quot;$(AndroidAotCustomProfilePath)&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/4152

And don't use `-f` option when calling `aprofutil` as the adb might not
be in the `PATH`