### PR TITLE
[Xamarin.Android.Build.Tasks] Set LatestSupportedJavaVersion=v11.0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
-    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.4</LatestSupportedJavaVersion>
+    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
@@ -32,9 +32,7 @@ namespace Xamarin.Android.Tasks.Legacy
 					if (versionNumber < requiredJavaForBuildTools) {
 						Log.LogCodedError ("XA0032", Properties.Resources.XA0032, requiredJavaForBuildTools, AndroidSdkBuildToolsVersion);
 					}
-					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
-					}
+					CheckJavaGreaterThanLatestSupported (versionNumber);
 				}
 			} catch (Exception ex) {
 				Log.LogWarningFromException (ex);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
@@ -75,9 +76,7 @@ namespace Xamarin.Android.Tasks
 					if (versionNumber < required) {
 						Log.LogCodedError ("XA0031", Properties.Resources.XA0031, required, "`<Project Sdk=\"Xamarin.Android.Sdk\">`");
 					}
-					if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-						Log.LogCodedError ("XA0030", Properties.Resources.XA0030, versionNumber, LatestSupportedJavaVersion);
-					}
+					CheckJavaGreaterThanLatestSupported (versionNumber);
 				}
 			} catch (Exception ex) {
 				Log.LogWarningFromException (ex);
@@ -86,6 +85,17 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return !Log.HasLoggedErrors;
+		}
+
+		protected void CheckJavaGreaterThanLatestSupported (Version javaVersion)
+		{
+			string latestSupported  = LatestSupportedJavaVersion;
+			if (latestSupported.Count (c => c == '.') == 1)
+				latestSupported += ".99";
+			Version latestSupportedVersion = Version.Parse (latestSupported);
+			if (javaVersion > latestSupportedVersion) {
+				Log.LogCodedError ("XA0030", Properties.Resources.XA0030, javaVersion, LatestSupportedJavaVersion);
+			}
 		}
 
 		protected Version GetVersionFromTool (string javaExe, Regex versionRegex)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -7,7 +7,7 @@
 		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0.4</LatestSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4853

`$(LatestSupportedJavaVersion)` is currently v11.0.4, which means if
e.g. JDK 11.0.7 is used -- which one would expect to be compatible! --
the build will fail with an XA0030 error:

	error XA0030: Building with JDK Version `11.0.7` is not supported. Please install JDK version `11.0.4`.

We *could* set `$(LatestSupportedJavaVersion)`=v11.0.99, but that
value is also used as part of the XA0030 message text, which could
result in an error message mentioning a version which doesn't exist:

	error XA0030: Building with JDK Version `14.0.0` is not supported. Please install JDK version `11.0.99`.

Instead of using a three-tuple in the `$(LatestSupportedJavaVersion)`
value -- which is "forwarded" to the XA0030 error -- instead use a
two-tuple value of `11.0`, which will result in a "saner" XA0030 error
message of `11.0` and not `11.0.4` or (worse!) `11.0.99`.

To bridge the gap between three-tuples (from `java -version`) and
the two-tuple in `$(LatestSupportedJavaVersion)`, add a new
`ValidateJavaVersion.CheckJavaGreaterThanLatestSupported()` method
which will *append* `.99` to `$(LatestSupportedJavaVersion)` if it
only contains two values, allowing us to compare `11.0.7 >= 11.0.99`.