### PR TITLE
[tests] don't delete NuGet.config files during MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1077,6 +1077,7 @@ namespace Lib2
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void AndroidResourceChange ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -1088,15 +1089,10 @@ namespace Lib2
 				proj.Touch ("Resources\\layout\\Main.axml");
 				Assert.IsTrue (builder.Build (proj), "second build should succeed");
 
-				var targets = new [] {
-					"_ResolveLibraryProjectImports",
-					"_GenerateJavaStubs",
-					"_CompileJava",
-					"_CompileToDalvik",
-				};
-				foreach (var target in targets) {
-					Assert.IsTrue (builder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
-				}
+				builder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
+				builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+				builder.Output.AssertTargetIsSkipped ("_CompileJava");
+				builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -348,6 +348,10 @@ $@"<Project>
 					var subname = fi.FullName.Substring (dirFullPath.Length).Replace ('\\', '/');
 					if (subname.StartsWith ("bin", StringComparison.OrdinalIgnoreCase) || subname.StartsWith ("obj", StringComparison.OrdinalIgnoreCase))
 						continue;
+					if (subname.Equals ("NuGet.config", StringComparison.OrdinalIgnoreCase))
+						continue;
+					if (subname.EndsWith (".log", StringComparison.OrdinalIgnoreCase) || subname.EndsWith (".binlog", StringComparison.OrdinalIgnoreCase))
+						continue;
 					if (!projectFiles.Any (p => p.Path != null && p.Path.Replace ('\\', '/').Equals (subname))) {
 						fi.Delete ();
 					}


### PR DESCRIPTION
Running under .NET 5+, the `AndroidResourceChange` test would always
fail with:

    The target _ResolveLibraryProjectImports should have been skipped.

It turns out our test infrastructure was deleting `NuGet.config` on
incremental builds. This triggers the `Restore` target to do its work
again on every build changing `$(ProjectAssetsFile)`. This is an input
of `_ResolveLibraryProjectImports`:

    <Target Name="_ResolveLibraryProjectImports"
        Inputs="$(ProjectAssetsFile)...

We shouldn't ever delete `NuGet.config` files during MSBuild tests.
This allowed the test to pass, and we can now run it under `dotnet`.

The same was happening for `build.log`, `msbuild.binlog`, and
`process.log`, so I thought it would be good to skip deletion of
`.log` or `.binlog` files.

I also cleaned up the test a little to use `AssertTargetIsSkipped`.