### PR TITLE
Bump NDK to r21c

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "21b";
-		public const string AndroidNdkPkgRevision = "21.1.6352462";
+		public const string AndroidNdkVersion = "21c";
+		public const string AndroidNdkPkgRevision = "21.2.6472646";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r21#r21c

Changes:

  * [Issue 1060][0]: A macOS app bundle that is signed and notarized is now
    available for download from our wiki and our website. Note that
    because only bundles may use RPATHs and pass notarization, the
    traditional NDK package for macOS *cannot be notarized. The SDK will
    continue to use the traditional package as the app bundle requires
    layout changes that would make it incompatible with Android Studio.
    The NDK is not quarantined when it is downloaded via the SDK manager,
    so is curently allowed by Gatekeeper. The SDK manager is currently the
    most reliable way to get the NDK for macOS.
  * [Issue 1207][1]: Fix fatal error in clang when building with -O2 on arm64.
  * [Issue 1239][2]: Fix network drive issues for clang.
  * [Issue 1229][3]: README.md turned back to ordinary file.

[0]: https://github.com/android/ndk/issues/1060
[1]: https://github.com/android/ndk/issues/1207
[2]: https://github.com/android/ndk/issues/1239
[3]: https://github.com/android/ndk/issues/1229