### PR TITLE
[Xamarin.Android.Build.Tasks] Support cmdline-tools

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
@@ -37,6 +37,7 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
         AndroidUseAapt2="$(AndroidUseAapt2)"
         AotAssemblies="$(AotAssemblies)"
         Aapt2ToolPath="$(Aapt2ToolPath)"
+        CommandLineToolsVersion="$(AndroidCommandLineToolsVersion)"
         SequencePointsMode="$(_AndroidSequencePointsMode)"
         ProjectFilePath="$(MSBuildProjectFullPath)"			
         LintToolPath="$(LintToolPath)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
     <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">1.8.0</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Android.Tasks
 
 		const int DefaultMinSDKVersion = 11;
 
+		public string CommandLineToolsVersion { get; set; }
+
 		[Required]
 		public string TargetFrameworkVersion { get; set; }
 
@@ -57,6 +59,9 @@ namespace Xamarin.Android.Tasks
 			dependencies.Add (CreateAndroidDependency ($"build-tools/{BuildToolsVersion}", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));
+			}
+			if (!string.IsNullOrEmpty (CommandLineToolsVersion)) {
+				dependencies.Add (CreateAndroidDependency ($"cmdline-tools/{CommandLineToolsVersion}", CommandLineToolsVersion));
 			}
 			if (!string.IsNullOrEmpty (ToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("tools", ToolsVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -195,17 +195,19 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
+			bool fromCmdlineTools   = ToolPath.IndexOf ("cmdline-tools", StringComparison.OrdinalIgnoreCase) >= 0;
+
 			Version lintToolVersion = GetLintVersion (GenerateFullPathToTool ());
 			Log.LogDebugMessage ("  LintVersion: {0}", lintToolVersion);
 			foreach (var issue in DisabledIssuesByVersion) {
-				if (lintToolVersion >= issue.Value) {
+				if (fromCmdlineTools || lintToolVersion >= issue.Value) {
 					if (string.IsNullOrEmpty (DisabledIssues) || !DisabledIssues.Contains (issue.Key))
 						DisabledIssues = issue.Key + (!string.IsNullOrEmpty (DisabledIssues) ? "," + DisabledIssues : "");
 				}
 			}
 
 			foreach (var issue in DisabledIssuesByVersion) {
-				if (lintToolVersion < issue.Value) {
+				if (!fromCmdlineTools || (lintToolVersion < issue.Value)) {
 					DisabledIssues = CleanIssues (issue.Key, lintToolVersion, DisabledIssues, nameof (DisabledIssues));
 					EnabledIssues = CleanIssues (issue.Key, lintToolVersion, EnabledIssues, nameof (EnabledIssues) );
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Android.Tasks
 
 		public string AndroidSdkBuildToolsVersion { get; set; }
 
+		public string CommandLineToolsVersion { get; set; }
+
 		public string ProjectFilePath { get; set; }
 
 		public string SequencePointsMode { get; set; }
@@ -80,8 +82,13 @@ namespace Xamarin.Android.Tasks
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
 
+			var commandLineToolsDir = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
+				.FirstOrDefault () ?? "";
+
 			var lintPaths = new string [] {
 				LintToolPath ?? string.Empty,
+				commandLineToolsDir,
+				Path.Combine (commandLineToolsDir, "bin"),
 				Path.Combine (AndroidSdkPath, "tools"),
 				Path.Combine (AndroidSdkPath, "tools", "bin"),
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -43,6 +43,11 @@ namespace Xamarin.Android.Tasks
 
 		public string [] ReferenceAssemblyPaths { get; set; }
 
+		public string CommandLineToolsVersion { get; set; }
+
+		[Output]
+		public string CommandLineToolsPath { get; set; }
+
 		[Output]
 		public string AndroidNdkPath { get; set; }
 
@@ -93,6 +98,10 @@ namespace Xamarin.Android.Tasks
 			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath;
 			AndroidSdkPath = MonoAndroidHelper.AndroidSdk.AndroidSdkPath;
 			JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
+
+			CommandLineToolsPath    = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
+				.FirstOrDefault () ??
+				Path.Combine (AndroidSdkPath, "tools");
 
 			if (string.IsNullOrEmpty (AndroidSdkPath)) {
 				Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Android_SDK);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -9,6 +9,7 @@
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
 		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">1.8.0</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
+		<AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">True</AndroidUseAapt2>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -657,10 +657,6 @@ because xbuild doesn't support framework reference assemblies.
 	
 	<!-- Misc paths -->
 
-	<CreateProperty Value="$(_AndroidSdkDirectory)tools\">
-		<Output TaskParameter="Value" PropertyName="_AndroidToolsDirectory"/>
-	</CreateProperty>
-
 	<CreateProperty Value="$(_AndroidSdkDirectory)platform-tools\">
 		<Output TaskParameter="Value" PropertyName="_AndroidPlatformToolsDirectory"/>
 	</CreateProperty>
@@ -2849,6 +2845,7 @@ because xbuild doesn't support framework reference assemblies.
   <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>
   <CalculateProjectDependencies
     TargetFrameworkVersion="$(TargetFrameworkVersion)"
+    CommandLineToolsVersion="$(AndroidCommandLineToolsVersion)"
     ManifestFile="$(_ProjectAndroidManifest)"
     BuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
     PlatformToolsVersion="$(AndroidSdkPlatformToolsVersion)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -188,6 +188,7 @@ projects. .NET 5 projects will not import this file.
         AndroidApplication="$(AndroidApplication)"
         AndroidSdkPath="$(_AndroidSdkDirectory)"
         AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        CommandLineToolsVersion="$(AndroidCommandLineToolsVersion)"
         UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
         AndroidUseAapt2="$(AndroidUseAapt2)"
         AotAssemblies="$(AotAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -64,10 +64,12 @@ projects.
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        CommandLineToolsVersion="$(AndroidCommandLineToolsVersion)"
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
         ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+      <Output TaskParameter="CommandLineToolsPath"      PropertyName="_AndroidToolsDirectory" />
       <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
       <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4567

The Android SDK `lint` utility is now in *two* Android SDK packages:
the `tools` package, and the `cmdline-tools` package, e.g. as of commit
d99facb1, *both* of these exist on e.g. macOS:

  * `$HOME/android-toolchain/sdk/tools/bin/lint`
  * `$HOME/android-toolchain/sdk/cmdline-tools/1.0/bin/lint`

There are two important differences of interest:

 1. `tools/bin/lint` will not run on OpenJDK 11.
 2. `cmdline-tools/1.0/bin/lint` has a *lower version* than
    `tools/bin/lint`.  *Much* lower:

        % ~/android-toolchain/sdk/tools/bin/lint --version
        lint: version 26.1.1
        % ~/android-toolchain/sdk/cmdline-tools/1.0/bin/lint --version
        lint: version 3.6.0

(1) means that we can't use the previous `lint` in an OpenJDK11 world,
and thus we should migrate to the cmdline-tools `lint`.

Support this by adding a new `$(AndroidCommandLineToolsVersion)`
MSBuild property to `Xamarin.Android.Common.props.in` and
`Microsoft.Android.Sdk.props`, which allows controlling which
`cmdline-tools` package version to use, if more than one is present.
The default value is `1.0`.

(2) means that the `<Lint/>` Task is *broken* when using the
cmdline-tools version of `lint`, becasuse certain `lint --disable`
flags are protected by version checks, which are now all "wrong" when
we "expect" >= 26.1.1 and instead get 3.6.0.

Attempt to address (2) by assuming that we're using the cmdline-tools
package if `ToolPath` contains `cmdline-tools`, in which case we treat
`lint` as newer than any previous version.

(This may be less than ideal.)