### PR TITLE
[One .NET] add debugging support for Run target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -11,8 +11,18 @@ This file contains targets specific for Android application projects.
   <PropertyGroup>
     <RunCommand>dotnet</RunCommand>
     <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>
+
+    <!-- If Xamarin.Android.Common.Debugging.targets exists, we can rely on _Run for debugging. -->
+    <_RunDependsOn Condition=" '$(_XASupportsFastDev)' == 'true' ">
+      Install;
+      _Run;
+    </_RunDependsOn>
+    <_RunDependsOn Condition=" '$(_XASupportsFastDev)' != 'true' ">
+      Install;
+      StartAndroidActivity;
+    </_RunDependsOn>
   </PropertyGroup>
 
-  <Target Name="Run" DependsOnTargets="Install;StartAndroidActivity" />
+  <Target Name="Run" DependsOnTargets="$(_RunDependsOn)" />
 
 </Project>

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -51,6 +51,8 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void DotNetDebug ()
 		{
+			if (!CommercialBuildAvailable)
+				Assert.Ignore ("Skipping Test. Commercial build required.");
 			if (!HasDevices)
 				Assert.Ignore ("Skipping Test. No devices available.");
 
@@ -94,7 +96,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			options.EvaluationOptions.UseExternalTypeResolver = true;
 			ClearAdbLogcat ();
-			Assert.True (dotnet.Build ("_Run", new string [] {
+			Assert.True (dotnet.Build ("Run", new string [] {
 				$"AndroidSdbTargetPort={port}",
 				$"AndroidSdbHostPort={port}",
 				"AndroidAttachDebugger=True",


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/blob/6e43a20ebaa2cd59532e130ef64585c5829e3373/tools/msbuild/Xamarin.Android.Common.Debugging.targets#L510-L528

In the commercial Xamarin.Android project, there is a `_Run` MSBuild
target that launches apps as well as configures debugging.

We should conditionally use this target for the public `Run` target in
.NET 5+, so you could attach a debugging session via:

    > dotnet build HelloAndroid/HelloAndroid.csproj -t:Run -p:AndroidAttachDebugger=true

Unfortunately, you can't add additional MSBuild properties to `dotnet
run`, so this command would not work:

    > dotnet run --project HelloAndroid/HelloAndroid.csproj -p:AndroidAttachDebugger=true
    MSBUILD : error MSB1008: Only one project can be specified.
    Switch: AndroidAttachDebugger=true
    For switch syntax, type "MSBuild -help"

OSS Xamarin.Android can continue using the `StartAndroidActivity`
target as a backup when `_Run` does not exist.

I updated the `DotNetDebug` test to use the `Run` MSBuild target.