### PR TITLE
[One .NET] fix debugging

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -13,7 +13,7 @@ namespace Android.Runtime {
 
 		static void get_runtime_types ()
 		{
-			if (mono_unhandled_exception_method != null)
+			if (exception_handler_method != null)
 				return;
 #if MONOANDROID1_0
 			mono_unhandled_exception_method = typeof (System.Diagnostics.Debugger).GetMethod (
@@ -70,10 +70,10 @@ namespace Android.Runtime {
 			ig.Emit (OpCodes.Leave, label);
 
 			bool  filter = Debugger.IsAttached || !JNIEnv.PropagateExceptions;
-			if (filter) {
+			if (filter && mono_unhandled_exception_method != null) {
 				ig.BeginExceptFilterBlock ();
 
-				ig.Emit (OpCodes.Call, mono_unhandled_exception_method!);
+				ig.Emit (OpCodes.Call, mono_unhandled_exception_method);
 				ig.Emit (OpCodes.Ldc_I4_1);
 				ig.BeginCatchBlock (null!);
 			} else {

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -44,8 +44,6 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     </PropertyGroup>
   </Target>
 
-  <Target Name="AndroidPrepareForBuild" DependsOnTargets="GetReferenceAssemblyPaths" />
-
   <Target Name="GenerateBindings"
       Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar)' != '' Or '@(EmbeddedJar)' != '' "
       DependsOnTargets="ExportJarToXml;_ResolveMonoAndroidSdks"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -75,6 +75,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
 
+  <Target Name="AndroidPrepareForBuild" DependsOnTargets="GetReferenceAssemblyPaths" />
+
   <!-- Warn about deprecated configurations.
        Do it here because we want them to appear on every build,
        even if we aren't rerunning generator -->

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
+using System.Threading;
+using Mono.Debugging.Client;
+using Mono.Debugging.Soft;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
 
@@ -26,7 +31,6 @@ namespace Xamarin.Android.Build.Tests
 					IsRelease = isRelease
 				};
 			}
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, DeviceAbi);
 			proj.SetRuntimeIdentifier (DeviceAbi);
 
 			var relativeProjDir = Path.Combine ("temp", TestName);
@@ -42,6 +46,78 @@ namespace Xamarin.Android.Build.Tests
 				Path.Combine (fullProjDir, "logcat.log"), 30);
 			RunAdbCommand ($"uninstall {proj.PackageName}");
 			Assert.IsTrue(didLaunch, "Activity should have started.");
+		}
+
+		[Test]
+		public void DotNetDebug ()
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping Test. No devices available.");
+
+			XASdkProject proj;
+			proj = new XASdkProject ();
+			proj.SetRuntimeIdentifier (DeviceAbi);
+
+			var relativeProjDir = Path.Combine ("temp", TestName);
+			var fullProjDir = Path.Combine (Root, relativeProjDir);
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
+			var files = proj.Save ();
+			proj.Populate (relativeProjDir, files);
+			proj.CopyNuGetConfig (relativeProjDir);
+			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
+			Assert.IsTrue (dotnet.Build ("Install"), "`dotnet build` should succeed");
+
+			bool breakpointHit = false;
+			ManualResetEvent resetEvent = new ManualResetEvent (false);
+			var sw = new Stopwatch ();
+			// setup the debugger
+			var session = new SoftDebuggerSession ();
+			session.Breakpoints = new BreakpointStore {
+				{ Path.Combine (Root, dotnet.ProjectDirectory, "MainActivity.cs"),  19 },
+			};
+			session.TargetHitBreakpoint += (sender, e) => {
+				Console.WriteLine ($"BREAK {e.Type}");
+				breakpointHit = true;
+				session.Continue ();
+			};
+			var rnd = new Random ();
+			int port = rnd.Next (10000, 20000);
+			TestContext.Out.WriteLine ($"{port}");
+			var args = new SoftDebuggerConnectArgs ("", IPAddress.Loopback, port) {
+				MaxConnectionAttempts = 10,
+			};
+			var startInfo = new SoftDebuggerStartInfo (args) {
+				WorkingDirectory = Path.Combine (dotnet.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets"),
+			};
+			var options = new DebuggerSessionOptions () {
+				EvaluationOptions = EvaluationOptions.DefaultOptions,
+			};
+			options.EvaluationOptions.UseExternalTypeResolver = true;
+			ClearAdbLogcat ();
+			Assert.True (dotnet.Build ("_Run", new string [] {
+				$"AndroidSdbTargetPort={port}",
+				$"AndroidSdbHostPort={port}",
+				"AndroidAttachDebugger=True",
+			}), "Project should have run.");
+
+			Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, dotnet.ProjectDirectory, "logcat.log")), "Activity should have started");
+			// we need to give a bit of time for the debug server to start up.
+			WaitFor (2000);
+			session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };
+			session.OutputWriter += (isStderr, text) => { Console.WriteLine (text); };
+			session.DebugWriter += (level, category, message) => { Console.WriteLine (message); };
+			session.Run (startInfo, options);
+			WaitFor (TimeSpan.FromSeconds (30), () => session.IsConnected);
+			Assert.True (session.IsConnected, "Debugger should have connected but it did not.");
+			// we need to wait here for a while to allow the breakpoints to hit
+			// but we need to timeout
+			TimeSpan timeout = TimeSpan.FromSeconds (60);
+			while (session.IsConnected && !breakpointHit && timeout >= TimeSpan.Zero) {
+				Thread.Sleep (10);
+				timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
+			}
+			WaitFor (2000);
+			Assert.IsTrue (breakpointHit, "Should have a breakpoint");
 		}
 	}
 }


### PR DESCRIPTION
If you tried to debug an app with:

    dotnet build HelloAndroid/HelloAndroid.csproj -t:Install,_Run -p:AndroidAttachDebugger=true

The presence of `$(AndroidAttachDebugger)` causes a crash on startup:

    06-24 11:57:42.538 14948 14948 E mono    : Unhandled Exception:
    06-24 11:57:42.538 14948 14948 E mono    : System.ArgumentNullException: Value cannot be null. (Parameter 'meth')
    06-24 11:57:42.538 14948 14948 E mono    :    at System.Reflection.Emit.ILGenerator.Emit(OpCode opcode, MethodInfo meth)
    06-24 11:57:42.538 14948 14948 E mono    :    at Android.Runtime.JNINativeWrapper.CreateDelegate(Delegate dlg)
    06-24 11:57:42.538 14948 14948 E mono    :    at Android.App.Activity.GetOnCreate_Landroid_os_Bundle_Handler()
    06-24 11:57:42.538 14948 14948 E mono    :    at Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType nativeClass, Type type, String methods)
    06-24 11:57:42.538 14948 14948 E mono    :    at Android.Runtime.JNIEnv.RegisterJniNatives(IntPtr typeName_ptr, Int32 typeName_len, IntPtr jniClass, IntPtr methods_ptr, Int32 methods_len)
    06-24 11:57:42.538 14948 14948 E mono-rt : [ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentNullException: Value cannot be null. (Parameter 'meth')
    06-24 11:57:42.538 14948 14948 E mono-rt :    at System.Reflection.Emit.ILGenerator.Emit(OpCode opcode, MethodInfo meth)
    06-24 11:57:42.538 14948 14948 E mono-rt :    at Android.Runtime.JNINativeWrapper.CreateDelegate(Delegate dlg)
    06-24 11:57:42.538 14948 14948 E mono-rt :    at Android.App.Activity.GetOnCreate_Landroid_os_Bundle_Handler()
    06-24 11:57:42.538 14948 14948 E mono-rt :    at Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType nativeClass, Type type, String methods)
    06-24 11:57:42.538 14948 14948 E mono-rt :    at Android.Runtime.JNIEnv.RegisterJniNatives(IntPtr typeName_ptr, Int32 typeName_len, IntPtr jniClass, IntPtr methods_ptr, Int32 methods_len)

We need to check if `mono_unhandled_exception_method` is `null` and
respond appropriately. In `get_runtime_types()`, we will use a
different null check for `exception_handler_method` to return early.

This surfaced another problem when using the `_Run` target by itself:

    Xamarin.Android.Common.Debugging.targets(518,2): error MSB3073: The command ""adb"  forward tcp:10000 tcp:10000" exited with code 9009.

The `$(_AndroidPlatformToolsDirectory)` was blank when running `_Run`
by itself, but things work fine if you run `Install,_Run` at the same
time.

This broke in fb637e08. I accidentally replaced the
`AndroidPrepareForBuild` MSBuild target with the version in
`Xamarin.Android.Bindings.Core.targets`:

https://github.com/xamarin/xamarin-android/blob/f99a3fad1b12d9674de2f624e243f296cfc40fc6/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets#L47

To fix this, I can just move the binding project version of
`AndroidPrepareForBuild` target to `Xamarin.Android.Bindings.targets`.

I added a new test verifying that breakpoints work, when running under
.NET 5.