### PR TITLE
[build] JavacSourceVersion JavacTargetVersion Harmonization

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -118,6 +118,10 @@
     <MingwCommandPrefix64>x86_64-w64-mingw32</MingwCommandPrefix64>
   </PropertyGroup>
   <PropertyGroup>
+    <JavacSourceVersion>1.8</JavacSourceVersion>
+    <JavacTargetVersion>1.8</JavacTargetVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <AndroidMxeFullPath Condition=" '$(AndroidMxeInstallPrefix)' != '' ">$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>
     <AndroidSdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidSdkDirectory)'))</AndroidSdkFullPath>

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -3,10 +3,6 @@
   <Target Name="_GetJavacVersions"
       DependsOnTargets="AndroidPrepareForBuild">
     <PropertyGroup>
-      <_JavacSourceVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacSourceVersion>
-      <_JavacSourceVersion Condition=" '$(_JavacSourceVersion)' == '' ">1.5</_JavacSourceVersion>
-      <_JavacTargetVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacTargetVersion>
-      <_JavacTargetVersion Condition=" '$(_JavacTargetVersion)' == '' ">1.6</_JavacTargetVersion>
       <JarPath Condition=" '$(JarPath)' == '' ">$(JavaSdkDirectory)\bin\jar</JarPath>
       <JavaCPath Condition=" '$(JavaCPath)' == '' ">$(JavaSdkDirectory)\bin\javac</JavaCPath>
     </PropertyGroup>
@@ -35,7 +31,7 @@
     <PropertyGroup>
       <_Javac>"$(JavaCPath)"</_Javac>
       <_Jar>"$(JarPath)"</_Jar>
-      <_Targets>-source $(_JavacSourceVersion) -target $(_JavacTargetVersion)</_Targets>
+      <_Targets>-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Targets>
       <_DestDir>$(IntermediateOutputPath)__CreateTestJarFile-bin</_DestDir>
       <_AndroidJar>-bootclasspath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
       <_CP>-cp "$(_JavaInteropJarPath)"</_CP>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -31,7 +31,7 @@
         Overwrite="True"
     />
     <PropertyGroup>
-      <_Target>-source $(JavacSourceVersion) -target $(JavacSourceVersion)</_Target>
+      <_Target>-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Target>
       <_D>-d "$(IntermediateOutputPath)jcw\bin"</_D>
       <_AndroidJar>"$(AndroidToolchainDirectory)\sdk\platforms\android-$(AndroidPlatformId)\android.jar"</_AndroidJar>
       <_MonoAndroidJar>$(OutputPath)mono.android.jar</_MonoAndroidJar>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -21,6 +21,9 @@
 		<BundleToolVersion Condition="'$(BundleToolVersion)' == ''">@BUNDLETOOL_VERSION@</BundleToolVersion>
 		<_XamarinAndroidMSBuildDirectory>$(MSBuildThisFileDirectory)</_XamarinAndroidMSBuildDirectory>
 
+		<JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.8</JavacSourceVersion>
+		<JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.8</JavacTargetVersion>
+
 		<!-- Enable nuget package conflict resolution -->
 		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -33,7 +33,7 @@
       Overwrite="True"
   />
   <PropertyGroup>
-    <_Target Condition="'$(JavacSourceVersion)' != ''">-source $(JavacSourceVersion) -target $(JavacSourceVersion)</_Target>
+    <_Target Condition="'$(JavacSourceVersion)' != ''">-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Target>
     <_AndroidJar>"$(AndroidToolchainDirectory)\sdk\platforms\android-$(AndroidFirstPlatformId)\android.jar"</_AndroidJar>
   </PropertyGroup>
   <Exec

--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -2,6 +2,14 @@ plugins {
     id 'java-library'
 }
 
+java {
+    ext.javaSourceVer = project.hasProperty('javaSourceVer') ? JavaVersion.toVersion(project.getProperty('javaSourceVer')) : JavaVersion.VERSION_1_8
+    ext.javaTargetVer = project.hasProperty('javaTargetVer') ? JavaVersion.toVersion(project.getProperty('javaTargetVer')) : JavaVersion.VERSION_1_8
+
+    sourceCompatibility = ext.javaSourceVer
+    targetCompatibility = ext.javaTargetVer
+}
+
 repositories {
     maven { url 'https://maven.google.com' }
     mavenCentral()

--- a/src/manifestmerger/manifestmerger.targets
+++ b/src/manifestmerger/manifestmerger.targets
@@ -17,7 +17,7 @@
       Inputs="$(MSBuildThisFile);build.gradle"
       Outputs="$(_Destination)">
     <Exec
-        Command="&quot;$(GradleWPath)&quot; build $(GradleArgs)"
+        Command="&quot;$(GradleWPath)&quot; build $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -1,6 +1,14 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
+java {
+    ext.javaSourceVer = project.hasProperty('javaSourceVer') ? JavaVersion.toVersion(project.getProperty('javaSourceVer')) : JavaVersion.VERSION_1_8
+    ext.javaTargetVer = project.hasProperty('javaTargetVer') ? JavaVersion.toVersion(project.getProperty('javaTargetVer')) : JavaVersion.VERSION_1_8
+
+    sourceCompatibility = ext.javaSourceVer
+    targetCompatibility = ext.javaTargetVer
+}
+
 // See: https://r8.googlesource.com/r8/+/refs/tags/1.6.82/build.gradle#55
 repositories {
     maven {

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -18,7 +18,7 @@
       Inputs="$(MSBuildThisFile);build.gradle"
       Outputs="$(_Destination)">
     <Exec
-        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
+        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4567

In order to support using JDK 11 to build Xamarin.Android, we need to
consistently use `javac -source 1.8 -target 1.8` ~everywhere, because
we also require `javac --boot-class-path`, and JDK11 doesn't support
`javac --boot-class-path` unless targeting < JDK 1.9:

	% javac --boot-class-path ~/android-toolchain/sdk/platforms/android-29/android.jar Example.java
	error: option --boot-class-path not allowed with target 11

The `<Javac/>` task use `javac --boot-class-path` to compile Java
code, so that Android's `android.jar` provides everything:

	Task "Javac" (TaskId:154)
	  Task Parameter:JavaPlatformJarPath=/Users/runner/Library/Android/sdk/platforms/android-29/android.jar
	  Task Parameter:ClassesOutputDirectory=obj/Release/android/bin/classes/
	  Task Parameter:ClassesZip=obj/Release/android/bin/classes.zip
	  Task Parameter:StubSourceDirectory=obj/Release/android/src/
	  Task Parameter:ToolPath=/Users/runner/Library/Android/jdk/bin
	  Task Parameter:
	      Jars=
	          /Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v10.0/mono.android.jar
	          /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/java_runtime.jar
	  /Users/runner/Library/Android/jdk/bin/javac -J-Dfile.encoding=UTF8 "@/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp2eba46d8.tmp"
	JAVAC : error : option --boot-class-path not allowed with target 11
	  The command exited with code 2. (TaskId:154)

Harmonize provisioning of `javac -source` and `javac -target` values:

  * Add `$(JavacSourceVersion)` and `$(JavacTargetVersion)` MSBuild
    properties to `Configuration.props`.

  * Update the `src/manifestmerger` and `src/r8` builds so that
    `$(JavacSourceVersion)` and `$(JavacTargetVersion)` are used to
    control the `.class` files that they create.

  * Update `build-tools/scripts/Jar.targets` to use the values from
    `Configuration.props`, instead of separate values.

  * Fix errant invocations of `javac -target $(JavacSourceVersion)`,
    which should be `javac -target $(JavacTargetVersion)`.