### PR TITLE
[tests] set /p:JavaSdkDirectory for MSBuild tests

### DIFF
--- a/build-tools/scripts/Paths.targets
+++ b/build-tools/scripts/Paths.targets
@@ -13,6 +13,12 @@
         Importance="High"
     />
   </Target>
+  <Target Name="GetJavaSdkDirectory">
+    <Message
+        Text="$(JavaSdkDirectory)"
+        Importance="High"
+    />
+  </Target>
   <Target Name="GetJavaInteropFullPath">
     <Message
         Text="$(JavaInteropFullPath)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -302,6 +302,10 @@ namespace Xamarin.ProjectTools
 				if (Directory.Exists (ndkPath)) {
 					sw.WriteLine (" /p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
 				}
+				string jdkPath = AndroidSdkResolver.GetJavaSdkPath ();
+				if (Directory.Exists (jdkPath)) {
+					sw.WriteLine (" /p:JavaSdkDirectory=\"{0}\" ", jdkPath);
+				}
 				if (parameters != null) {
 					foreach (var param in parameters) {
 						sw.WriteLine (" /p:{0}", param);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -14,6 +14,7 @@ namespace Xamarin.ProjectTools
 		public string Verbosity { get; set; } = "diag";
 		public string AndroidSdkPath { get; set; } = AndroidSdkResolver.GetAndroidSdkPath ();
 		public string AndroidNdkPath { get; set; } = AndroidSdkResolver.GetAndroidNdkPath ();
+		public string JavaSdkPath { get; set; } = AndroidSdkResolver.GetJavaSdkPath ();
 
 		public string ProjectDirectory { get; private set; }
 
@@ -126,6 +127,9 @@ namespace Xamarin.ProjectTools
 			}
 			if (Directory.Exists (AndroidNdkPath)) {
 				arguments.Add ($"/p:AndroidNdkDirectory=\"{AndroidNdkPath}\"");
+			}
+			if (Directory.Exists (JavaSdkPath)) {
+				arguments.Add ($"/p:JavaSdkDirectory=\"{JavaSdkPath}\"");
 			}
 			return arguments;
 		}


### PR DESCRIPTION
This makes the behavior match what we are doing for the
`$(AndroidSdkDirectory)` and `$(AndroidNdkDirectory)` properties.

Additionally, if `$(JavaSdkDirectory)` isn't set, try to use the
`JI_JAVA_HOME` and `JAVA_HOME` environment variables, to allow paths
to be reasonably overridden for test purposes.