### PR TITLE
[Xamarin.Android.Build.Tasks] don't delete ILMerge'd assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -363,7 +363,6 @@
       Command="&quot;$(ILRepack)&quot; $(_ILRepackArgs)"
       WorkingDirectory="$(OutputPath)"
     />
-    <Delete Files="@(_InputAssembliesThatExist)" />
     <Touch
       Files="$(IntermediateOutputPath)ILRepacker.stamp"
       AlwaysCreate="True"


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/1101
Context: https://build.azdo.io/3823945

The monodroid build is failing with:

    create-pkg.targets(34,5): error MSB3030: Could not copy the file "/Users/builder/azdo/_work/2/s/external/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/System.Collections.Immutable.dll" because it was not found.
        0 Warning(s)
        1 Error(s)

We added this file to `create-installers.targets` in 2f677ef, because
it is needed for the new "delta install" support.

However, there is an issue depending on the ordering of how things are
built. If `Xamarin.Android.Build.Tasks.csproj` is built *last*, it
will `ILMerge `this assembly and delete it.

Let's not delete the ILMerge'd assemblies. This may solve the problem.