### PR TITLE
[Xamarin.Android.Build.Tasks] add $(AndroidSupportedAbis) to build.props

### DIFF
--- a/Documentation/release-notes/4790.md
+++ b/Documentation/release-notes/4790.md
@@ -1,0 +1,7 @@
+#### Application and library build and deployment
+
+  * [GitHub 4790](https://github.com/xamarin/xamarin-android/issues/4790):
+    Fixes a build error such as _Error: can't open typemaps.x86.s for
+    reading: No such file or directory_ after the
+    `$(AndroidSupportedAbis)` MSBuild property was changed from a
+    previous build.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1181,5 +1181,18 @@ namespace Lib2
 				}
 			}
 		}
+
+		[Test]
+		public void ChangeSupportedAbis ()
+		{
+			var proj = new XamarinFormsAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a");
+			using (var b = CreateApkBuilder ()) {
+				b.Build (proj);
+
+				var parameters = new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
+				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -930,6 +930,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
 		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
 		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
+		<_PropertyCacheItems Include="AndroidSupportedAbis=$(AndroidSupportedAbis)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4790

If you change `$(AndroidSupportedAbis)` in the IDE and perform an
incremental build, you can hit:

    [i686-linux-android-as.EXE stderr] Assembler messages:
    [i686-linux-android-as.EXE stderr] Error: can't open typemaps.x86.s for reading: No such file or directory
    Xamarin.Android.Common.targets(2245,3): error XA3006: Could not compile native assembly file: typemaps.x86.s

I was able to reproduce the issue in a test by using the `.csproj`:

    <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>

Then command-line pass a different ABI, such as:

    -p:AndroidSupportedAbis=x86

`$(AndroidSupportedAbis)` needs to be listed in `build.props`, so that
changes to this value will trigger all MSBuild targets to run again.
In particular `_GenerateJavaStubs` and `_GeneratePackageManagerJava`
need to run in this case.