### PR TITLE
[tests] remove XA5213IsRaisedWhenOutOfMemoryErrorIsThrown

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1710,66 +1710,6 @@ namespace App1
 		[Test]
 		/// <summary>
 		/// Based on issue raised in
-		/// https://bugzilla.xamarin.com/show_bug.cgi?id=28224
-		/// </summary>
-		public void XA5213IsRaisedWhenOutOfMemoryErrorIsThrown ()
-		{
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
-				TextContent = () => "public class ManyMethods { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
-				TextContent = () => "public class ManyMethods2 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "\n}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods3.java") {
-				TextContent = () => "public class ManyMethods3 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "\n}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods4.java") {
-				TextContent = () => "public class ManyMethods4 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "\n}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods5.java") {
-				TextContent = () => "public class ManyMethods5 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "\n}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods6.java") {
-				TextContent = () => "public class ManyMethods6 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "\n}",
-				Encoding = Encoding.ASCII
-			});
-			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.GooglePlayServicesMaps_42_1021_1);
-			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
-			proj.SetProperty ("AndroidEnableMultiDex", "True");
-			proj.SetProperty (proj.DebugProperties, "JavaMaximumHeapSize", "64m");
-			proj.SetProperty (proj.ReleaseProperties, "JavaMaximumHeapSize", "64m");
-			using (var b = CreateApkBuilder ("temp/XA5213IsRaisedWhenOutOfMemoryErrorIsThrown")) {
-				b.ThrowOnBuildFailure = false;
-				Assert.IsFalse (b.Build (proj), "Build should have failed.");
-				StringAssertEx.Contains ("XA5213", b.LastBuildOutput);
-				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
-			}
-		}
-
-		[Test]
-		/// <summary>
-		/// Based on issue raised in
 		/// https://bugzilla.xamarin.com/show_bug.cgi?id=28721
 		/// </summary>
 		public void DuplicateValuesInResourceCaseMap ()


### PR DESCRIPTION
Context: https://build.azdo.io/3834197

Frequently, the `MSBuild - Mac 1` test phase hangs and just times out.

A log was showing:

    Task "R8" (TaskId:191)
      ...
        processing ClassesZip, JavaLibrariesToEmbed... (TaskId:191)
      /Users/runner/Library/Android/jdk-11/bin/java -Xmx64m -classpath /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/r8.jar com.android.tools.r8.R8 --debug --min-api 16 --output obj/Debug/android/bin/ --lib /Users/runner/Library/Android/sdk/platforms/android-30/android.jar obj/Debug/android/bin/classes.zip /Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v11.0/mono.android.jar /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/java_runtime_fastdev.jar /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/android-support-multidex.jar obj/Debug/lp/0/jl/arch-core-common.jar obj/Debug/lp/1/jl/arch-lifecycle-common.jar obj/Debug/lp/15/jl/classes.jar obj/Debug/lp/16/jl/classes.jar obj/Debug/lp/17/jl/classes.jar obj/Debug/lp/18/jl/classes.jar obj/Debug/lp/10/jl/bin/classes.jar obj/Debug/lp/11/jl/bin/classes.jar obj/Debug/lp/12/jl/bin/classes.jar obj/Debug/lp/13/jl/bin/classes.jar obj/Debug/lp/14/jl/bin/classes.jar obj/Debug/lp/2/jl/bin/classes.jar obj/Debug/lp/3/jl/bin/classes.jar obj/Debug/lp/5/jl/bin/classes.jar obj/Debug/lp/6/jl/bin/classes.jar obj/Debug/lp/7/jl/bin/classes.jar obj/Debug/lp/8/jl/bin/classes.jar obj/Debug/lp/9/jl/bin/classes.jar --main-dex-list /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp5347ba9d.tmp --main-dex-rules /Users/runner/Library/Android/sdk/build-tools/29.0.2/mainDexClasses.rules --main-dex-list-output obj/Debug/multidex.keep --no-tree-shaking --no-minification --pg-conf /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp5b718c4d.tmp --pg-conf /Users/runner/Library/Android/sdk/tools/proguard/proguard-android.txt --pg-conf /Users/runner/runners/2.170.1/work/1/s/packages/xamarin.android.arch.lifecycle.runtime/1.0.3.1/build/MonoAndroid80/../../proguard/proguard.txt --pg-conf /Users/runner/runners/2.170.1/work/1/s/packages/xamarin.android.support.media.compat/27.0.2.1/build/MonoAndroid81/../../proguard/proguard.txt --pg-conf /Users/runner/runners/2.170.1/work/1/s/packages/xamarin.android.support.core.ui/27.0.2.1/build/MonoAndroid81/../../proguard/proguard.txt --pg-conf /Users/runner/runners/2.170.1/work/1/s/packages/xamarin.android.support.animated.vector.drawable/27.0.2.1/build/MonoAndroid81/../../proguard/proguard.txt  (TaskId:191)
      Exception in thread "ForkJoinPool-1-worker-7" java.lang.OutOfMemoryError: Java heap space (TaskId:191)

I think that `java` sometimes does not exit during this test. It
probably started happening since 380e95e3 started using JDK 11 for the
MSBuild tests.

This test verifies an old private bug:

https://bugzilla.xamarin.com/show_bug.cgi?id=28224

I think we should simply remove this test to fix the hang. I don't
think we would likely regress the original bug.