### PR TITLE
[tests] mark F# tests NonParallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -183,20 +183,14 @@ class MemTest {
 
 		[Test]
 		[Category ("Minor")]
-		public void BuildBasicApplicationFSharp ()
+		[NonParallelizable] // parallel NuGet restore causes failures
+		public void BuildBasicApplicationFSharp ([Values (true, false)] bool isRelease)
 		{
-			var proj = new XamarinAndroidApplicationProject () { Language = XamarinAndroidProjectLanguage.FSharp };
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationFSharp")) {
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-			}
-		}
-
-		[Test]
-		[Category ("Minor")]
-		public void BuildBasicApplicationReleaseFSharp ()
-		{
-			var proj = new XamarinAndroidApplicationProject () { Language = XamarinAndroidProjectLanguage.FSharp, IsRelease = true };
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseFSharp")) {
+			var proj = new XamarinAndroidApplicationProject {
+				Language = XamarinAndroidProjectLanguage.FSharp,
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
@@ -475,6 +469,7 @@ class MemTest {
 		}
 
 		[Test]
+		[NonParallelizable] // parallel NuGet restore causes failures
 		public void FSharpAppHasAndroidDefine ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {


### PR DESCRIPTION
Context: https://build.azdo.io/3775041

We've been seeing the F# tests fail with errors such as:

    NuGet.targets(124,5): error : Could not find file "/Users/runner/.local/share/NuGet/v3-cache/1ca707a4d90792ce8e42453d4e350886a0fdaa4d$ps:_api.nuget.org_v3_index.json/nupkg_fsharp.core.4.7.1.dat"

These are likely due to `FSharp.Core` being restored in parallel.

I added `[NonParallelizable]` to the F# tests, which has fixed this
problem for certain tests in the past.

I also cleaned up the `BuildBasicApplicationFSharp` test to use a
parameter for `Debug` vs `Release`.