### PR TITLE
[tests] Fix network interface tests for Android 30

### DIFF
--- a/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
+++ b/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
@@ -170,7 +170,7 @@ namespace System.NetTests
 
 				default:
 					// Android considers 'lo' to be always up
-					return inf.NetworkInterfaceType == NetworkInterfaceType.Loopback;
+					return IsLoopbackInterface (inf);
 			}
 		}
 
@@ -188,9 +188,10 @@ namespace System.NetTests
 			var ret = new List <InterfaceInfo> ();
 
 			foreach (MNetworkInterface inf in interfaces) {
+				Console.WriteLine ($"inf: {inf} (name: {inf.Name}; type: {inf.NetworkInterfaceType})");
 				ret.Add (new InterfaceInfo {
 					Name = inf.Name,
-					IsLoopback = inf.NetworkInterfaceType == NetworkInterfaceType.Loopback,
+					IsLoopback = IsLoopbackInterface (inf),
 					IsUp = IsInterfaceUp (inf),
 					HardwareAddress = GetHardwareAddress (inf),
 					Addresses = CollectAddresses (inf)
@@ -219,6 +220,13 @@ namespace System.NetTests
 			}
 
 			return ret;
+		}
+
+		static bool IsLoopbackInterface (MNetworkInterface inf)
+		{
+			// Android 30 will not tell us the interface type if the app targets API 30, we need to look at the
+			// name then.
+			return inf.NetworkInterfaceType == NetworkInterfaceType.Loopback || String.Compare ("lo", inf.Name, StringComparison.OrdinalIgnoreCase) == 0;
 		}
 	}
 }


### PR DESCRIPTION
Context: https://developer.android.com/preview/behavior-changes-11#netlink-mac
Context: https://developer.android.com/reference/java/net/NetworkInterface#getNetworkInterfaces()

If an application targets `Android 11`/`API 30` (and newer) then the
number of reported interfaces as well as the amount of information about
them change to include less detail.

First of all, only interfaces with associated IP addresses will be
reported by both the `NetworkInterface` Java API and the `getifaddrs(3)`
native libc API:

 * Application targetting API 28 on API 30 device:
   * name: wlan0; type: Ethernet
   * name: dummy0; type: Ethernet
   * name: lo; type: Loopback
   * name: hwsim0; type: Unknown
   * name: ip6tnl0; type: Tunnel
   * name: sit0; type: Tunnel
   * name: ip6_vti0; type: Tunnel
   * name: ip_vti0; type: Tunnel
 * Application targetting API 30 on API 30 device:
   * name: wlan0; type: 0
   * name: dummy0; type: 0
   * name: lo; type: 0

Second of all, as can be seen above, device information does not include
the type of interface.  This bit of information is what the
`DotNetInterfacesShouldEqualJavaInterfaces` test relied on so far.

That change broke our `DotNetInterfacesShouldEqualJavaInterfaces` test:

    DotNetInterfacesShouldEqualJavaInterfaces
		Mono interfaces:
      [InterfaceInfo: Name=radio0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::d4d9:5aff:fe48:60be%11, fec0::d4d9:5aff:fe48:60be, fec0::397c:d582:6278:ca2c, 10.0.2.15>]
      [InterfaceInfo: Name=wlan0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::e00a:8bb6:415b:4c97%9, fec0::f925:950b:4c31:eea7, fec0::315a:4cc4:796:6915, 10.0.2.16>]
      [InterfaceInfo: Name=dummy0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::4c41:86ff:fe93:6354%2>]
      [InterfaceInfo: Name=lo, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<::1, 127.0.0.1>]
    Java interfaces:
      [InterfaceInfo: Name=dummy0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::4c41:86ff:fe93:6354%2>]
      [InterfaceInfo: Name=wlan0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::e00a:8bb6:415b:4c97%9, fec0::f925:950b:4c31:eea7, fec0::315a:4cc4:796:6915, 10.0.2.16>]
      [InterfaceInfo: Name=lo, IsLoopback=True, IsUp=True, HardwareAddress=<>, Addresses=<::1, 127.0.0.1>]
      [InterfaceInfo: Name=radio0, IsLoopback=False, IsUp=True, HardwareAddress=<>, Addresses=<fe80::d4d9:5aff:fe48:60be%11, fec0::d4d9:5aff:fe48:60be, fec0::397c:d582:6278:ca2c, 10.0.2.15>]
    Interface radio0: passed
    Interface wlan0: passed
    Interface dummy0: passed
    [FAIL] :   #8.3 (lo not found in Java interfaces)
       Expected: True
       But was:  False
         at System.NetTests.NetworkInterfacesTest.DotNetInterfacesShouldEqualJavaInterfaces () [0x00152] in <c0e2a2f723184a6080f550609db0528d>:0
         at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
         at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)

Note that both Java and Mono return the same number of interfaces, with
the same names but the `lo` interface in Mono list is not marked as
loopback (`IsLoopback=False`) while the corresponding Java entry reports
the interface is a loopback.

In order to account for the above Android changes, we now look not only
at the hardware type but also at its name in order to determine whether
the device is a loopback one or not.