### PR TITLE
Bump to xamarin/Java.Interop/master@1de5501b

### DIFF
--- a/Documentation/release-notes/4823.md
+++ b/Documentation/release-notes/4823.md
@@ -1,0 +1,19 @@
+#### Application behavior on device and emulator
+
+  * [GitHub 661](https://github.com/xamarin/java.interop/issues/661):
+    Fixes a `TypeLoadException` that could result when an app is built
+    with the API-R preview bindings, `$(TargetFrameworkVersion)`=v10.0.99,
+    when instantiating a type which implements an interface which contains
+    default interface members.
+
+#### Application and library build and deployment
+
+  * [GitHub 515](https://github.com/xamarin/java.interop/issues/515):
+    Allow `.csv` files to declare C# enumeration members without requiring
+    a corresponding Java field.
+
+#### Android API binding
+
+  * [GitHub 588](https://github.com/xamarin/java.interop/issues/588):
+    Don't invalidate an interface binding if it contains a static method
+    that couldn't be bound.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -192,7 +192,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\LineEditor.dll"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />


### PR DESCRIPTION
Changes: https://github.com/xamarin/Java.Interop/compare/b00e644e0d701114a6a1325c0b2ffe7a431e3d48...1de5501b2d49df3d8d3b187df026d611996a67da

  * xamarin/Java.Interop@1de5501: [CI] Add an "macOS .NET Core" build (#655)
  * xamarin/Java.Interop@9a56465: [generator] Use proper syntax for nested classes for DIM invokers (#662)
  * xamarin/Java.Interop@267c3f3: [generator] Support XML defined enums with no JNI info (#659)
  * xamarin/Java.Interop@5dcf896: [generator] Don't invalidate interface if static method is invalidated (#660)
  * xamarin/Java.Interop@1b59dcc: [java-interop] Update to SDK style project (#657)
  * xamarin/Java.Interop@b136ac9: [param-name-importer] Bump to Microsoft.Xml.SgmlReader 1.8.16 (#656)
  * xamarin/Java.Interop@eb39a3a: Bump to xamarin/xamarin-android-tools/master@3974fc38 (#658)
  * xamarin/Java.Interop@a99b451: [logcat-parse] Update to Mono.Terminal 5.4.0 (#654)
  * xamarin/Java.Interop@425f79d: [Java.Interop] Fix C# warnings (#652)
  * xamarin/Java.Interop@2e0f55d: [Java.Interop.Tools.Generator] Specify $(OutputPath) (#650)
  * xamarin/Java.Interop@4b266fa: [Xamarin.Android.Tools.Bytecode] Support @JvmOverloads (#651)