### PR TITLE
[Xamarin.Android.Build.Tasks] <CreateMultiDexMainDexClassList/> & JDK11

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using System.Text;
 
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
@@ -97,7 +98,7 @@ namespace Xamarin.Android.Tasks
 			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
 			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "..", "classes.zip") });
-			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
+			cmd.AppendSwitchUnquotedIfNotNull ("-classpath ", "\"" + GetMainDexListBuilderClasspath () + "\"");
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
 			if (!string.IsNullOrWhiteSpace (ExtraArgs))
 				cmd.AppendSwitch (ExtraArgs);
@@ -106,6 +107,12 @@ namespace Xamarin.Android.Tasks
 				string.Join ($"{enclosingQuote}{Path.PathSeparator}{enclosingQuote}", jars) + 
 				$"{enclosingQuote}{enclosingDoubleQuote}");
 			writeOutputToKeepFile = true;
+		}
+
+		string GetMainDexListBuilderClasspath ()
+		{
+			var libdir      = Path.Combine (AndroidSdkBuildToolsPath, "lib");
+			return string.Join (Path.PathSeparator.ToString (), Directory.EnumerateFiles (libdir, "*.jar"));
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4567
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3729696&view=ms.vss-test-web.build-test-results-tab&runId=13228096&resultId=100066&paneView=attachments

`<CreateMultiDexMainDexClassList/>` fails under JDK11:

	$ /Users/runner/Library/Android/jdk/bin/java \
		-Djava.ext.dirs=/Users/runner/Library/Android/sdk/build-tools/29.0.2/lib \
		com.android.multidex.MainDexListBuilder …
	-Djava.ext.dirs=/Users/runner/Library/Android/sdk/build-tools/29.0.2/lib is not supported.  Use -classpath instead.
	CREATEMULTIDEXMAINDEXCLASSLIST : error : Could not create the Java Virtual Machine.
	CREATEMULTIDEXMAINDEXCLASSLIST : error : A fatal exception has occurred. Program will exit.
	The command exited with code 1.

Under JDK11, `java` no longer supports `-Djava.ext.dirs`.

Update `<CreateMultiDexMainDexClassList/>` so that it constructs a
`java -classpath` value and uses that.