### PR TITLE
Bump Android NDK to r21d

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "21c";
-		public const string AndroidNdkPkgRevision = "21.2.6472646";
+		public const string AndroidNdkVersion = "21d";
+		public const string AndroidNdkPkgRevision = "21.3.6528147";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r21#r21d

Changes:

  * Added APIs for Android 11:
    * New [ImageDecoder][0] API.
    * New [Thermal][1] API.
  * Updated [AAudio][2] APIs.
  * Updated [Bitmap][3] APIs.
  * Updated [Camera][4] APIs.
  * Updated [Choreographer][5] APIs.
  * Updated [Native Window][6] APIs.
  * Updated [NdkBinder][7] APIs.
  * Updated [NeuralNetworks][8] APIs.
  * OpenSLES is deprecated in favor of [AAudio][2]. Developers should use [Oboe][9] to automatically select the best available API.

[0]: https://developer.android.com/ndk/reference/group/image-decoder
[1]: https://developer.android.com/ndk/reference/group/thermal
[2]: https://developer.android.com/ndk/reference/group/audio
[3]: https://developer.android.com/ndk/reference/group/bitmap
[4]: https://developer.android.com/ndk/reference/group/camera
[5]: https://developer.android.com/ndk/reference/group/choreographer
[6]: https://developer.android.com/ndk/reference/group/a-native-window
[7]: https://developer.android.com/ndk/reference/group/ndk-binder
[8]: https://developer.android.com/ndk/reference/group/neural-networks
[9]: https://github.com/google/oboe