### PR TITLE
[ci] Trim new line from multi-line MSBuild arguments

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -524,10 +524,7 @@ stages:
       inputs:
         solution: build-tools/check-boot-times/check-boot-times.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /restore
-          /t:Build
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
+        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
       continueOnError: true
 
     - task: MSBuild@1
@@ -535,9 +532,7 @@ stages:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /t:CheckBootTimes
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
+        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
       continueOnError: true
 
     - template: yaml-templates/apk-instrumentation.yaml
@@ -700,7 +695,7 @@ stages:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /t:AcquireAndroidTarget,ReleaseAndroidTarget
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/shutdown-emulator.binlog
       condition: always()
@@ -716,7 +711,7 @@ stages:
       inputs:
         solution: build-tools/plots-to-appinsights/ProcessPlotCSVFile.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /restore
           /t:Build
           /v:normal
@@ -808,7 +803,7 @@ stages:
       inputs:
         solution: tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /t:AcquireAndroidTarget,ReleaseAndroidTarget
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       condition: always()
@@ -871,8 +866,7 @@ stages:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+        msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
@@ -893,7 +887,7 @@ stages:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /t:AcquireAndroidTarget,ReleaseAndroidTarget
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       condition: always()

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -345,7 +345,7 @@ stages:
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /restore
           /t:RunJavaInteropTests
           /p:TestAssembly="bin\Test$(XA.Build.Configuration)\generator-Tests.dll;bin\Test$(XA.Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(XA.Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll"

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -16,7 +16,7 @@ steps:
   inputs:
     solution: ${{ parameters.project }}
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: >
+    msbuildArguments: >-
       /restore
       /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
       /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run${{ parameters.testName }}.binlog

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
     - template: run-nunit-tests.yaml
@@ -39,7 +39,7 @@ jobs:
       inputs:
         solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
+        msbuildArguments: >-
           /t:AcquireAndroidTarget,ReleaseAndroidTarget
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       condition: always()


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3893162&view=logs&j=cac0e8d3-0ef5-5d2b-b57e-e8fde7204df3&t=ecb52562-b867-5d86-aae7-56a38766a1ce&l=170

The Java.Interop test step has recently started failing on our Windows
builds due to a strange error which seems to indicate that there is an
extra new line character in an invalid location.  I believe that this
has to do with the `>` character we're using to allow for blocks of
strings in various places.  Updating this to `>-` should hopefully trim
any trailing new lines that aren't intended according to this resource
for YAML multi-line string syntax https://yaml-multiline.info/.