### PR TITLE
[tests] update and consolidate NUnit packages

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@6e43a20ebaa2cd59532e130ef64585c5829e3373
+xamarin/monodroid:master@82bea9c6b963cb855a6e01775084182ab45cf9ac
 mono/mono:2020-02@83105ba22461455f4343d6bb14976eba8b0b3f39

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Launch",
             "type": "mono",
             "request": "launch",
-            "program": "${workspaceRoot}packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe ${workspaceRoot}bin/TestDebug/Xamarin.Android.Build.Tests.dll",
+            "program": "${workspaceRoot}packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe ${workspaceRoot}bin/TestDebug/Xamarin.Android.Build.Tests.dll",
             "cwd": "${workspaceRoot}bin/TestDebug/"
         },
         {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "nxunitExplorer.nunit": "packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe",
+    "nxunitExplorer.nunit": "packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe",
     "nxunitExplorer.modules": [
         "bin/TestDebug/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll",
         "bin/TestDebug/Xamarin.Android.Build.Tests.dll",

--- a/Configuration.props
+++ b/Configuration.props
@@ -196,8 +196,9 @@
 
   <!-- Unit Test Properties -->
   <PropertyGroup>
+    <NUnitConsoleVersion Condition=" '$(NUnitConsoleVersion)' == '' ">3.11.1</NUnitConsoleVersion>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime) $(ManagedRuntimeArgs)</_Runtime>
-    <_NUnit>$(_Runtime) $(XAPackagesDir)\nunit.consolerunner\3.9.0\tools\nunit3-console.exe</_NUnit>
+    <_NUnit>$(_Runtime) $(XAPackagesDir)\nunit.consolerunner\$(NUnitConsoleVersion)\tools\nunit3-console.exe</_NUnit>
   </PropertyGroup>
 
   <!-- Fix for IDEs -->

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -49,7 +49,7 @@ variables:
   NuGetArtifactName: nupkgs
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
-  NUnitConsoleVersion: 3.9.0
+  NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
   DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3

--- a/build-tools/scripts/NUnitReferences.projitems
+++ b/build-tools/scripts/NUnitReferences.projitems
@@ -1,0 +1,8 @@
+<Project>
+  <!-- This file assumes Configuration.props has been imported -->
+  <ItemGroup>
+    <PackageReference Include="NUnit"               Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="$(NUnitConsoleVersion)" />
+    <PackageReference Include="NUnit3TestAdapter"   Version="3.16.1" />
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -9,17 +9,12 @@
 
   <Import Project="..\..\..\..\Configuration.props" />
   <Import Project="..\..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
+  <Import Project="..\..\..\..\build-tools\scripts\NUnitReferences.projitems" />
 
   <ItemGroup>
     <Reference Include="Xamarin.Android.Cecil">
       <HintPath>..\..\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Cecil.dll</HintPath>
     </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
+++ b/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
@@ -8,10 +8,7 @@
 
   <Import Project="..\..\..\Configuration.props" />
   <Import Project="..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
-  </ItemGroup>
+  <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj" />

--- a/tests/CodeBehind/UnitTests/run.sh
+++ b/tests/CodeBehind/UnitTests/run.sh
@@ -4,4 +4,4 @@ export USE_MSBUILD=1
 export MSBUILD=msbuild
 msbuild CodeBehindUnitTests.csproj
 cd ../../../
-exec mono --debug packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll
+exec mono --debug packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -9,10 +9,7 @@
 
   <Import Project="..\..\..\Configuration.props" />
   <Import Project="..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
-  </ItemGroup>
+  <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj" />

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -10,6 +10,7 @@
 
   <Import Project="..\..\..\Configuration.props" />
   <Import Project="..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
+  <Import Project="..\..\..\build-tools\scripts\NUnitReferences.projitems" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
 
   <ItemGroup>
@@ -29,10 +30,6 @@
        <Link>XABuildConfig.cs</Link>
     </Compile>
     <Compile Include="..\..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\EnvironmentHelper.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
@@ -5,4 +5,4 @@ export MSBUILD=msbuild
 CONFIGURATION=${1:-Debug}
 msbuild /p:Configuration=${CONFIGURATION} EmbeddedDSO-UnitTests.csproj
 cd ../../../
-exec mono --debug packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe bin/Test${CONFIGURATION}/EmbeddedDSOUnitTests.dll
+exec mono --debug packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe bin/Test${CONFIGURATION}/EmbeddedDSOUnitTests.dll

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -10,6 +10,7 @@
 
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
+  <Import Project="..\..\build-tools\scripts\NUnitReferences.projitems" />
 
   <ItemGroup>
     <Compile Include="..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\DeviceTest.cs">
@@ -25,8 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.5" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to:

* NUnit 3.12.0
* NUnit.ConsoleRunner 3.11.1
* NUnit3TestAdapter 3.16.1

These are all different numbers, but these are the latest stable
versions on nuget.org.

I also went ahead and consolidated all NUnit `@(PackageReference)` to
a `NUnitReferences.projitems` file. This way we can list the versions
for all NUnit packages in one MSBuild file.

NUnit.ConsoleRunner was still listed in a few other files we will have
to manually update.

Bump to xamarin/monodroid/master@82bea9c6

Changes: https://github.com/xamarin/monodroid/compare/6e43a20e...82bea9c6