### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore CS8632 warning about using NRT annotations without enabling NRT.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -16,6 +16,7 @@
     <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
     <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\monoandroid10\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
     <LangVersion>latest</LangVersion>
+    <NoWarn>8632</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We have enabled nullable reference types (NRT) for `Mono.Android.dll`, and `Xamarin.Android.Build.Tasks.dll` imports several source files from MA like `IntentFilterAttribute.cs`.

Because `Xamarin.Android.Build.Tasks.csproj` does not enable NRT this results in 100+ warnings like:
```
src\Mono.Android\Android.App\IntentFilterAttribute.cs(28,16): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
```

The easiest fix is to simply ignore this warning until XABT enables NRT.