### PR TITLE
[Microsoft.Android.Sdk] fixes for ILLink and @(ProguardConfiguration)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -30,7 +30,12 @@ _ResolveAssemblies MSBuild target.
       <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
     </ItemGroup>
     <PropertyGroup>
-      <_AdditionalProperties>_ComputeFilesToPublishForRuntimeIdentifiers=true;_OuterIntermediateAssembly=@(IntermediateAssembly)</_AdditionalProperties>
+      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
+      <_AdditionalProperties>
+        _ComputeFilesToPublishForRuntimeIdentifiers=true;
+        _OuterIntermediateAssembly=@(IntermediateAssembly);
+        _ProguardProjectConfiguration=$(_ProguardProjectConfiguration);
+      </_AdditionalProperties>
     </PropertyGroup>
     <MSBuild
         Projects="$(MSBuildProjectFile)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Linker.targets
@@ -31,8 +31,8 @@ This file contains the .NET 5-specific targets to customize ILLink
       <_AdditionalTaskAssembly>$(_AdditionalTaskAssemblyDirectory)dotnet-linker.dll</_AdditionalTaskAssembly>
     </PropertyGroup>
     <PropertyGroup
-        Condition=" '$(AndroidLinkTool)' != '' ">
-      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data ProguardConfiguration="$(IntermediateOutputPath)proguard\proguard_project_references.cfg"</_ExtraTrimmerArgs>
+        Condition=" '$(_ProguardProjectConfiguration)' != '' ">
+      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data ProguardConfiguration="$(_ProguardProjectConfiguration)"</_ExtraTrimmerArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- add our custom steps -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1080,7 +1080,7 @@ namespace UnamedProject
 
 		[Test]
 		[NonParallelizable] // On MacOS, parallel /restore causes issues
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void BuildProguardEnabledProject ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
@@ -1101,12 +1101,12 @@ namespace UnamedProject
 
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
+				var toolbar_class = Builder.UseDotNet ? "androidx.appcompat.widget.Toolbar" : "android.support.v7.widget.Toolbar";
 				if (isRelease && !string.IsNullOrEmpty (linkTool)) {
 					var proguardProjectPrimary = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "proguard", "proguard_project_primary.cfg");
 					FileAssert.Exists (proguardProjectPrimary);
 					Assert.IsTrue (StringAssertEx.ContainsText (File.ReadAllLines (proguardProjectPrimary), $"-keep class {proj.JavaPackageName}.MainActivity"), $"`{proj.JavaPackageName}.MainActivity` should exist in `proguard_project_primary.cfg`!");
 
-					var toolbar_class = "android.support.v7.widget.Toolbar";
 					var aapt_rules = b.Output.GetIntermediaryPath ("aapt_rules.txt");
 					FileAssert.Exists (aapt_rules);
 					Assert.IsTrue (StringAssertEx.ContainsText (File.ReadAllLines (aapt_rules), $"-keep class {toolbar_class}"), $"`{toolbar_class}` should exist in `{aapt_rules}`!");
@@ -1117,7 +1117,7 @@ namespace UnamedProject
 				var classes = new [] {
 					"Lmono/MonoRuntimeProvider;",
 					"Landroid/runtime/JavaProxyThrowable;",
-					"Landroid/support/v7/widget/Toolbar;"
+					$"L{toolbar_class.Replace ('.', '/')};"
 				};
 				foreach (var className in classes) {
 					Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");


### PR DESCRIPTION
When using r8 or ProGuard in .NET 5, `proguard_project_references.cfg`
or `$(_ProguardProjectConfiguration)` was not being generated. It
turns out that the `$(_ProguardProjectConfiguration)` MSBuild property
was completely blank.

`$(_ProguardProjectConfiguration)` is used when deciding if
r8/ProGuard need to run such as:

https://github.com/xamarin/xamarin-android/blob/a944a8923c0f5e782af308525a3e99ebc2470fe8/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets#L28

The way the inner/outer builds work in .NET 5+, we need to set
`$(_ProguardProjectConfiguration)` from the outer build and pass it
through to the inner build running the `ILLink` MSBuild target.

After this fix, I could enable the `BuildProguardEnabledProject` test
under .NET 5. The only thing to note is that the `*.widget.Toolbar`
class is the AndroidX version due to a newer Xamarin.Forms used:

https://github.com/xamarin/xamarin-android/blob/a944a8923c0f5e782af308525a3e99ebc2470fe8/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs#L43-L48

Xamarin.Forms 4.5.x will bring in AndroidX if `$(TFV)` >= `v10.0`.