### PR TITLE
[Xamarin.Android.Build.Tasks] support JDK 11.0.7

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,8 +15,8 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string JetBrainsOpenJDK11Version = "11.0.4";
-		const string JetBrainsOpenJDK11Release = "546.1";
+		const string JetBrainsOpenJDK11Version = "11.0.7";
+		const string JetBrainsOpenJDK11Release = "944.14";
 		static readonly string JetBrainsOpenJDK11DownloadVersion = JetBrainsOpenJDK11Version.Replace ('.', '_');
 
 		const string JetBrainsOpenJDK8Version = "8.202";
@@ -35,10 +35,10 @@ namespace Xamarin.Android.Prepare
 			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-8u202-windows-x64-b1483.37.tar.gz
 			public static readonly Uri JetBrainsOpenJDK8 = new Uri ($"https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-{JetBrainsOpenJDK8DownloadVersion}-{JetBrainsOpenJDKOperatingSystem}-b{JetBrainsOpenJDK8Release}.tar.gz");
 
-			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_4-linux-x64-b546.1.tar.gz
-			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_4-osx-x64-b546.1.tar.gz
-			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_4-windows-x64-b546.1.tar.gz
-			public static readonly Uri JetBrainsOpenJDK11 = new Uri ($"https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-{JetBrainsOpenJDK11DownloadVersion}-{JetBrainsOpenJDKOperatingSystem}-b{JetBrainsOpenJDK11Release}.tar.gz");
+			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-linux-x64-b944.14.tar.gz
+			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-osx-x64-b944.14.tar.gz
+			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-windows-x64-b944.14.tar.gz
+			public static readonly Uri JetBrainsOpenJDK11 = new Uri ($"https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-{JetBrainsOpenJDK11DownloadVersion}-{JetBrainsOpenJDKOperatingSystem}-b{JetBrainsOpenJDK11Release}.tar.gz");
 
 			/// <summary>
 			///   Base URL for all Android SDK and NDK downloads. Used in <see cref="AndroidToolchain"/>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
-    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.4</LatestSupportedJavaVersion>
+    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.99</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
@@ -32,8 +32,9 @@ namespace Xamarin.Android.Tasks.Legacy
 					if (versionNumber < requiredJavaForBuildTools) {
 						Log.LogCodedError ("XA0032", Properties.Resources.XA0032, requiredJavaForBuildTools, AndroidSdkBuildToolsVersion);
 					}
-					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
+					var latest = Version.Parse (LatestSupportedJavaVersion);
+					if (versionNumber > latest) {
+						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, latest.ToString (fieldCount: 2));
 					}
 				}
 			} catch (Exception ex) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -75,8 +75,9 @@ namespace Xamarin.Android.Tasks
 					if (versionNumber < required) {
 						Log.LogCodedError ("XA0031", Properties.Resources.XA0031, required, "`<Project Sdk=\"Xamarin.Android.Sdk\">`");
 					}
-					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
+					var latest = Version.Parse (LatestSupportedJavaVersion);
+					if (versionNumber > latest) {
+						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, latest.ToString (fieldCount: 2));
 					}
 				}
 			} catch (Exception ex) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -7,7 +7,7 @@
 		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0.4</LatestSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0.99</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4853
Context: https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime

Using JDK 11.0.7, builds currently fail with:

    error XA0030: Building with JDK version `11.0.7` is not supported. Please install JDK version `11.0.4`. See https://aka.ms/xamarin/jdk9-errors

We could set `$(LatestSupportedJavaVersion)` to `11.0.7` to allow this
version to work, but it is not future-proof.

So if we used `11.0.99`, this would allow Xamarin.Android to continue
to work with minor JDK bumps if 11.0.8 happened to come out tomorrow.

Unfortunately, this makes the error message bad:

    error XA0030: Building with JDK version `14.0.0` is not supported. Please install JDK version `11.0.99`.

I updated the `<ValidateJavaVersion/>` MSBuild task, so that only the
first two components of the version appear in this message:

    error XA0030: Building with JDK version `14.0.0` is not supported. Please install JDK version `11.0`.