### PR TITLE
[build] Fix local $(AdbToolPath)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -133,7 +133,7 @@
     <ProGuardSourceFullPath>$([System.IO.Path]::GetFullPath ('$(ProGuardSourceDirectory)'))</ProGuardSourceFullPath>
   </PropertyGroup>
   <PropertyGroup>
-    <AdbToolPath Condition=" '$(AdbToolPath)' == '' ">$(AndroidSdkFullPath)\platform-tools</AdbToolPath>
+    <AdbToolPath Condition=" '$(AdbToolPath)' == '' ">$(AndroidSdkFullPath)\platform-tools\</AdbToolPath>
     <AdbToolExe Condition=" '$(AdbToolExe)' == '' ">adb</AdbToolExe>
     <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' ">avdmanager</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2771,7 +2771,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_DeployApk"
     Condition=" '$(AndroidPackageFormat)' != 'aab' ">
   <PropertyGroup>
-    <_DeployCommand>&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
+    <_DeployCommand>&quot;$(AdbToolPath)adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
   </PropertyGroup>
   <Exec
       ContinueOnError="True"
@@ -2825,7 +2825,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_Uninstall">
-  <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) uninstall $(_AndroidPackage)" />
+  <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) uninstall $(_AndroidPackage)" />
 </Target>
 
 <Target Name="Uninstall"

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -121,7 +121,7 @@
   <Import Project="..\..\..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\..\..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
 
   <Target Name="_GrantPermissions">
-    <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) shell pm grant %(TestApkPermission.Package) android.permission.%(TestApkPermission.Identity)" />
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell pm grant %(TestApkPermission.Package) android.permission.%(TestApkPermission.Identity)" />
   </Target>
 
   <PropertyGroup>

--- a/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
@@ -107,7 +107,7 @@
   <Import Project="$(RelativeRootPath)\build-tools\scripts\TestApks.targets" />
 
   <Target Name="_GrantPermissions">
-    <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) shell pm grant %(TestApkPermission.Package) android.permission.%(TestApkPermission.Identity)" />
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell pm grant %(TestApkPermission.Package) android.permission.%(TestApkPermission.Identity)" />
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix "in-tree" usage of `$(AdbToolPath)` for projects which import
`Configuration.props`, e.g.

	> cd samples/HelloWorld
	> msbuild /t:Install
	> msbuild /t:StartAndroidActivity
	…
	StartAndroidActivity:
	    PackageName: com.xamarin.android.helloworld
	  "…/android-toolchain/sdk/platform-toolsadb"  shell am start -n "com.xamarin.android.helloworld/example.MainActivity"
	  /var/folders/j4/t8z2dw2d7pndmvwcxz71njf40000gn/T/tmp04a537baf06445baa371ef57689ad833.exec.cmd: line 2: …/android-toolchain/sdk/platform-toolsadb: No such file or directory
	…/Xamarin.Android.Application.targets(27,5): error MSB3073: The command ""…/android-toolchain/sdk/platform-toolsadb"  shell am start -n "com.xamarin.android.helloworld/example.MainActivity"" exited with code 127.
	Done Building Project "…/xamarin-android/samples/HelloWorld/HelloWorld.csproj" (StartAndroidActivity target(s)) -- FAILED.

The problem is that a directory separator character is missing: what
*is* `…/platform-toolsadb` *should be* `…/platform-tools/adb`.

The cause is because the default value for `$(AdbToolPath)` within
`Configuration.props` packs a trailing `\`.  Fix the default value,
and the `StartAndroidActivity` target works as intended.

Additionally, update `Xamarin.Android.Common.targets` and other
projects so that they consistently use `$(AdbToolPath)adb`, instead of
a mix of `$(AdbToolPath)adb` *and* `$(AdbToolPath)\adb`, as the latter
will hide such issues.