### PR TITLE
[One .NET] initial implementation of 'dotnet run'

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -131,8 +131,10 @@ Play. It could be able to sign the `.apk` or `.aab` with different
 keys. As a starting point, this would copy the output to a `publish`
 directory on disk.
 
-Down the road `dotnet run` would be used to launch applications on a
-device or emulator.
+`dotnet run` can be used to launch applications on a
+device or emulator via the `--project` switch:
+
+    dotnet run --project HelloAndroid.csproj
 
 [illink]: https://github.com/mono/linker/blob/master/src/linker/README.md
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.Application.targets
+
+This file contains targets specific for Android application projects.
+
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <RunCommand>dotnet</RunCommand>
+    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>
+  </PropertyGroup>
+
+  <Target Name="Run" DependsOnTargets="Install;StartAndroidActivity" />
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -40,6 +40,6 @@
   </ItemGroup>
 
   <!-- NOTE: We have to replace the Run target after Microsoft.NET.Sdk.targets are imported -->
-  <Target Name="Run" DependsOnTargets="Install;StartAndroidActivity" />
+  <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -88,8 +88,12 @@ namespace Xamarin.ProjectTools
 
 		public bool Run ()
 		{
-			//TODO: this should eventually run `dotnet run --project foo.csproj`
-			var arguments = GetDefaultCommandLineArgs ("build", "Run");
+			string binlog = Path.Combine (Path.GetDirectoryName (projectOrSolution), "msbuild.binlog");
+			var arguments = new List<string> {
+				"run",
+				"--project", $"\"{projectOrSolution}\"",
+				$"/bl:\"{binlog}\""
+			};
 			return Execute (arguments.ToArray ());
 		}
 


### PR DESCRIPTION
We currently have a `Run` target for .NET 6 projects:

    <Target Name="Run" DependsOnTargets="Install;StartAndroidActivity" />

But the following command does not work:

    > dotnet run --project HelloAndroid.csproj

It fails with:

    Unable to run your project.
    Ensure you have a runnable project type and ensure 'dotnet run' supports this project.
    A runnable project should target a runnable TFM (for instance, net5.0) and have OutputType 'Exe'.
    The current OutputType is 'Library'.

This occurs if `$(RunCommand)` is empty after MSBuild evaluation:

https://github.com/dotnet/sdk/blob/70cee0d6d445e332d3f926a66e7f4334cdca87e3/src/Cli/dotnet/commands/dotnet-run/RunCommand.cs#L203-L206

We can get our `Run` target hooked up to `dotnet run` by setting:

    <RunCommand>dotnet</RunCommand>
    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>

I setup all this logic in `Microsoft.Android.Sdk.Application.targets`,
which is only imported for Android application projects.

I updated `DotNetCLI.Run()` to use the new `dotnet run` verb.