### PR TITLE
Bump to xamarin/java.interop/jcw-interfaces@05f41ebd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = master
+    branch = jcw-interfaces
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -378,5 +378,12 @@ namespace Xamarin.Android.JcwGenTests {
 			}
 		}
 	}
+
+	public class JI590 : Java.Lang.Object, IInvokeMyRunnable {
+		public void Invoke (global::Java.Lang.Object p0)
+		{
+			p0.JavaCast<Java.Lang.IRunnable> ().Run ();
+		}
+	}
 }
 

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
@@ -100,6 +100,12 @@
     <TestJarEntry Include="java\com\xamarin\android\Gxa4098.java">
       <OutputFile>Jars/xamarin-test.jar</OutputFile>
     </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\InvokeRunnable.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\InvokeMyRunnable.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
     <TestJarEntry Include="java\com\xamarin\android\Logger.java">
       <OutputFile>Jars/xamarin-test.jar</OutputFile>
     </TestJarEntry>
@@ -107,6 +113,9 @@
       <OutputFile>Jars/xamarin-test.jar</OutputFile>
     </TestJarEntry>
     <TestJarEntry Include="java\com\xamarin\android\MyCanvas.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\MyRunnable.java">
       <OutputFile>Jars/xamarin-test.jar</OutputFile>
     </TestJarEntry>
     <TestJarEntry Include="java\com\xamarin\android\Timing.java">

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/InvokeMyRunnable.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/InvokeMyRunnable.java
@@ -1,0 +1,4 @@
+package com.xamarin.android;
+
+public interface InvokeMyRunnable extends InvokeRunnable<MyRunnable> {
+}

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/InvokeRunnable.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/InvokeRunnable.java
@@ -1,0 +1,5 @@
+package com.xamarin.android;
+
+public interface InvokeRunnable<T extends Runnable> {
+    void invoke (T runnable);
+}

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/MyRunnable.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/MyRunnable.java
@@ -1,0 +1,6 @@
+package com.xamarin.android;
+
+public final class MyRunnable implements Runnable {
+    public void run() {
+    }
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/590

Without the Java.Interop bump, fails with:

    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(4,8): javac error JAVAC0000:  error: JI590 is not abstract and does not override abstract method invoke(MyRunnable) in InvokeRunnable [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]
    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(4,8): javac error JAVAC0000: public class JI590 [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]
    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(4,8): javac error JAVAC0000:  [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]
    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(29,14): javac error JAVAC0000:  error: name clash: invoke(Runnable) in JI590 and invoke(MyRunnable) in InvokeRunnable have the same erasure, yet neither overrides the other [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]
    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(29,14): javac error JAVAC0000: 	public void invoke (java.lang.Runnable p0) [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]
    obj/Debug/android/src/crc64eadbb4d7d7a577cd/JI590.java(29,14): javac error JAVAC0000:  [/Volumes/Xamarin-Work/xamarin-android/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj]