### PR TITLE
[debugger] Remove usage of Mono_UnhandledException

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -277,7 +277,7 @@ namespace Android.Runtime {
 
 			// Disabled until Linker error surfaced in https://github.com/xamarin/xamarin-android/pull/4302#issuecomment-596400025 is resolved
 			//System.Diagnostics.Debugger.Mono_UnhandledException (javaException);
-			mono_unhandled_exception (javaException);
+			//mono_unhandled_exception (javaException);
 
 			try {
 				var jltp = javaException as JavaProxyThrowable;

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -69,22 +69,10 @@ namespace Android.Runtime {
 
 			ig.Emit (OpCodes.Leave, label);
 
-			bool  filter = Debugger.IsAttached || !JNIEnv.PropagateExceptions;
-			if (filter) {
-				ig.BeginExceptFilterBlock ();
-
-				ig.Emit (OpCodes.Call, mono_unhandled_exception_method!);
-				ig.Emit (OpCodes.Ldc_I4_1);
-				ig.BeginCatchBlock (null!);
-			} else {
-				ig.BeginCatchBlock (typeof (Exception));
-			}
-
+			ig.BeginCatchBlock (typeof (Exception));
+			
 			ig.Emit (OpCodes.Dup);
 			ig.Emit (OpCodes.Call, exception_handler_method!);
-
-			if (filter)
-				ig.Emit (OpCodes.Throw);
 
 			ig.EndExceptionBlock ();
 


### PR DESCRIPTION
Draft for @peppers test the behavior of Exception handler when debugger is attached without Mono_UnhandledException.
[libmonosgen-32bit-2.0.so.zip](https://github.com/xamarin/xamarin-android/files/4921474/libmonosgen-32bit-2.0.so.zip)
