### PR TITLE
[Xamarin.Android.Build.Tasks] @(LinkDescription) should be in Inputs for the linker

### DIFF
--- a/Documentation/release-notes/incremental-linkdescription.md
+++ b/Documentation/release-notes/incremental-linkdescription.md
@@ -1,0 +1,7 @@
+#### Application and library build and deployment
+
+  * [Developer Community 1061307][0]: Fixes an issue where modifying
+    `@(LinkDescription)` files would require a `Rebuild` to see the
+    changes reflected in the Android application build output.
+
+[0]: https://developercommunity.visualstudio.com/content/problem/1061307/changes-not-applied-on-build-after-linker-configur.html

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1474,7 +1474,7 @@ because xbuild doesn't support framework reference assemblies.
 	
 <Target Name="_LinkAssembliesShrink"
   Condition="'$(AndroidLinkMode)' != 'None' and '$(UsingAndroidNETSdk)' != 'true' "
-  Inputs="@(ResolvedUserAssemblies);$(_AndroidBuildPropertiesCache)"
+  Inputs="@(ResolvedUserAssemblies);@(LinkDescription);$(_AndroidBuildPropertiesCache)"
   Outputs="$(_AndroidLinkFlag)">
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/1061307/changes-not-applied-on-build-after-linker-configur.html

Changes to a `@(LinkDescription)` file did not trigger the
`_LinkAssembliesShrink` MSBuild target to run again.

The only way to see changes from this file was to `Rebuild` every time.

:eyes:

Adding a test for this scenario is also nice, as it didn't seem like
we had an MSBuild test verifying that `@(LinkDescription)` works in
general.