### PR TITLE
[build] run designer tests on $(HostedMacMojave)

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -874,7 +874,7 @@ stages:
   # Check - "Xamarin.Android (Test Designer - macOS)"
   - job: designer_integration_mac
     displayName: Designer - macOS
-    pool: $(HostedMac)
+    pool: $(HostedMacMojave)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3827329&view=logs&j=051336c7-58fc-58df-2c99-9295b706a641&t=20716647-8442-5250-dfa5-2cf363e96f19

The designer tests have been failing to build with:

    Xamarin.Designer.iOS/external/ios-sim-sharp/MonoTouch.Hosting/MonoTouch.Hosting.csproj(163,5): error MSB3073:
    The command "unset XCODE_DEVELOPER_DIR_PATH && xcodebuild -workspace libspawnapp.xcworkspace -scheme libspawnapp -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath ." exited with code 65.

We think this could be fixed by using the agent pool running macOS
10.14.