### PR TITLE
[tests] ignore IOException in some MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
@@ -1,20 +1,27 @@
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
-using Xamarin.ProjectTools;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
-using System.Text;
-using Xamarin.Android.Tasks;
 using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
 
-namespace Xamarin.Android.Build.Tests {
-
+namespace Xamarin.Android.Build.Tests
+{
 	[TestFixture]
 	[Category ("Node-2")]
 	[Parallelizable (ParallelScope.Self)]
-	public class ConvertResourcesCasesTests  : BaseTest {
+	public class ConvertResourcesCasesTests  : BaseTest
+	{
+		void DeleteDirectory (string path)
+		{
+			try {
+				Directory.Delete (path, recursive: true);
+			} catch (Exception ex) {
+				TestContext.WriteLine ($"Error deleting '{path}': {ex}");
+			}
+		}
+
 		[Test]
 		public void CheckAdaptiveIconIsConverted ()
 		{
@@ -42,8 +49,9 @@ namespace Xamarin.Android.Build.Tests {
 			var output = File.ReadAllText (Path.Combine (resPath, "mipmap-anydpi-v26", "adaptiveicon.xml"));
 			StringAssert.DoesNotContain ("AdaptiveIcon_background", output, "AdaptiveIcon_background should have been replaced with adaptiveicon_background");
 			StringAssert.DoesNotContain ("AdaptiveIcon_foreground", output, "AdaptiveIcon_foreground should have been replaced with adaptiveicon_foreground");
-			Directory.Delete (path, recursive: true);
+			DeleteDirectory (path);
 		}
+
 		[Test]
 		public void CheckClassIsReplacedWithMd5 ()
 		{
@@ -90,7 +98,7 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (custom.Execute (), "Task should have executed successfully");
 			var secondOutput = File.ReadAllText (Path.Combine(resPath, "layout", "main.xml"));
 			StringAssert.AreEqualIgnoringCase (output, secondOutput, "Files should not have changed.");
-			Directory.Delete (path, recursive: true);
+			DeleteDirectory (path);
 		}
 
 		[Test]
@@ -147,7 +155,7 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsFalse (custom.Execute (), "Task should have executed successfully");
 			var secondOutput = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
 			StringAssert.AreEqualIgnoringCase (output, secondOutput, "Files should not have changed.");
-			Directory.Delete (path, recursive: true);
+			DeleteDirectory (path);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
@@ -34,9 +34,17 @@ namespace Xamarin.Android.Build.Tests
 			if (TestContext.CurrentContext.Result.Outcome.Status != NUnit.Framework.Interfaces.TestStatus.Passed) {
 				return;
 			}
-			Directory.Delete (TestPath, recursive: true);
-			File.Delete (Zip);
-			paths.TryRemove (TestContext.CurrentContext.Test.Name, out string value);
+			try {
+				Directory.Delete (TestPath, recursive: true);
+			} catch (Exception ex) {
+				TestContext.WriteLine ($"Error deleting '{TestPath}': {ex}");
+			}
+			try {
+				File.Delete (Zip);
+			} catch (Exception ex) {
+				TestContext.WriteLine ($"Error deleting '{Zip}': {ex}");
+			}
+			paths.TryRemove (TestContext.CurrentContext.Test.Name, out _);
 		}
 
 		public string TestPath {


### PR DESCRIPTION
Context: https://build.azdo.io/3845868

Some tests have been randomly failing such as:

    SkipExistingFile_TimeStamp
      TearDown : System.IO.IOException : The directory is not empty
    --TearDown
      at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
      at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
      at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
      at Xamarin.Android.Build.Tests.ZipArchiveExTests.TearDown() in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs:line 40

Or another example:

    Xamarin.Android.Build.Tests.ConvertResourcesCasesTests.CheckClassIsReplacedWithMd5
    System.IO.IOException : The directory is not empty.
      at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
      at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
      at Xamarin.Android.Build.Tests.ConvertResourcesCasesTests.CheckClassIsReplacedWithMd5() in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs:line 94

Both of these tests *passed*, but there was a failure in the cleanup
step of the test.

I think we should log these errors, but not fail the test completely
if this occurs.

I also did some general cleanup in `ConvertResourcesCasesTests`.