### PR TITLE
[git] Re-format `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
     branch = master
+[submodule "external/lz4"]
+    path = external/lz4
+    url = https://github.com/lz4/lz4.git
+    branch = master
 [submodule "external/mman-win32"]
     path = external/mman-win32
     url = https://github.com/witwall/mman-win32.git
@@ -39,7 +43,3 @@
     path = external/xamarin-android-tools
     url = https://github.com/xamarin/xamarin-android-tools
     branch = master
-[submodule "lz4"]
-	path = external/lz4
-	url = https://github.com/lz4/lz4.git
-	branch = master


### PR DESCRIPTION
Context: 059c2c07f05ca27b024292e1e7f3c97b3c99c04f

Commit d236af54 added the `external/lz4` submodule and updated
`.gitmodules` in a manner *not* in accordance with 059c2c07:

  * It used tabs instead of spaces, which means @MSylvia's branch
    tooling will cause larger commit diffs for this file

  * It used a submodule name of "lz4", instead of "conventional"
    name mirroring the checkout location of "external/lz4".

Reformat the `lz4` entry within `.gitmodules`, replacing tabs with
spaces and renaming to `external/lz4`, and sort the entry
appropriately.