### PR TITLE
[tests] fixes for ILLink vs _LinkAssembliesShrink

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -461,7 +461,7 @@ namespace Lib2
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void ProduceReferenceAssembly ()
 		{
 			var path = Path.Combine ("temp", TestName);
@@ -501,35 +501,21 @@ namespace Lib2
 				Assert.IsTrue (libBuilder.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
-				var targetsShouldSkip = new [] {
-					"CoreCompile",
-					"_BuildLibraryImportsCache",
-					"_ResolveLibraryProjectImports",
-					"_GenerateJavaStubs",
-				};
-				foreach (var target in targetsShouldSkip) {
-					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
-				}
+				appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
+				appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
+				appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
+				appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
 
-				var targetsShouldPartiallyRun = new [] {
-					"_LinkAssembliesNoShrink",
-				};
-				foreach (var target in targetsShouldPartiallyRun) {
-					Assert.IsTrue (appBuilder.Output.IsTargetPartiallyBuilt (target), $"`{target}` should *partially* run!");
-				}
+				appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
 
-				var targetsShouldRun = new [] {
-					"_BuildApkEmbed",
-					"_CopyPackage",
-					"_Sign",
-				};
-				foreach (var target in targetsShouldRun) {
-					Assert.IsFalse (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
-				}
+				appBuilder.Output.AssertTargetIsNotSkipped ("_BuildApkEmbed");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_CopyPackage");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_Sign");
 			}
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void LinkAssembliesNoShrink ()
 		{
 			var proj = new XamarinFormsAndroidApplicationProject ();
@@ -540,11 +526,11 @@ namespace Lib2
 				var formsViewGroup = b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", "FormsViewGroup.dll"));
 				File.SetLastWriteTimeUtc (formsViewGroup, new DateTime (1970, 1, 1));
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "build should have succeeded.");
-				Assert.IsFalse (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "_LinkAssembliesNoShrink should *not* be skipped.");
+				b.Output.AssertTargetIsNotSkipped (KnownTargets.LinkAssembliesNoShrink);
 
 				// No changes
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "build should have succeeded.");
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "_LinkAssembliesNoShrink should be skipped.");
+				b.Output.AssertTargetIsSkipped (KnownTargets.LinkAssembliesNoShrink);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	public static class AssertionExtensions
+	{
+		public static void AssertTargetIsSkipped (this BuildOutput output, string target, int? occurrence = null)
+		{
+			if (occurrence != null)
+				Assert.IsTrue (output.IsTargetSkipped (target), $"The target {target} should have been skipped. ({occurrence})");
+			else
+				Assert.IsTrue (output.IsTargetSkipped (target), $"The target {target} should have been skipped.");
+		}
+
+		public static void AssertTargetIsNotSkipped (this BuildOutput output, string target, int? occurrence = null)
+		{
+			if (occurrence != null)
+				Assert.IsFalse (output.IsTargetSkipped (target), $"The target {target} should have *not* been skipped. ({occurrence})");
+			else
+				Assert.IsFalse (output.IsTargetSkipped (target), $"The target {target} should have *not* been skipped.");
+		}
+
+		public static void AssertTargetIsPartiallyBuilt (this BuildOutput output, string target, int? occurrence = null)
+		{
+			if (occurrence != null)
+				Assert.IsTrue (output.IsTargetPartiallyBuilt (target), $"The target {target} should have been partially built. ({occurrence})");
+			else
+				Assert.IsTrue (output.IsTargetPartiallyBuilt (target), $"The target {target} should have been partially built.");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Xamarin.ProjectTools
+{
+	public static class KnownTargets
+	{
+		public const string LinkAssembliesNoShrink = "_LinkAssembliesNoShrink";
+
+		public static string LinkAssembliesShrink => Builder.UseDotNet ? "ILLink" : "_LinkAssembliesShrink";
+	}
+}


### PR DESCRIPTION
When running under .NET 5+, the `ILLink` MSBuild target runs the
linker. A lot of our MSBuild tests check for the
`_LinkAssembliesShrink` target, and so they currently fail.

To fix this, and improve things:

* Add a `KnownTargets` class similar to the `KnownProperties` class we
  already have.
* Add a property that conditionally returns `ILLink` or
  `_LinkAssembliesShrink`.
* Add an `AssertionExtensions` class to check if targets are skipped
  or not with less code.
* Cleanup any tests using `_LinkAssembliesShrink` to use the new
  helpers.

Any tests I changed were added to the `dotnet` category.