### PR TITLE
[build] fixes for .nupkg's on Linux

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -166,6 +166,13 @@ stages:
     - script: make package-deb V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make package-deb
 
+    - task: MSBuild@1
+      displayName: pack all nupkgs
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)/build-tools/create-packs/Microsoft.Android.Sdk.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:CreateAllPacks /restore /bl:$(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
         cp $(System.DefaultWorkingDirectory)/*xamarin.android*.tar.bz2 $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&
@@ -179,6 +186,12 @@ stages:
       inputs:
         artifactName: Linux Packages
         targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload nupkgs
+      inputs:
+        artifactName: Linux $(NuGetArtifactName)
+        targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -49,8 +49,11 @@ the new entry point for short-form style Android projets in .NET 5.
       <AndroidSdkBuildToolsUnix Include="@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSwab);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)" >
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildToolsUnix>
-      <AndroidSdkBuildToolsUnix Include="$(PkgMono_Posix_NETStandard)\runtimes\osx\native\libMonoPosixHelper.dylib" >
+      <AndroidSdkBuildToolsUnix Include="$(PkgMono_Posix_NETStandard)\runtimes\osx\native\libMonoPosixHelper.dylib" Condition="$([MSBuild]::IsOSPlatform('osx'))">
         <RelativePath>libMonoPosixHelper.dylib</RelativePath>
+      </AndroidSdkBuildToolsUnix>
+      <AndroidSdkBuildToolsUnix Include="$(PkgMono_Posix_NETStandard)\runtimes\linux-x64\native\libMonoPosixHelper.so" Condition="$([MSBuild]::IsOSPlatform('linux'))" >
+        <RelativePath>libMonoPosixHelper.so</RelativePath>
       </AndroidSdkBuildToolsUnix>
     </ItemGroup>
     <!-- Copy only the required tools to new folder. Skip Unix item copying on Windows. -->
@@ -63,7 +66,7 @@ the new entry point for short-form style Android projets in .NET 5.
         SourceFiles="@(AndroidSdkBuildToolsUnix)"
         DestinationFiles="@(AndroidSdkBuildToolsUnix->'$(ToolsSourceDir)%(RelativePath)')"
         SkipUnchangedFiles="True"
-        Condition="$([MSBuild]::IsOSPlatform('osx'))"
+        Condition="$([MSBuild]::IsOSPlatform('osx')) or $([MSBuild]::IsOSPlatform('linux'))"
     />
     <ItemGroup>
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -192,7 +192,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />
@@ -253,8 +253,8 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.ApiXmlAdjuster.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Bytecode.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Bytecode.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavaDocImporter.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavaDocImporter.pdb" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavadocImporter.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavadocImporter.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.VisualBasic.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.pdb" />


### PR DESCRIPTION
`Mono.Terminal` has a timestamp:

    $ ls -l ./Debug/lib/xamarin.android/xbuild/Xamarin/Android/Mono.Terminal.dll
    -rwxr--r-- 1 grendel grendel 20480 Jan  1  1980 ./Debug/lib/xamarin.android/xbuild/Xamarin/Android/Mono.Terminal.dll

That causes the failure:

    "build-tools/create-packs/Microsoft.Android.Sdk.proj" (CreateAllPacks target) (1) ->
        /usr/share/dotnet/sdk/3.1.300/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(198,5): error : The DateTimeOffset specified cannot be converted into a Zip file timestamp. (Parameter 'value')

`Mono.Terminal` is only used by `logcat-parse`, so we should exclude
this file for .NET 5 packages. `logcat-parse` is already excluded.

There is also some incorrect casing that causes:

    (CreateAllPacks target) ->
        build-tools/create-packs/Microsoft.Android.Sdk.proj(57,5): error MSB3030: Could not copy the file "bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Tools.JavaDocImporter.pdb" because it was not found.
        build-tools/create-packs/Microsoft.Android.Sdk.proj(57,5): error MSB3030: Could not copy the file "bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Tools.JavaDocImporter.dll" because it was not found.

These should be `JavadocImporter` instead of `JavaDocImporter`.

I also fixed two issues in `Microsoft.Android.Sdk.proj` that was
preventing native libraries from being added to the `.nupkg` files on
Linux.

I added CI steps for Linux to create the `.nupkg` files and publish
them as build artifacts.