### PR TITLE
[build] bump to .NET 5.0.100-preview.7.20307.3

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -27,8 +27,8 @@ variables:
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.201
-  # Version number from: https://dotnet.microsoft.com/download/dotnet-core/5.0
-  DotNetCorePreviewVersion: 5.0.100-preview.6.20265.2
+  # Version number from: https://github.com/dotnet/installer#installers-and-binaries
+  DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3
 
 stages:
 - stage: mac_stage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -51,7 +51,7 @@ variables:
   NUnitConsoleVersion: 3.9.0
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-preview.6.20265.2
+  DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019


### PR DESCRIPTION
Context: https://github.com/xamarin/net6-samples/pull/20

`xamarin-android` has been building / testing against .NET 5 Preview 6.

`libmono.a` was renamed to `libmonosgen-2.0.a` recently.

`xamarin-macios` depends on this name, and so `xamarin-macios`
requires .NET 5 Preview 7 now.

Update to `xamarin-android` to use .NET 5 Preview 7, so we can keep
both repos in sync.