### PR TITLE
Bump to xamarin/monodroid/d16-7@0d0e4527

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:d16-7@8d51d0af0572db1583a8ab5ec095bec3046ae476
+xamarin/monodroid:d16-7@0d0e4527f142e73bdff9fa1b63349bb0a1631900
 mono/mono:2020-02@87ef5557017a8d822ae31587846a54fcd66daf1b


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/8d51d0af0572db1583a8ab5ec095bec3046ae476...0d0e4527f142e73bdff9fa1b63349bb0a1631900

Context: 5bba16ec4e72365a77e0996fd0ea4a4769ad9f9a

  * xamarin/monodroid@0d0e4527f: Bump to xamarin/androidtools/d16-7@315b97be (#1096)