### PR TITLE
[tests] BuildApplicationWithMonoEnvironment is [NonParallelizable]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Build.Tests
 	public class EnvironmentContentTests : BaseTest
 	{
 		[Test]
+		[NonParallelizable]
 		[Category ("SmokeTests"), Category ("dotnet")]
 		public void BuildApplicationWithMonoEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
 		{


### PR DESCRIPTION
Context: https://build.azdo.io/3890818

This test seems to be consistently failing on macOS with:

    (Restore target) ->
      /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(124,5): error :
      Could not find file '/Users/runner/work/1/s/packages/xamarin.android.support.transition/28.0.0.1/nvzgjsmt.a6m'.

We've generally just added `[NonParallelizable]` for tests hitting
this in the past to work around it.