### PR TITLE
[Microsoft.Android.Sdk] set $(PublishTrimmed) after .csproj evaluated

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -42,9 +42,6 @@
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">SdkOnly</AndroidLinkMode>
     <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
   </PropertyGroup>
-  <PropertyGroup>
-    <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
-  </PropertyGroup>
 
   <Import Project="Microsoft.Android.Sdk.BundledVersions.props" Condition=" Exists('Microsoft.Android.Sdk.BundledVersions.props') " />
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -9,6 +9,7 @@
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
     <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
     <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
+    <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' And '$(AndroidApplication)' == 'true' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Build.Tests
 	public class EnvironmentContentTests : BaseTest
 	{
 		[Test]
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void BuildApplicationWithMonoEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
 		{
 			const string supportedAbis = "armeabi-v7a;x86";
@@ -36,10 +36,14 @@ namespace Xamarin.Android.Build.Tests
 				},
 			};
 			//LinkSkip one assembly that contains __AndroidLibraryProjects__.zip
-			string linkSkip = KnownPackages.SupportV7AppCompat_27_0_2_1.Id;
+			string linkSkip = "FormsViewGroup";
 			app.SetProperty ("AndroidLinkSkip", linkSkip);
 			app.SetProperty ("_AndroidSequencePointsMode", sequencePointsMode);
-			app.SetProperty (app.ReleaseProperties, KnownProperties.AndroidSupportedAbis, supportedAbis);
+			if (Builder.UseDotNet) {
+				app.SetRuntimeIdentifiers (supportedAbis.Split (';'));
+			} else {
+				app.SetProperty (app.ReleaseProperties, KnownProperties.AndroidSupportedAbis, supportedAbis);
+			}
 			using (var libb = CreateDllBuilder (Path.Combine ("temp", TestName, lib.ProjectName)))
 			using (var appb = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
 				Assert.IsTrue (libb.Build (lib), "Library build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 
 namespace Xamarin.ProjectTools
 {
@@ -15,6 +15,23 @@ namespace Xamarin.ProjectTools
 			} else if (androidAbi == "x86_64") {
 				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x64");
 			}
+		}
+
+		public static void SetRuntimeIdentifiers (this IShortFormProject project, string [] androidAbis)
+		{
+			var abis = new List<string> ();
+			foreach (var androidAbi in androidAbis) {
+				if (androidAbi == "armeabi-v7a") {
+					abis.Add ("android.21-arm");
+				} else if (androidAbi == "arm64-v8a") {
+					abis.Add ("android.21-arm64");
+				} else if (androidAbi == "x86") {
+					abis.Add ("android.21-x86");
+				} else if (androidAbi == "x86_64") {
+					abis.Add ("android.21-x64");
+				}
+			}
+			project.SetProperty (KnownProperties.RuntimeIdentifiers, string.Join (";", abis));
 		}
 	}
 }


### PR DESCRIPTION
I noticed that if you define `<AndroidLinkMode>Full</AndroidLinkMode>`
in a `.csproj` file, the `ILLink` MSBuild target did not run.

It turns out that we were setting `$(PublishTrimmed)` by default too
early. If set in `Microsoft.Android.Sdk.props`, this is evaluated
before the user's `.csproj` file. If we set this in
`Microsoft.Android.Sdk.targets`, then we can rely on values set in the
`.csproj` file.

I found a test that was failing due to this issue and added it to the
`dotnet` category. I made a couple other changes to the test so it
passed under .NET 5+:

* Test against `FormsViewGroup.dll` instead of a support library, so
  the test still passes if using AndroidX libraries.
* Use `$(RuntimeIdentifiers)` over `$(AndroidSupportedAbis)`. I added
  a new helper method for multiple RIDs.