### PR TITLE
Run policheck as part of code analysis job

### DIFF
--- a/build-tools/automation/PoliCheckExclusions.xml
+++ b/build-tools/automation/PoliCheckExclusions.xml
@@ -1,10 +1,10 @@
 <PoliCheckExclusions>
   <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
-  <!--<Exclusion Type="FolderPathFull">NREFACTORY</Exclusion>-->
+  <Exclusion Type="FolderPathFull">NREFACTORY</Exclusion>
   <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be skipped -->
   <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
   <!-- Each of these file types will be completely skipped for the entire scan -->
   <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
   <!-- The specified file names will be skipped during the scan regardless which folder they are in -->
-  <Exclusion Type="FileName">REMAINING-INT-CONSTS.TXT|TAIWANCALENDAR.XML|SQLITE3.C|MAP.CSV</Exclusion>
+  <Exclusion Type="FileName">REMAINING-INT-CONSTS.TXT|TAIWANCALENDAR.XML|XAMARIN-ANDROID-SDK-9.XML|SQLITE3.C|MAP.CSV</Exclusion>
 </PoliCheckExclusions>

--- a/build-tools/automation/PoliCheckExclusions.xml
+++ b/build-tools/automation/PoliCheckExclusions.xml
@@ -1,6 +1,6 @@
 <PoliCheckExclusions>
   <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
-  <Exclusion Type="FolderPathFull">NREFACTORY</Exclusion>
+  <!--<Exclusion Type="FolderPathFull">NREFACTORY</Exclusion>-->
   <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be skipped -->
   <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
   <!-- Each of these file types will be completely skipped for the entire scan -->

--- a/build-tools/automation/PoliCheckExclusions.xml
+++ b/build-tools/automation/PoliCheckExclusions.xml
@@ -1,0 +1,10 @@
+<PoliCheckExclusions>
+  <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
+  <Exclusion Type="FolderPathFull">NREFACTORY</Exclusion>
+  <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be skipped -->
+  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <!-- Each of these file types will be completely skipped for the entire scan -->
+  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+  <!-- The specified file names will be skipped during the scan regardless which folder they are in -->
+  <Exclusion Type="FileName">REMAINING-INT-CONSTS.TXT|TAIWANCALENDAR.XML|SQLITE3.C|MAP.CSV</Exclusion>
+</PoliCheckExclusions>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjcollins_xa-policheck
+    ref: refs/heads/master
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/master
+    ref: refs/heads/pjcollins_xa-policheck
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -78,9 +78,34 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: security\xa-static-analysis\v2.yml@yaml
+
+    - template: security\credscan\v2.yml@yaml
       parameters:
-        credScanSuppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
+        suppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
+
+    - template: security\policheck\v1.yml@yaml
+      parameters:
+        exclusionFile: $(System.DefaultWorkingDirectory)\build-tools\automation\PoliCheckExclusions.xml
+
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+      displayName: Create Security Analysis Report
+      inputs:
+        CredScan: true
+        PoliCheck: true
+      condition: succeededOrFailed()
+
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+      displayName: Publish Security Analysis Logs
+      inputs:
+        ArtifactName: CodeAnalysisLogs
+      condition: succeededOrFailed()
+
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+      displayName: Fail Job if Security Issues are Detected
+      inputs:
+        CredScan: true
+        PoliCheck: true
+      condition: succeededOrFailed()
 
 - stage: mac_build
   displayName: Mac

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -69,9 +69,9 @@ stages:
 - stage: code_analysis
   displayName: Code Analysis
   jobs:
-  # Check - "Xamarin.Android (Code Analysis CredScan)"
+  # Check - "Xamarin.Android (Code Analysis CredScan and PoliCheck)"
   - job: run_static_analysis
-    displayName: CredScan
+    displayName: CredScan and PoliCheck
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/42

PoliCheck has been added to our code analysis job.  Initial results from
running this tool reported 27 failures, which are all present in
external sources and have been added to an exclusion list.

All code anaylsis steps and reporting for the xamarin-android pipeline
previously lived in yet another template (xa-static-analysis/v2.yml),
but the content of that file is no longer well suited for a template.
Rather than creating another version of this template in the
yaml-templates repo, the core logic has been moved here.