### PR TITLE
[Xamarin.ProjectTools] use Directory.Build.props for $(Configuration)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
@@ -47,4 +47,13 @@ This file contains the .NET 5-specific targets to customize ILLink
       DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink"
   />
 
+  <Target Name="_TouchAndroidLinkFlag"
+      AfterTargets="ILLink"
+      Condition=" '$(PublishTrimmed)' == 'true' and Exists('$(_LinkSemaphore)') "
+      Inputs="$(_LinkSemaphore)"
+      Outputs="$(_AndroidLinkFlag)">
+    <!-- This file is an input for _RemoveRegisterAttribute -->
+    <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
+  </Target>
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -4,6 +4,20 @@ namespace Xamarin.ProjectTools
 {
 	public static class KnownPackages
 	{
+		/// <summary>
+		/// Adds additional dependencies for Xamarin.Forms, support libraries, etc. on .NET 5+
+		/// to workaround the issue similar to https://github.com/mono/linker/issues/1139
+		/// </summary>
+		public static void AddDotNetCompatPackages (this IShortFormProject project)
+		{
+			project.PackageReferences.Add (SystemCodeDom_5_0_0_preview_3_20214_6);
+			project.PackageReferences.Add (SystemDiagnosticsEventLog_5_0_0_preview_3_20214_6);
+			project.PackageReferences.Add (SystemDiagnosticsPerformanceCounter_5_0_0_preview_3_20214_6);
+			project.PackageReferences.Add (SystemIOPorts_5_0_0_preview_3_20214_6);
+			project.PackageReferences.Add (SystemSecurityPermissions_5_0_0_preview_3_20214_6);
+			project.PackageReferences.Add (SystemThreadingAccessControl_5_0_0_preview_3_20214_6);
+		}
+
 		public static Package AndroidSupportV4_27_0_2_1 = new Package () {
 			Id = "Xamarin.Android.Support.v4",
 			Version = "27.0.2.1",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
@@ -6,6 +6,7 @@ namespace Xamarin.ProjectTools
 	{
 		public const string LinkAssembliesNoShrink = "_LinkAssembliesNoShrink";
 
-		public static string LinkAssembliesShrink => Builder.UseDotNet ? "ILLink" : "_LinkAssembliesShrink";
+		// _RunILLink is found at: https://github.com/dotnet/sdk/blob/1ed51bc8f9cb06760c5b2f26798ee0278bd75f54/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L69-L72
+		public static string LinkAssembliesShrink => Builder.UseDotNet ? "_RunILLink" : "_LinkAssembliesShrink";
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -69,8 +69,6 @@ namespace Xamarin.ProjectTools
 
 		protected override bool SetExtraNuGetConfigSources => true;
 
-		public string Configuration => IsRelease ? "Release" : "Debug";
-
 		public string OutputPath => Path.Combine ("bin", Configuration, TargetFramework.ToLowerInvariant ());
 
 		public string IntermediateOutputPath => Path.Combine ("obj", Configuration, TargetFramework.ToLowerInvariant ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
@@ -51,7 +51,7 @@ namespace Xamarin.ProjectTools
 			foreach (var import in Imports) {
 				var projectName = import.Project ();
 				if (projectName != "Directory.Build.props" && projectName != "Directory.Build.targets")
-					root.AddImport (import.Project ());
+					root.AddImport (projectName);
 			}
 			return root;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -76,8 +76,11 @@ namespace Xamarin.ProjectTools
 		{
 			var root = base.Construct ();
 			root.AddImport (XamarinAndroidLanguage.NormalProjectImport);
-			foreach (var import in Imports)
-				root.AddImport (import.Project ());
+			foreach (var import in Imports) {
+				var projectName = import.Project ();
+				if (projectName != "Directory.Build.props" && projectName != "Directory.Build.targets")
+					root.AddImport (projectName);
+			}
 			return root;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -40,8 +40,12 @@ namespace Xamarin.ProjectTools
 		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			//NOTE: we can get all the other dependencies transitively, yay!
-			PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
+			if (Builder.UseDotNet) {
+				PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
+				this.AddDotNetCompatPackages ();
+			} else {
+				PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
+			}
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
 				TextContent = () => colors_xml,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
@@ -44,14 +44,7 @@ namespace Xamarin.ProjectTools
 			: base (outputType)
 		{
 			PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
-			// additional deps for XForms on NET5
-			// to workaround the issue similar to https://github.com/mono/linker/issues/1139
-			PackageReferences.Add (KnownPackages.SystemCodeDom_5_0_0_preview_3_20214_6);
-			PackageReferences.Add (KnownPackages.SystemDiagnosticsEventLog_5_0_0_preview_3_20214_6);
-			PackageReferences.Add (KnownPackages.SystemDiagnosticsPerformanceCounter_5_0_0_preview_3_20214_6);
-			PackageReferences.Add (KnownPackages.SystemIOPorts_5_0_0_preview_3_20214_6);
-			PackageReferences.Add (KnownPackages.SystemSecurityPermissions_5_0_0_preview_3_20214_6);
-			PackageReferences.Add (KnownPackages.SystemThreadingAccessControl_5_0_0_preview_3_20214_6);
+			this.AddDotNetCompatPackages ();
 
 			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
 			Imports.Add (new Import (() => "Directory.Build.targets") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -22,7 +22,6 @@ namespace Xamarin.ProjectTools
 			ItemGroupList.Add (OtherBuildItems);
 			ItemGroupList.Add (Sources);
 
-			SetProperty (KnownProperties.Configuration, debugConfigurationName, "'$(Configuration)' == ''");
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
 


### PR DESCRIPTION
When running `dotnet build` and setting `IsRelease=true` in our
MSBuild tests, the current MSBuild tests generate `.csproj` files such
as:

    <Project Sdk="Microsoft.Android.Sdk">
      <PropertyGroup>
        <Configuration>Release</Configuration>

The problem with this is how the ordering of imports work in SDK-style
projects:

1. Any `Directory.Build.props` are imported.
2. The SDK targets are imported, such as:

https://github.com/dotnet/sdk/blob/b7c7f33aa44b23dc1f984a9a1162ee2d57439897/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L39-L45

3. The `.csproj` is imported.

The result, is even though `Configuration=Release` in this project,
some defaults are set such as `Optimize=False` and `DebugSymbols=True`.

This works for legacy projects because
`Xamarin.Android.CSharp.targets` is imported at the bottom of
`.csproj` files. `Directory.Build.props` is imported after the user's
`.csproj` file.

To fix this:

* If `Builder.UseDotNet` is `true`, set `$(Configuration)` in a
  `Directory.Build.props`.
* "legacy" projects continue the old way.

To make everything work, I had to make changes to
`Xamarin.ProjectTools`. `IsRelease` is now just a plain C# property
instead of calling `SetProperty("Configuration", value)`.

Once `Release` builds were working, a couple tests were really broken
under `dotnet build`:

* `_RemoveRegisterAttribute` was running on every `Release` build. I
  had to make a new target to touch `$(_AndroidLinkFlag)` when
  `ILLink` runs. Due to the way the nested `<MSBuild/>` can run
  `ILLink` multiple times, I think we have to do it this way.
* Several tests needed the workaround for:
  https://github.com/mono/linker/issues/1139
  I moved this to an extension method.
* I needed to update the version of Xamarin.Forms in
  `XamarinFormsAndroidApplicationProject`.
* I needed one exception for `CheckTimestamps(False)`, as `ILLink`
  will output some assemblies with older timestamps. This is probably
  not a problem at all for `Release` builds.

Other changes:

* We don't need a `Condition` when setting `$(Configuration)`, as it
  is the very first property evaluated.
* Fixed how `Directory.Build.props` and `Directory.Build.targets` are
  handled when saving `.csproj` files.
* Added one test to the `dotnet` category that verifies a `Release`
  build works along with a `<ProjectReference/>`.
* Fixed an NRE that could occur when using `<Import/>`.