### PR TITLE
[One .NET] drop support for DX

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -104,6 +104,9 @@ previous Xamarin.Android releases.
 `$(AndroidClassParser)` will be `class-parse` by default. `jar2xml`
 will not be supported.
 
+`$(AndroidDexTool)` will be `d8` by default. `dx` will not be
+supported.
+
 `$(AndroidCodegenTarget)` will be `XAJavaInterop1` by default.
 `XamarinAndroid` will not be supported.
 

--- a/Documentation/guides/messages/xa1023.md
+++ b/Documentation/guides/messages/xa1023.md
@@ -1,14 +1,18 @@
 ---
-title: Xamarin.Android warning XA1023
-description: XA1023 warning code
+title: Xamarin.Android error/warning XA1023
+description: XA1023 error/warning code
 ms.date: 05/18/2020
 ---
-# Xamarin.Android warning XA1023
+# Xamarin.Android error/warning XA1023
 
 ## Example messages
 
 ```
-warning XA1023: Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.
+warning XA1023: Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.
+```
+
+```
+error XA1023: Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.
 ```
 
 ## Issue
@@ -16,6 +20,8 @@ warning XA1023: Using the DX DEX Compiler is deprecated. Please update `$(Androi
 Google has deprecated the DX DEX Compiler in favor of the [D8 DEX
 Compiler][d8]. On [February 1, 2021][dx], DX will no longer be a part
 of Android SDK or Android Studio.
+
+The DX DEX Compiler will not supported in .NET 5 or higher.
 
 [d8]: https://developer.android.com/studio/command-line/d8
 [dx]: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -236,7 +236,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.D8.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Designer.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DesignTime.targets" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DX.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.DX.targets" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.EmbeddedResource.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.FSharp.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Legacy.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -574,11 +574,20 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`..
+        ///   Looks up a localized string similar to Using the DX DEX Compiler is deprecated. Please set the DEX compiler to &apos;d8&apos; in the Visual Studio project property pages or edit the project file in a text editor and set the &apos;AndroidDexTool&apos; MSBuild property to &apos;d8&apos;..
         /// </summary>
         internal static string XA1023 {
             get {
                 return ResourceManager.GetString("XA1023", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to &apos;d8&apos; in the Visual Studio project property pages or edit the project file in a text editor and set the &apos;AndroidDexTool&apos; MSBuild property to &apos;d8&apos;..
+        /// </summary>
+        internal static string XA1023_dotnet {
+            get {
+                return ResourceManager.GetString("XA1023_dotnet", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -395,8 +395,12 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</comment>
   </data>
   <data name="XA1023" xml:space="preserve">
-    <value>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</value>
-    <comment>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</comment>
+    <value>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</value>
+    <comment>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</comment>
+  </data>
+  <data name="XA1023_dotnet" xml:space="preserve">
+    <value>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</value>
+    <comment>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</comment>
   </data>
   <data name="XA1024" xml:space="preserve">
     <value>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -339,9 +339,14 @@ In this message, the term "binding" means a piece of generated code that makes i
 {0} - The file name of the library</note>
       </trans-unit>
       <trans-unit id="XA1023">
-        <source>Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</source>
-        <target state="new">Using the DX DEX Compiler is deprecated. Please update `$(AndroidDexTool)` to `d8`.</target>
-        <note>The following are literal names and should not be translated: D8, DEX, `$(AndroidDexTool)`, `d8`</note>
+        <source>Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is deprecated. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
+      </trans-unit>
+      <trans-unit id="XA1023_dotnet">
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="new">Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
         <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1083,6 +1083,7 @@ namespace UnamedProject
 		[Category ("SmokeTests"), Category ("dotnet")]
 		public void BuildProguardEnabledProject ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 				DexTool = dexTool,
@@ -1144,11 +1145,10 @@ namespace UnamedProject
 		}
 
 		[Test]
-		[Category ("Minor")]
+		[Category ("Minor"), Category ("dotnet")]
 		public void BuildApplicationOver65536Methods ([Values ("dx", "d8")] string dexTool)
 		{
-			if (dexTool == "d8")
-				Assert.Ignore ("The build currently *succeeds* with d8, when API 21 is our minimum.");
+			AssertDexToolSupported (dexTool);
 			var proj = CreateMultiDexRequiredApplication ();
 			proj.DexTool = dexTool;
 			using (var b = CreateApkBuilder ()) {
@@ -1158,8 +1158,10 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void CreateMultiDexWithSpacesInConfig ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = CreateMultiDexRequiredApplication (releaseConfigurationName: "Test Config");
 			proj.DexTool = dexTool;
 			proj.IsRelease = true;
@@ -1170,13 +1172,15 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void BuildMultiDexApplication ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = CreateMultiDexRequiredApplication ();
 			proj.UseLatestPlatformSdk = false;
 			proj.DexTool = dexTool;
 			proj.SetProperty ("AndroidEnableMultiDex", "True");
-			if (IsWindows) {
+			if (IsWindows && !Builder.UseDotNet) {
 				proj.SetProperty ("AppendTargetFrameworkToIntermediateOutputPath", "True");
 			}
 
@@ -1184,7 +1188,7 @@ namespace UnamedProject
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
 
 				string intermediateDir;
-				if (IsWindows) {
+				if (IsWindows && !Builder.UseDotNet) {
 					intermediateDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, proj.TargetFrameworkAbbreviated);
 				} else {
 					intermediateDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
@@ -1195,14 +1199,17 @@ namespace UnamedProject
 				var multidexKeepPath  = Path.Combine (Root, b.ProjectDirectory, intermediateDir, "multidex.keep");
 				Assert.IsTrue (File.Exists (multidexKeepPath), "multidex.keep exists");
 				Assert.IsTrue (File.ReadAllLines (multidexKeepPath).Length > 1, "multidex.keep must contain more than one line.");
-				Assert.IsTrue (b.LastBuildOutput.ContainsText (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");
+				if (!Builder.UseDotNet)
+					Assert.IsTrue (b.LastBuildOutput.ContainsText (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");
 				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 			}
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void BuildAfterMultiDexIsNotRequired ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = CreateMultiDexRequiredApplication ();
 			proj.DexTool = dexTool;
 			proj.SetProperty ("AndroidEnableMultiDex", "True");
@@ -1244,8 +1251,10 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void MultiDexCustomMainDexFileList ([Values ("dx", "d8")] string dexTool, [Values ("19", "21")] string minSdkVersion)
 		{
+			AssertDexToolSupported (dexTool);
 			var expected = new [] {
 				"android/support/multidex/ZipUtil$CentralDirectory.class",
 				"android/support/multidex/MultiDexApplication.class",
@@ -2560,9 +2569,10 @@ public class Test
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void BuildApplicationWithSpacesInPath ([Values (true, false)] bool enableMultiDex, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var folderName = $"BuildReleaseApp AndÜmläüts({enableMultiDex}{dexTool}{linkTool})";
 			var lib = new XamarinAndroidLibraryProject {
 				IsRelease = true,
@@ -3519,6 +3529,7 @@ namespace UnnamedProject {
 				DexTool = "dx",
 				LinkTool = "proguard",
 			};
+			AssertDexToolSupported (proj.DexTool);
 			var rules = new List<string> {
 				"-dontwarn com.google.devtools.build.android.desugar.**",
 				"-dontwarn javax.annotation.**",
@@ -3540,6 +3551,7 @@ namespace UnnamedProject {
 		[Category ("SmokeTests"), Category ("dotnet")]
 		public void Desugar ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				EnableDesugar = true, //It is certain this test would fail without desugar
@@ -3649,8 +3661,10 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 
 		//See: https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client
 		[Test]
+		[Category ("dotnet")]
 		public void MissingOrgApacheHttpClient ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			var proj = new XamarinAndroidApplicationProject {
 				DexTool = dexTool,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void CheckClassesDexIsIncluded ([Values ("dx", "d8", "invalid")] string dexTool)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -111,8 +112,13 @@ namespace Xamarin.Android.Build.Tests
 				DexTool = dexTool,
 			};
 			using (var b = CreateApkBuilder ()) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
+				if (Builder.UseDotNet && dexTool == "dx") {
+					Assert.IsFalse (b.Build (proj), "build failed");
+					StringAssertEx.Contains ("XA1023", b.LastBuildOutput, "Output should contain XA1023 errors");
+					return;
+				}
+
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -152,6 +152,13 @@ namespace Xamarin.Android.Build.Tests
 		/// </summary>
 		public const int MaxFileName = 255;
 
+		protected static void AssertDexToolSupported (string dexTool)
+		{
+			if (Builder.UseDotNet && dexTool == "dx") {
+				Assert.Ignore ("dx is not supported in .NET 5+");
+			}
+		}
+
 		protected static void WaitFor(int milliseconds)
 		{
 			var pause = new ManualResetEvent(false);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -365,7 +365,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 -->
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" Condition=" '$(AndroidDexTool)' == 'dx' " />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DX.targets" Condition=" '$(AndroidDexTool)' == 'dx' and '$(UsingAndroidNETSdk)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
@@ -460,6 +460,18 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA0119_AAB"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidPackageFormat)' == 'aab' "
   />
+  <AndroidError Code="XA1011"
+      ResourceName="XA1011"
+      Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "
+  />
+  <AndroidWarning Code="XA1023"
+      ResourceName="XA1023"
+      Condition=" '$(AndroidDexTool)' == 'dx' and '$(UsingAndroidNETSdk)' != 'true' "
+  />
+  <AndroidError Code="XA1023"
+      ResourceName="XA1023_dotnet"
+      Condition="  '$(AndroidDexTool)' == 'dx' and '$(UsingAndroidNETSdk)' == 'true' "
+  />
 </Target>
 
 <!--
@@ -472,14 +484,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="None" Condition="'$(AndroidLinkMode)' == 'SdkOnly' And '$(AndroidUseSharedRuntime)' == 'true'">
 		<Output TaskParameter="Value" PropertyName="AndroidLinkMode" />
 	</CreateProperty>
-	<AndroidError Code="XA1011"
-		ResourceName="XA1011"
-		Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "
-	/>
-	<AndroidWarning Code="XA1023"
-		ResourceName="XA1023"
-		Condition=" '$(AndroidDexTool)' == 'dx' "
-	/>
 </Target>
 
 <Target Name="UpdateGeneratedFiles"


### PR DESCRIPTION
Context: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

On February 1, 2021 DX will be removed from the Android SDK. It is
very possible this will happen before .NET 6 ships. There are also
currently a few MSBuild tests that fail when using DX.

* Drop support for DX in .NET 5+. Emit `XA1023` as an *error*.
* Don't even include `Xamarin.Android.DX.targets` in .NET 5+ packages.
* Add several tests to the `dotnet` category.
* Any tests using `AndroidDexTool=dx` will be ignored.

I left the `PackagingTest.CheckClassesDexIsIncluded` test so that it
verifies you get an `XA1023` build error when using DX with .NET 5+.

Other changes:

* There were some related warning messages that I moved to the
  `_CheckNonIdealConfigurations` MSBuild target. These seem like they
  should all be in the same MSBuild target.