### PR TITLE
[java-runtime, build] Use r8.jar instead of dx

### DIFF
--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -53,9 +53,16 @@
       AfterTargets="GenerateJavaCallableWrappers"
       Inputs="$(OutputPath)mono.android.jar"
       Outputs="$(OutputPath)mono.android.dex">
+    <PropertyGroup>
+      <R8JarPath>$(XAInstallPrefix)xbuild\Xamarin\Android\r8.jar</R8JarPath>
+    </PropertyGroup>
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;$(OutputPath)mono.android.dex&quot; &quot;$(OutputPath)mono.android.jar&quot;"
+        Command="&quot;$(JavaPath)&quot; -classpath &quot;$(R8JarPath)&quot; com.android.tools.r8.D8 --release --no-desugaring --output &quot;$(IntermediateOutputPath.TrimEnd('\'))&quot; &quot;$(OutputPath)mono.android.jar&quot;"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+    />
+    <Move
+        SourceFiles="$(IntermediateOutputPath)\classes.dex"
+        DestinationFiles="$(OutputPath)mono.android.dex"
     />
   </Target>
 </Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -352,6 +352,7 @@
     <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472"/>
     <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\src\java-runtime\java-runtime.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 
   <!--NOTE: a workaround for the test runner in VS Windows-->

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -614,5 +614,6 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 </Project>

--- a/src/java-runtime/java-runtime.csproj
+++ b/src/java-runtime/java-runtime.csproj
@@ -14,6 +14,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <ItemGroup>
     <AllRuntimeSource Include="java/mono/**/*.java" />

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+<PropertyGroup>
+  <BuildDependsOn>
+    ResolveReferences;
+    _BuildJavaRuntimeJar;
+  </BuildDependsOn>
+  <CleanDependsOn>
+    _CleanJavaRuntimeJar;
+  </CleanDependsOn>
+</PropertyGroup>
+
 <ItemGroup>
   <_RuntimeOutput Include="$(OutputPath)java_runtime.jar">
     <OutputJar>$(OutputPath)java_runtime.jar</OutputJar>
@@ -17,7 +27,11 @@
     <RemoveItems>java\mono\android\release\MultiDexLoader.java;java\mono\android\release\BuildConfig.java</RemoveItems>
   </_RuntimeOutput>
 </ItemGroup>
-<Target Name="Build"
+
+<Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
+<Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
+
+<Target Name="_BuildJavaRuntimeJar"
       Inputs="@(AllRuntimeSource)"
       Outputs="%(_RuntimeOutput.OutputJar)"
 >
@@ -57,8 +71,17 @@
     Inputs="@(_RuntimeOutput->'%(Identity)')"
     Outputs="@(_RuntimeOutput->'%(OutputDex)')">
   <Exec
-      Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;%(_RuntimeOutput.OutputDex)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
+      Command="&quot;$(JavaPath)&quot; -classpath &quot;$(OutputPath)\r8.jar&quot; com.android.tools.r8.D8 --release --no-desugaring --output &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
       EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
   />
+  <Move
+      SourceFiles="@(_RuntimeOutput->'%(IntermediateRuntimeOutputPath)\classes.dex')"
+      DestinationFiles="%(_RuntimeOutput.OutputDex)"
+  />
 </Target>
+
+<Target Name="_CleanJavaRuntimeJar">
+  <Delete Files="%(_RuntimeOutput.OutputJar)" />
+</Target>
+
 </Project>

--- a/src/manifestmerger/manifestmerger.csproj
+++ b/src/manifestmerger/manifestmerger.csproj
@@ -9,6 +9,11 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
   <PropertyGroup Condition="'$(Configuration)'=='Release'" />
   <Import Project="..\..\Configuration.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\r8\r8.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <Import Project="manifestmerger.targets" />
 </Project>


### PR DESCRIPTION
`dx` doesn't like OpenJDK 11 on Windows:

	  "C:\Users\dlab14\android-toolchain\sdk\build-tools\29.0.2\dx" --dex --no-strict --output="C:\A\vs2019xam00000H-1\_work\2\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\java_runtime.dex" "C:\A\vs2019xam00000H-1\_work\2\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\java_runtime.jar"

	##[debug]Processed: ##vso[task.logdetail id=dffb25d4-cb0b-4e58-94d2-4b9a4f215bed;parentid=;name=EXEC;type=Build;starttime=2020-04-19T01:21:10.0332656Z;state=InProgress;]
	##[error]EXEC(0,0): Error : No suitable Java found. In order to properly use the Android Developer
	##[debug]Processed: ##vso[task.logissue type=Error;sourcepath=EXEC;linenumber=0;columnnumber=0;code=;]No suitable Java found. In order to properly use the Android Developer
	##[debug]Processed: ##vso[task.logdetail id=dffb25d4-cb0b-4e58-94d2-4b9a4f215bed;parentid=;type=Build;result=Failed;finishtime=2020-04-19T01:21:10.0488457Z;progress=100;state=Completed;parentid=;name=;]
	EXEC : error : No suitable Java found. In order to properly use the Android Developer [C:\A\vs2019xam00000H-1\_work\2\s\src\java-runtime\java-runtime.csproj]
	  Tools, you need a suitable version of Java JDK installed on your system.
	  We recommend that you install the JDK version of JavaSE, available here:
	    http://www.oracle.com/technetwork/java/javase/downloads

	  If you already have Java installed, you can define the JAVA_HOME environment
	  variable in Control Panel / System / Avanced System Settings to point to the
	  JDK folder.

	  You can find the complete Android SDK requirements here:
	    http://developer.android.com/sdk/requirements.html

	##[error]src\java-runtime\java-runtime.targets(59,3): Error MSB3073: The command ""C:\Users\dlab14\android-toolchain\sdk\build-tools\29.0.2\dx" --dex --no-strict --output="C:\A\vs2019xam00000H-1\_work\2\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\java_runtime.dex" "C:\A\vs2019xam00000H-1\_work\2\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\java_runtime.jar"" exited with code -1.

Use `r8.jar` instead of `dx` *everywhere*, to avoid the problem.