### PR TITLE
[Xamarin.Android.Build.Tasks] add //manifest/queries for API 30

### DIFF
--- a/Documentation/release-notes/api30-queries.md
+++ b/Documentation/release-notes/api30-queries.md
@@ -19,4 +19,10 @@ device or emulator, the following `<queries/>` entries must be present in
 These will be generated if `$(AndroidUseSharedRuntime)` is `true` and
 `android:targetSdkVersion` is 30 or higher.
 
+### manifestmerger.jar version update to 27.0.0
+
+The version of the [manifest merger][1] included in Xamarin.Android
+has been updated from 26.5.0 to 27.0.0.
+
 [0]: https://developer.android.com/preview/privacy/package-visibility#package-name
+[1]: https://developer.android.com/studio/build/manifest-merge.html

--- a/Documentation/release-notes/api30-queries.md
+++ b/Documentation/release-notes/api30-queries.md
@@ -1,0 +1,22 @@
+#### Application and library build and deployment
+
+Starting in [Android 11][0], for Fast Deployment to work on an API 30
+device or emulator, the following `<queries/>` entries must be present in
+`AndroidManifest.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.android.helloworld">
+  <uses-sdk android:targetSdkVersion="30" />
+  <!-- ... -->
+  <queries>
+    <package android:name="Mono.Android.DebugRuntime" />
+    <package android:name="Mono.Android.Platform.ApiLevel_30" />
+  </queries>
+</manifest>
+```
+
+These will be generated if `$(AndroidUseSharedRuntime)` is `true` and
+`android:targetSdkVersion` is 30 or higher.
+
+[0]: https://developer.android.com/preview/privacy/package-visibility#package-name

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -267,6 +267,7 @@ namespace Xamarin.Android.Tasks
 			manifest.MultiDex = MultiDex;
 			manifest.NeedsInternet = NeedsInternet;
 			manifest.InstantRunEnabled = InstantRunEnabled;
+			manifest.UseSharedRuntime = UseSharedRuntime;
 
 			var additionalProviders = manifest.Merge (Log, cache, allJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -88,6 +88,7 @@ namespace Xamarin.Android.Tasks {
 		public bool MultiDex { get; set; }
 		public bool NeedsInternet { get; set; }
 		public bool InstantRunEnabled { get; set; }
+		public bool UseSharedRuntime { get; set; }
 		public string VersionCode {
 			get {
 				XAttribute attr = doc.Root.Attribute (androidNs + "versionCode");
@@ -404,6 +405,8 @@ namespace Xamarin.Android.Tasks {
 			AddUsesPermissions (app);
 			AddUsesFeatures (app);
 			AddSupportsGLTextures (app);
+			if (UseSharedRuntime && targetSdkVersionValue >= 30)
+				AddQueries (app, targetSdkVersionValue);
 
 			ReorderActivityAliases (log, app);
 			ReorderElements (app);
@@ -824,6 +827,17 @@ namespace Xamarin.Android.Tasks {
 			foreach (var upa in assemblyAttrs.Distinct (new UsesPermissionAttribute.UsesPermissionComparer ()))
 				if (!application.Parent.Descendants ("uses-permission").Any (x => (string)x.Attribute (attName) == upa.Name))
 					application.AddBeforeSelf (upa.ToElement (PackageName));
+		}
+
+		void AddQueries (XElement application, int targetSdkVersion)
+		{
+			var queries = application.Parent.Element ("queries");
+			if (queries == null) {
+				application.AddAfterSelf (queries = new XElement ("queries"));
+			}
+
+			queries.Add (new XElement ("package", new XAttribute (androidNs + "name", "Mono.Android.DebugRuntime")));
+			queries.Add (new XElement ("package", new XAttribute (androidNs + "name", $"Mono.Android.Platform.ApiLevel_{targetSdkVersion}")));
 		}
 
 		void AddUsesConfigurations (XElement application, IEnumerable<UsesConfigurationAttribute> configs)

--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    compile group: 'com.android.tools.build', name: 'manifest-merger', version: '26.5.0'
+    compile group: 'com.android.tools.build', name: 'manifest-merger', version: '27.0.0'
 }
 
 sourceSets {


### PR DESCRIPTION
Context: https://developer.android.com/preview/privacy/package-visibility#package-name

If using Fast Deployment with an API 30 device or emulator and
`targetSdkVersion="30"`, the app will crash on startup with:

    06-18 09:40:54.530   557   853 I AppsFilter: interaction: PackageSetting{f346c3d com.companyname.app72/10152} -> PackageSetting{67adc32 Mono.Android.Platform.ApiLevel_30/10151} BLOCKED
    ...
    06-18 09:40:54.531  8624  8624 E AndroidRuntime: java.lang.RuntimeException: Unable to get provider mono.MonoRuntimeProvider: java.lang.RuntimeException: Unable to find application Mono.Android.Platform.ApiLevel_30!
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.installProvider(ActivityThread.java:7135)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.installContentProviders(ActivityThread.java:6675)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6592)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.access$1300(ActivityThread.java:233)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1896)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:223)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7523)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:941)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime: Caused by: java.lang.RuntimeException: Unable to find application Mono.Android.Platform.ApiLevel_30!
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at mono.MonoRuntimeProvider.attachInfo(MonoRuntimeProvider.java:38)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ActivityThread.installProvider(ActivityThread.java:7130)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        ... 10 more
    06-18 09:40:54.531  8624  8624 E AndroidRuntime: Caused by: android.content.pm.PackageManager$NameNotFoundException: Mono.Android.Platform.ApiLevel_30
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ApplicationPackageManager.getApplicationInfoAsUser(ApplicationPackageManager.java:419)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:408)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        at mono.MonoRuntimeProvider.attachInfo(MonoRuntimeProvider.java:35)
    06-18 09:40:54.531  8624  8624 E AndroidRuntime:        ... 11 more

In Android 11, any calls to `getApplicationInfo`:

https://github.com/xamarin/xamarin-android/blob/17db4dc1e8ba6438fc02fdbb0e2fbe6c16fb4b58/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.java#L35

will throw `NameNotFoundException` unless a new entries are added to
`AndroidManifest.xml`:

    <?xml version="1.0" encoding="utf-8"?>
    <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.android.helloworld">
        <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
        ...
        <queries>
            <package android:name="Mono.Android.Platform.ApiLevel_30" />
            <package android:name="Mono.Android.DebugRuntime" />
        </queries>
    </manifest>

We should generate these entries if:

* `$(AndroidUseSharedRuntime)` is `true`
* `android:targetSdkVersion` is 30 or higher

The only problem with the new `<queries/>` element is that some
versions of `aapt2` would fail with:

    error APT2263: unexpected element <queries> found in <manifest>.

Luckily in cbdb5d15, we bumped to a version of `aapt2` that works.
`aapt(1)` appears to already work, it must not do any validation
against new XML element names.

I added a test for this scenario as well.