### PR TITLE
Stop using `__Internal` in our p/invoke calls

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -280,7 +280,7 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr _monodroid_timezone_get_default_id ();
 
 		// This is invoked by
@@ -301,7 +301,7 @@ namespace Android.Runtime {
 		// These are invoked by
 		// System.dll!System.AndroidPlatform.getifaddrs
 		// DO NOT REMOVE
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern int _monodroid_getifaddrs (out IntPtr ifap);
 
 		static int GetInterfaceAddresses (out IntPtr ifap)
@@ -312,7 +312,7 @@ namespace Android.Runtime {
 		// These are invoked by
 		// System.dll!System.AndroidPlatform.freeifaddrs
 		// DO NOT REMOVE
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
                 static extern void _monodroid_freeifaddrs (IntPtr ifap);
 
 		static void FreeInterfaceAddresses (IntPtr ifap)
@@ -320,7 +320,7 @@ namespace Android.Runtime {
 			_monodroid_freeifaddrs (ifap);
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern void _monodroid_detect_cpu_and_architecture (ref ushort built_for_cpu, ref ushort running_on_cpu, ref byte is64bit);
 
 		static void DetectCPUAndArchitecture (out ushort builtForCPU, out ushort runningOnCPU, out bool is64bit)

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -16,6 +16,8 @@ namespace Android.Runtime {
 
 	class AndroidRuntime : JniRuntime {
 
+		public const string InternalDllName = "xa-internal-api";
+
 		internal AndroidRuntime (IntPtr jnienv,
 				IntPtr vm,
 				bool allocNewObjectSupported,
@@ -100,7 +102,7 @@ namespace Android.Runtime {
 
 	class AndroidObjectReferenceManager : JniRuntime.JniObjectReferenceManager {
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern int _monodroid_gref_get ();
 
 		public override int GlobalReferenceCount {

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -66,16 +66,16 @@ namespace Android.Runtime {
 
 		internal    static      AndroidValueManager? AndroidValueManager;
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static void monodroid_log (LogLevel level, LogCategories category, string message);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal extern static IntPtr monodroid_timing_start (string? message);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal extern static void monodroid_timing_stop (IntPtr sequence, string? message);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal extern static void monodroid_free (IntPtr ptr);
 
 		public static IntPtr Handle {
@@ -296,7 +296,7 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static void _monodroid_gc_wait_for_bridge_processing ();
 
 #pragma warning disable CS0649 // Field is never assigned to.  This field is assigned from monodroid-glue.cc.
@@ -310,7 +310,7 @@ namespace Android.Runtime {
 			_monodroid_gc_wait_for_bridge_processing ();
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static IntPtr _monodroid_get_identity_hash_code (IntPtr env, IntPtr value);
 
 		internal static Func<IntPtr, IntPtr>? IdentityHash;
@@ -597,25 +597,25 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int _monodroid_gref_log (string message);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int _monodroid_gref_log_new (IntPtr curHandle, byte curType, IntPtr newHandle, byte newType, string? threadName, int threadId, [In] StringBuilder? from, int from_writable);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void _monodroid_gref_log_delete (IntPtr handle, byte type, string? threadName, int threadId, [In] StringBuilder? from, int from_writable);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void _monodroid_weak_gref_new (IntPtr curHandle, byte curType, IntPtr newHandle, byte newType, string? threadName, int threadId, [In] StringBuilder? from, int from_writable);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void _monodroid_weak_gref_delete (IntPtr handle, byte type, string? threadName, int threadId, [In] StringBuilder? from, int from_writable);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int _monodroid_lref_log_new (int lrefc, IntPtr handle, byte type, string? threadName, int threadId, [In] StringBuilder from, int from_writable);
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void _monodroid_lref_log_delete (int lrefc, IntPtr handle, byte type, string? threadName, int threadId, [In] StringBuilder from, int from_writable);
 
 		public static IntPtr NewGlobalRef (IntPtr jobject)

--- a/src/Mono.Android/Android.Runtime/Logger.cs
+++ b/src/Mono.Android/Android.Runtime/Logger.cs
@@ -60,7 +60,7 @@ namespace Android.Runtime {
 			}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static uint monodroid_get_log_categories ();
 
 		static Logger ()

--- a/src/Mono.Android/Java.Interop/Runtime.cs
+++ b/src/Mono.Android/Java.Interop/Runtime.cs
@@ -20,14 +20,14 @@ namespace Java.Interop {
 			return r;
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern int _monodroid_max_gref_get ();
 
 		public static int MaxGlobalReferenceCount {
 			get {return _monodroid_max_gref_get ();}
 		}
 
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		static extern int _monodroid_gref_get ();
 
 		public static int GlobalReferenceCount {

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -38,7 +38,7 @@ namespace Java.Interop {
 	}
 
 	public static partial class TypeManager {
-		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
 		extern static IntPtr monodroid_TypeManager_get_java_class_name (IntPtr klass);
 
 		internal static string GetClassName (IntPtr class_ptr)

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -139,7 +139,7 @@ namespace xamarin::android::internal
 	private:
 		unsigned int convert_dl_flags (int flags);
 #if defined (WINDOWS) || defined (APPLE_OS_X)
-		static const char* get_my_location ();
+		static const char* get_my_location (bool remove_file_name = true);
 #endif  // defined(WINDOWS) || defined(APPLE_OS_X)
 		static void* monodroid_dlopen (const char *name, int flags, char **err, void *user_data);
 		static void* monodroid_dlsym (void *handle, const char *name, char **err, void *user_data);

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -55,11 +55,7 @@ namespace Xamarin.Android.Build.Tests
 			AssertHasDevices ();
 
 			XASdkProject proj;
-			proj = new XASdkProject {
-				//TODO: targetSdkVersion="30" causes a crash on startup in .NET 5
-				MinSdkVersion = null,
-				TargetSdkVersion = null,
-			};
+			proj = new XASdkProject ();
 			proj.SetRuntimeIdentifier (DeviceAbi);
 
 			var relativeProjDir = Path.Combine ("temp", TestName);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4914
Context: https://github.com/xamarin/xamarin-android/commit/d583b7c215fe9be2f732b4a52423be0aea7f0809

The .NET5 version of the Mono runtime "hijacked" `__Internal` for its
own purposes and the change causes us trouble when trying to resolve
p/invokes from our managed code to our runtime.  Instead we now use
`xa-internal-api` (added in d583b7c2) to specify the p/invoke library
name.