### PR TITLE
[CI] Only push NET5 pkgs when PushXAPackages is true.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -199,7 +199,7 @@ stages:
         packagesToPush: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: xamarin-impl public feed
-      condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['PushXAPackages'], 'true')))
+      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
     - task: PublishPipelineArtifact@1
       displayName: upload nupkgs


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4635

In https://github.com/xamarin/xamarin-android/pull/4635 we changed our `push nupkgs` step to fire on every build where `Build.Reason != PullRequest`, however this causes problems when doing manual builds run the AzDO UI, because the `Build.Reason` is `Manual`.  This causes the step to run, and running it more than once fails the build with:
```
Response status code does not indicate success: 409 (Conflict - The feed already contains 
'Microsoft.Android.Ref 10.0.100-ci.qa-test.113+sha.003be50'.
```
There is no way to opt out of this behavior because `Build.Reason` is OR'd with `variables['PushXAPackages']`, so setting `PushXAPackages` to `false` is ignored.

This PR changes the behavior to rely solely on `variables['PushXAPackages']` and sets this variable as defaulted to `true` on the `Xamarin.Android` pipeline and `false` on the `Xamarin.Android-PR` pipeline.  This causes the packages to only be built on `master`/release branches, while allowing a user to opt into the step on a PR build.  It also allows the user to opt-out of the behavior on the commit build, should they need to re-run a commit.