### PR TITLE
[xaprepare] Nuke $(AndroidToolchainDirectory)/jdk if found

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -338,6 +338,7 @@ namespace Xamarin.Android.Prepare
 			public static string Mingw64CmakePath                    => GetCachedPath (ref mingw64CmakePath, ()                    => Path.Combine (BuildBinDir, "mingw-64.cmake"));
 
 			// JetBrains OpenJDK
+			public static string OldOpenJDKInstallDir                => GetCachedPath (ref oldOpenJDKInstallDir, ()                => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk"));
 			public static string OpenJDK8InstallDir                  => GetCachedPath (ref openJDK8InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-1.8"));
 			public static string OpenJDK8CacheDir                    => GetCachedPath (ref openJDK8CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
 
@@ -430,6 +431,7 @@ namespace Xamarin.Android.Prepare
 			static string? monoLlvmTpnPath;
 			static string? openJDK8InstallDir,  openJDK11InstallDir;
 			static string? openJDK8CacheDir,    openJDK11CacheDir;
+			static string? oldOpenJDKInstallDir;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.cs
@@ -38,6 +38,11 @@ namespace Xamarin.Android.Prepare
 
 		protected override async Task<bool> Execute (Context context)
 		{
+			if (Directory.Exists (Configurables.Paths.OldOpenJDKInstallDir)) {
+				Log.DebugLine ($"Found old OpenJDK directory at {Configurables.Paths.OldOpenJDKInstallDir}, removing");
+				Utilities.DeleteDirectorySilent (Configurables.Paths.OldOpenJDKInstallDir);
+			}
+
 			string jdkInstallDir = JdkInstallDir;
 			if (OpenJDKExistsAndIsValid (jdkInstallDir, out string installedVersion)) {
 				Log.Status ($"{ProductName} version ");


### PR DESCRIPTION
Now that we install JetBrains OpenJDK in two, versioned, directories, it
makes sense to get rid of the old Corretto directory if found so that
we're sure we always use one of the JetBrains OpenJDK versions.