### PR TITLE
[Xamarin.Android.Build.Tasks] fix IsSdkAssembly() checks in LinkAssembliesNoShrink

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -57,7 +57,8 @@ namespace Xamarin.Android.Tasks
 					var destination = DestinationFiles [i];
 					AssemblyDefinition assemblyDefinition = null;
 
-					if (!MTProfile.IsSdkAssembly (source.ItemSpec) && !MTProfile.IsProductAssembly (source.ItemSpec)) {
+					var assemblyName = Path.GetFileNameWithoutExtension (source.ItemSpec);
+					if (!MTProfile.IsSdkAssembly (assemblyName) && !MTProfile.IsProductAssembly (assemblyName)) {
 						assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
 						step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogMessageFromText (msg, MessageImportance.High));
 					}


### PR DESCRIPTION
I discovered the `Profile.IsSdkAssembly()` and
`Profile.IsProductAssembly()` checks only work against assembly names:

https://github.com/xamarin/xamarin-android/blob/a134aa72df62d7d1bfb4da52b5c642dbfe4d0490/src/Xamarin.Android.Build.Tasks/Linker/Mobile.Tuner/MobileProfile.cs#L12-L197

So we were actually checking for obsolete `AppDomain` usage in the BCL,
`Mono.Android.dll`, `Java.Interop.dll`, etc.

I fixed these checks by using `Path.GetFileNameWithoutExtension()`.
Now these assemblies shouldn't even be loaded with Mono.Cecil at all.

## Results ##

    Before:
    2596 ms  LinkAssembliesNoShrink                     1 calls
    After:
    1849 ms  LinkAssembliesNoShrink                     1 calls

Saved ~750ms.

This was running an initial build of the Xamarin.Forms integration
project on macOS. There will likely be not much of an improvement for
incremental builds, as the MSBuild target runs partially.