### PR TITLE
[build] enable One .NET MSBuild tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -63,6 +63,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
+  DotNetNUnitCategories: '&& cat != DotNetIgnore && cat != AOT && cat != FSharp && cat != LibraryProjectZip && cat != MkBundle && cat != MonoSymbolicate && cat != PackagesConfig && cat != StaticProject'
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
@@ -796,31 +797,45 @@ stages:
 
     - template: yaml-templates/fail-on-issue.yaml
 
-  # Xamarin.Android (Test MSBuild - macOS)
+  # Xamarin.Android (Test MSBuild - macOS - Legacy)
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
       node_id: 1
+      job_name: mac_msbuild_tests_1
+      job_suffix: Legacy
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
       node_id: 2
+      job_name: mac_msbuild_tests_2
+      job_suffix: Legacy
+      run_extra_tests: true
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
       node_id: 3
+      job_name: mac_msbuild_tests_3
+      job_suffix: Legacy
 
-  # Xamarin.Android (Test MSBuild - Windows)
+  # Xamarin.Android (Test MSBuild - Windows - Legacy)
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
       node_id: 1
+      job_name: win_msbuild_tests_1
+      job_suffix: Legacy
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
       node_id: 2
+      job_name: win_msbuild_tests_2
+      job_suffix: Legacy
+      run_extra_tests: true
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
       node_id: 3
+      job_name: win_msbuild_tests_3
+      job_suffix: Legacy
 
   # Check - "Xamarin.Android (Test MSBuild With Emulator - macOS)"
   - job: mac_msbuilddevice_tests
@@ -1025,6 +1040,62 @@ stages:
         artifactName: Test Results - Designer - Windows
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
       condition: always()
+
+- stage: dotnet_tests
+  displayName: One .NET Tests
+  dependsOn: mac_build
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['RunAllTests'], true))
+  jobs:
+
+  # Xamarin.Android (Test MSBuild - macOS - One .NET)
+  - template: yaml-templates\run-msbuild-mac-tests.yaml
+    parameters:
+      node_id: 1
+      job_name: mac_dotnet_tests_1
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
+
+  - template: yaml-templates\run-msbuild-mac-tests.yaml
+    parameters:
+      node_id: 2
+      job_name: mac_dotnet_tests_2
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
+
+  - template: yaml-templates\run-msbuild-mac-tests.yaml
+    parameters:
+      node_id: 3
+      job_name: mac_dotnet_tests_3
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
+
+  # Xamarin.Android (Test MSBuild - Windows - One .NET)
+  - template: yaml-templates\run-msbuild-win-tests.yaml
+    parameters:
+      node_id: 1
+      job_name: win_dotnet_tests_1
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
+
+  - template: yaml-templates\run-msbuild-win-tests.yaml
+    parameters:
+      node_id: 2
+      job_name: win_dotnet_tests_2
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
+
+  - template: yaml-templates\run-msbuild-win-tests.yaml
+    parameters:
+      node_id: 3
+      job_name: win_dotnet_tests_3
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      nunit_extra: --testparam dotnet=true
 
 - stage: integrated_regression_test
   displayName: Regression Tests

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -2,10 +2,15 @@
 
 parameters:
   node_id: 0
+  job_name: ''
+  job_suffix: ''
+  nunit_categories: ''
+  nunit_extra: ''
+  run_extra_tests: false
 
 jobs:
-  - job: mac_msbuild_tests${{ parameters.node_id }}
-    displayName: MSBuild - Mac-${{ parameters.node_id }}
+  - job: ${{ parameters.job_name }}
+    displayName: MSBuild - Mac-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
     pool: $(HostedMac)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
@@ -26,13 +31,13 @@ jobs:
 
     - template: run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - macOS-${{ parameters.node_id }}
+        testRunTitle: Xamarin.Android.Build.Tests - macOS-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-        nunitConsoleExtraArgs: --where "cat == Node-${{ parameters.node_id }}"
-        testResultsFile: TestResult-MSBuildTests-macOS-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
+        nunitConsoleExtraArgs: --where "cat == Node-${{ parameters.node_id }} ${{ parameters.nunit_categories }}" ${{ parameters.nunit_extra }}
+        testResultsFile: TestResult-MSBuildTests-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 
     # Only run these tests on node 2
-    - ${{ if eq(parameters.node_id, 2) }}:
+    - ${{ if eq(parameters.run_extra_tests, true) }}:
       - template: run-nunit-tests.yaml
         parameters:
           testRunTitle: Xamarin.Android.Build.Tests.Commercial - macOS
@@ -46,15 +51,8 @@ jobs:
           nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
           testResultsFile: TestResult-MSBuildTests-macOS-NoNode-$(XA.Build.Configuration).xml
 
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: Xamarin.Android.Build.Tests - macOS - One .NET
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-          nunitConsoleExtraArgs: --where "cat == dotnet" --params dotnet=true
-          testResultsFile: TestResult-MSBuildTests-macOS-dotnet-$(XA.Build.Configuration).xml
-
     - template: upload-results.yaml
       parameters:
-        artifactName: Test Results - MSBuild - Mac-${{ parameters.node_id }}
+        artifactName: Test Results - MSBuild - Mac-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
 
     - template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -2,10 +2,15 @@
 
 parameters:
   node_id: 0
+  job_name: ''
+  job_suffix: ''
+  nunit_categories: ''
+  nunit_extra: ''
+  run_extra_tests: false
 
 jobs:
-  - job: win_msbuild_tests${{ parameters.node_id }}
-    displayName: MSBuild - Windows-${{ parameters.node_id }}
+  - job: ${{ parameters.job_name }}
+    displayName: MSBuild - Windows-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
@@ -37,13 +42,13 @@ jobs:
     # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
     - template: run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Windows-${{ parameters.node_id }}
+        testRunTitle: Xamarin.Android.Build.Tests - Windows-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
-        nunitConsoleExtraArgs: --workers=4 --where "cat == Node-${{ parameters.node_id }}"
-        testResultsFile: TestResult-MSBuildTests-Windows-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
+        nunitConsoleExtraArgs: --workers=4 --where "cat == Node-${{ parameters.node_id }} ${{ parameters.nunit_categories }}" ${{ parameters.nunit_extra }}
+        testResultsFile: TestResult-MSBuildTests-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 
     # Only run these tests on node 2
-    - ${{ if eq(parameters.node_id, 2) }}:
+    - ${{ if eq(parameters.run_extra_tests, true) }}:
       - template: run-nunit-tests.yaml
         parameters:
           testRunTitle: Xamarin.Android.Build.Tests.Commercial - Windows
@@ -55,17 +60,10 @@ jobs:
           testRunTitle: Xamarin.Android.Build.Tests - Windows - No Node
           testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
           nunitConsoleExtraArgs: --workers=4 --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
-          testResultsFile: TestResult-MSBuildTests-Windows-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
-
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: Xamarin.Android.Build.Tests - Windows - One .NET
-          testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
-          nunitConsoleExtraArgs: --workers=4 --where "cat == dotnet" --params dotnet=true
-          testResultsFile: TestResult-MSBuildTests-Windows-dotnet-$(XA.Build.Configuration).xml
+          testResultsFile: TestResult-MSBuildTests-Windows-NoNode-$(XA.Build.Configuration).xml
 
     - template: upload-results.yaml
       parameters:
-        artifactName: Test Results - MSBuild - Windows-${{ parameters.node_id }}
+        artifactName: Test Results - MSBuild - Windows-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
 
     - template: fail-on-issue.yaml

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -13,6 +13,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[Category ("Node-2")]
+	[Category ("StaticProject")] // TODO: enable for .NET 5
 	[Parallelizable (ParallelScope.Children)]
 	public class CodeBehindTests
 	{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
@@ -18,6 +18,7 @@ using Xamarin.Tools.Zip;
 namespace Xamarin.Android.Build.Tests
 {
 	[Category ("Node-2")]
+	[Category ("StaticProject")] // TODO: enable for .NET 5
 	[Parallelizable (ParallelScope.Children)]
 	public class EmbeddedDSOTests : BaseTest
 	{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -142,6 +142,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("MonoSymbolicate")]
 		public void CheckBuildIdIsUnique ([Values ("apk", "aab")] string packageFormat)
 		{
 			const string supportedAbis = "armeabi-v7a;x86";
@@ -234,6 +235,7 @@ namespace Xamarin.Android.Build.Tests
 		};
 
 		[Test]
+		[Category ("DotNetIgnore")] // .NET 5+ does not use these native libraries
 		[TestCaseSource (nameof (TlsProviderTestCases))]
 		public void BuildWithTlsProvider (string androidTlsProvider, bool isRelease, bool expected)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -179,11 +179,13 @@ namespace Lib
 
 			var app1 = new XamarinAndroidApplicationProject () {
 				ProjectName = "App1",
+				PackageName = "com.companyname.App1",
 				OutputPath = Path.Combine("..","bin","Debug"),
 			};
 			sb.Projects.Add (app1);
 			var app2 = new XamarinAndroidApplicationProject () {
 				ProjectName = "App2",
+				PackageName = "com.companyname.App2",
 				OutputPath = Path.Combine("..","bin","Debug"),
 			};
 			sb.Projects.Add (app2);
@@ -886,6 +888,7 @@ namespace Lib2
 #pragma warning restore 414
 
 		[Test]
+		[Category ("AOT")]
 		[TestCaseSource (nameof (AotChecks))]
 		public void BuildIncrementalAot (string supportedAbis, string androidAotMode, bool aotAssemblies, bool expectedResult)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MSBuildSdkExtrasTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MSBuildSdkExtrasTests.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[NonParallelizable] // On MacOS, parallel /restore causes issues
-	[Category ("Node-3")]
+	[Category ("Node-3"), Category ("DotNetIgnore")] // Uses MSBuild.Sdk.Extras
 	public class MSBuildSdkExtrasTests : BaseTest
 	{
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
@@ -16,7 +16,7 @@ using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Category ("Node-2")]
+	[Category ("Node-2"), Category ("MkBundle"), Category ("StaticProject")]
 	[Parallelizable (ParallelScope.Children)]
 	public class MakeBundleTests
 	{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -585,6 +585,7 @@ namespace Bug12935
 		}
 
 		[Test]
+		[Category ("LibraryProjectZip")]
 		public void MergeLibraryManifest ()
 		{
 			byte [] classesJar;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -467,6 +467,17 @@ namespace Xamarin.Android.Build.Tests
 			return GetPathToLatestBuildTools (exe);
 		}
 
+		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project)
+		{
+			string path;
+			if (Builder.UseDotNet) {
+				path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
+			} else {
+				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
+			}
+			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
+		}
+
 		[SetUp]
 		public void TestSetup ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[NonParallelizable] // On MacOS, parallel /restore causes issues
-	[Category ("Node-2")]
+	[Category ("Node-2"), Category ("DotNetIgnore")] // These don't need to run under `--params dotnet=true`
 	public class XASdkTests : BaseTest
 	{
 		[Test]

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -13,7 +13,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[NonParallelizable]
-	[Category ("UsesDevices")]
+	[Category ("UsesDevices"), Category ("DotNetIgnore")] // These don't need to run under `--params dotnet=true`
 	public class XASdkDeployTests : DeviceTest
 	{
 		[Test]


### PR DESCRIPTION
This will enable all MSBuild tests in
`Xamarin.Android.Build.Tests.dll` except for the new categories:
`DotNetIgnore`, `AOT`, `FSharp`, `LibraryProjectZip`, `MkBundle`,
`MonoSymbolicate`, `PackagesConfig`, and `StaticProject`.

Reasoning:

* `AOT` - need Mono AOT support in .NET 5.
* `FSharp` - [Xamarin.Android.FSharp.ResourceProvider][0] support
  needed on .NET 5.
* `LibraryProjectZip` - will need future support in Xamarin.Android.
* `MkBundle` - may not ever come to .NET 5.
* `MonoSymbolicate` - need symbolication support in .NET 5.
* `PackagesConfig` - n/a for .NET 5.
* `StaticProject` a few tests that were migrated to
  `Xamarin.Android.Build.Tests` in d447aa66 are ignored for now.

This also reworks our build pipeline to run the MSBuild tests across 12
CI machines:

* Windows - Node 1 - Legacy
* Windows - Node 2 - Legacy
* Windows - Node 3 - Legacy
* Windows - Node 1 - One .NET
* Windows - Node 2 - One .NET
* Windows - Node 3 - One .NET
* macOS - Node 1 - Legacy
* macOS - Node 2 - Legacy
* macOS - Node 3 - Legacy
* macOS - Node 1 - One .NET
* macOS - Node 2 - One .NET
* macOS - Node 3 - One .NET

Since this is a lot of machines:

1. I moved all the `One .NET` tests to their own phase.
2. The phase only runs when `RunAllTests=true`. This means the `One .NET` tests will run on master, release branches, and Mono bumps. You can manually queue a build to enable `RunAllTests` on a PR.

To be completed in another PR, there are still more test assemblies
that need to be run under a `dotnet` context:

* `Xamarin.Android.Build.Tests.Commercial.dll`
* `MSBuildDeviceIntegration.dll`

[0]: https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider