### PR TITLE
Bump to xamarin/Java.Interop/d16-7@1f3388af

### DIFF
--- a/Documentation/release-notes/4823.md
+++ b/Documentation/release-notes/4823.md
@@ -1,0 +1,19 @@
+#### Application behavior on device and emulator
+
+  * [GitHub 661](https://github.com/xamarin/java.interop/issues/661):
+    Fixes a `TypeLoadException` that could result when an app is built
+    with the API-R preview bindings, `$(TargetFrameworkVersion)`=v10.0.99,
+    when instantiating a type which implements an interface which contains
+    default interface members.
+
+#### Application and library build and deployment
+
+  * [GitHub 515](https://github.com/xamarin/java.interop/issues/515):
+    Allow `.csv` files to declare C# enumeration members without requiring
+    a corresponding Java field.
+
+#### Android API binding
+
+  * [GitHub 588](https://github.com/xamarin/java.interop/issues/588):
+    Don't invalidate an interface binding if it contains a static method
+    that couldn't be bound.


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/76d1ac70ec740e1118678525b2e07f53ef53b622...1f3388af4897e6d8aca0e41c86ff02fa0ef4e67e

  * xamarin/Java.Interop@1f3388a: [generator] Use proper syntax for nested classes for DIM invokers (#662)
  * xamarin/Java.Interop@5e23163: [generator] Support XML defined enums with no JNI info (#659)
  * xamarin/Java.Interop@5c4581d: [generator] Don't invalidate interface if static method is invalidated (#660)
  * xamarin/Java.Interop@9687bb5: Bump to xamarin/xamarin-android-tools/d16-7@017078f2 (#658)
  * xamarin/Java.Interop@abfade5: [Java.Interop] Fix C# warnings (#652)
  * xamarin/Java.Interop@fb6d5f9: [Java.Interop.Tools.Generator] Specify $(OutputPath) (#650)
  * xamarin/Java.Interop@a3f148c: [Xamarin.Android.Tools.Bytecode] Support @JvmOverloads (#651)