### PR TITLE
[One .NET] exclude MSBuild targets for .dll.config files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <ProductVersion>11.1.99</ProductVersion>
-    <!-- NuGet package version numbers. See Documentation/guides/DotNet5.md.
+    <!-- NuGet package version numbers. See Documentation/guides/OneDotNet.md.
          Rules:
          * Reset patch version (third number) to 100 every time either major or minor version is bumped.
          * Bump last two digits of the patch version for service releases.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -17,6 +17,7 @@
 
 # Guides
 
+  * [One .NET](guides/OneDotNet.md)
   * [Build Process](guides/BuildProcess.md)
   * [`.axml` CodeBehind Support](guides/LayoutCodeBehind.md)
   * [MSBuild Best Practices](guides/MSBuildBestPractices.md)

--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -1,15 +1,15 @@
-# .NET 5 and Xamarin.Android
+# .NET 6 and Xamarin.Android
 
 _NOTE: this document is very likely to change, as the requirements for
-.NET 5 are better understood._
+.NET 6 are better understood._
 
-A .NET 5 project for a Xamarin.Android application will look something
+A .NET 6 project for a Xamarin.Android application will look something
 like:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>
@@ -24,10 +24,10 @@ See the [Target Framework Names in .NET 5][net5spec] spec for details.
 
 ## Consolidation of binding projects
 
-In .NET 5, there will no longer be a concept of a [binding
+In .NET 6, there will no longer be a concept of a [binding
 project][binding] as a separate project type. Any of the MSBuild item
 groups or build actions that currently work in binding projects will
-be supported through a .NET 5 Android application or library.
+be supported through a .NET 6 Android application or library.
 
 For example, a binding library could look like:
 
@@ -48,18 +48,30 @@ the metadata fixups from `Metadata.xml`.
 
 [binding]: https://docs.microsoft.com/xamarin/android/platform/binding-java-library/
 
+## .NET Configuration Files
+
+No support for [configuration files][config] such as `Foo.dll.config`
+or `Foo.exe.config` is available in Xamarin.Android projects targeting
+.NET 6. [`<dllmap>`][dllmap] configuration elements are not supported
+in .NET Core at all, and other element types for compatibility
+packages like [System.Configuration.ConfigurationManager][nuget] have
+never been supported in Xamarin.Android projects.
+
+[config]: https://docs.microsoft.com/dotnet/framework/configure-apps/
+[nuget]: https://www.nuget.org/packages/System.Configuration.ConfigurationManager/
+
 ## Changes to MSBuild tasks
 
-In .NET 5 the behavior of the following MSBuild tasks will change, but
+In .NET 6 the behavior of the following MSBuild tasks will change, but
 "legacy" projects will stay the same:
 
 * `<ValidateJavaVersion/>` - used to require Java 1.6, 1.7, or 1.8
   based on the version of the Android Build Tools or
-  `$(TargetFrameworkVersion)`. .NET 5 will require Java 1.8.
+  `$(TargetFrameworkVersion)`. .NET 6 will require Java 1.8.
 
 * `<ResolveAndroidTooling/>` - used to support the
   `$(AndroidUseLatestPlatformSdk)` setting or multiple
-  `$(TargetFrameworkVersion)`. .NET 5 will always target the latest
+  `$(TargetFrameworkVersion)`. .NET 6 will always target the latest
   Android APIs for `Mono.Android.dll`.
 
 ## Changes to MSBuild properties
@@ -86,7 +98,7 @@ Instead use .NET's concept of [runtime identifiers][rids]:
 
 `$(AndroidBoundExceptionType)` will be `System` by default.  This will
 [alter the types of exceptions thrown from various methods][abet-sys] to
-better align with existing .NET 5 semantics, at the cost of compatibility with
+better align with existing .NET 6 semantics, at the cost of compatibility with
 previous Xamarin.Android releases.
 
 `$(AndroidClassParser)` will be `class-parse` by default. `jar2xml`

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -96,6 +96,7 @@ ms.date: 01/24/2020
 + XA1021: Specified source Java library not found: {file}
 + XA1022: Specified reference Java library not found: {file}
 + [XA1023](xa1023.md): Using the DX DEX Compiler is deprecated.
++ [XA1024](xa1024.md): Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.
 
 ## XA2xxx: Linker
 

--- a/Documentation/guides/messages/xa1024.md
+++ b/Documentation/guides/messages/xa1024.md
@@ -1,0 +1,36 @@
+---
+title: Xamarin.Android warning XA1024
+description: XA1024 warning code
+ms.date: 07/08/2020
+---
+# Xamarin.Android warning XA1024
+
+## Example messages
+
+```
+warning XA1024: Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.
+```
+
+## Issue
+
+No support for [configuration files][config] such as `Foo.dll.config`
+or `Foo.exe.config` is available in Xamarin.Android projects targeting
+.NET 5 or higher. [`<dllmap>`][dllmap] configuration elements are not
+supported in .NET 5 at all, and other element types for compatibility
+packages like [System.Configuration.ConfigurationManager][nuget] have
+never been supported in Xamarin.Android projects.
+
+[config]: https://docs.microsoft.com/dotnet/framework/configure-apps/
+[nuget]: https://www.nuget.org/packages/System.Configuration.ConfigurationManager/
+
+## Solution
+
+Use a supported alternative for [`<dllmap>`][dllmap], such as the
+[NativeLibrary][native] API.
+
+Use an alternative for application settings such as
+[Preferences][preferences] in Xamarin.Essentials.
+
+[dllmap]: https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/dllmap.md
+[native]: https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.nativelibrary
+[preferences]: https://docs.microsoft.com/xamarin/essentials/preferences

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -45,7 +45,14 @@ _ResolveAssemblies MSBuild target.
     </MSBuild>
     <ItemGroup>
       <_ResolvedAssemblyFiles Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' " />
+      <_UnusedConfigFiles     Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.config' " />
     </ItemGroup>
+    <AndroidWarning
+        Code="XA1024"
+        ResourceName="XA1024"
+        FormatArguments="%(_UnusedConfigFiles.Identity)"
+        Condition=" '%(Identity)' != '' "
+    />
     <ProcessAssemblies
         InputAssemblies="@(_ResolvedAssemblyFiles)"
         IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
@@ -77,6 +84,17 @@ _ResolveAssemblies MSBuild target.
       <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
     </ItemGroup>
   </Target>
+
+  <PropertyGroup>
+    <_PrepareAssembliesDependsOnTargets>
+      _ResolveAssemblies;
+      _CheckForObsoleteAssemblies;
+      _ResolveSatellitePaths;
+      _CreatePackageWorkspace;
+      _ConvertPdbFiles;
+      _LinkAssemblies;
+    </_PrepareAssembliesDependsOnTargets>
+  </PropertyGroup>
 
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -37,6 +37,33 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       Build;
       _CopyPackage;
     </_PackageForAndroidDependsOn>
+    <_PrepareBuildApkDependsOnTargets>
+      _SetLatestTargetFrameworkVersion;
+      _GetLibraryImports;
+      _RemoveRegisterAttribute;
+      _ResolveAssemblies;
+      _ResolveSatellitePaths;
+      _CreatePackageWorkspace;
+      _ConvertPdbFiles;
+      _LinkAssemblies;
+      _GenerateJavaStubs;
+      _ManifestMerger;
+      _ConvertCustomView;
+      $(_AfterConvertCustomView);
+      $(AfterGenerateAndroidManifest);
+      _GenerateEnvironmentFiles;
+      _CompileJava;
+      _CreateApplicationSharedLibraries;
+      _CompileDex;
+      $(_AfterCompileDex);
+      _CreateBaseApk;
+      _PrepareAssemblies;
+      _ResolveSatellitePaths;
+      _CheckApkPerAbiFlag;
+      _LintChecks;
+      _IncludeNativeSystemLibraries;
+      _CheckGoogleSdkRequirements;
+    </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -583,6 +583,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ignoring configuration file &apos;{0}&apos;. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher..
+        /// </summary>
+        internal static string XA1024 {
+            get {
+                return ResourceManager.GetString("XA1024", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released..
         /// </summary>
         internal static string XA2000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -398,6 +398,11 @@ In this message, the term "binding" means a piece of generated code that makes i
     <value>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</value>
     <comment>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</comment>
   </data>
+  <data name="XA1024" xml:space="preserve">
+    <value>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</value>
+    <comment>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">V sestavení {0} se zjistilo, že se používá AppDomain.CreateDomain(). .NET 5 bude podporovat jen jednu doménu AppDomain, proto toto rozhraní API už nebude po vydání rozhraní .NET 5 v Xamarin.Androidu k dispozici.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">In der Assembly "{0}" wurde die Verwendung von "AppDomain.CreateDomain()" festgestellt. .NET 5 unterstützt nur eine einzelne AppDomain, sodass diese API nach dem Release von .NET 5 nicht mehr in Xamarin.Android verfügbar ist.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Se detectó el uso de AppDomain.CreateDomain() en el ensamblado: {0}. En .NET 5 solo se admitirá una instancia de AppDomain, por lo que esta API ya no estará disponible en Xamarin.Android una vez que se haya lanzado .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Utilisation de AppDomain.CreateDomain() détectée dans l'assembly {0}. .NET 5 prend uniquement en charge un seul AppDomain. Cette API ne sera donc plus disponible dans Xamarin.Android après la publication de .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">È stato rilevato l'uso di AppDomain.CreateDomain() nell'assembly: {0}. .NET 5 supporterà solo un'unica istanza di AppDomain, di conseguenza questa API non sarà più disponibile in Xamarin.Android dopo il rilascio di .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">アセンブリ {0} で AppDomain.CreateDomain() が使用されていることが検出されました。.NET 5 では単一の AppDomain のみがサポートされる予定のため、.NET 5 がリリースされるとこの API は Xamarin.Android では使用できなくなります。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">{0} 어셈블리에서 AppDomain.CreateDomain() 사용이 검색되었습니다. .NET 5는 단일 AppDomain만 지원하므로 .NET 5가 릴리스되면 이 API는 Xamarin.Android에서 더는 사용할 수 없습니다.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Wykryto użycie metody AppDomain.CreateDomain() w następującym zestawie: {0}. Program .NET 5 obsługuje tylko jeden obiekt AppDomain, dlatego ten interfejs API nie będzie już dostępny w interfejsie Xamarin.Android po wydaniu programu .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">O uso de AppDomain.CreateDomain() foi detectado no assembly: {0}. O .NET 5 dá suporte apenas a um único AppDomain, portanto, essa API não estará mais disponível no Xamarin.Android quando o .NET 5 for lançado.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">В сборке обнаружено использование AppDomain.CreateDomain(): {0}. .NET 5 поддерживает только один домен AppDomain, поэтому этот API не будет доступен в Xamarin.Android после выпуска .NET 5.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">Bütünleştirilmiş kodda AppDomain.CreateDomain() metodunun kullanıldığı saptandı: {0}. .NET 5 yalnızca tek bir AppDomain'i destekleyeceğinden bu API, .NET 5 yayımlandıktan sonra artık Xamarin.Android içinde kullanılamayacak.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">在程序集 {0} 中检测到使用了 AppDomain.CreateDomain()。.NET 5 将仅支持一个 AppDomain，因此 .NET 5 发布后，将无法再在 Xamarin.Android 中使用此 API。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -343,6 +343,12 @@ In this message, the term "binding" means a piece of generated code that makes i
         <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
         <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
       </trans-unit>
+      <trans-unit id="XA1024">
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
+        <target state="new">Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</target>
+        <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
+{0} - The file name such as 'Foo.dll.config'</note>
+      </trans-unit>
       <trans-unit id="XA2000">
         <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
         <target state="translated">在下列組件中偵測到使用 AppDomain.CreateDomain(): {0}。.NET 5 只支援單一 AppDomain，因此在 .NET 5 發行之後，此 API 就無法再於 Xamarin.Android 中使用。</target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1319,24 +1319,6 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<Target Name="_CollectConfigFiles">
-	<GetFilesThatExist
-			Files="@(ResolvedAssemblies->'%(identity).config')">
-		<Output TaskParameter="FilesThatExist" ItemName="_ResolvedConfigFiles" />
-	</GetFilesThatExist>
-</Target>
-
-<Target Name="_CopyConfigFiles"
-		Inputs="@(_ResolvedConfigFiles)"
-		Outputs="$(_AndroidStampDirectory)_CopyConfigFiles.stamp"
-		DependsOnTargets="_CollectConfigFiles">
-	<CopyIfChanged
-			SourceFiles="@(_ResolvedConfigFiles)"
-			DestinationFiles="@(_ResolvedConfigFiles->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-	/>
-	<Touch Files="$(_AndroidStampDirectory)_CopyConfigFiles.stamp" AlwaysCreate="True" />
-</Target>
-
 <Target Name="_CollectMdbFiles"
 		DependsOnTargets="_CollectPdbFiles">
 	<GetFilesThatExist
@@ -1415,18 +1397,6 @@ because xbuild doesn't support framework reference assemblies.
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)**" />
   </ItemGroup>
 </Target>
-
-<PropertyGroup>
-	<_PrepareAssembliesDependsOnTargets>
-		_ResolveAssemblies
-		;_CheckForObsoleteAssemblies
-		;_ResolveSatellitePaths
-		;_CreatePackageWorkspace
-		;_CopyConfigFiles
-		;_ConvertPdbFiles
-		;_LinkAssemblies
-	</_PrepareAssembliesDependsOnTargets>
-</PropertyGroup>
 
 <!-- _PrepareAssemblies lives in Xamarin.Android.Legacy.targets and Microsoft.Android.Sdk.AssemblyResolution.targets -->
 
@@ -2014,37 +1984,6 @@ because xbuild doesn't support framework reference assemblies.
     <FileWrites Include="@(_ApplicationSharedLibrary)" />
   </ItemGroup>
 </Target>
-
-<PropertyGroup>
-	<_PrepareBuildApkDependsOnTargets>
-		_SetLatestTargetFrameworkVersion;
-		_GetLibraryImports;
-		_RemoveRegisterAttribute;
-		_ResolveAssemblies;
-		_ResolveSatellitePaths;
-		_CreatePackageWorkspace;
-		_CopyConfigFiles;
-		_ConvertPdbFiles;
-		_LinkAssemblies;
-		_GenerateJavaStubs;
-		_ManifestMerger;
-		_ConvertCustomView;
-		$(_AfterConvertCustomView);
-		$(AfterGenerateAndroidManifest);
-		_GenerateEnvironmentFiles;
-		_CompileJava;
-		_CreateApplicationSharedLibraries;
-		_CompileDex;
-		$(_AfterCompileDex);
-		_CreateBaseApk;
-		_PrepareAssemblies;
-		_ResolveSatellitePaths;
-		_CheckApkPerAbiFlag;
-		;_LintChecks
-		;_IncludeNativeSystemLibraries
-		;_CheckGoogleSdkRequirements
-	</_PrepareBuildApkDependsOnTargets>
-</PropertyGroup>
 
 <Target Name="_PrepareBuildApk"
     DependsOnTargets="$(_PrepareBuildApkDependsOnTargets)">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -116,6 +116,34 @@ projects. .NET 5 projects will not import this file.
       _CleanMonoAndroidIntermediateDir;
       _CleanAndroidBuildPropertiesCache;
     </CleanDependsOn>
+    <_PrepareBuildApkDependsOnTargets>
+      _SetLatestTargetFrameworkVersion;
+      _GetLibraryImports;
+      _RemoveRegisterAttribute;
+      _ResolveAssemblies;
+      _ResolveSatellitePaths;
+      _CreatePackageWorkspace;
+      _CopyConfigFiles;
+      _ConvertPdbFiles;
+      _LinkAssemblies;
+      _GenerateJavaStubs;
+      _ManifestMerger;
+      _ConvertCustomView;
+      $(_AfterConvertCustomView);
+      $(AfterGenerateAndroidManifest);
+      _GenerateEnvironmentFiles;
+      _CompileJava;
+      _CreateApplicationSharedLibraries;
+      _CompileDex;
+      $(_AfterCompileDex);
+      _CreateBaseApk;
+      _PrepareAssemblies;
+      _ResolveSatellitePaths;
+      _CheckApkPerAbiFlag;
+      _LintChecks;
+      _IncludeNativeSystemLibraries;
+      _CheckGoogleSdkRequirements;
+    </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>
 
   <!-- Binding projects -->
@@ -273,6 +301,36 @@ projects. .NET 5 projects will not import this file.
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
     />
   </Target>
+
+  <Target Name="_CollectConfigFiles">
+    <GetFilesThatExist
+        Files="@(ResolvedAssemblies->'%(identity).config')">
+      <Output TaskParameter="FilesThatExist" ItemName="_ResolvedConfigFiles" />
+    </GetFilesThatExist>
+  </Target>
+
+  <Target Name="_CopyConfigFiles"
+      Inputs="@(_ResolvedConfigFiles)"
+      Outputs="$(_AndroidStampDirectory)_CopyConfigFiles.stamp"
+      DependsOnTargets="_CollectConfigFiles">
+    <CopyIfChanged
+        SourceFiles="@(_ResolvedConfigFiles)"
+        DestinationFiles="@(_ResolvedConfigFiles->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+    />
+    <Touch Files="$(_AndroidStampDirectory)_CopyConfigFiles.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <PropertyGroup>
+    <_PrepareAssembliesDependsOnTargets>
+      _ResolveAssemblies;
+      _CheckForObsoleteAssemblies;
+      _ResolveSatellitePaths;
+      _CreatePackageWorkspace;
+      _CopyConfigFiles;
+      _ConvertPdbFiles;
+      _LinkAssemblies;
+    </_PrepareAssembliesDependsOnTargets>
+  </PropertyGroup>
 
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">


### PR DESCRIPTION
Running under .NET 5+, the `BuildBasicApplicationCheckConfigFiles`
test fails with:

    UnnamedProject.dll.config was must be copied to Intermediate directory
    Expected: True
    But was: False

After review, it doesn't seem like Xamarin.Android needs to support
`.dll.config` files in .NET 5+ at all.

1. `<dllmap>` is not supported. It was a feature of Mono.
2. `appSettings` only work via a compat NuGet package:

```xml
<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
```

This NuGet package does not work in the current Xamarin.Android
(throws `PlatformNotSupportedException`), and there is no other
mechanism to support `appSettings`.

Any MSBuild targets related to `.config` files have been moved to
`Xamarin.Android.Legacy.targets`.

I added `XA1024` to warn going forward and updated tests around the
`_CopyConfigFiles` MSBuild target to run under `dotnet` context.