### PR TITLE
[build, win] Display (log) VS and MSBuild installation details for win_build_test stage

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -271,7 +271,7 @@ stages:
       displayName: downgrade XA to stable
       ignoreLASTEXITCODE: true
 
-    - template: environment/win/vs-msbuild.v1.yml@yaml   # VS installations with associated MSBuild locations
+    - template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Prepare

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -271,6 +271,8 @@ stages:
       displayName: downgrade XA to stable
       ignoreLASTEXITCODE: true
 
+    - template: environment/win/vs-msbuild.v1.yml@yaml   # VS installations with associated MSBuild locations
+
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Prepare
       inputs:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -17,6 +17,8 @@ jobs:
 
     - template: clean.yaml
 
+    - template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
+
     - template: setup-test-environment.yaml
       parameters:
         provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)" -f


### PR DESCRIPTION
There have been a few issues involving Android builds on Windows involving problems with the VS installation or an incorrect (older) version of MSBuild being invoked. This build step provides visibility into the VS and MSBuild installations installed on the windows build agent. It utilizes `vswhere` as a means to enumerate and obtain the VS installations on the agent. Additionally, the template being called leverages code from the MSBuild task to locate the version of MSBuild that will be used.