### PR TITLE
[One .NET] support for multiple $(RuntimeIdentifiers)

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -64,6 +64,24 @@ In .NET 5 the behavior of the following MSBuild tasks will change, but
 
 ## Changes to MSBuild properties
 
+`$(AndroidSupportedAbis)` should not be used. Instead of:
+
+```xml
+<PropertyGroup>
+  <!-- Used in legacy Xamarin.Android projects -->
+  <AndroidSupportedAbis>armeabi-v7a;arm64-v8a;x86;x86_64</AndroidSupportedAbis>
+</PropertyGroup>
+```
+
+Instead use .NET's concept of [runtime identifiers][rids]:
+
+```xml
+<PropertyGroup>
+  <!-- Used going forward in .NET -->
+  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+</PropertyGroup>
+```
+
 `$(AndroidUseIntermediateDesignerFile)` will be `True` by default.
 
 `$(AndroidBoundExceptionType)` will be `System` by default.  This will
@@ -84,6 +102,7 @@ If Java binding is enabled with `@(InputJar)`, `@(EmbeddedJar)`,
 `@(LibraryProjectZip)`, etc. then `$(AllowUnsafeBlocks)` will default
 to `True`.
 
+[rids]: https://docs.microsoft.com/dotnet/core/rid-catalog
 [abet-sys]: https://github.com/xamarin/xamarin-android/issues/4127
 
 ## Default file inclusion

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -46,6 +46,8 @@ ms.date: 01/24/2020
 + [XA0032](xa0032.md): Java SDK {requiredJavaForBuildTools} or above is required when using Android SDK Build-Tools {buildToolsVersion}.
 + [XA0033](xa0033.md): Failed to get the Java SDK version because the returned value does not appear to contain a valid version number.
 + [XA0034](xa0034.md): Failed to get the Java SDK version.
++ [XA0035](xa0035.md): Failed to determine the Android ABI for the project.
++ [XA0036](xa0036.md): $(AndroidSupportedAbis) is not supported in .NET 5 and higher.
 + XA0100: EmbeddedNativeLibrary is invalid in Android Application projects. Please use AndroidNativeLibrary instead.
 + [XA0101](xa0101.md): warning XA0101: @(Content) build action is not supported.
 + [XA0102](xa0102.md): Generic `lint` Warning.

--- a/Documentation/guides/messages/xa0035.md
+++ b/Documentation/guides/messages/xa0035.md
@@ -1,0 +1,37 @@
+---
+title: Xamarin.Android error XA0035
+description: XA0035 error code
+ms.date: 06/17/2020
+---
+# Xamarin.Android error XA0035
+
+## Issue
+
+Xamarin.Android was not able to determine the application's target
+[Android ABIs][abis] as specified by the `.csproj` file.
+
+[abis]: https://developer.android.com/ndk/guides/abis
+
+## Solution
+
+Open the project file [in Visual Studio][edit-project-files] or another text
+editor and make sure all of the values in the `RuntimeIdentifiers` MSBuild
+property are valid:
+
+```xml
+<PropertyGroup>
+  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+</PropertyGroup>
+```
+
+See the Microsoft documentation on [runtime identifiers][rids] for more
+information.
+
+[edit-project-files]: https://docs.microsoft.com/visualstudio/msbuild/visual-studio-integration-msbuild#edit-project-files-in-visual-studio
+[rids]: https://docs.microsoft.com/dotnet/core/rid-catalog
+
+## Example messages
+
+```
+error XA0035: Unable to determine the Android ABI from the value 'XYZ'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.
+```

--- a/Documentation/guides/messages/xa0036.md
+++ b/Documentation/guides/messages/xa0036.md
@@ -1,0 +1,35 @@
+---
+title: Xamarin.Android warning XA0036
+description: XA0036 warning code
+ms.date: 06/17/2020
+---
+# Xamarin.Android warning XA0036
+
+## Issue
+
+The `$(AndroidSupportedAbis)` MSBuild property is no longer supported
+in .NET 5 and higher.
+
+## Solution
+
+Open the project file [in Visual Studio][edit-project-files] or
+another text editor and remove `<AndroidSupportedAbis/>`. Use the
+`RuntimeIdentifiers` MSBuild property instead:
+
+```xml
+<PropertyGroup>
+  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+</PropertyGroup>
+```
+
+See the Microsoft documentation on [runtime identifiers][rids] for more
+information.
+
+[edit-project-files]: https://docs.microsoft.com/visualstudio/msbuild/visual-studio-integration-msbuild#edit-project-files-in-visual-studio
+[rids]: https://docs.microsoft.com/dotnet/core/rid-catalog
+
+## Example messages
+
+```
+error XA0036: The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.
+```

--- a/Documentation/guides/messages/xa0036.md
+++ b/Documentation/guides/messages/xa0036.md
@@ -31,5 +31,5 @@ information.
 ## Example messages
 
 ```
-error XA0036: The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.
+warning XA0036: The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.
 ```

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -10,42 +10,54 @@ _ResolveAssemblies MSBuild target.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="_ResolveAssemblies" DependsOnTargets="ComputeFilesToPublish">
+  <UsingTask TaskName="Xamarin.Android.Tasks.ProcessAssemblies" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
-    <!--
-        TODO: not yet complete.
+  <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
+      DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish"
+      Returns="@(ResolvedFileToPublish)">
+  </Target>
 
-        Two things here are placeholders for later:
+  <Target Name="_FixupIntermediateAssembly" Condition=" '$(_OuterIntermediateAssembly)' != '' ">
+    <ItemGroup>
+      <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <IntermediateAssembly Include="$(_OuterIntermediateAssembly)" />
+    </ItemGroup>
+  </Target>
 
-        * %(HasMonoAndroidReference) is always True to disable
-          performance improvements around $(TargetFrameworkVersion)
-          detection.
-
-        * Is there better metadata to use other than %(NuGetPackageId)
-          to determine which runtime components are coming from our
-          known @(FrameworkReference)s?
-    -->
-
+  <Target Name="_ResolveAssemblies">
+    <ItemGroup>
+      <_RIDs Include="$(RuntimeIdentifier)"  Condition=" '$(RuntimeIdentifiers)' == '' " />
+      <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
+    </ItemGroup>
+    <PropertyGroup>
+      <_AdditionalProperties>_ComputeFilesToPublishForRuntimeIdentifiers=true;_OuterIntermediateAssembly=@(IntermediateAssembly)</_AdditionalProperties>
+    </PropertyGroup>
+    <MSBuild
+        Projects="$(MSBuildProjectFile)"
+        Targets="_ComputeFilesToPublishForRuntimeIdentifiers"
+        Properties="RuntimeIdentifier=%(_RIDs.Identity);$(_AdditionalProperties)">
+      <Output TaskParameter="TargetOutputs" ItemName="ResolvedFileToPublish" />
+    </MSBuild>
+    <ItemGroup>
+      <_ResolvedAssemblyFiles Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' " />
+    </ItemGroup>
+    <ProcessAssemblies
+        InputAssemblies="@(_ResolvedAssemblyFiles)"
+        IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
+        LinkMode="$(AndroidLinkMode)">
+      <Output TaskParameter="OutputAssemblies" ItemName="ResolvedAssemblies" />
+      <Output TaskParameter="ShrunkAssemblies" ItemName="_ShrunkAssemblies" />
+    </ProcessAssemblies>
     <ItemGroup>
       <ResolvedFrameworkAssemblies
-          Include="@(ResolvedFileToPublish)"
-          Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.NuGetPackageId)' == 'Microsoft.Android.Runtime.$(RuntimeIdentifier)' "
-          HasMonoAndroidReference="True"
-      />
-      <ResolvedFrameworkAssemblies
-          Include="@(ResolvedFileToPublish)"
-          Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.NuGetPackageId)' == 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)' "
-          HasMonoAndroidReference="True"
+          Include="@(ResolvedAssemblies)"
+          Condition=" '%(ResolvedAssemblies.FrameworkAssembly)' == 'true' "
       />
       <ResolvedUserAssemblies
-          Include="@(ResolvedFileToPublish)"
-          Exclude="@(ResolvedFrameworkAssemblies)"
-          Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' "
-          HasMonoAndroidReference="True"
+          Include="@(ResolvedAssemblies)"
+          Condition=" '%(ResolvedAssemblies.FrameworkAssembly)' != 'true' "
       />
-      <ResolvedAssemblies Include="@(ResolvedFrameworkAssemblies);@(ResolvedUserAssemblies)" />
     </ItemGroup>
-
     <Hash ItemsToHash="@(ResolvedAssemblies)">
       <Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
     </Hash>
@@ -57,6 +69,37 @@ _ResolveAssemblies MSBuild target.
     />
     <ItemGroup>
       <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_PrepareAssemblies"
+      DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
+    <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' ">
+      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')" />
+      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'%(IntermediateLinkerOutput)')" />
+      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'%(IntermediateLinkerOutput)')" />
+      <_ShrunkAssemblies            Include="@(_ResolvedAssemblies)" />
+      <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
+      <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidLinkMode)' != 'None' ">
+      <_ResolvedAssemblies          Include="@(ResolvedAssemblies)" />
+      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies)" />
+      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+      <_ShrunkFrameworkAssemblies
+          Include="@(_ShrunkAssemblies)"
+          Condition=" '%(_ShrunkAssemblies.FrameworkAssembly)' == 'true' "
+      />
+      <_ShrunkUserAssemblies
+          Include="@(_ShrunkAssemblies)"
+          Condition=" '%(_ShrunkAssemblies.FrameworkAssembly)' != 'true' "
+      />
+    </ItemGroup>
+    <ItemGroup>
+      <_ResolvedUserMonoAndroidAssemblies
+          Include="@(_ResolvedUserAssemblies)"
+          Condition=" '%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True' "
+      />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -45,18 +45,8 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
     </BuildDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <CompileDependsOn>
-      _SetupDesignTimeBuildForCompile;
-      _AddAndroidDefines;
-      _IncludeLayoutBindingSources;
-      AddLibraryJarsToBind;
-      $(CompileDependsOn);
-    </CompileDependsOn>
-    <CoreCompileDependsOn>
-      UpdateGeneratedFiles;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
+  <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
+  <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">
     <CoreResolveReferencesDependsOn>
       _SeparateAppExtensionReferences;
       _PrepareWearApplication;
@@ -71,6 +61,20 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       AddEmbeddedJarsAsResources;
       AddEmbeddedReferenceJarsAsResources;
     </ResolveReferencesDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CompileDependsOn>
+      _SetupDesignTimeBuildForCompile;
+      _AddAndroidDefines;
+      _IncludeLayoutBindingSources;
+      AddLibraryJarsToBind;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+    <CoreCompileDependsOn>
+      UpdateGeneratedFiles;
+      $(CoreCompileDependsOn)
+    </CoreCompileDependsOn>
     <DeferredBuildDependsOn>
       $(DeferredBuildDependsOn);
       UpdateAndroidResources;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
@@ -10,6 +10,7 @@ This file contains the .NET 5-specific targets to customize ILLink
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="_PrepareLinking"
+      Condition=" '$(PublishTrimmed)' == 'true' "
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths">
     <ItemGroup>
@@ -22,9 +23,7 @@ This file contains the .NET 5-specific targets to customize ILLink
     </ItemGroup>
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->
-      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose --custom-data XATargetFrameworkDirectories="$(_XATargetFrameworkDirectories)"</_ExtraTrimmerArgs>
-
-      <IntermediateLinkDir>$(MonoAndroidIntermediateAssemblyDir)</IntermediateLinkDir>
+      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose --deterministic --custom-data XATargetFrameworkDirectories="$(_XATargetFrameworkDirectories)"</_ExtraTrimmerArgs>
 
       <!-- we don't want to ignore stuff we can't find -->
       <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --skip-unresolved false</_ExtraTrimmerArgs>
@@ -43,4 +42,9 @@ This file contains the .NET 5-specific targets to customize ILLink
       </_TrimmerCustomSteps>
     </ItemGroup>
   </Target>
+
+  <Target Name="_LinkAssemblies"
+      DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink"
+  />
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
@@ -58,6 +58,7 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
     <RuntimeIdentifierToAbi
         Condition=" '$(AndroidApplication)' == 'true' "
         RuntimeIdentifier="$(RuntimeIdentifier)"
+        RuntimeIdentifiers="$(RuntimeIdentifiers)"
         SupportedAbis="$(AndroidSupportedAbis)">
       <Output TaskParameter="SupportedAbis" PropertyName="AndroidSupportedAbis" />
     </RuntimeIdentifierToAbi>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -9,7 +9,9 @@
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
     <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
-    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == '' And '$(AndroidApplication)' == 'true' ">android.21-x86</RuntimeIdentifier>
+    <!-- Prefer $(RuntimeIdentifiers) plural -->
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' And '$(AndroidApplication)' == 'true' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
+    <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' And '$(AndroidApplication)' == 'true' ">Properties\AndroidManifest.xml</AndroidManifest>
     <!-- We don't ever need a `static void Main` method, so switch to Library here-->
     <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -205,6 +205,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to determine the Android ABI from the value &apos;{0}&apos;. Edit the project file in a text editor and set the &apos;RuntimeIdentifiers&apos; MSBuild property to contain only valid identifiers for the Android platform..
+        /// </summary>
+        internal static string XA0035 {
+            get {
+                return ResourceManager.GetString("XA0035", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;AndroidSupportedAbis&apos; MSBuild property is no longer supported. Edit the project file in a text editor and use the &apos;RuntimeIdentifiers&apos; MSBuild property instead..
+        /// </summary>
+        internal static string XA0036 {
+            get {
+                return ResourceManager.GetString("XA0036", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EmbeddedNativeLibrary &apos;{0}&apos; is invalid in Android Application projects. Please use AndroidNativeLibrary instead..
         /// </summary>
         internal static string XA0100 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -193,6 +193,15 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Failed to get the Java SDK version. Please ensure you have Java {0} or above installed.</value>
     <comment>{0} - The Java version number</comment>
   </data>
+  <data name="XA0035" xml:space="preserve">
+    <value>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</value>
+    <comment>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</comment>
+  </data>
+  <data name="XA0036" xml:space="preserve">
+    <value>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</value>
+    <comment>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</comment>
+  </data>
   <data name="XA0100" xml:space="preserve">
     <value>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</value>
     <comment>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Nepovedlo se získat verzi sady Java SDK. Ujistěte se prosím, že máte nainstalovanou Javu {0} nebo novější.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">Knihovna EmbeddedNativeLibrary {0} v projektech aplikací pro Android není platná. Použijte prosím místo ní AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Fehler beim Abrufen der Java SDK-Version. Stellen Sie sicher, dass Java {0} oder höher installiert ist.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary "{0}" ist in Android-Anwendungsprojekten ungültig. Verwenden Sie stattdessen AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">No se pudo obtener la versión del SDK de Java. Asegúrese de que tiene instalado Java {0} o una versión posterior.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary "{0}" no es válido en los proyectos de aplicación Android. Use en su lugar AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Échec de l'obtention de la version du Kit Java SDK. Vérifiez que Java {0} (ou une version ultérieure) est installé.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary '{0}' est non valide dans les projets d'application Android. Utilisez AndroidNativeLibrary à la place.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Non è stato possibile ottenere la versione di Java SDK. Assicurarsi di aver installato Java {0} o versioni successive.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">La libreria '{0}' di EmbeddedNativeLibrary non è valida in progetti Applicazione Android. In alternativa usare AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Java SDK バージョンを取得できませんでした。Java {0} 以上がインストールされていることをご確認ください。</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary '{0}' は Android アプリケーション プロジェクトでは無効です。代わりに AndroidNativeLibrary を使用してください。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Java SDK 버전을 가져오지 못했습니다. Java {0} 이상이 설치되어 있는지 확인하세요.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">Android 애플리케이션 프로젝트의 EmbeddedNativeLibrary '{0}'이(가) 잘못되었습니다. 대신 AndroidNativeLibrary를 사용하세요.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Nie udało się pobrać wersji zestawu Java SDK. Upewnij się, że masz zainstalowany język Java {0} lub nowszy.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">Biblioteka EmbeddedNativeLibrary „{0}” jest nieprawidłowa w projektach aplikacji systemu Android. Zamiast niej należy użyć biblioteki AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Falha ao obter a versão do SDK do Java. Verifique se o Java {0} ou superior está instalado.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">A EmbeddedNativeLibrary '{0}' é inválida nos projetos de Aplicativo Android. Use a AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Не удалось получить версию пакета SDK для Java. Убедитесь, что на компьютере установлен пакет Java {0} или более поздней версии.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">Библиотека EmbeddedNativeLibrary "{0}" недопустима в проектах приложений Android. Используйте библиотеку AndroidNativeLibrary.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">Java SDK sürümü alınamadı. Lütfen Java {0} veya üzeri bir sürümün yüklü olduğundan emin olun.</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">Android Uygulama projelerinde '{0}' EmbeddedNativeLibrary geçersiz. Lütfen bunun yerine AndroidNativeLibrary kullanın.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">未能获取 Java SDK 版本。请确保安装了 Java {0} 或更高版本。</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary“{0}”在 Android 应用程序项目中无效。请改用 AndroidNativeLibrary。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -94,6 +94,17 @@ In this message, the phrase "should not be reached" means that this error messag
         <target state="translated">無法取得 Java SDK 版本。請確認您已安裝 Java {0} 或更新版本。</target>
         <note>{0} - The Java version number</note>
       </trans-unit>
+      <trans-unit id="XA0035">
+        <source>Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</source>
+        <target state="new">Unable to determine the Android ABI from the value '{0}'. Edit the project file in a text editor and set the 'RuntimeIdentifiers' MSBuild property to contain only valid identifiers for the Android platform.</target>
+        <note>The following are literal names and should not be translated: Android, ABI, RuntimeIdentifiers, MSBuild
+{0} - The $(RuntimeIdentifier) supplied by the user.</note>
+      </trans-unit>
+      <trans-unit id="XA0036">
+        <source>The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</source>
+        <target state="new">The 'AndroidSupportedAbis' MSBuild property is no longer supported. Edit the project file in a text editor, remove any uses of 'AndroidSupportedAbis', and use the 'RuntimeIdentifiers' MSBuild property instead.</target>
+        <note>The following are literal names and should not be translated: AndroidSupportedAbis, MSBuild, RuntimeIdentifiers</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="translated">EmbeddedNativeLibrary '{0}' 在 Android 應用程式專案中無效。請改用 AndroidNativeLibrary。</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -327,23 +327,24 @@ namespace Xamarin.Android.Tasks
 				sourcePath = CompressAssembly (assembly);
 
 				// Add assembly
-				AddFileToArchiveIfNewer (apk, sourcePath, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
+				var assemblyPath = GetAssemblyPath (assembly, frameworkAssembly: false);
+				AddFileToArchiveIfNewer (apk, sourcePath, assemblyPath + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
 
 				// Try to add config if exists
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
-				AddAssemblyConfigEntry (apk, config);
+				AddAssemblyConfigEntry (apk, assemblyPath, config);
 
 				// Try to add symbols if Debug
 				if (debug) {
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						AddFileToArchiveIfNewer (apk, symbols, AssembliesPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
+						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 
 					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 
 					if (File.Exists (symbols))
-						AddFileToArchiveIfNewer (apk, symbols, AssembliesPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
+						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 				}
 				count++;
 				if (count == ZipArchiveEx.ZipFlushLimit) {
@@ -368,20 +369,21 @@ namespace Xamarin.Android.Tasks
 				}
 
 				sourcePath = CompressAssembly (assembly);
-				AddFileToArchiveIfNewer (apk, sourcePath, AssembliesPath + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
+				var assemblyPath = GetAssemblyPath (assembly, frameworkAssembly: true);
+				AddFileToArchiveIfNewer (apk, sourcePath, assemblyPath + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
-				AddAssemblyConfigEntry (apk, config);
+				AddAssemblyConfigEntry (apk, assemblyPath, config);
 				// Try to add symbols if Debug
 				if (debug) {
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						AddFileToArchiveIfNewer (apk, symbols, AssembliesPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
+						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 
 					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 
 					if (File.Exists (symbols))
-						AddFileToArchiveIfNewer (apk, symbols, AssembliesPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
+						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 				}
 				count++;
 				if (count == ZipArchiveEx.ZipFlushLimit) {
@@ -409,7 +411,8 @@ namespace Xamarin.Android.Tasks
 					return assembly.ItemSpec;
 				}
 
-				if (compressedAssembliesInfo.TryGetValue (Path.GetFileName (assembly.ItemSpec), out CompressedAssemblyInfo info) && info != null) {
+				var key = CompressedAssemblyInfo.GetDictionaryKey (assembly);
+				if (compressedAssembliesInfo.TryGetValue (key, out CompressedAssemblyInfo info) && info != null) {
 					EnsureCompressedAssemblyData (assembly.ItemSpec, info.DescriptorIndex);
 					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly);
 					if (result != AssemblyCompression.CompressionResult.Success) {
@@ -429,6 +432,8 @@ namespace Xamarin.Android.Tasks
 						return assembly.ItemSpec;
 					}
 					return compressedAssembly.DestinationPath;
+				} else {
+					Log.LogDebugMessage ($"Assembly missing from {nameof (CompressedAssemblyInfo)}: {key}");
 				}
 
 				return assembly.ItemSpec;
@@ -447,9 +452,9 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 
-		void AddAssemblyConfigEntry (ZipArchiveEx apk, string configFile)
+		void AddAssemblyConfigEntry (ZipArchiveEx apk, string assemblyPath, string configFile)
 		{
-			string inArchivePath = AssembliesPath + Path.GetFileName (configFile);
+			string inArchivePath = assemblyPath + Path.GetFileName (configFile);
 			existingEntries.Remove (inArchivePath);
 
 			if (!File.Exists (configFile))
@@ -470,13 +475,20 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		string GetTargetDirectory (string path)
+		/// <summary>
+		/// Returns the in-archive path for an assembly
+		/// </summary>
+		string GetAssemblyPath (ITaskItem assembly, bool frameworkAssembly)
 		{
-			string culture, file;
-			if (SatelliteAssembly.TryGetSatelliteCultureAndFileName (path, out culture, out file)) {
-				return AssembliesPath + culture;
+			var assembliesPath = AssembliesPath;
+			var abiDirectory = assembly.GetMetadata ("AbiDirectory");
+			if (!string.IsNullOrEmpty (abiDirectory)) {
+				assembliesPath += abiDirectory + "/";
 			}
-			return AssembliesPath.TrimEnd ('/');
+			if (!frameworkAssembly && SatelliteAssembly.TryGetSatelliteCultureAndFileName (assembly.ItemSpec, out var culture, out _)) {
+				assembliesPath += culture + "/";
+			}
+			return assembliesPath;
 		}
 
 		class LibInfo

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -20,7 +20,6 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "FLT";
 
 		const string TargetFrameworkIdentifier = "MonoAndroid";
-		const string MonoAndroidReference = "Mono.Android";
 
 		public bool DesignTimeBuild { get; set; }
 
@@ -53,8 +52,8 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ($"{nameof (TargetFrameworkIdentifier)} did not match: {assemblyItem.ItemSpec}");
 
 					// Fallback to looking for a Mono.Android reference
-					if (HasReference (reader)) {
-						Log.LogDebugMessage ($"{MonoAndroidReference} reference found: {assemblyItem.ItemSpec}");
+					if (MonoAndroidHelper.HasMonoAndroidReference (reader)) {
+						Log.LogDebugMessage ($"Mono.Android reference found: {assemblyItem.ItemSpec}");
 						output.Add (assemblyItem);
 						continue;
 					}
@@ -102,18 +101,6 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 			return targetFrameworkIdentifier;
-		}
-
-		bool HasReference (MetadataReader reader)
-		{
-			foreach (var handle in reader.AssemblyReferences) {
-				var reference = reader.GetAssemblyReference (handle);
-				var name = reader.GetString (reference.Name);
-				if (MonoAndroidReference == name) {
-					return true;
-				}
-			}
-			return false;
 		}
 
 		bool HasEmbeddedResource (MetadataReader reader)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -56,7 +56,8 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 
-				assemblies.Add (Path.GetFileName (assembly.ItemSpec), new CompressedAssemblyInfo (checked((uint)fi.Length)));
+				assemblies.Add (CompressedAssemblyInfo.GetDictionaryKey (assembly),
+					new CompressedAssemblyInfo (checked((uint)fi.Length)));
 			}
 
 			uint index = 0;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Processes .dll files coming from @(ResolvedFileToPublish). Removes duplicate .NET assemblies by MVID.
+	/// 
+	/// Also sets some metadata:
+	/// * %(FrameworkAssembly)=True to determine if framework or user assembly
+	/// * %(HasMonoAndroidReference)=True for incremental build performance
+	/// * %(AbiDirectory) if an assembly has an architecture-specific version
+	/// </summary>
+	public class ProcessAssemblies : AndroidTask
+	{
+		public override string TaskPrefix => "PRAS";
+
+		public string LinkMode { get; set; }
+		
+		[Required]
+		public string IntermediateAssemblyDirectory { get; set; }
+
+		public ITaskItem [] InputAssemblies { get; set; }
+
+		[Output]
+		public ITaskItem [] OutputAssemblies { get; set; }
+
+		[Output]
+		public ITaskItem [] ShrunkAssemblies { get; set; }
+
+		public override bool RunTask ()
+		{
+			var output = new Dictionary<Guid, ITaskItem> ();
+
+			foreach (var assembly in InputAssemblies) {
+				using (var pe = new PEReader (File.OpenRead (assembly.ItemSpec))) {
+					var reader = pe.GetMetadataReader ();
+					var module = reader.GetModuleDefinition ();
+					var mvid = reader.GetGuid (module.Mvid);
+					if (!output.ContainsKey (mvid)) {
+						output.Add (mvid, assembly);
+
+						// Set metadata, such as %(FrameworkAssembly) and %(HasMonoAndroidReference)
+						string packageId = assembly.GetMetadata ("NuGetPackageId");
+						bool frameworkAssembly = packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
+							packageId.StartsWith ("Microsoft.Android.Runtime.");
+						assembly.SetMetadata ("FrameworkAssembly", frameworkAssembly.ToString ());
+						assembly.SetMetadata ("HasMonoAndroidReference", MonoAndroidHelper.HasMonoAndroidReference (reader).ToString ());
+					} else {
+						Log.LogDebugMessage ($"Removing duplicate: {assembly.ItemSpec}");
+					}
+				}
+			}
+
+			OutputAssemblies = output.Values.ToArray ();
+
+			// Set %(AbiDirectory) for architecture-specific assemblies
+			var fileNames = new Dictionary<string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
+			foreach (var assembly in OutputAssemblies) {
+				var fileName = Path.GetFileName (assembly.ItemSpec);
+				if (fileNames.TryGetValue (fileName, out ITaskItem other)) {
+					SetAbiDirectory (assembly, fileName);
+					SetAbiDirectory (other, fileName);
+				} else {
+					fileNames.Add (fileName, assembly);
+					assembly.SetMetadata ("IntermediateLinkerOutput", Path.Combine (IntermediateAssemblyDirectory, fileName));
+				}
+			}
+
+			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
+			if (!string.IsNullOrEmpty (LinkMode) && !string.Equals (LinkMode, "None", StringComparison.OrdinalIgnoreCase)) {
+				ShrunkAssemblies = OutputAssemblies.Select (a => {
+					var dir = Path.GetDirectoryName (a.ItemSpec);
+					var file = Path.GetFileName (a.ItemSpec);
+					return new TaskItem (a) {
+						ItemSpec = Path.Combine (dir, "shrunk", file),
+					};
+				}).ToArray ();
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		/// <summary>
+		/// Sets %(AbiDirectory) based on %(RuntimeIdentifier)
+		/// </summary>
+		void SetAbiDirectory (ITaskItem assembly, string fileName)
+		{
+			var rid = assembly.GetMetadata ("RuntimeIdentifier");
+			var abi = MonoAndroidHelper.RuntimeIdentifierToAbi (rid);
+			if (!string.IsNullOrEmpty (abi)) {
+				assembly.SetMetadata ("AbiDirectory", abi);
+				assembly.SetMetadata ("IntermediateLinkerOutput", Path.Combine (IntermediateAssemblyDirectory, abi, fileName));
+			} else {
+				Log.LogDebugMessage ($"Android ABI not found for: {assembly.ItemSpec}");
+				assembly.SetMetadata ("IntermediateLinkerOutput", Path.Combine (IntermediateAssemblyDirectory, fileName));
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -34,6 +34,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ProjectFile { get; set; }
 
+		[Required]
+		public string IntermediateAssemblyDirectory { get; set; }
+
 		public string ProjectAssetFile { get; set; }
 
 		public string TargetMoniker { get; set; }
@@ -138,6 +141,7 @@ namespace Xamarin.Android.Tasks
 				} else {
 					resolvedUserAssemblies.Add (assembly);
 				}
+				assembly.SetMetadata ("IntermediateLinkerOutput", Path.Combine (IntermediateAssemblyDirectory, Path.GetFileName (assembly.ItemSpec)));
 			}
 			ResolvedAssemblies = resolvedAssemblies.ToArray ();
 			ResolvedSymbols = resolvedSymbols.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1431,9 +1431,13 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_Sign"),
 					"the _Sign target should not run");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_LinkAssembliesShrink"),
-					"the _LinkAssembliesShrink target should not run");
+				if (Builder.UseDotNet) {
+					Assert.IsTrue (b.Output.IsTargetSkipped ("ILLink"),
+						"the ILLink target should not run");
+				} else {
+					Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesShrink"),
+						"the _LinkAssembliesShrink target should not run");
+				}
 				foo.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("CoreCompile"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -15,6 +15,7 @@ namespace Xamarin.ProjectTools
 
 		public const string AndroidSupportedAbis = "AndroidSupportedAbis";
 		public const string RuntimeIdentifier = "RuntimeIdentifier";
+		public const string RuntimeIdentifiers = "RuntimeIdentifiers";
 
 		public const string Deterministic = "Deterministic";
 		public const string BundleAssemblies = "BundleAssemblies";

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
@@ -21,6 +23,16 @@ namespace Xamarin.Android.Tasks
 				throw new ArgumentException ("must be a non-empty string", nameof (projectFullPath));
 
 			return $"{CompressedAssembliesInfoKey}:{projectFullPath}";
+		}
+
+		public static string GetDictionaryKey (ITaskItem assembly)
+		{
+			var key = Path.GetFileName (assembly.ItemSpec);
+			var abiDirectory = assembly.GetMetadata ("AbiDirectory");
+			if (!string.IsNullOrEmpty (abiDirectory)) {
+				key = abiDirectory + "/" + key;
+			}
+			return key;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -308,6 +308,18 @@ namespace Xamarin.Android.Tasks
 			return bool.TryParse (hasReference, out bool value) && value;
 		}
 
+		public static bool HasMonoAndroidReference (MetadataReader reader)
+		{
+			foreach (var handle in reader.AssemblyReferences) {
+				var reference = reader.GetAssemblyReference (handle);
+				var name = reader.GetString (reference.Name);
+				if ("Mono.Android" == name) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		public static bool IsReferenceAssembly (string assembly)
 		{
 			using (var stream = File.OpenRead (assembly))

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -70,7 +70,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.GetMonoPlatformJar" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Javac" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.KeyTool" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssembliesNoShrink" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Lint" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LogErrorsForFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1410,9 +1409,6 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
-<Target Name="_LinkAssemblies"
-  DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
-
 <Target Name="_GenerateJniMarshalMethods"
     Condition="'$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(AndroidLinkMode)' != 'None' And '$(OS)' != 'Windows_NT'"
     DependsOnTargets="_GetReferenceAssemblyPaths;_SetLatestTargetFrameworkVersion"
@@ -1448,69 +1444,16 @@ because xbuild doesn't support framework reference assemblies.
     DependsOnTargets="_LinkAssembliesNoShrinkInputs"
     Condition="'$(AndroidLinkMode)' == 'None'"
     Inputs="@(ResolvedAssemblies);$(_AndroidBuildPropertiesCache)"
-    Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+    Outputs="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')">
   <LinkAssembliesNoShrink
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
-      DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+      DestinationFiles="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')"
       Deterministic="$(Deterministic)"
   />
   <ItemGroup>
-    <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
+    <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)**" />
   </ItemGroup>
-</Target>
-	
-<Target Name="_LinkAssembliesShrink"
-  Condition="'$(AndroidLinkMode)' != 'None' and '$(UsingAndroidNETSdk)' != 'true' "
-  Inputs="@(ResolvedUserAssemblies);@(LinkDescription);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidLinkFlag)">
-
-    <PropertyGroup>
-      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">$(TargetPath)</_MainAssembly>
-      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">$(_JniMarshalMethodsOutputDir)$(TargetFileName)</_MainAssembly>
-    </PropertyGroup>
-    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">
-      <_AssembliesToLink Include="@(ResolvedAssemblies)" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">
-      <_PossibleAssembliesToLink Include="@(ResolvedAssemblies)">
-        <JniAssembly>$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)</JniAssembly>
-      </_PossibleAssembliesToLink>
-      <_AssembliesToLink Condition="Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.JniAssembly)" />
-      <_AssembliesToLink Condition="!Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.Identity)" />
-    </ItemGroup>
-
-    <CreateProperty
-    	Condition=" '$(AndroidLinkTool)' != '' "
-    	Value="$(IntermediateOutputPath)proguard\proguard_project_references.cfg">
-    	<Output TaskParameter="Value" PropertyName="_ProguardProjectConfiguration" />
-    </CreateProperty>
-
-    <MakeDir Condition=" '$(AndroidLinkTool)' != '' " Directories="$(IntermediateOutputPath)proguard" />
-
-    <LinkAssemblies
-      UseSharedRuntime="$(AndroidUseSharedRuntime)"
-      MainAssembly="$(_MainAssembly)"
-      OutputDirectory="$(MonoAndroidIntermediateAssemblyDir)"
-      I18nAssemblies="$(MandroidI18n)"
-      LinkMode="$(AndroidLinkMode)"
-      LinkSkip="$(AndroidLinkSkip)"
-      LinkDescriptions="@(LinkDescription)"
-      ProguardConfiguration="$(_ProguardProjectConfiguration)"
-      PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
-      EnableProguard="$(AndroidEnableProguard)"
-      Deterministic="$(Deterministic)"
-      DumpDependencies="$(LinkerDumpDependencies)"
-      ResolvedAssemblies="@(_AssembliesToLink)"
-      HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
-      TlsProvider="$(AndroidTlsProvider)" />
-
-    <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
-    <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_AndroidLinkFlag)" />
-      <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
-    </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -1524,58 +1467,8 @@ because xbuild doesn't support framework reference assemblies.
 		;_LinkAssemblies
 	</_PrepareAssembliesDependsOnTargets>
 </PropertyGroup>
-  
-<Target Name="_PrepareAssemblies"
-    DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
-  <!-- Update our assembly lists to the copies for linking.  We also need to verify
-       they still exist cause linking will delete them if they aren't used -->
-  <GetFilesThatExist
-    Condition="'$(AndroidLinkMode)' != 'None'"
-    Files="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
-    <Output TaskParameter="FilesThatExist" ItemName="_ResolvedAssemblies" />
-  </GetFilesThatExist>
 
-  <GetFilesThatExist
-    Condition="'$(AndroidLinkMode)' != 'None'"
-    Files="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
-    <Output TaskParameter="FilesThatExist" ItemName="_ResolvedSymbols" />
-  </GetFilesThatExist>
-
-  <GetFilesThatExist
-    Condition="'$(AndroidLinkMode)' != 'None'"
-    Files="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
-    <Output TaskParameter="FilesThatExist" ItemName="_ResolvedUserAssemblies" />
-  </GetFilesThatExist>
-
-  <GetFilesThatExist
-    Condition="'$(AndroidLinkMode)' != 'None'"
-    Files="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
-    <Output TaskParameter="FilesThatExist" ItemName="_ResolvedFrameworkAssemblies" />
-  </GetFilesThatExist>
-
-  <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' ">
-    <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
-    <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
-    <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
-    <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' Or '$(AndroidUseSharedRuntime)' == 'True' ">
-    <_ShrunkAssemblies          Include="@(_ResolvedAssemblies)" />
-    <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies)" />
-    <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies)" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(AndroidLinkMode)' != 'None' And '$(AndroidUseSharedRuntime)' != 'True' ">
-    <_ShrunkAssemblies          Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
-    <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
-    <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
-  </ItemGroup>
-  <ItemGroup>
-    <_ResolvedUserMonoAndroidAssemblies
-        Include="@(_ResolvedUserAssemblies)"
-        Condition=" '%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True' "
-    />
-  </ItemGroup>
-</Target>
+<!-- _PrepareAssemblies lives in Xamarin.Android.Legacy.targets and Microsoft.Android.Sdk.AssemblyResolution.targets -->
 
 <Target Name="_PrepareNativeAssemblySources">
   <PrepareAbiItems

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -158,6 +158,7 @@ projects. .NET 5 projects will not import this file.
   <UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies"               AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
   <Target Name="_GetReferenceAssemblyPaths">
     <GetReferenceAssemblyPaths
@@ -238,6 +239,7 @@ projects. .NET 5 projects will not import this file.
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         ProjectAssetFile="$(ProjectLockFile)"
         TargetMoniker="$(NuGetTargetMoniker)"
+        IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
         ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
       <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />
       <Output TaskParameter="ResolvedUserAssemblies" ItemName="ResolvedUserAssemblies" />
@@ -265,6 +267,120 @@ projects. .NET 5 projects will not import this file.
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
     />
+  </Target>
+
+  <Target Name="_PrepareAssemblies"
+      DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
+
+    <!--
+      Update our assembly lists to the copies for linking. We also
+      need to verify they still exist, because linking will delete
+      them if they aren't used.
+    -->
+    <GetFilesThatExist
+      Condition=" '$(AndroidLinkMode)' != 'None' "
+      Files="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+      <Output TaskParameter="FilesThatExist" ItemName="_ResolvedAssemblies" />
+    </GetFilesThatExist>
+
+    <GetFilesThatExist
+      Condition=" '$(AndroidLinkMode)' != 'None' "
+      Files="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+      <Output TaskParameter="FilesThatExist" ItemName="_ResolvedSymbols" />
+    </GetFilesThatExist>
+
+    <GetFilesThatExist
+      Condition=" '$(AndroidLinkMode)' != 'None'"
+      Files="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+      <Output TaskParameter="FilesThatExist" ItemName="_ResolvedUserAssemblies" />
+    </GetFilesThatExist>
+
+    <GetFilesThatExist
+      Condition=" '$(AndroidLinkMode)' != 'None' "
+      Files="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+      <Output TaskParameter="FilesThatExist" ItemName="_ResolvedFrameworkAssemblies" />
+    </GetFilesThatExist>
+
+    <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' ">
+      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+      <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+    </ItemGroup>
+    <ItemGroup Condition=" ('$(AndroidLinkMode)' == 'None' Or '$(AndroidUseSharedRuntime)' == 'true') ">
+      <_ShrunkAssemblies          Include="@(_ResolvedAssemblies)" />
+      <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies)" />
+      <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidLinkMode)' != 'None' And '$(AndroidUseSharedRuntime)' != 'true' ">
+      <_ShrunkAssemblies          Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+      <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+      <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <ItemGroup>
+      <_ResolvedUserMonoAndroidAssemblies
+          Include="@(_ResolvedUserAssemblies)"
+          Condition=" '%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'true' "
+      />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_LinkAssemblies"
+      DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink"
+  />
+
+  <Target Name="_LinkAssembliesShrink"
+      Condition="'$(AndroidLinkMode)' != 'None'"
+      Inputs="@(ResolvedUserAssemblies);@(LinkDescription);$(_AndroidBuildPropertiesCache)"
+      Outputs="$(_AndroidLinkFlag)">
+
+    <PropertyGroup>
+      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">$(TargetPath)</_MainAssembly>
+      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">$(_JniMarshalMethodsOutputDir)$(TargetFileName)</_MainAssembly>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">
+      <_AssembliesToLink Include="@(ResolvedAssemblies)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">
+      <_PossibleAssembliesToLink Include="@(ResolvedAssemblies)">
+        <JniAssembly>$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)</JniAssembly>
+      </_PossibleAssembliesToLink>
+      <_AssembliesToLink Condition="Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.JniAssembly)" />
+      <_AssembliesToLink Condition="!Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.Identity)" />
+    </ItemGroup>
+
+    <CreateProperty
+        Condition=" '$(AndroidLinkTool)' != '' "
+        Value="$(IntermediateOutputPath)proguard\proguard_project_references.cfg">
+      <Output TaskParameter="Value" PropertyName="_ProguardProjectConfiguration" />
+    </CreateProperty>
+
+    <MakeDir Condition=" '$(AndroidLinkTool)' != '' " Directories="$(IntermediateOutputPath)proguard" />
+
+    <LinkAssemblies
+        UseSharedRuntime="$(AndroidUseSharedRuntime)"
+        MainAssembly="$(_MainAssembly)"
+        OutputDirectory="$(MonoAndroidIntermediateAssemblyDir)"
+        I18nAssemblies="$(MandroidI18n)"
+        LinkMode="$(AndroidLinkMode)"
+        LinkSkip="$(AndroidLinkSkip)"
+        LinkDescriptions="@(LinkDescription)"
+        ProguardConfiguration="$(_ProguardProjectConfiguration)"
+        PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
+        EnableProguard="$(AndroidEnableProguard)"
+        Deterministic="$(Deterministic)"
+        DumpDependencies="$(LinkerDumpDependencies)"
+        ResolvedAssemblies="@(_AssembliesToLink)"
+        HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
+        TlsProvider="$(AndroidTlsProvider)"
+    />
+
+    <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
+    <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidLinkFlag)" />
+      <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -9,6 +9,7 @@ using namespace xamarin::android::internal;
 char* BasicAndroidSystem::override_dirs [MAX_OVERRIDES];
 const char **BasicAndroidSystem::app_lib_directories;
 size_t BasicAndroidSystem::app_lib_directories_size = 0;
+const char* BasicAndroidSystem::built_for_abi_name = nullptr;
 
 void
 BasicAndroidSystem::setup_app_library_directories (jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel)
@@ -60,4 +61,16 @@ char*
 BasicAndroidSystem::determine_primary_override_dir (jstring_wrapper &home)
 {
 	return utils.path_combine (home.get_cstr (), ".__override__");
+}
+
+const char*
+BasicAndroidSystem::get_built_for_abi_name ()
+{
+	if (built_for_abi_name == nullptr) {
+		unsigned short built_for_cpu = 0, running_on_cpu = 0;
+		unsigned char is64bit = 0;
+		_monodroid_detect_cpu_and_architecture (&built_for_cpu, &running_on_cpu, &is64bit);
+		built_for_abi_name = android_abi_names [built_for_cpu];
+	}
+	return built_for_abi_name;
 }

--- a/src/monodroid/jni/basic-android-system.hh
+++ b/src/monodroid/jni/basic-android-system.hh
@@ -25,6 +25,7 @@ namespace xamarin::android::internal
 			[CPU_KIND_X86_64]   = "x86_64",
 		};
 		static constexpr size_t ANDROID_ABI_NAMES_SIZE = sizeof(android_abi_names) / sizeof (android_abi_names[0]);
+		static const char* built_for_abi_name;
 
 	public:
 #ifdef ANDROID64
@@ -51,6 +52,7 @@ namespace xamarin::android::internal
 		static char* override_dirs [MAX_OVERRIDES];
 		static const char **app_lib_directories;
 		static size_t app_lib_directories_size;
+		static const char* get_built_for_abi_name ();
 
 	public:
 		void setup_app_library_directories (jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel);

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -163,6 +163,8 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, bool ref_only)
 
 	log_info (LOG_ASSEMBLY, "open_from_bundles: looking for bundled name: '%s'", name);
 
+	char *abi_name = utils.string_concat (BasicAndroidSystem::get_built_for_abi_name (), "/", name);
+
 	for (p = bundled_assemblies; p != nullptr && *p; ++p) {
 		MonoImage *image = nullptr;
 		MonoImageOpenStatus status;
@@ -171,7 +173,11 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, bool ref_only)
 		uint32_t assembly_data_size;
 
 		if (strcmp (e->name, name) != 0) {
-			continue;
+			if (strcmp (e->name, abi_name) != 0) {
+				continue;
+			} else {
+				log_info (LOG_ASSEMBLY, "open_from_bundles: found architecture-specific: '%s'", abi_name);
+			}
 		}
 
 		get_assembly_data (e, assembly_data, assembly_data_size);
@@ -183,6 +189,7 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, bool ref_only)
 		}
 	}
 	delete[] name;
+	delete[] abi_name;
 
 	if (a && utils.should_log (LOG_ASSEMBLY)) {
 		log_info_nocheck (LOG_ASSEMBLY, "open_from_bundles: loaded assembly: %p\n", a);


### PR DESCRIPTION
To mirror what we have for `$(AndroidSupportedAbis)` in the existing
Xamarin.Android world, we need a way for .NET 6 apps to support
multiple architectures.

A `HelloAndroid.csproj` targeting all architectures might look like:

    <Project Sdk="Microsoft.NET.Sdk">
      <PropertyGroup>
        <TargetFramework>net5.0-android</TargetFramework>
        <RuntimeIdentifiers>android.21-x86;android.21-x64;android.21-arm;android.21-arm64</RuntimeIdentifiers>
        <OutputType>Exe</OutputType>
      </PropertyGroup>
    </Project>

To achieve this, we can do a nested `<MSBuild/>` call:

    <ItemGroup>
      <_RIDs Include="$(RuntimeIdentifiers)" />
    </ItemGroup>
    <MSBuild
        Projects="$(MSBuildProjectFile)"
        Targets="_ComputeFilesToPublishForRuntimeIdentifiers"
        Properties="RuntimeIdentifier=%(_RIDs.Identity)">
      <Output TaskParameter="TargetOutputs" ItemName="ResolvedFileToPublish" />
    </MSBuild>

For a new target:

    <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
        DependsOnTargets="ResolveReferences;ComputeFilesToPublish"
        Returns="@(ResolvedFileToPublish)">
    </Target>

This is equivalent to what would happen in the legacy
`_ResolveAssemblies` target.

The linker then outputs files to:

    obj\Release\net5.0\$(RuntimeIdentifier)\linked\

One problem with this, is you receive multiple BCL assemblies for each
architecture:

    obj\Release\net5.0\android.21-arm\linked\System.Linq.dll
    obj\Release\net5.0\android.21-arm64\linked\System.Linq.dll
    obj\Release\net5.0\android.21-x86\linked\System.Linq.dll
    obj\Release\net5.0\android.21-x64\linked\System.Linq.dll

I created a `<ProcessAssemblies/>` MSBuild task that checks the mvid
of each assembly to detect duplicates. Non-duplicates will be placed
in a sub-directory within the `.apk` file, such as:

* `assemblies\HelloAndroid.dll`
* `assemblies\System.Linq.dll`
* `assemblies\arm64-v8a\System.Private.CoreLib.dll`
* `assemblies\armeabi-v7a\System.Private.CoreLib.dll`
* `assemblies\x86\System.Private.CoreLib.dll`
* `assemblies\x86_64\System.Private.CoreLib.dll`

I had to make a few build & runtime changes for these ABI
sub-directories to work.

Other notes:

* We must pass `@(IntermediateAssembly)` from the outer build to the
  nested `<MSBuild/>` calls. Otherwise, the inner calls look for
  `obj\Release\net5.0\android.21-arm\HelloAndroid.dll` instead of
  `obj\Release\net5.0\HelloAndroid.dll` that actually exists.
* `_ComputeFilesToPublishForRuntimeIdentifiers` was running some extra
  targets causing `<ResolveSdks/>` to run 5 times for 4 ABIs. I had to
  make changes in `BuildOrder.targets` to fix this.
* `<ResolveAssemblies/>` now sets `%(IntermediateLinkerOutput)` on
  each assembly item. This allows .NET 6 builds to support multiple
  linker directories.