### PR TITLE
[Xamarin.Android.Build.Tasks] Make XA0119 an error for App Bundles in Debug

### DIFF
--- a/Documentation/release-notes/xa0119-aab-err.md
+++ b/Documentation/release-notes/xa0119-aab-err.md
@@ -1,0 +1,31 @@
+### XA0119 error for unsupported use of Android App Bundle format in Debug configuration
+
+The Android App Bundle publishing format is not currently compatible with the
+recommended fast deployment settings for Debug configuration deployments.
+Previously, projects that had **Android Package Format**
+(`AndroidPackageFormat`) set to **aab** in the Debug configuration along with
+the recommended **Use Shared \[Mono\] Runtime** setting would produce a build
+warning, but they would also fail to launch on device.
+
+Since this configuration is not currently supported, Xamarin.Android now emits a
+build error for it instead of warning:
+
+```
+error XA0119: Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.
+```
+
+To resolve this error, change the **Android Package Format** setting in the
+Visual Studio project property pages to **apk** for the Debug configuration.
+This corresponds to the `apk` value for the `AndroidPackageFormat` MSBuild
+property in the _.csproj_ file:
+
+```xml
+<PropertyGroup>
+  <AndroidPackageFormat>apk</AndroidPackageFormat>
+</PropertyGroup>
+```
+
+This error is only relevant for Debug configuration builds. Release
+configuration builds can continue to use the Android App Bundle packaging
+format.
+

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -322,6 +322,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations..
+        /// </summary>
+        internal static string XA0119_AAB {
+            get {
+                return ResourceManager.GetString("XA0119_AAB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Assembly &apos;{0}&apos; is using &apos;[assembly: {1}]&apos;, which is no longer supported. Use a newer version of this NuGet package or notify the library author..
         /// </summary>
         internal static string XA0121 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -256,6 +256,10 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</comment>
   </data>
+  <data name="XA0119_AAB" xml:space="preserve">
+    <value>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: Android App Bundles</comment>
+  </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Sestavení {0} používá atribut [assembly: {1}], který se už nepodporuje. Použijte novější verzi tohoto balíčku NuGet, nebo to oznamte autorovi knihovny.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Die Assembly "{0}" verwendet das Attribut "[assembly: {1}]", dieses wird nicht mehr unterstützt. Verwenden Sie eine neuere Version dieses NuGet-Pakets, oder benachrichtigen Sie den Bibliotheksautor.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">El ensamblado "{0}" usa "[assembly: {1}]", que ya no se admite. Utilice una versión más reciente de este paquete NuGet o informe al autor de la biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' utilise '[assembly : {1}]', qui n'est plus pris en charge. Utilisez une version plus récente de ce package NuGet ou notifiez l'auteur de la bibliothèque.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' usa '[assembly: {1}]', che non è più supportato. Usare una versione più recente di questo pacchetto NuGet o inviare una notifica all'autore della libreria.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">アセンブリ '{0}' は、今はサポートされていない '[assembly: {1}]' を使用しています。この NuGet パッケージの新しいバージョンを使用するか、ライブラリの作成者に連絡してください。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' 어셈블리가 더 이상 지원되지 않는 '[assembly: {1}]'을(를) 사용하고 있습니다. 이 NuGet 패키지의 최신 버전을 사용하거나 라이브러리 작성자에게 알리세요.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Zestaw „{0}” korzysta z atrybutu „[assembly: {1}]”, który nie jest już obsługiwany. Użyj nowszej wersji tego pakietu NuGet lub powiadom autora biblioteki.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">O assembly '{0}' está usando '[assembly: {1}]', que não tem mais suporte. Use uma versão mais recente deste pacote NuGet ou notifique o autor da biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Сборка "{0}" использует "[assembly: {1}]", которая больше не поддерживается. Используйте более новую версию этого пакета NuGet или уведомите автора библиотеки.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' bütünleştirilmiş kodu artık desteklenmeyen '[assembly: {1}]' kullanıyor. Bu NuGet paketinin daha yeni bir sürümünü kullanın veya bu durumu kitaplık yazarına bildirin.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">程序集“{0}”使用不再受支持的“[assembly: {1}]”。请使用此 NuGet 包的较新版本或通知库作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -171,6 +171,11 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
 
 {0} - A NuGet target framework moniker string</note>
       </trans-unit>
+      <trans-unit id="XA0119_AAB">
+        <source>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</source>
+        <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Android App Bundles</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">組件 '{0}' 正在使用不再受到支援的 '[assembly: {1}]'。請使用此 NuGet 套件的較新版本，或通知程式庫作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3825,6 +3825,23 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		public void XA0119AAB ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("_XASupportsFastDev", "True");
+			proj.SetProperty (KnownProperties.AndroidUseSharedRuntime, "True");
+			proj.SetProperty ("AndroidPackageFormat", "aab");
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				string error = builder.LastBuildOutput
+						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.FirstOrDefault (x => x.Contains ("error XA0119:"));
+				Assert.IsNotNull (error, "Build should have failed with XA0119.");
+			}
+		}
+
+		[Test]
 		public void FastDeploymentDoesNotAddContentProvider ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -728,6 +728,9 @@ namespace UnamedProject
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
+			if (packageFormat == "aab")
+				// Disable the shared runtime for aabs because it is not currently compatible and so gives an XA0119 build error.
+				proj.AndroidUseSharedRuntime = false;
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
@@ -4281,6 +4284,9 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
+			if (packageFormat == "aab")
+				// Disable the shared runtime for aabs because it is not currently compatible and so gives an XA0119 build error.
+				proj.AndroidUseSharedRuntime = false;
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "kotlinx-coroutines-android-1.3.2.jar") {
 				WebContent = "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.3.2/kotlinx-coroutines-android-1.3.2.jar"
 			});

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -393,6 +393,8 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidPackageFormat", "aab");
+			// Disable the shared runtime because it is not currently compatible with aabs and so gives an XA0119 build error.
+			proj.AndroidUseSharedRuntime = false;
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -490,8 +490,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       Text="Using Fast Deployment and a Code Shrinker at the same time is not recommended. Use Fast Deployment for Debug configurations and a Code Shrinker for Release configurations."
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkTool)' != '' "
   />
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and Android App Bundles at the same time is not recommended. Use Fast Deployment for Debug configurations and Android App Bundles for Release configurations."
+  <AndroidError Code="XA0119"
+      ResourceName="XA0119_AAB"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidPackageFormat)' == 'aab' "
   />
 </Target>


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/1076396/fatal-signal-11-sigsegv-code-1-segv-maperr-fault-a.html
Context: https://github.com/xamarin/xamarin-android/issues/4071#issuecomment-625589592
Context: https://forums.xamarin.com/discussion/comment/414288/#Comment_414288

A few reports have come in from users about the crashes that happen when
`$(AndroidPackageFormat)`=`aab` in the Debug configuration.

There was already a build warning for this scenario, but since it is
known that this scenario currently produces a crash, change that warning
to an error to improve the visibility of the known limitation and save
users time.

Example of the current crash:

        D Mono    : DllImport attempting to load: '__Internal'.
        D Mono    : DllImport error loading library '__Internal': 'Could not load library: Library '/system/lib64/libmonodroid.so' not found.'.
        W Mono    : DllImport unable to load library '__Internal'.
        F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x5f656b6f766e59 in tid 17118 (dsingleviewapp1), pid 17118 (dsingleviewapp1)
        I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
        I /system/bin/tombstoned: received crash request for pid 17118
        I crash_dump64: performing dump of process 17118 (target tid = 17118)
        F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
        F DEBUG   : Build fingerprint: 'google/blueline/blueline:9/PQ3A.190505.002/5450365:user/release-keys'
        F DEBUG   : Revision: 'MP1.0'
        F DEBUG   : ABI: 'arm64'
        F DEBUG   : pid: 17118, tid: 17118, name: dsingleviewapp1  >>> com.contoso.androidsingleviewapp1 <<<
        F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x5f656b6f766e59
        F DEBUG   :     x0  0000000000000012  x1  0000007fcf419058  x2  0000000000000012  x3  0000007fcf002020
        F DEBUG   :     x4  0000000000000010  x5  0000000000000010  x6  fefeff7ecdff1f1f  x7  7f7f7f7fff7f7f7f
        F DEBUG   :     x8  0000000000000000  x9  67fd524936ad3dce  x10 00000000000003ef  x11 000000007fffffef
        F DEBUG   :     x12 0000000000000012  x13 00000000ffffffff  x14 0000007fcf418cc4  x15 0000007fcf41885c
        F DEBUG   :     x16 000000728cc9acf0  x17 0000007326bf2afc  x18 0000007fcf41885a  x19 0000000000000000
        F DEBUG   :     x20 0000000000000000  x21 0000000000000040  x22 000000728cc73908  x23 000000728cbd3955
        F DEBUG   :     x24 000000728cbf0067  x25 000000000000002e  x26 000000728cbee031  x27 000000728cbd3953
        F DEBUG   :     x28 005f656b6f766e59  x29 0000007fcf4194e0
        F DEBUG   :     sp  0000007fcf419480  lr  000000728cba1b74  pc  000000728cba1b84
        F DEBUG   :
        F DEBUG   : backtrace:
        F DEBUG   :     #00 pc 0000000000272b84  /data/app/Mono.Android.DebugRuntime-bnHNXx4CyZU9L_ryuctu_A==/lib/arm64/libmonosgen-64bit-2.0.so
        W ActivityManager:   Force finishing activity com.contoso.androidsingleviewapp1/crc647d7dcab8da8ee782.MainActivity
        E /system/bin/tombstoned: Tombstone written to: /data/tombstones/tombstone_09
        I BootReceiver: Copying /data/tombstones/tombstone_09 to DropBox (SYSTEM_TOMBSTONE)

Other changes:

Adjust the wording of the message slightly to align with the fact that
it is now an error and to reflect that it is the shared runtime in
particular that causes the current issue.  Using
`$(EmbedAssembliesIntoApk)`=`false` with
`$(AndroidUseSharedRuntime)`=`false` currently succeeds on device, so
this error can likely be removed or changed back to a warning about fast
deployment whenever the shared runtime feature is removed.

Move the message string to the `.resx` file and switch to the
`<AndroidError/>` task to make the message localizable.