### PR TITLE
[tests] raise PerformanceTest times again

### DIFF
--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,14 +2,14 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,10500
-Build_No_Changes,2000
+Build_From_Clean_DontIncludeRestore,11000
+Build_No_Changes,2250
 Build_CSharp_Change,3350
-Build_AndroidResource_Change,3000
+Build_AndroidResource_Change,3250
 Build_AndroidManifest_Change,3500
 Build_Designer_Change,2650
-Build_JLO_Change,9600
-Build_CSProj_Change,10200
+Build_JLO_Change,10000
+Build_CSProj_Change,10750
 Build_XAML_Change,7250
 Build_XAML_Change_RefAssembly,4000
 Install_CSharp_Change,4000


### PR DESCRIPTION
Context: https://build.azdo.io/3804575
Context: https://build.azdo.io/3804792

In 1f0e632b, I raised the times for a few tests, but I think we need
to raise them more:

    Build_CSProj_Change
    Exceeded expected time of 10200ms, actual 10293.371ms
    Exceeded expected time of 10200ms, actual 10224.05ms
    Build_From_Clean_DontIncludeRestore
    Exceeded expected time of 10500ms, actual 10512.716ms
    Build_JLO_Change
    Exceeded expected time of 9600ms, actual 9780.282ms
    Build_AndroidResource_Change
    Exceeded expected time of 3000ms, actual 3004.573ms
    Build_No_Changes
    Exceeded expected time of 2000ms, actual 2004.638ms

I also suspect that the newer `aapt2` version bumped in cbdb5d15 could
be slightly slower, and that is why these have started failing. We
happened to get lucky (unlucky?) and #4794 was green.

If this continues to be a problem, I think we could potentially remove
these tests:

* `Build_From_Clean_DontIncludeRestore`
* `Build_CSProj_Change`
* `Build_JLO_Change`

Since these tests are doing complete builds, their timings fluctuate a
lot due to unknown reasons: phase of the moon, sunspots, butterflies,
etc.