### PR TITLE
[Microsoft.Android.Sdk] fix $(AndroidUseSharedRuntime) w/ linker

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -49,6 +49,7 @@ _ResolveAssemblies MSBuild target.
     <ProcessAssemblies
         InputAssemblies="@(_ResolvedAssemblyFiles)"
         IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
+        UseSharedRuntime="$(AndroidUseSharedRuntime)"
         LinkMode="$(AndroidLinkMode)">
       <Output TaskParameter="OutputAssemblies" ItemName="ResolvedAssemblies" />
       <Output TaskParameter="ShrunkAssemblies" ItemName="_ShrunkAssemblies" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "PRAS";
 
+		public bool UseSharedRuntime { get; set; }
+
 		public string LinkMode { get; set; }
 		
 		[Required]
@@ -74,7 +76,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
-			if (!string.IsNullOrEmpty (LinkMode) && !string.Equals (LinkMode, "None", StringComparison.OrdinalIgnoreCase)) {
+			if (!string.IsNullOrEmpty (LinkMode) && !string.Equals (LinkMode, "None", StringComparison.OrdinalIgnoreCase) && !UseSharedRuntime) {
 				ShrunkAssemblies = OutputAssemblies.Select (a => {
 					var dir = Path.GetDirectoryName (a.ItemSpec);
 					var file = Path.GetFileName (a.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3753,6 +3753,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void XA0119 ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -3767,6 +3768,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void XA0119AAB ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
The `XA0119` test was failing under a `dotnet` context:

    (_BuildApkEmbed target) ->
        System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\A\_work\1\s\bin\TestRelease\temp\XA0119\obj\Debug\linked\shrunk\UnnamedProject.dll'.
        at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
        at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
        at Xamarin.Android.Tasks.MonoAndroidHelper.IsReferenceAssembly(String assembly)
        at Xamarin.Android.Tasks.BuildApk.AddAssemblies(ZipArchiveEx apk, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo)
        at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo)
        at Xamarin.Android.Tasks.BuildApk.RunTask()
        at Xamarin.Android.Tasks.AndroidTask.Execute()

This appears to be caused by using the linker and
`$(AndroidUseSharedRuntime)` at the same time.

It turns out that the `_RemoveRegisterAttribute` MSBuild task is not
run at all in this `Condition`:

    <Target Name="_RemoveRegisterAttribute"
      Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">

And so we were passing a list of assemblies in a `shrunk` directory
that did not exist. We need to update the `<ProcessAssemblies/>`
MSBuild task to check the same condition.

After doing this, I could add two more tests under the `dotnet` context.