### PR TITLE
[Xamarin.Android.Build.Tasks] Don't create NOTICE in App packages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/NOTICE.txt
+++ b/src/Xamarin.Android.Build.Tasks/Resources/NOTICE.txt
@@ -1,4 +1,0 @@
-Xamarin built applications contain open source software.
-For detailed attribution and licensing notices, please visit:
-
-	http://xamarin.com/mobile-licensing

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -132,7 +132,6 @@ namespace Xamarin.Android.Tasks
 				File.Copy (apkInputPath, apkOutputPath, overwrite: true);
 				refresh = false;
 			}
-			using (var notice = Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"))
 			using (var apk = new ZipArchiveEx (apkOutputPath, File.Exists (apkOutputPath) ? FileMode.Open : FileMode.Create )) {
 				if (refresh) {
 					for (long i = 0; i < apk.Archive.EntryCount; i++) {
@@ -172,10 +171,6 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				apk.FixupWindowsPathSeparators ((a, b) => Log.LogDebugMessage ($"Fixing up malformed entry `{a}` -> `{b}`"));
-				string noticeName = RootPath + "NOTICE";
-				existingEntries.Remove (noticeName);
-				if (!apk.Archive.ContainsEntry (noticeName))
-					apk.Archive.AddEntry (noticeName, notice);
 
 				// Add classes.dx
 				foreach (var dex in DalvikClasses) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -153,7 +153,6 @@ namespace Xamarin.Android.Build.Tests
 				"root/assemblies/Localization.dll",
 				"root/assemblies/es/Localization.resources.dll",
 				"root/assemblies/UnnamedProject.dll",
-				"root/NOTICE",
 				//These are random files from Google Play Services .jar/.aar files
 				"root/build-data.properties",
 				"root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt",
@@ -206,7 +205,6 @@ namespace Xamarin.Android.Build.Tests
 				"base/root/assemblies/Localization.dll",
 				"base/root/assemblies/es/Localization.resources.dll",
 				"base/root/assemblies/UnnamedProject.dll",
-				"base/root/NOTICE",
 				"BundleConfig.pb",
 				//These are random files from Google Play Services .jar/.aar files
 				"base/root/build-data.properties",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -360,9 +360,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\NOTICE.txt">
-      <LogicalName>NOTICE.txt</LogicalName>
-    </EmbeddedResource>
     <EmbeddedResource Include="Resources\machine.config">
       <LogicalName>machine.config</LogicalName>
     </EmbeddedResource>

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
@@ -727,9 +727,6 @@
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
     },
-    "NOTICE": {
-      "Size": 157
-    },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
     },

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
@@ -163,9 +163,6 @@
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 308
     },
-    "NOTICE": {
-      "Size": 157
-    },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
     },

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
@@ -727,9 +727,6 @@
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
     },
-    "NOTICE": {
-      "Size": 157
-    },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
     },

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
@@ -349,9 +349,6 @@
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
     },
-    "NOTICE": {
-      "Size": 157
-    },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
     },


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/issues/8849
Context: https://github.com/xamarin/xamarin-macios/pull/8857

Long ago it was decided that all created `.apk` and `.aab` packages
should contain a `NOTICE` file, which stated:

> Xamarin built applications contain open source software.
> For detailed attribution and licensing notices, please visit:
>
> 	http://xamarin.com/mobile-licensing

In the meantime, the world has moved on, and the above URL has
bitrotten, and is thus meaningless.

Additionally, we have gotten updated guidance that we don't need to
emit such a file anymore.

Instead of fixing the above URL, remove the `NOTICE` file.
This will be less work for everyone. 😏

If one *really* wants to know what 3rd party open-source software is
being redistributed, please see the installed `ThirdPartyNotices.txt`:

  * macOS:

        /Library/Frameworks/Xamarin.Android.framework/Versions/Current/ThirdPartyNotices.txt

  * Windows, Visual Studio 2019:

        %ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\Xamarin\Xamarin.Android.Sdk

See also, but not only:

  * 2bd13c4a: What is `ThirdPartyNotices.txt`, and how do we deal with it?
  * 310e8c89: Adds `ThirdPartyNotices.txt` to macOS install
  * 9302d514: Replace 2bd13c4a infrastructure; `xaprepare` is
    responsible for creating the `ThirdPartyNotices.txt` files.