### PR TITLE
[One .NET] updated implementation for 'dotnet publish'

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -127,9 +127,9 @@ This means Xamarin.Android would run:
 * Create an `.apk` or `.aab` and sign it
 
 `dotnet publish` will be reserved for publishing an app for Google
-Play. It could be able to sign the `.apk` or `.aab` with different
-keys. As a starting point, this would copy the output to a `publish`
-directory on disk.
+Play, ad-hoc distribution, etc. It could be able to sign the `.apk` or
+`.aab` with different keys. As a starting point, this will currently
+copy the output to a `publish` directory on disk.
 
 Down the road `dotnet run` would be used to launch applications on a
 device or emulator.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
@@ -1,0 +1,30 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.Publish.targets
+
+This file contains the implementation for 'dotnet publish'.
+
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <_PublishDependsOn>
+      Build;
+      PrepareForPublish;
+      _CalculateAndroidFilesToPublish;
+      CopyFilesToPublishDirectory;
+    </_PublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Publish" DependsOnTargets="$(_PublishDependsOn)" />
+
+  <Target Name="_CalculateAndroidFilesToPublish">
+    <ItemGroup>
+      <_AndroidFilesToPublish Include="$(OutputPath)*.$(AndroidPackageFormat)" />
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
+      <ResolvedFileToPublish Include="@(_AndroidFilesToPublish)" RelativePath="%(FileName)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -27,6 +27,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Linker.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.NuGet.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Publish.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Tooling.targets" />
 
   <!-- Automatically supply project capabilities for IDE use -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -139,6 +139,32 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void DotNetPublish ([Values (false, true)] bool isRelease)
+		{
+			const string runtimeIdentifier = "android.21-arm";
+			var proj = new XASdkProject {
+				IsRelease = isRelease
+			};
+			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
+			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Publish (), "first `dotnet publish` should succeed");
+
+			var publishDirectory = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, runtimeIdentifier, "publish");
+			var apk = Path.Combine (publishDirectory, $"{proj.PackageName}.apk");
+			var apkSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.apk");
+			FileAssert.Exists (apk);
+			FileAssert.Exists (apkSigned);
+
+			Assert.IsTrue (dotnet.Publish (parameters: new [] { "AndroidPackageFormat=aab" }), "second `dotnet publish` should succeed");
+			FileAssert.DoesNotExist (apk);
+			FileAssert.DoesNotExist (apkSigned);
+			var aab = Path.Combine (publishDirectory, $"{proj.PackageName}.aab");
+			var aabSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.aab");
+			FileAssert.Exists (aab);
+			FileAssert.Exists (aabSigned);
+		}
+
+		[Test]
 		public void BuildWithLiteSdk ()
 		{
 			var proj = new XASdkProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -74,15 +74,15 @@ namespace Xamarin.ProjectTools
 			return succeeded;
 		}
 
-		public bool Build (string target = null)
+		public bool Build (string target = null, string [] parameters = null)
 		{
-			var arguments = GetDefaultCommandLineArgs ("build", target);
+			var arguments = GetDefaultCommandLineArgs ("build", target, parameters);
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Publish (string target = null)
+		public bool Publish (string target = null, string [] parameters = null)
 		{
-			var arguments = GetDefaultCommandLineArgs ("publish", target);
+			var arguments = GetDefaultCommandLineArgs ("publish", target, parameters);
 			return Execute (arguments.ToArray ());
 		}
 
@@ -102,7 +102,7 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		List<string> GetDefaultCommandLineArgs (string verb, string target = null)
+		List<string> GetDefaultCommandLineArgs (string verb, string target = null, string [] parameters = null)
 		{
 			string testDir = Path.GetDirectoryName (projectOrSolution);
 			if (string.IsNullOrEmpty (ProcessLogFile))
@@ -130,6 +130,11 @@ namespace Xamarin.ProjectTools
 			}
 			if (Directory.Exists (JavaSdkPath)) {
 				arguments.Add ($"/p:JavaSdkDirectory=\"{JavaSdkPath}\"");
+			}
+			if (parameters != null) {
+				foreach (var parameter in parameters) {
+					arguments.Add ($"/p:{parameter}");
+				}
 			}
 			return arguments;
 		}


### PR DESCRIPTION
Currently `dotnet publish` is incomplete; it uses the built-in behavior
in dotnet/sdk that copies all the managed assemblies to a `publish`
directory. Ideally an `.apk` or `.aab` should be the output instead?

For example:

    > dotnet publish foo.android.csproj

This should copy any `.apk` files to `$(PublishDir)` and nothing else.

To achieve this, we need to declare our own minimal `Publish` target
that depends on:

    Build;
    PrepareForPublish;
    CopyFilesToPublishDirectory;

We don't want *our* `Publish` target to run things like `ILLink`, AOT,
etc. because our `Build` target will be in charge of running those
build steps.

The current implementation in `Microsoft.Android.Sdk.Publish.targets`
is based on the `_CopyResolvedFilesToPublishPreserveNewest` target in
dotnet/sdk:

https://github.com/dotnet/sdk/blob/22fc243c1f6c9455a56bda014f1c32b6e1af18fc/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L218-L240

The only hangup was making sure:

    > dotnet publish foo.android.csproj -p:AndroidPackageFormat=apk
    > dotnet publish foo.android.csproj -p:AndroidPackageFormat=aab

After the second command, the `_IncrementalCleanPublishDirectory`
MSBuild target needs to actually cleanup the previous `.apk` files.

https://github.com/dotnet/sdk/blob/22fc243c1f6c9455a56bda014f1c32b6e1af18fc/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L137-L157

To make this work, we need to fixup `@(ResolvedFileToPublish)` before
the `CopyFilesToPublishDirectory` MSBuild target runs. It also needs
the `%(RelativePath)` metadata to be filled out with the expected path
after `$(PublishDir)`.

Down the road we can extend the `Publish` target for other scenarios.

I added a test changing `$(AndroidPackageFormat)` and verifying the
correct files land in `$(PublishDir)`. I also updated `DotNetCLI`, so
you can pass global MSBuild parameters.