### PR TITLE
[One .NET] fix code path for unhandled exceptions

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -244,8 +244,9 @@ namespace Android.Runtime {
 		{
 			if (mono_unhandled_exception == null) {
 				var mono_UnhandledException = typeof (System.Diagnostics.Debugger)
-					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static)!;
-				mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_UnhandledException);
+					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
+				if (mono_UnhandledException != null)
+					mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_UnhandledException);
 			}
 
 			if (AppDomain_DoUnhandledException == null) {
@@ -277,7 +278,7 @@ namespace Android.Runtime {
 
 			// Disabled until Linker error surfaced in https://github.com/xamarin/xamarin-android/pull/4302#issuecomment-596400025 is resolved
 			//System.Diagnostics.Debugger.Mono_UnhandledException (javaException);
-			mono_unhandled_exception (javaException);
+			mono_unhandled_exception?.Invoke (javaException);
 
 			try {
 				var jltp = javaException as JavaProxyThrowable;
@@ -289,7 +290,7 @@ namespace Android.Runtime {
 
 				// Disabled until Linker error surfaced in https://github.com/xamarin/xamarin-android/pull/4302#issuecomment-596400025 is resolved
 				//AppDomain.CurrentDomain.DoUnhandledException (args);
-				AppDomain_DoUnhandledException (AppDomain.CurrentDomain, args);
+				AppDomain_DoUnhandledException?.Invoke (AppDomain.CurrentDomain, args);
 			} catch (Exception e) {
 				Logger.Log (LogLevel.Error, "monodroid", "Exception thrown while raising AppDomain.UnhandledException event: " + e.ToString ());
 			}


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/38465

Both of these methods are missing in .NET 5+:

* `System.Diagnostics.Debugger.Mono_UnhandledException`
* `AppDomain.CurrentDomain.DoUnhandledException`

The code path that runs during an unhandled exception relies on these
methods. Currently, an unhandled exception will throw several additional
exceptions we should fix:

    Unable to initialize UncaughtExceptionHandler. Nested exception caught: System.ArgumentNullException: Value cannot be null. (Parameter 'method')
        at System.Delegate.CreateDelegate(Type type, Object firstArgument, MethodInfo method, Boolean throwOnBindFailure, Boolean allowClosed)
        at System.Delegate.CreateDelegate(Type type, MethodInfo method, Boolean throwOnBindFailure)
        at System.Delegate.CreateDelegate(Type type, MethodInfo method)
        at Android.Runtime.JNIEnv.Initialize()
        at Android.Runtime.JNIEnv.PropagateUncaughtException(IntPtr env, IntPtr javaThreadPtr, IntPtr javaExceptionPtr)

And:

    Exception thrown while raising AppDomain.UnhandledException event: System.NullReferenceException: Object reference not set to an instance of an object
        at Android.Runtime.JNIEnv.PropagateUncaughtException(IntPtr env, IntPtr javaThreadPtr, IntPtr javaExceptionPtr)

Added the appropriate null checks in `JNIEnv.PropagateUncaughtException`
to fix the additional exceptions.