### PR TITLE
[Xamarin.Android.Build.Tasks] Wrong AndroidManifest.xml packaged to the APK while using binding library

### DIFF
--- a/Documentation/release-notes/Issue4804.md
+++ b/Documentation/release-notes/Issue4804.md
@@ -1,0 +1,13 @@
+#### Wrong AndroidManifest.xml packaged to the APK while using binding library
+
+   * [GitHub 4812][0]: We were overwriting the AndroidManifest.xml file
+    in the apk with ones from Support Libraries. This manifests itself
+    with the following error
+
+    ```
+    Failed to parse APK info: failed to parse AndroidManifest.xml, error: %!s()
+deploy failed, error: failed to get apk infos, output: W/ResourceType( 5266): Bad XML block:
+    ```
+
+
+ [0]: https://github.com/xamarin/xamarin-android/pull/4812

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string ApkInputPath { get; set; }
-		
+
 		[Required]
 		public string ApkOutputPath { get; set; }
 
@@ -101,7 +101,7 @@ namespace Xamarin.Android.Tasks
 		}
 
 		SequencePointsMode sequencePointsMode = SequencePointsMode.None;
-		
+
 		public ITaskItem[] LibraryProjectJars { get; set; }
 		string [] uncompressedFileExtensions;
 
@@ -241,6 +241,10 @@ namespace Xamarin.Android.Tasks
 								Log.LogDebugMessage ($"Skipping {path} as the archive file is up to date.");
 								continue;
 							}
+							if (apk.Archive.Any (e => e.FullName == path)) {
+								Log.LogDebugMessage ("Failed to add jar entry {0} from {1}: the same file already exists in the apk", name, Path.GetFileName (jarFile));
+								continue;
+							}
 							byte [] data;
 							using (var d = new MemoryStream ()) {
 								jarItem.Extract (d);
@@ -256,7 +260,7 @@ namespace Xamarin.Android.Tasks
 						count = 0;
 					}
 				}
-				// Clean up Removed files. 
+				// Clean up Removed files.
 				foreach (var entry in existingEntries) {
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");
 					apk.Archive.DeleteEntry (entry);
@@ -296,7 +300,7 @@ namespace Xamarin.Android.Tasks
 					var apk = Path.GetFileNameWithoutExtension (ApkOutputPath);
 					ExecuteWithAbi (new [] { abi }, String.Format ("{0}-{1}", ApkInputPath, abi),
 						Path.Combine (path, String.Format ("{0}-{1}.apk", apk, abi)),
-					    debug, compress, compressedAssembliesInfo);
+						debug, compress, compressedAssembliesInfo);
 					outputFiles.Add (Path.Combine (path, String.Format ("{0}-{1}.apk", apk, abi)));
 				}
 			}
@@ -548,7 +552,7 @@ namespace Xamarin.Android.Tasks
 		{
 			// If Abi is explicitly specified, simply return it.
 			var lib_abi = MonoAndroidHelper.GetNativeLibraryAbi (lib);
-			
+
 			if (string.IsNullOrWhiteSpace (lib_abi)) {
 				Log.LogCodedError ("XA4301", lib.ItemSpec, 0, Properties.Resources.XA4301_ABI, lib.ItemSpec);
 				return null;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -672,7 +672,7 @@ namespace App1
 			ns.SetProperty ("Description", "Test");
 			ns.SetProperty ("PackageOutputPath", path);
 
-			
+
 			var xa = new XamarinAndroidApplicationProject () {
 				ProjectName = "App",
 				PackageReferences = {
@@ -786,6 +786,54 @@ namespace App1
 					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
+				}
+			}
+		}
+
+		[Test]
+		public void IgnoreManifestFromJar ()
+		{
+			string java = @"
+package com.xamarin.testing;
+
+public class Test
+{
+}
+";
+			var path = Path.Combine (Root, "temp", TestName);
+			var javaDir = Path.Combine (path, "java", "com", "xamarin", "testing");
+			if (Directory.Exists (javaDir))
+				Directory.Delete (javaDir, true);
+			Directory.CreateDirectory (javaDir);
+			File.WriteAllText (Path.Combine (javaDir, "..", "..", "..", "AndroidManifest.xml"), @"<?xml version='1.0' ?><maniest />");
+			var lib = new XamarinAndroidBindingProject () {
+				AndroidClassParser = "class-parse",
+				ProjectName = "Binding1",
+			};
+			lib.MetadataXml = "<metadata></metadata>";
+			lib.Jars.Add (new AndroidItem.EmbeddedJar (Path.Combine ("java", "test.jar")) {
+				BinaryContent = new JarContentBuilder () {
+					BaseDirectory = Path.Combine (path, "java"),
+					JarFileName = "test.jar",
+					JavaSourceFileName = Path.Combine ("com", "xamarin", "testing", "Test.java"),
+					JavaSourceText = java,
+					AdditionalFileExtensions = "*.xml",
+				}.Build
+			});
+			var app = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
+
+			using (var builder = CreateDllBuilder (Path.Combine (path, lib.ProjectName))) {
+				Assert.IsTrue (builder.Build (lib), "Build of jar should have succeeded.");
+				using (var zip = ZipHelper.OpenZip (Path.Combine (path, "java", "test.jar"))) {
+					Assert.IsTrue (zip.ContainsEntry ($"AndroidManifest.xml"), "Jar should contain AndroidManifest.xml");
+				}
+				using (var b = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+					Assert.IsTrue (b.Build (app), "Build of jar should have succeeded.");
+					string expected = "Failed to add jar entry AndroidManifest.xml from test.jar: the same file already exists in the apk";
+					Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"AndroidManifest.xml for test.jar should have been ignored.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
@@ -16,6 +16,8 @@ namespace Xamarin.ProjectTools
 		public string JavaSourceFileName { get; set; }
 		public string JavaSourceText { get; set; }
 
+		public string AdditionalFileExtensions { get; set; }
+
 		public JarContentBuilder ()
 		{
 			Action<TraceLevel, string> logger = (level, value) => {
@@ -57,6 +59,10 @@ namespace Xamarin.ProjectTools
 				File.Delete (jarfile);
 			var args = new string [] { "cvf", JarFileName };
 			var classes = Directory.GetFiles (Path.GetDirectoryName (src), "*.class", SearchOption.AllDirectories);
+			if (!string.IsNullOrEmpty (AdditionalFileExtensions)) {
+				var additionalFiles = Directory.GetFiles (Path.GetDirectoryName (BaseDirectory), AdditionalFileExtensions, SearchOption.AllDirectories);
+				classes = classes.Concat (additionalFiles).ToArray ();
+			}
 			var jarPsi = new ProcessStartInfo () {
 				FileName = JarFullPath,
 				Arguments = string.Join (" ", args.Concat (classes.Select (c => c.Substring (BaseDirectory.Length + 1)).ToArray ())),


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/4804

We were overwriting the AndroidManifest.xml file in the apk with
ones from Support Libraries. This manifests itself with the following error

```
Failed to parse APK info: failed to parse AndroidManifest.xml, error: %!s()
deploy failed, error: failed to get apk infos, output: W/ResourceType( 5266): Bad XML block: 
```

This commit fixes this issue by ignoring files from .jar files
which already exist in the apk. This stops things from being
overwritten. A test has also been added.