### PR TITLE
[compression] Store assembly information with unique key

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@e795bcef375bc77da0bbe995fc9e57560ed5ddc0
+xamarin/monodroid:master@6d05c4929db1ba12ba3a04174938256e435dbbd4
 mono/mono:2020-02@87ef5557017a8d822ae31587846a54fcd66daf1b

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -24,6 +24,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public bool EnableCompression { get; set; }
 
+		[Required]
+		public string ProjectFullPath { get; set; }
+
 		public override bool RunTask ()
 		{
 			GenerateCompressedAssemblySources ();
@@ -61,7 +64,9 @@ namespace Xamarin.Android.Tasks
 				kvp.Value.DescriptorIndex = index++;
 			}
 
-			BuildEngine4.RegisterTaskObject (CompressedAssemblyInfo.CompressedAssembliesInfoKey, assemblies, RegisteredTaskObjectLifetime.Build, false);
+			string key = CompressedAssemblyInfo.GetKey (ProjectFullPath);
+			Log.LogDebugMessage ($"Storing compression assemblies info with key '{key}'");
+			BuildEngine4.RegisterTaskObject (key, assemblies, RegisteredTaskObjectLifetime.Build, false);
 			Generate (assemblies);
 
 			void Generate (IDictionary<string, CompressedAssemblyInfo> dict)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace Xamarin.Android.Tasks
 {
 	class CompressedAssemblyInfo
 	{
-		public const string CompressedAssembliesInfoKey = "__CompressedAssembliesInfo";
+		const string CompressedAssembliesInfoKey = "__CompressedAssembliesInfo";
 
 		public uint FileSize { get; }
 		public uint DescriptorIndex { get; set; }
@@ -11,6 +13,14 @@ namespace Xamarin.Android.Tasks
 		{
 			FileSize = fileSize;
 			DescriptorIndex = 0;
+		}
+
+		public static string GetKey (string projectFullPath)
+		{
+			if (String.IsNullOrEmpty (projectFullPath))
+				throw new ArgumentException ("must be a non-empty string", nameof (projectFullPath));
+
+			return $"{CompressedAssembliesInfoKey}:{projectFullPath}";
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2113,6 +2113,7 @@ because xbuild doesn't support framework reference assemblies.
       SupportedAbis="@(_BuildTargetAbis)"
       Debug="$(AndroidIncludeDebugSymbols)"
       EnableCompression="$(AndroidEnableAssemblyCompression)"
+      ProjectFullPath="$(MSBuildProjectFullPath)"
   />
   <ItemGroup>
     <FileWrites Include="@(_CompressedAssembliesAssemblySource)" />
@@ -2303,7 +2304,8 @@ because xbuild doesn't support framework reference assemblies.
     LibraryProjectJars="@(ExtractedJarImports)"
     TlsProvider="$(AndroidTlsProvider)"
     UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-	InterpreterEnabled="$(_AndroidUseInterpreter)">
+    InterpreterEnabled="$(_AndroidUseInterpreter)"
+    ProjectFullPath="$(MSBuildProjectFullPath)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle
@@ -2332,7 +2334,8 @@ because xbuild doesn't support framework reference assemblies.
       AndroidSequencePointsMode="$(_SequencePointsMode)"
       LibraryProjectJars="@(ExtractedJarImports)"
       TlsProvider="$(AndroidTlsProvider)"
-      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
+      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
+      ProjectFullPath="$(MSBuildProjectFullPath)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>
   <BuildAppBundle


### PR DESCRIPTION
Context: d236af54538ef1fe62d0125798cdde78e46dcd8e

d236af54 introduced assembly compression and one part of the process is
to gather information about the size of all the assemblies to be
packaged with the application, in order to generate native assembly code
which pre-allocates memory for them.  To do that, the native runtime must
be sure that the the assembly being currently decompressed will fit in
the pre-allocated memory area and thus it stores the original file size
both in the compressed assembly header and in the generated native
assembler source (compiled into `libxamarin-app.so`).  If the sizes
mismatch, we will see an error in the logcat similar to:

    F/monodroid-assembly(11348): Compressed assembly 'mscorlib.dll' is larger than when the application was built (expected at most 146432, got 2043392). Assemblies don't grow just like that!

In addition to the assembly size, the compressed assembly header
contains also an index into an array of assembly descriptors which is
placed in the generated native assembler source code.  The
index **must** point to the correct descriptor or bad things happen.
This is the reason for the particular error shown above, coming from a
test app (here)[0].

During build time, the information about assembly sizes is carried
between the involved tasks in an object registered with MSBuild using
its `BuildEngine4.RegisterTaskObject` API.  The API uses a key to access
the registered object which, in d236af54, was defined to be a constant
string, shared across all the builds.  However, it turns out
that *somehow* if two or more projects store the registered object with
the same key the end result is that the cache contains entries from more
than one object (how it happened is unclear, it should be "impossible")
which results in the descriptor indexes in compressed assembly header to
point to incorrect locations.

In order to fix the issue, this commit makes two changes:

 * Make sure the assembly info object is unregistered by the `BuildApk`.
   This ensures that "merging" of two dictionaries (however/wherever it
   happened) will not take place.
 * Make the key to the registered object unique by addition of the
   project GUID (from the `$(ProjectGuid)` MSBuild property).
   This ensures correct operation during builds which take advantage of
   MSBuild's parallel build feature.

[0]: https://github.com/xamarin/QualityAssurance/tree/master/Samples/android/Bug15162
    
Co-authored-by: Jonathan Peppers <jonathan.peppers@gmail.com>