### PR TITLE
[Xamarin.Android.Build.Tasks] deprecate %(ProjectReference.IsAppExtension)

### DIFF
--- a/Documentation/guides/DotNet5.md
+++ b/Documentation/guides/DotNet5.md
@@ -102,6 +102,15 @@ If Java binding is enabled with `@(InputJar)`, `@(EmbeddedJar)`,
 `@(LibraryProjectZip)`, etc. then `$(AllowUnsafeBlocks)` will default
 to `True`.
 
+Referencing an Android Wear project from an Android application will
+not be supported:
+
+```xml
+<ProjectReference Include="..\Foo.Wear\Foo.Wear.csproj">
+  <IsAppExtension>True</IsAppExtension>
+</ProjectReference>
+```
+
 [rids]: https://docs.microsoft.com/dotnet/core/rid-catalog
 [abet-sys]: https://github.com/xamarin/xamarin-android/issues/4127
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -152,6 +152,7 @@ ms.date: 01/24/2020
 + [XA4309](xa4309.md): 'MultiDexMainDexList' file '{file}' does not exist.
 + [XA4310](xa4310.md): \`$(AndroidSigningKeyStore)\` file \`{keystore}\` could not be found.
 + XA4311: The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.
++ [XA4312](xa4312.md): Referencing an Android Wear application project from an Android application project is deprecated.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/guides/messages/xa4312.md
+++ b/Documentation/guides/messages/xa4312.md
@@ -1,0 +1,29 @@
+---
+title: Xamarin.Android error/warning XA4312
+description: XA4312 error/warning code
+ms.date: 07/07/2020
+---
+# Xamarin.Android error/warning XA4312
+
+Referencing an [Android Wear][0] application project from an Android
+application project is deprecated.
+
+From a `Foo.Android.csproj` in past versions of Xamarin.Android, you
+could reference a `Foo.Wear.csproj` such as:
+
+```xml
+<ProjectReference Include="..\Foo.Wear\Foo.Wear.csproj">
+  <IsAppExtension>True</IsAppExtension>
+</ProjectReference>
+```
+
+This would embed `com.foo.wear.apk` *inside* `com.foo.android.apk` in
+`Resources/raw`.
+
+## Solution
+
+Distribute `Foo.Wear.csproj` in the above example as a [standalone][1]
+Android Wear application instead.
+
+[0]: https://docs.microsoft.com/xamarin/android/wear/get-started/intro-to-wear
+[1]: https://developer.android.com/training/wearables/apps/standalone-apps

--- a/Documentation/release-notes/wear.md
+++ b/Documentation/release-notes/wear.md
@@ -1,0 +1,35 @@
+#### Deprecation of Android Wear Embedding
+
+* warning XA4312: Embedding an [Android Wear][0] application inside an
+  Android application is deprecated. Distribute the Wear application
+  as a [standalone application][1] instead.
+
+From a `Foo.Android.csproj` Xamarin.Android project, you could
+reference a `Foo.Wear.csproj` such as:
+
+```xml
+<ProjectReference Include="..\Foo.Wear\Foo.Wear.csproj">
+  <Name>Wearable</Name>
+  <IsAppExtension>True</IsAppExtension>
+  <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+</ProjectReference>
+```
+
+This would embed `com.foo.wear.apk` *inside* `com.foo.android.apk` in
+`Resources/raw`.
+
+Distribute `Foo.Wear.csproj` in the above example as a [standalone][1]
+Android Wear application instead.
+
+##### Android Wear 1.x
+
+Note that only Android Wear 2.0 and higher is supported by
+Xamarin.Android. Android Wear 1.x applications fail to compile with:
+
+```
+error XA0121: Assembly 'Xamarin.Android.Wearable' is using '[assembly: Java.Interop.JavaLibraryReferenceAttribute]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.
+error XA0121: Assembly 'Xamarin.Android.Wearable' is using '[assembly: Android.IncludeAndroidResourcesFromAttribute]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.
+```
+
+[0]: https://docs.microsoft.com/xamarin/android/wear/get-started/intro-to-wear
+[1]: https://developer.android.com/training/wearables/apps/standalone-apps

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -258,6 +258,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavadocImporter.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Versions.props" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.VisualBasic.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Wear.targets" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\K4os.Compression.LZ4.dll" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
@@ -17,14 +17,15 @@ This file is only used by "legacy" Xamarin.Android projects.
     <WearAppTarget>SignAndroidPackage</WearAppTarget>
   </PropertyGroup>
 
-  <Target Name="_PrepareWearApplication" DependsOnTargets="_ValidateAndroidPackageProperties"
-      Condition="$(AndroidApplication) And '@(_AppExtensionReference)' != ''">
+  <Target Name="_PrepareWearApplication"
+      Condition=" $(AndroidApplication) And '@(_AppExtensionReference)' != '' "
+      DependsOnTargets="_ValidateAndroidPackageProperties">
     <ParseAndroidWearProjectAndManifest ProjectFiles="@(_AppExtensionReference)">
       <Output TaskParameter="ApplicationManifestFile" PropertyName="BundledWearApplicationManifestFile" />
       <Output TaskParameter="ApplicationPackageName" PropertyName="BundledWearApplicationPackageName" />
     </ParseAndroidWearProjectAndManifest>
     <CreateProperty
-        Condition="$(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True'"
+        Condition=" $(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True' "
         Value="AndroidKeyStore=True;AndroidSigningKeyStore=$([System.IO.Path]::GetFullPath ('$(AndroidSigningKeyStore)'));AndroidSigningStorePass=$(AndroidSigningStorePass);AndroidSigningKeyAlias=$(AndroidSigningKeyAlias);AndroidSigningKeyPass=$(AndroidSigningKeyPass)">
       <Output TaskParameter="Value" PropertyName="_AdditionaEmbeddedWearAppProperties" />
     </CreateProperty>
@@ -51,7 +52,7 @@ This file is only used by "legacy" Xamarin.Android projects.
     </PrepareWearApplicationFiles>
     <!-- in case there is no actual wear apk to be bundled, we don't generate wear_app_desc.xml and we shouldn't modify AndroidManifest.xml as if it had the apk -->
     <CreateProperty Value=""
-        Condition="'@(_WearableApplicationDescriptionFile)' == ''">
+        Condition=" '@(_WearableApplicationDescriptionFile)' == '' ">
       <Output TaskParameter="Value" PropertyName="BundledWearApplicationPackageName" />
     </CreateProperty>
   </Target>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
@@ -1,0 +1,65 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Wear.targets
+
+This file contains MSBuild targets related to Android Wear.
+
+This file is only used by "legacy" Xamarin.Android projects.
+
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.ParseAndroidWearProjectAndManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.PrepareWearApplicationFiles"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+  <PropertyGroup>
+    <WearAppTarget>SignAndroidPackage</WearAppTarget>
+  </PropertyGroup>
+
+  <Target Name="_PrepareWearApplication" DependsOnTargets="_ValidateAndroidPackageProperties"
+      Condition="$(AndroidApplication) And '@(_AppExtensionReference)' != ''">
+    <ParseAndroidWearProjectAndManifest ProjectFiles="@(_AppExtensionReference)">
+      <Output TaskParameter="ApplicationManifestFile" PropertyName="BundledWearApplicationManifestFile" />
+      <Output TaskParameter="ApplicationPackageName" PropertyName="BundledWearApplicationPackageName" />
+    </ParseAndroidWearProjectAndManifest>
+    <CreateProperty
+        Condition="$(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True'"
+        Value="AndroidKeyStore=True;AndroidSigningKeyStore=$([System.IO.Path]::GetFullPath ('$(AndroidSigningKeyStore)'));AndroidSigningStorePass=$(AndroidSigningStorePass);AndroidSigningKeyAlias=$(AndroidSigningKeyAlias);AndroidSigningKeyPass=$(AndroidSigningKeyPass)">
+      <Output TaskParameter="Value" PropertyName="_AdditionaEmbeddedWearAppProperties" />
+    </CreateProperty>
+    <MSBuild Projects="@(_AppExtensionReference)" Properties="Configuration=$(Configuration);AndroidUseSharedRuntime=False;EmbedAssembliesIntoApk=True;$(_AdditionaEmbeddedWearAppProperties)" Targets="Build;SignAndroidPackage"/>
+    <CreateProperty
+        Condition="$(BundledWearApplicationApkPath) == '' And ($(WearAppTarget) == 'SignAndroidPackage' Or !Exists('%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)$(_AndroidDebugKeyStoreFlag)'))"
+        Value="%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)bin\$(Configuration)\$(BundledWearApplicationPackageName)-Signed.apk">
+      <Output TaskParameter="Value" PropertyName="BundledWearApplicationApkPath" />
+    </CreateProperty>
+    <CreateProperty
+        Condition="$(BundledWearApplicationApkPath) == '' And $(WearAppTarget) == 'PackageForAndroid' And Exists('%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)$(_AndroidDebugKeyStoreFlag)')"
+        Value="%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)bin\$(Configuration)\$(BundledWearApplicationPackageName).apk">
+      <Output TaskParameter="Value" PropertyName="BundledWearApplicationApkPath" />
+    </CreateProperty>
+    <PrepareWearApplicationFiles
+        PackageName="$(_AndroidPackage)"
+        IntermediateOutputPath="$(IntermediateOutputPath)"
+        AndroidLibraryFlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
+        WearAndroidManifestFile="$(BundledWearApplicationManifestFile)"
+        WearApplicationApkPath="$(BundledWearApplicationApkPath)">
+      <Output TaskParameter="WearableApplicationDescriptionFile" ItemName="_WearableApplicationDescriptionFile" />
+      <Output TaskParameter="BundledWearApplicationApkResourceFile" ItemName="_BundledWearApplicationApkResourceFile" />
+      <Output TaskParameter="ModifiedFiles" ItemName="_ModifiedResources" />
+    </PrepareWearApplicationFiles>
+    <!-- in case there is no actual wear apk to be bundled, we don't generate wear_app_desc.xml and we shouldn't modify AndroidManifest.xml as if it had the apk -->
+    <CreateProperty Value=""
+        Condition="'@(_WearableApplicationDescriptionFile)' == ''">
+      <Output TaskParameter="Value" PropertyName="BundledWearApplicationPackageName" />
+    </CreateProperty>
+  </Target>
+
+  <Target Name="SetWearAppTargetToPackageForAndroid">
+    <CreateProperty Value="PackageForAndroid">
+      <Output TaskParameter="Value" PropertyName="WearAppTarget" />
+    </CreateProperty>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -33,6 +33,10 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       $(_AfterCompileDex);
       _AddFilesToFileWrites;
     </_BeforeIncrementalClean>
+    <_PackageForAndroidDependsOn>
+      Build;
+      _CopyPackage;
+    </_PackageForAndroidDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
@@ -56,14 +60,10 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
 
   <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
   <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">
-    <CoreResolveReferencesDependsOn>
+    <ResolveReferencesDependsOn>
       _SeparateAppExtensionReferences;
-      _PrepareWearApplication;
       $(ResolveReferencesDependsOn);
       _AddAndroidCustomMetaData;
-    </CoreResolveReferencesDependsOn>
-    <ResolveReferencesDependsOn>
-      $(CoreResolveReferencesDependsOn);
       UpdateAndroidInterfaceProxies;
       UpdateAndroidResources;
       AddBindingsToCompile;

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1060,6 +1060,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Referencing the Android Wear application project &apos;{0}&apos; from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead..
+        /// </summary>
+        internal static string XA4312 {
+            get {
+                return ResourceManager.GetString("XA4312", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing Android NDK toolchains directory &apos;{0}&apos;. Please install the Android NDK..
         /// </summary>
         internal static string XA5101 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -655,6 +655,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</comment>
   </data>
+  <data name="XA4312" xml:space="preserve">
+    <value>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</value>
+    <comment>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</comment>
+  </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>
     <comment>{0} - The path of the missing directory</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Chybí adresář sady nástrojů Android NDK {0}. Nainstalujte prosím sadu Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Das Android NDK-Toolkettenverzeichnis "{0}" fehlt. Installieren Sie das Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Falta el directorio de cadenas de herramientas de Android NDK "{0}". Instale Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Répertoire de chaînes d'outils du kit Android NDK manquant '{0}'. Installez le kit Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">La directory '{0}' delle toolchain di Android NDK non è presente. Installare Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Android NDK のツールチェーン ディレクトリ '{0}' がありません。Android NDK をインストールしてください。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Android NDK 도구 체인 디렉터리 '{0}'이(가) 없습니다. Android NDK를 설치하세요.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Brak katalogu łańcuchów narzędzi zestawu Android NDK „{0}”. Zainstaluj zestaw Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">O diretório de cadeias de ferramentas '{0}' do Android NDK está ausente. Instale o Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">Отсутствует каталог цепочек инструментов Android NDK "{0}". Установите Android NDK.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">'{0}' Android NDK araç zincirleri dizini eksik. Lütfen Android NDK'yi yükleyin.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">缺少 Android NDK 工具链目录“{0}”。请安装 Android NDK。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -657,6 +657,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The following are literal names and should not be translated: Wear, APK, SignAndroidPackage
 "Wear" is a short version of the full product name "Wear OS" and so should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA4312">
+        <source>Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</source>
+        <target state="new">Referencing the Android Wear application project '{0}' from an Android application project is deprecated and will no longer be supported in a future version of Xamarin.Android. Remove the Android Wear application project reference from the Android application project and distribute the Wear application as a standalone application instead.</target>
+        <note>The following are literal names and should not be translated: Android Wear, Android, Wear.
+{0} - The referenced Android Wear project.</note>
+      </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
         <target state="translated">缺少 Android NDK 工具鏈目錄 '{0}'。請安裝 Android NDK。</target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3012,30 +3012,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		public void ResolveLibraryImportsWithReadonlyFiles ()
-		{
-			//NOTE: doesn't need to be a full Android Wear app
-			var proj = new XamarinAndroidApplicationProject {
-				PackageReferences = {
-					KnownPackages.AndroidWear_2_2_0,
-					KnownPackages.Android_Arch_Core_Common_26_1_0,
-					KnownPackages.Android_Arch_Lifecycle_Common_26_1_0,
-					KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0,
-					KnownPackages.SupportCompat_27_0_2_1,
-					KnownPackages.SupportCoreUI_27_0_2_1,
-					KnownPackages.SupportPercent_27_0_2_1,
-					KnownPackages.SupportV7RecyclerView_27_0_2_1,
-				},
-			};
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				b.Target = "Restore";
-				Assert.IsTrue (b.Build (proj), "Restore should have succeeded.");
-				b.Target = "Build";
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-			}
-		}
-
-		[Test]
 		public void AndroidLibraryProjectsZipWithOddPaths ()
 		{
 			var proj = new XamarinAndroidLibraryProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -30,6 +30,9 @@ namespace Xamarin.ProjectTools
 			TargetFrameworkVersion = Versions.KitkatWatch;
 			UseLatestPlatformSdk = true;
 			PackageReferences.Add (KnownPackages.AndroidWear_2_2_0);
+			if (Builder.UseDotNet) {
+				this.AddDotNetCompatPackages ();
+			}
 
 			MainActivity = default_main_activity;
 			StringsXml = default_strings_xml;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -72,6 +72,11 @@
       <Link>Xamarin.Android.Bindings.JarToXml.targets</Link>
     </None>
     <None
+        Include="MSBuild\Xamarin\Android\Xamarin.Android.Wear.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.Wear.targets</Link>
+    </None>
+    <None
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets</Link>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -89,8 +89,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckProjectItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckDuplicateJavaLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectLibraryAssets" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.ParseAndroidWearProjectAndManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-<UsingTask TaskName="Xamarin.Android.Tasks.PrepareWearApplicationFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.DetermineJavaLibrariesToCompile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileNativeAssembly" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LinkApplicationSharedLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -375,6 +373,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Tooling.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Legacy.targets" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Wear.targets"   Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
 
 <Target Name="_WriteLockFile" Condition=" '$(_AndroidDetectParallelBuilds)' == 'True' ">
   <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
@@ -385,49 +384,17 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AppExtensionReference Condition=" '%(ProjectReference.IsAppExtension)' == 'True' " Include="@(ProjectReference)" />
     <ProjectReference Remove="@(_AppExtensionReference)" />
   </ItemGroup>
-</Target>
-
-<PropertyGroup>
-	<WearAppTarget>SignAndroidPackage</WearAppTarget>
-</PropertyGroup>
-
-<Target Name="_PrepareWearApplication" DependsOnTargets="_ValidateAndroidPackageProperties"
-	Condition="$(AndroidApplication) And '@(_AppExtensionReference)' != ''">
-	<ParseAndroidWearProjectAndManifest ProjectFiles="@(_AppExtensionReference)">
-		<Output TaskParameter="ApplicationManifestFile" PropertyName="BundledWearApplicationManifestFile" />
-		<Output TaskParameter="ApplicationPackageName" PropertyName="BundledWearApplicationPackageName" />
-	</ParseAndroidWearProjectAndManifest>
-	<CreateProperty
-		Condition="$(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True'"
-		Value="AndroidKeyStore=True;AndroidSigningKeyStore=$([System.IO.Path]::GetFullPath ('$(AndroidSigningKeyStore)'));AndroidSigningStorePass=$(AndroidSigningStorePass);AndroidSigningKeyAlias=$(AndroidSigningKeyAlias);AndroidSigningKeyPass=$(AndroidSigningKeyPass)">
-		<Output TaskParameter="Value" PropertyName="_AdditionaEmbeddedWearAppProperties" />
-	</CreateProperty>
-	<MSBuild Projects="@(_AppExtensionReference)" Properties="Configuration=$(Configuration);AndroidUseSharedRuntime=False;EmbedAssembliesIntoApk=True;$(_AdditionaEmbeddedWearAppProperties)" Targets="Build;SignAndroidPackage"/>
-	<CreateProperty
-		Condition="$(BundledWearApplicationApkPath) == '' And ($(WearAppTarget) == 'SignAndroidPackage' Or !Exists('%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)$(_AndroidDebugKeyStoreFlag)'))"
-		Value="%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)bin\$(Configuration)\$(BundledWearApplicationPackageName)-Signed.apk">
-		<Output TaskParameter="Value" PropertyName="BundledWearApplicationApkPath" />
-	</CreateProperty>
-	<CreateProperty
-		Condition="$(BundledWearApplicationApkPath) == '' And $(WearAppTarget) == 'PackageForAndroid' And Exists('%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)$(_AndroidDebugKeyStoreFlag)')"
-		Value="%(_AppExtensionReference.RootDir)%(_AppExtensionReference.Directory)bin\$(Configuration)\$(BundledWearApplicationPackageName).apk">
-		<Output TaskParameter="Value" PropertyName="BundledWearApplicationApkPath" />
-	</CreateProperty>
-	<PrepareWearApplicationFiles
-		PackageName="$(_AndroidPackage)"
-		IntermediateOutputPath="$(IntermediateOutputPath)"
-		AndroidLibraryFlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
-		WearAndroidManifestFile="$(BundledWearApplicationManifestFile)"
-		WearApplicationApkPath="$(BundledWearApplicationApkPath)">
-		<Output TaskParameter="WearableApplicationDescriptionFile" ItemName="_WearableApplicationDescriptionFile" />
-		<Output TaskParameter="BundledWearApplicationApkResourceFile" ItemName="_BundledWearApplicationApkResourceFile" />
-		<Output TaskParameter="ModifiedFiles" ItemName="_ModifiedResources" />
-	</PrepareWearApplicationFiles>
-	<!-- in case there is no actual wear apk to be bundled, we don't generate wear_app_desc.xml and we shouldn't modify AndroidManifest.xml as if it had the apk -->
-	<CreateProperty Value=""
-		Condition="'@(_WearableApplicationDescriptionFile)' == ''">
-		<Output TaskParameter="Value" PropertyName="BundledWearApplicationPackageName" />
-	</CreateProperty>
+  <PropertyGroup>
+    <_AppExtensionContinueOnError Condition=" '$(UsingAndroidNETSdk)' == 'true' ">ErrorAndStop</_AppExtensionContinueOnError>
+    <_AppExtensionContinueOnError Condition=" '$(UsingAndroidNETSdk)' != 'true' ">WarnAndContinue</_AppExtensionContinueOnError>
+  </PropertyGroup>
+  <AndroidError
+      Code="XA4312"
+      ResourceName="XA4312"
+      FormatArguments="%(_AppExtensionReference.FullPath)"
+      ContinueOnError="$(_AppExtensionContinueOnError)"
+      Condition=" '%(FullPath)' != '' "
+  />
 </Target>
 
 <!-- When looking for related files to copy, look for Mono debugging files as well -->
@@ -1272,16 +1239,9 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-
-<Target Name="SetWearAppTargetToPackageForAndroid">
-	<CreateProperty Value="PackageForAndroid">
-		<Output TaskParameter="Value" PropertyName="WearAppTarget" />
-	</CreateProperty>
-</Target>
-
 <!-- Package Build -->
 <Target Name="PackageForAndroid"
-	DependsOnTargets="SetWearAppTargetToPackageForAndroid;Build;_CopyPackage" />
+	DependsOnTargets="$(_PackageForAndroidDependsOn)" />
 	
 <Target Name="_CheckForObsoleteAssemblies">
 	<PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -46,6 +46,11 @@ projects. .NET 5 projects will not import this file.
       $(_AfterCompileDex);
       _AddFilesToFileWrites;
     </_BeforeIncrementalClean>
+    <_PackageForAndroidDependsOn>
+      SetWearAppTargetToPackageForAndroid;
+      Build;
+      _CopyPackage;
+    </_PackageForAndroidDependsOn>
   </PropertyGroup>
 
   <!-- Class library projects -->


### PR DESCRIPTION
Context: https://developer.android.com/training/wearables/apps/standalone-apps

Going forward in .NET 5+, we will be dropping support for embedding
Android Wear applications inside a "main" application.

From a `Foo.Android.csproj` you can:

    <ProjectReference Include="..\Foo.Wear\Foo.Wear.csproj">
      <Name>Wearable</Name>
      <IsAppExtension>True</IsAppExtension>
      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
    </ProjectReference>

This would embed `com.foo.wear.apk` *inside* `com.foo.android.apk` in
`Resources/raw`.

We are removing this functionality, because it is not widely used. You
can distribute Android Wear as standalone applications since Android
Wear 2.0, so this should be the option going forward. I added a new
`XA4312` warning to be emitted for projects using this feature.

I moved the relevant MSBuild targets to
`Xamarin.Android.Wear.targets`, which is only imported by "legacy"
Xamarin.Android projects. .NET 5+ projects will not even import this
file.

I also added a `Wear` NUnit category to be used for excluding tests
down the road.