### PR TITLE
[dotnet] Consolidate default item properties

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -88,7 +88,9 @@ to `True`.
 
 ## Default file inclusion
 
-Default Android related file globbing behavior is defined in `Microsoft.Android.Sdk.DefaultItems.props`.
+Default Android related file globbing behavior is defined in `Microsoft.Android.Sdk.DefaultItems.targets`.
+This behavior can be disabled for Android items by setting `$(EnableDefaultAndroidItems)` to `false`, or
+all default item inclusion behavior can be disabled by setting `$(EnableDefaultItems)` to `false`.
 
 ## dotnet cli
 

--- a/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
+++ b/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
@@ -19,7 +19,7 @@ temporary MSBuild project SDK that redirects to a Xamarin.Android installation o
   <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
-    <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.DefaultItems.props" PackagePath="targets\Microsoft.Android.Sdk.DefaultItems.props" />
+    <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.DefaultItems.targets" PackagePath="targets\Microsoft.Android.Sdk.DefaultItems.targets" />
     <!-- The Lite SDK replaces the full Sdk.props/Sdk.targets -->
     <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Xamarin.Android.Sdk.Lite.props" PackagePath="targets\Microsoft.Android.Sdk.props" />
     <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Xamarin.Android.Sdk.Lite.targets" PackagePath="targets\Microsoft.Android.Sdk.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.props
@@ -2,7 +2,7 @@
 
   <!-- Default Resource file inclusion -->
   <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultAndroidResourceItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.xml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.axml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.png" />
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <!-- Default Asset file inclusion -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultAndroidAssetItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" />
   </ItemGroup>
 
   <!-- Default References -->
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' And '$(DisableImplicitAndroidFrameworkReference)' != 'true' ">
+  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
     <FrameworkReference
         Include="Microsoft.Android"
         IsImplicitlyDefined="true"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
@@ -1,5 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
+  </PropertyGroup>
+
   <!-- Default Resource file inclusion -->
   <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
   <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -8,7 +8,6 @@
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' ">true</EnableDefaultOutputPaths>
-    <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
     <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -6,9 +6,6 @@
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
     <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">1.8.0</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
-    <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>
-    <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' ">true</EnableDefaultOutputPaths>
-    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
@@ -49,9 +46,6 @@
   </PropertyGroup>
 
   <Import Project="Microsoft.Android.Sdk.BundledVersions.props" Condition=" Exists('Microsoft.Android.Sdk.BundledVersions.props') " />
-
-  <!-- Default item includes (globs and implicit references) -->
-  <Import Project="Microsoft.Android.Sdk.DefaultItems.props" />
 
   <PropertyGroup>
     <MicrosoftAndroidSdkPropsImported>true</MicrosoftAndroidSdkPropsImported>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -8,9 +8,8 @@
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' ">true</EnableDefaultOutputPaths>
-    <DisableImplicitAndroidFrameworkReference Condition=" '$(DisableImplicitAndroidFrameworkReference)' == '' ">false</DisableImplicitAndroidFrameworkReference>
-    <EnableDefaultAndroidResourceItems Condition=" '$(EnableDefaultAndroidResourceItems)' == '' ">true</EnableDefaultAndroidResourceItems>
-    <EnableDefaultAndroidAssetItems Condition=" '$(EnableDefaultAndroidAssetItems)' == '' ">true</EnableDefaultAndroidAssetItems>
+    <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
+    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -17,7 +17,9 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />
+  <!-- Default item includes (globs and implicit references) -->
+  <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
+
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.Core.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.ClassParse.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <DisableImplicitAndroidFrameworkReference>true</DisableImplicitAndroidFrameworkReference>
+    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">true</EnableDefaultAndroidItems>
   </PropertyGroup>
 
   <!-- This is the renamed-on-pack Xamarin.Android.Sdk.props from the full SDK -->
@@ -11,11 +11,6 @@
     <!-- Ensure $(UsingAndroidNETSdk) is not set to retain legacy behavior -->
     <UsingAndroidNETSdk />
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Remove Microsoft.Android FrameworkReference in favor of default references below. -->
-    <FrameworkReference Remove="Microsoft.Android" />
-  </ItemGroup>
 
   <!-- Default References -->
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
@@ -12,6 +12,11 @@
     <UsingAndroidNETSdk />
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Remove Microsoft.Android FrameworkReference in favor of default references below. -->
+    <FrameworkReference Remove="Microsoft.Android" />
+  </ItemGroup>
+
   <!-- Default References -->
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
     <Reference Include="Mono.Android" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.targets
@@ -31,6 +31,12 @@
     <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
   </PropertyGroup>
 
+  <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
+  <ItemGroup>
+    <!-- Remove Microsoft.Android FrameworkReference as it is incompatible with the Lite SDK. -->
+    <FrameworkReference Remove="Microsoft.Android" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.DefaultOutputPaths.targets" Condition="'$(EnableDefaultOutputPaths)' == 'true'" />
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Common.targets"/>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/pull/8752

Reduces the amount of SDK / Target Framework Profile specific properties
which control default item inclusion behavior.  For now, we will only
have one property, $(EnableDefaultAndroidItems), which controls default
inclusion for all Android specific file types.

Default Android item inclusion behavior has been moved from a .props
to a .targets file for better consistency with xamarin-macios SDKs, and to
allow usage of the default value of `$(EnableDefaultItems)` which is set in
Microsoft.NET.Sdk.DefaultItems.targets.

$(DisableImplicitAndroidFrameworkReference) has also been removed as it
was only used by our "Lite" SDK, and we can explicitly remove the
Microsoft.Android @(FrameworkReference) from that SDK instead.

Finally, The `Xamarin.Android.DefaultOutputPaths.targets` import has been
removed as we should use the default OutputPath suffix behavior from
Microsoft.NET.Sdk on both macOS and Windows if possible.