### PR TITLE
Bump to Android SDK Build-tools 29.0.2

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -97,8 +97,8 @@
     <AllSupported32BitTargetAndroidAbis>armeabi-v7a;x86</AllSupported32BitTargetAndroidAbis>
     <AllSupported64BitTargetAndroidAbis>arm64-v8a;x86_64</AllSupported64BitTargetAndroidAbis>
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
-    <XABuildToolsVersion>30-rc4</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">30.0.0-rc4</XABuildToolsFolder>
+    <XABuildToolsVersion>29.0.2</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">29.0.2</XABuildToolsFolder>
     <XAPlatformToolsVersion>29.0.5</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.14.0</XABundleToolVersion>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android-tools/pull/85
Context: https://github.com/xamarin/xamarin-android/pull/4567

Partially reverts commit 5ad666d5a591a0a18ab6645664a3a0a0e17ca7d6.

Commit 5ad666d5 bumped the Android SDK Build-tools version that
`xaprepare` installs to be 30.0.0-rc4, which is problematic becuase it
contains an `apksigner.jar` which requires JDK11, support for which
has not yet been merged (see PR #4567).

In retrospect, bumping the `$(XABuildToolsVersion)` value was a
Bad Idea™.  It was the `DexUtils.cs` change that we wanted.

Revert the `$(XABuildToolsVersion)` bump, and thus once again provision
Android SDK Build-tools 29.0.2.