### PR TITLE
[xaprepare] Emit ThirdPartyNotices entries for mman, dlfcn

### DIFF
--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/dlfcn.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/dlfcn.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	[TPN]
+	class dlfcn_TPN : ThirdPartyNotice
+	{
+		static readonly Uri url = new Uri ("https://github.com/dlfcn-win32/dlfcn-win32/");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.ExternalDir, "dlfcn-win32", "COPYING");
+
+
+		public override string LicenseFile => licenseFile;
+		public override string Name        => "dlfcn-win32/dlfcn-win32";
+		public override Uri    SourceUrl   => url;
+		public override string LicenseText => "";
+
+		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
+	}
+}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/witwall_mman.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/witwall_mman.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	[TPN]
+	class witwall_mman_TPN : ThirdPartyNotice
+	{
+		static readonly Uri    url         = new Uri ("https://github.com/witwall/mman-win32/");
+
+		public override string LicenseFile => string.Empty;
+		public override string Name        => "witwall/mman-win32";
+		public override Uri    SourceUrl   => url;
+		public override string LicenseText => @"
+MIT License
+
+Copyright (c) 2018 Steven Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the ""Software""), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+";
+
+		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
+	}
+}

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Steps\Step_ThirdPartyNotices.cs" />
     <Compile Include="ThirdPartyNotices\aapt2.cs" />
     <Compile Include="ThirdPartyNotices\bundletool.cs" />
+    <Compile Include="ThirdPartyNotices\dlfcn.cs" />
     <Compile Include="ThirdPartyNotices\Java.Interop.cs" />
     <Compile Include="ThirdPartyNotices\K4os.Compression.LZ4.cs" />
     <Compile Include="ThirdPartyNotices\lz4.cs" />
@@ -164,6 +165,7 @@
     <Compile Include="ThirdPartyNotices\proguard.cs" />
     <Compile Include="ThirdPartyNotices\r8.cs" />
     <Compile Include="ThirdPartyNotices\sqlite.cs" />
+    <Compile Include="ThirdPartyNotices\witwall_mman.cs" />
     <Compile Include="ThirdPartyNotices\Xamarin.Android.Build.Tasks.cs" />
     <Compile Include="ThirdPartyNotices\Xamarin.Android.NunitLite.cs" />
     <Compile Include="ThirdPartyNotices\Xamarin.Android.Tools.Aidl.cs" />


### PR DESCRIPTION
`external/dlfcn-win32` and `external/mman-win32` were added in
commit d8fdbcfc, but we accidentally overlooked that the content of
these submodules was included into built binary artifacts, and
redistributed via our installers.'

Consequently, these resources *should* have been listed in the
generated `ThirdPartyNotices.txt` which is included in the installers,
but they were not.

Add appropriate `ThirdPartyNotices.txt` entries for
[dlfcn-win32/dlfcn-win32][0] and [witwall/mman-win32][1].

[0]: https://github.com/dlfcn-win32/dlfcn-win32
[1]: https://github.com/witwall/mman-win32