### PR TITLE
[ci] Add Anti-Malware Scan to code analysis job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -91,6 +91,7 @@ stages:
       displayName: Run AntiMalware (Defender) Scan
       inputs:
         FileDirPath: $(System.DefaultWorkingDirectory)
+        EnableServices: true
       condition: succeededOrFailed()
 
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -69,9 +69,9 @@ stages:
 - stage: code_analysis
   displayName: Code Analysis
   jobs:
-  # Check - "Xamarin.Android (Code Analysis CredScan and PoliCheck)"
+  # Check - "Xamarin.Android (Code Analysis Security and Compliance)"
   - job: run_static_analysis
-    displayName: CredScan and PoliCheck
+    displayName: Security and Compliance
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
@@ -86,6 +86,12 @@ stages:
     - template: security\policheck\v1.yml@yaml
       parameters:
         exclusionFile: $(System.DefaultWorkingDirectory)\build-tools\automation\PoliCheckExclusions.xml
+
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+      displayName: Run AntiMalware (Defender) Scan
+      inputs:
+        FileDirPath: $(System.DefaultWorkingDirectory)
+      condition: succeededOrFailed()
 
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
       displayName: Create Security Analysis Report


### PR DESCRIPTION
Context: https://www.1eswiki.com/wiki/AntiMalware_Scan_Build_Task
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139581

Adds the Anti-Malware Scan build task to our code analysis job.  This
tool uses Windows Defender to scan the specified folder for malware,
and will ensure that we don't check any offending binaries into source
control.