### PR TITLE
Bump Android Emulator to v30.0.12

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -135,8 +135,8 @@
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
     <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
-    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">6306047</EmulatorVersion>
-    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.0.5</EmulatorPkgRevision>
+    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">6466327</EmulatorVersion>
+    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.0.12</EmulatorPkgRevision>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>


### PR DESCRIPTION
Context: https://androidstudio.googleblog.com/
Context: https://androidstudio.googleblog.com/2020/03/emulator-3006-canary-windows-performance.html
Context: https://androidstudio.googleblog.com/2020/04/emulator-3007-canary.html
Context: https://androidstudio.googleblog.com/2020/04/emulator-3008-canary.html
Context: https://androidstudio.googleblog.com/2020/04/emulator-3009-canary.html
Context: https://androidstudio.googleblog.com/2020/05/emulator-30012-canary-psa-if-emulator.html

Changes (cumulative, since 30.0.5):

 * Upgraded protobuf verison to 3.11.4
 * Added experimental car data replay feature for when running
   Android Auto Embedded system images to the car data page in
   the extended controls.
 * Fixed kernel version parsing issue when running aarch64 guest kernels
 * Vulkan
   * Worked around issue that occurs on Windows NVIDIA GPUs when
     creating/destroying VkPipelineLayouts in multiple threads.
   * Improved support (fixes, performance improvements) for host-side
     video codecs. Requires a future Android R system image.
 * Fixed hang on starting Windows emulator that happened right after
   the boot animation.
 * Fixed issue where Vulkan external semaphore type OPAQUE_FD (in the
   guest) was not working on Windows hosts (due to bug in translation
   to win32 handle semaphores).
 * Added support for vendor boot images (emulator side).
 * GLES translator libraries have been changed to be linked statically.
   This should slightly improve download size and startup time, while
   having fewer ways to link the wrong GLES libraries.
 * Removed libGLES12Translator as we use an internal GLES1 translator
   in all cases now for GLES1.
 * Metrics are now tracked for extended window usage.
 * Fixed issue where glTexStorage2D did not work with ASTC compressed
   texture formats (Requires corresponding change in system image)
 * Removed prints about certs and GRPC on startup.
 * macOS emulator no longer disables App Nap. If also run with
   -no-audio, the emulator should now stop from preventing sleep on
   macOS.
 * Relaxed logical core requirement to 6 from 8 on macOS so more users
   can run images with multiple vCPUs.
 * Fixed issue in Car AVDs where in the HAL property page, LEFT_FRONT
   was incorrectly labeled as "Front right".
 * Fixed some GLES3 extensions not being able to be found after the move
   to static build in 30.0.8.
 * eglChooseConfig called with null attrib_list argument now more
   liberally returns the first config found rather than bailing out.
 * The emulator can now run embedded inside Android Studio. This
   requires Android Studio 4.1 Canary 8 or later, and needs to be
   enabled manually via Android Studio's Preferences > Tools > Emulator.
 * We now detect 3rd party graphics driver hooks that have been
   observed in crash reports, and alert the user if any were involved
   in the crashing stack trace.
 * Fixed graphics error when orphaning EGL images in the guest via
   glTexImage2D.
 * Vulkan: Fixed a possible crash on guest process cleanup.
 * Fixed possible issue in Linux embedded emulator where the
   advertisement file might have been written to the wrong location.
 * Fixed a hang on AMD machines with AMD Hypervisor. This will require
   downloading and installing the latest Android Emulator Hypervisor
   for AMD Processors (v 1.5).
 * Fixed possible memory corruption on Linux / macOS due to a path
   that used select() and did not check FD_SETSIZE limit.
 * On Linux, instructions to enable KVM if permission is denied should
   print more visibly now.
 * Removed "Screenshot failed to find cb 0" messages.
 * Addressed a possible race condition with some versions of Vulkan
   loaders when creating many VkDevice/VkInstances in parallel.