### PR TITLE
[Xamarin.Android.Build.Tasks] fix IDE builds missing satellite assemblies in apps

### DIFF
--- a/Documentation/release-notes/4805.md
+++ b/Documentation/release-notes/4805.md
@@ -1,0 +1,9 @@
+#### Application behavior on device and emulator
+
+  - [GitHub 4805](https://github.com/xamarin/xamarin-android/issues/4805):
+    Starting in Xamarin.Android 10.3, localized resources from _.resx_
+    files in Xamarin.Android application projects were no longer
+    deployed when building and deploying from within Visual Studio to
+    an attached device or emulator.  (In contrast, clean builds
+    started via the **Build > Archive** command or on the command line
+    worked as expected.)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -725,7 +725,7 @@ namespace App1
 		}
 
 		[Test]
-		public void MissingSatelliteAssembly ()
+		public void MissingSatelliteAssemblyInLibrary ()
 		{
 			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidLibraryProject {
@@ -740,7 +740,7 @@ namespace App1
 				}
 			};
 
-			var app = new XamarinFormsMapsApplicationProject {
+			var app = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
@@ -754,9 +754,38 @@ namespace App1
 				Assert.IsTrue (appBuilder.Build (app), "App SignAndroidPackage should have succeeded.");
 
 				var apk = Path.Combine (Root, appBuilder.ProjectDirectory,
-					app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+					app.IntermediateOutputPath, "android", "bin", $"{app.PackageName}.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
-					Assert.IsTrue (zip.ContainsEntry ("assemblies/es/Localization.resources.dll"), "Apk should contain satellite assemblies!");
+					Assert.IsTrue (zip.ContainsEntry ($"assemblies/es/{lib.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
+				}
+			}
+		}
+
+		[Test]
+		public void MissingSatelliteAssemblyInApp ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				OtherBuildItems = {
+					new BuildItem ("EmbeddedResource", "Foo.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+					},
+					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+					}
+				}
+			};
+
+			using (var b = CreateApkBuilder ()) {
+				b.Target = "Build";
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.Target = "SignAndroidPackage";
+				Assert.IsTrue (b.Build (proj), "SignAndroidPackage should have succeeded.");
+
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+					Assert.IsTrue (zip.ContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2603,6 +2603,8 @@ because xbuild doesn't support framework reference assemblies.
     BuildOnlySettings;
     _CreatePropertiesCache;
     ResolveReferences;
+    PrepareResources;
+    CreateSatelliteAssemblies;
     _CopyPackage;
     _Sign;
   </SignAndroidPackageDependsOn>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4805
Context: https://github.com/xamarin/xamarin-android/issues/4664

There are still reports of `.resx` files not working inside IDEs...
65a917a9 was the original cause of this problem.

Unfortunately, the original problem in #4664 still occurs if the
`.resx` files are in the Xamarin.Android application project. The
original fix in d298fdaa, only solved the problem for missing
satellite assemblies in referenced projects.

Two missing targets need to run for `SignAndroidPackage` in IDE builds:

    PrepareResources;
    CreateSatelliteAssemblies;

These targets fill out the
`@(IntermediateSatelliteAssembliesWithTargetPath)` item group, that
contains all satellite assemblies for the current project.

In IDE builds, this item group was empty and `<BuildApk/>` was not
adding satellite assemblies to the `.apk` file at all.

I was able to reproduce this problem pretty easily with a test. I
reworked the `MissingSatelliteAssembly` test to have a version for
libraries and apps.

I also cleaned the test up a bit, in general, using less hardcoded
strings.