### PR TITLE
[Mono.Android] Only log *actual* unhandled exceptions

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -114,9 +114,6 @@ namespace Android.Runtime {
 
 		internal static void UnhandledException (Exception e)
 		{
-			Logger.Log (LogLevel.Info, "MonoDroid", "UNHANDLED EXCEPTION:");
-			Logger.Log (LogLevel.Info, "MonoDroid", e.ToString ());
-
 			var info = new RaiseThrowableEventArgs (e);
 			bool handled = false;
 			foreach (EventHandler<RaiseThrowableEventArgs> handler in GetUnhandledExceptionRaiserInvocationList ()) {

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -284,6 +284,9 @@ namespace Android.Runtime {
 				Exception? innerException = jltp?.InnerException;
 				var args  = new UnhandledExceptionEventArgs (innerException ?? javaException, isTerminating: true);
 
+				Logger.Log (LogLevel.Info, "MonoDroid", "UNHANDLED EXCEPTION:");
+				Logger.Log (LogLevel.Info, "MonoDroid", javaException.ToString ());
+
 				// Disabled until Linker error surfaced in https://github.com/xamarin/xamarin-android/pull/4302#issuecomment-596400025 is resolved
 				//AppDomain.CurrentDomain.DoUnhandledException (args);
 				AppDomain_DoUnhandledException (AppDomain.CurrentDomain, args);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4632

The `UNHANDLED EXCEPTION` message was printed from
`AndroidEnvironment.UnhandledException()`, which is invoked during
exception propagation, at each Managed::Java VM boundary.

It need not be from an *actual* unhandled exception!

Consequently, if there is a Managed :: Java :: Managed stack frame,
and *either* the 1st Managed or the Java frames catch the exception
thrown from the 2nd Managed frame -- meaning the exception is in fact
handled! -- we would still "spam" `adb logcat` with
`UNHANDLED EXCEPTION` messages, because at the "scope" in which it's
emitted, it can't know whether or not it's *actually* unhandled.

To avoid spamming `adb logcat` with unecessary noise, move the
`UNHANDLED EXCEPTION` log message into
`JNIEnv.PropagateUncaughtException()`.  This method is invoked *only*
when there is a *Java-side* unhandled exception, via
[`java.lang.Thread.setUncaughtExceptionHandler()`][0] and
[`java.lang.Thread.UncaughtExceptionHandler.uncaughtException()`][1].

[0]: https://developer.android.com/reference/java/lang/Thread#setUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)
[1]: https://developer.android.com/reference/java/lang/Thread.UncaughtExceptionHandler#uncaughtException(java.lang.Thread,%20java.lang.Throwable)