### PR TITLE
[ci] Use new scaling VM pool for Windows build and test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -54,7 +54,7 @@ variables:
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: VSEng-Xamarin-Android
+  VSEngWinVS2019: Xamarin-Android-Win2019
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
@@ -432,7 +432,7 @@ stages:
   - job: queue_vsix_signing
     displayName: Queue Vsix Signing
     dependsOn: notarize_pkg_upload_storage
-    pool: $(VSEngWinVS2019)
+    pool: VSEng-MicroBuildVS2019
     timeoutInMinutes: 90
     cancelTimeoutInMinutes: 1
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -258,7 +258,7 @@ stages:
         $vsixInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe"
         $ts = Get-Date -Format FileDateTimeUniversal
         $log = "xavsixdowngrade-$ts.log"
-        $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru
+        $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru -RedirectStandardError "err.txt"
         Get-Content "${env:TEMP}\$log" | Write-Host
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
         Remove-Item "${env:TEMP}\$log"

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -259,6 +259,7 @@ stages:
         $ts = Get-Date -Format FileDateTimeUniversal
         $log = "xavsixdowngrade-$ts.log"
         $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru -RedirectStandardError "err.txt"
+        Get-Content "err.txt" | Write-Host
         Get-Content "${env:TEMP}\$log" | Write-Host
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
         Remove-Item "${env:TEMP}\$log"

--- a/build-tools/automation/yaml-templates/clean.yaml
+++ b/build-tools/automation/yaml-templates/clean.yaml
@@ -1,8 +1,10 @@
 steps:
 - powershell: |
     $ErrorActionPreference = 'Continue'
-    git clean -xffd
-    git submodule foreach --recursive git clean -xffd
+    Start-Process -NoNewWindow -FilePath git -ArgumentList "clean -xffd" -Wait -RedirectStandardError "$(Build.BinariesDirectory)\clean.txt"
+    Get-Content "$(Build.BinariesDirectory)\clean.txt" | Write-Host
+    Start-Process -NoNewWindow -FilePath git -ArgumentList "submodule foreach --recursive git clean -xffd" -Wait -RedirectStandardError "$(Build.BinariesDirectory)\submodule-clean.txt"
+    Get-Content "$(Build.BinariesDirectory)\submodule-clean.txt" | Write-Host
     Remove-Item -Recurse $(Build.BinariesDirectory) -ErrorAction Ignore
     $LastExitCode = 0
   displayName: manual clean

--- a/build-tools/automation/yaml-templates/kill-processes.yaml
+++ b/build-tools/automation/yaml-templates/kill-processes.yaml
@@ -1,12 +1,16 @@
 steps:
 - powershell: |
-    $ErrorActionPreference = 'Continue'
+    $ErrorActionPreference = 'SilentlyContinue'
     Get-Process
-    Stop-Process -Name nunit3-console
-    Stop-Process -Name xabuild
-    Stop-Process -Name MSBuild
-    Stop-Process -Name adb
-    $LastExitCode=0
+    Write-Host "Attempting to kill stray processes..."
+    Stop-Process -Name nunit3-console -ErrorVariable nunitError -PassThru
+    if ($nunitError) { Write-Host "A process named 'nunit3-console' could not be found or stopped."}
+    Stop-Process -Name xabuild -ErrorVariable xabuildError -PassThru
+    if ($xabuildError) { Write-Host "A process named 'xabuild' could not be found or stopped." }
+    Stop-Process -Name MSBuild -ErrorVariable msbuildError -PassThru
+    if ($msbuildError) { Write-Host "A process named 'MSBuild' could not be found or stopped." }
+    Stop-Process -Name adb -ErrorVariable adbError -PassThru
+    if ($adbError) { Write-Host "A process named 'adb' could not be found or stopped." }
   displayName: kill leftover processes
-  failOnStderr: false
+  ignoreLASTEXITCODE: true
   condition: and(always(), eq(variables['agent.os'], 'Windows_NT'))

--- a/build-tools/automation/yaml-templates/kill-processes.yaml
+++ b/build-tools/automation/yaml-templates/kill-processes.yaml
@@ -2,15 +2,11 @@ steps:
 - powershell: |
     $ErrorActionPreference = 'SilentlyContinue'
     Get-Process
-    Write-Host "Attempting to kill stray processes..."
-    Stop-Process -Name nunit3-console -ErrorVariable nunitError -PassThru
-    if ($nunitError) { Write-Host "A process named 'nunit3-console' could not be found or stopped."}
-    Stop-Process -Name xabuild -ErrorVariable xabuildError -PassThru
-    if ($xabuildError) { Write-Host "A process named 'xabuild' could not be found or stopped." }
-    Stop-Process -Name MSBuild -ErrorVariable msbuildError -PassThru
-    if ($msbuildError) { Write-Host "A process named 'MSBuild' could not be found or stopped." }
-    Stop-Process -Name adb -ErrorVariable adbError -PassThru
-    if ($adbError) { Write-Host "A process named 'adb' could not be found or stopped." }
+    $procsToKill = @("nunit3-console", "xabuild", "MSBuild", "adb")
+    Write-Host "Attempting to kill stray processes: $procsToKill ..."
+    Stop-Process -Name $procsToKill -PassThru
+    Write-Host "Running processes that should have been killed:"
+    Get-Process -Name $procsToKill
   displayName: kill leftover processes
   ignoreLASTEXITCODE: true
   condition: and(always(), eq(variables['agent.os'], 'Windows_NT'))

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -12,7 +12,6 @@ jobs:
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
-
     - template: kill-processes.yaml
 
     - template: clean.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -12,6 +12,7 @@ jobs:
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
+
     - template: kill-processes.yaml
 
     - template: clean.yaml


### PR DESCRIPTION
A new [Virtual machine scale set][0] has been created for our Windows
build and test jobs.  This new pool should improve Windows queue times,
as it will automatically scale up and down based on demand.  The agent
pool is currently configured to scale between 3-12 machines.  This range
is set in the [agent pool settings][1] and can easily be changed to meet
future changes in demand.

The new agent pool will also give us greater control over the VMs and
machine images used for build and test.  This pool can be configured to
have every job spin up a fresh VM, and will generally shut down older
instances and create fresh ones as it scales with demand.  This
functionality should help alleviate some of the issues we've seen on our
static machine pool related to file permissions and Visual Studio
instance corruption.

The job that queues the .vsix signing Jenkins job has been moved
back to the `MicroBuildVS2019` pool to fulfill corpnet requirements.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/64e11c84-c922-4ffd-bea9-67ab39354edd/resourceGroups/xamarin-vm-scale-sets/providers/Microsoft.Compute/virtualMachineScaleSets/xa-winserver2019-vmss/overview
[1]: https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=2501&view=settings
