### PR TITLE
[One .NET] fixes for IncrementalClean and FileWrites

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -27,6 +27,12 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CopyPackage;
       _Sign;
     </BuildDependsOn>
+    <_BeforeIncrementalClean>
+      _PrepareAssemblies;
+      _CompileDex;
+      $(_AfterCompileDex);
+      _AddFilesToFileWrites;
+    </_BeforeIncrementalClean>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
@@ -43,6 +49,9 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _ValidateAndroidPackageProperties;
       $(BuildDependsOn);
     </BuildDependsOn>
+    <_BeforeIncrementalClean>
+      _AddFilesToFileWrites;
+    </_BeforeIncrementalClean>
   </PropertyGroup>
 
   <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
@@ -64,6 +73,9 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
   </PropertyGroup>
 
   <PropertyGroup>
+    <CoreBuildDependsOn>
+      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
+    </CoreBuildDependsOn>
     <CompileDependsOn>
       _SetupDesignTimeBuildForCompile;
       _AddAndroidDefines;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1954,9 +1954,7 @@ namespace App1
 		[TestCaseSource (nameof (RuntimeChecks))]
 		public void CheckWhichRuntimeIsIncluded (string supportedAbi, bool debugSymbols, string debugType, bool? optimize, bool? embedAssemblies, string expectedRuntime) {
 			var proj = new XamarinAndroidApplicationProject ();
-			if (Builder.UseDotNet) {
-				proj.SetRuntimeIdentifier (supportedAbi);
-			}
+			proj.SetAndroidSupportedAbis (supportedAbi);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", debugType);
 			if (optimize.HasValue)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -39,11 +39,7 @@ namespace Xamarin.Android.Build.Tests
 			string linkSkip = "FormsViewGroup";
 			app.SetProperty ("AndroidLinkSkip", linkSkip);
 			app.SetProperty ("_AndroidSequencePointsMode", sequencePointsMode);
-			if (Builder.UseDotNet) {
-				app.SetRuntimeIdentifiers (supportedAbis.Split (';'));
-			} else {
-				app.SetProperty (app.ReleaseProperties, KnownProperties.AndroidSupportedAbis, supportedAbis);
-			}
+			app.SetAndroidSupportedAbis (supportedAbis);
 			using (var libb = CreateDllBuilder (Path.Combine ("temp", TestName, lib.ProjectName)))
 			using (var appb = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
 				Assert.IsTrue (libb.Build (lib), "Library build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -774,6 +774,7 @@ namespace Lib2
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void GenerateJavaStubsAndAssembly ([Values (true, false)] bool isRelease)
 		{
 			var targets = new [] {
@@ -785,6 +786,7 @@ namespace Lib2
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
+			proj.SetAndroidSupportedAbis ("armeabi-v7a");
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidEnvironment ("Foo.txt") {
 				TextContent = () => "Foo=Bar",
 			});

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -4,6 +4,31 @@ namespace Xamarin.ProjectTools
 {
 	public static class ProjectExtensions
 	{
+		/// <summary>
+		/// Sets $(AndroidSupportedAbis) or $(RuntimeIdentifiers) depending if running under dotnet
+		/// </summary>
+		public static void SetAndroidSupportedAbis (this IShortFormProject project, params string [] abis)
+		{
+			if (Builder.UseDotNet || project is XASdkProject) {
+				project.SetRuntimeIdentifiers (abis);
+			} else {
+				project.SetAndroidSupportedAbis (string.Join (";", abis));
+			}
+		}
+
+		/// <summary>
+		/// Sets $(AndroidSupportedAbis) or $(RuntimeIdentifiers) depending if running under dotnet
+		/// </summary>
+		/// <param name="abis">A semi-colon-delimited list of ABIs</param>
+		public static void SetAndroidSupportedAbis (this IShortFormProject project, string abis)
+		{
+			if (Builder.UseDotNet || project is XASdkProject) {
+				project.SetRuntimeIdentifiers (abis.Split (';'));
+			} else {
+				project.SetProperty (KnownProperties.AndroidSupportedAbis, abis);
+			}
+		}
+
 		public static void SetRuntimeIdentifier (this IShortFormProject project, string androidAbi)
 		{
 			if (androidAbi == "armeabi-v7a") {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/792d61d116cc0293bd457d1c418d1972829ec226/Documentation/guides/MSBuildBestPractices.md#filewrites-and-incrementalclean

Running under `dotnet`, a test is failing with:

    GenerateJavaStubsAndAssembly(True)
    android\environment.armeabi-v7a.o is not in FileWrites!
    Expected: some item equal to "C:\A_work\1\s\bin\TestRelease\temp\GenerateJavaStubsAndAssemblyTrue\obj\Release\android\environment.armeabi-v7a.o"

When I authored `Microsoft.Android.Sdk.BuildOrder.targets`, I didn't
bring over the workaround to make `IncrementalClean` and `FileWrites`
work appropriately:

    <CoreBuildDependsOn>
      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
    </CoreBuildDependsOn>

It appears this is still needed in the new `dotnet` world order. I
brought over the missing pieces from `Xamarin.Android.Legacy.targets`.

We also need to specify the `armeabi-v7a` ABI in this test, because
the default ABIs are different in .NET 5+.

I added some helper methods to check `Builder.UseDotNet` to decide if
`$(RuntimeIdentifier)` should be used instead of `$(AndroidSupportedAbis)`.
I updated a couple tests that should use these helpers.