### PR TITLE
[CI] Delete VS installer before provisioning VS

### DIFF
--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -40,6 +40,11 @@ steps:
   clean: true
   fetchDepth: 10
 
+  # Clear out VS installer content before provisioning VS to avoid using unstable tools from pre-release installers.
+- powershell: Remove-Item "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer" -Recurse -Force -ErrorAction Ignore
+  displayName: Delete VS Installer
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies
   inputs:


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3765530&view=logs&jobId=1cfdb47b-00d6-51ee-9189-006d3307b76f

Our Windows regression test jobs have been failing for a number of weeks
due to a timeout during provisioning.  After getting access to one of
these machines, I noticed that 'VSIXInstaller.exe' processes were being
kept open even after invocations of the tool completed succesfully.
I was able to avoid this issue by deleting the Visual Studio `Installer`
directory that was left behind, and running a stable VS Installer to
replace the old installer with a stable version.  It seems that an early
16.7 preview version of VSIXInstaller.exe was problematic, and the
latest public preview and stable installers do not have this issue.