### PR TITLE
[tests] Disable a Mono.Posix test

### DIFF
--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
@@ -12,6 +12,9 @@
 # accept4(), which was added to API-21.
 MonoTests.Mono.Unix.Native.SocketTest.Accept4
 
+# Android 11 (API 30) broke the API for apps targetting API 30
+MonoTests.Mono.Unix.Native.MemfdTest.TestMemfd
+
 # No idea why these no longer throw:
 MonoTests.Mono.Unix.Native.SocketTest.BindConnect
 MonoTests.Mono.Unix.Native.SocketTest.SendMsgRecvMsgAddress


### PR DESCRIPTION
`Android 11` / `API 30` made the `memfd_create(2)` Linux-specific API
fail whenever the `MFD_CLOEXEC | MFD_ALLOW_SEALING` combination of flags
is passed to it:

    Xamarin.Android.Bcl_Tests, MonoTests.Mono.Unix.Native.MemfdTest.TestMemfd / Release

    System.ArgumentOutOfRangeException : Current platform doesn't support this value.
    Parameter name: value
    Actual value was MFD_CLOEXEC, MFD_ALLOW_SEALING.

Disable the test altogether, since this API isn't used by
`Xamarin.Android` and any applications using it will/should check the
`errno` variable for the `ENOSYS` value to see if the API is supported
or not.  This will unblock us, allowing update of our Android emulator
system image to API 30.