### PR TITLE
[tests] don't fail MSBuild tests if CleanupTest hits IOException

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -442,7 +442,12 @@ namespace Xamarin.Android.Build.Tests
 			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed || 
 			    TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped) {
 				FileSystemUtils.SetDirectoryWriteable (output);
-				Directory.Delete (output, recursive: true);
+				try {
+					Directory.Delete (output, recursive: true);
+				} catch (IOException ex) {
+					// This happens on CI occasionally, let's not fail the test
+					TestContext.Out.WriteLine ($"Failed to delete '{output}': {ex}");
+				}
 			} else {
 				foreach (var file in Directory.GetFiles (Path.Combine (output), "*.log", SearchOption.AllDirectories)) {
 					TestContext.AddTestAttachment (file, Path.GetFileName (output));


### PR DESCRIPTION
Context: https://build.azdo.io/3786371

We've been somewhat plagued by errors on Windows CI like:

    TearDown : System.IO.IOException : The directory is not empty.
      at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
      at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
      at Xamarin.Android.Build.Tests.BaseTest.CleanupTest() in /Users/builder/azdo/_work/3/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs:line 445

The test *passed*, it just encountered an `IOException` attempting to
cleanup a temporary directory.

Let's catch `IOException` here and log the error instead. If this
occurs, we shouldn't fail the test as it is just *noise*.