### PR TITLE
[build] Fix compression of assemblies in unwritable directories

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -317,6 +317,7 @@ namespace Xamarin.Android.Tasks
 			bool use_shared_runtime = String.Equals (UseSharedRuntime, "true", StringComparison.OrdinalIgnoreCase);
 			string sourcePath;
 			AssemblyCompression.AssemblyData compressedAssembly = null;
+			string compressedOutputDir = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (ApkOutputPath), "..", "lz4"));
 
 			int count = 0;
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
@@ -418,7 +419,7 @@ namespace Xamarin.Android.Tasks
 				var key = CompressedAssemblyInfo.GetDictionaryKey (assembly);
 				if (compressedAssembliesInfo.TryGetValue (key, out CompressedAssemblyInfo info) && info != null) {
 					EnsureCompressedAssemblyData (assembly.ItemSpec, info.DescriptorIndex);
-					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly);
+					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly, compressedOutputDir);
 					if (result != AssemblyCompression.CompressionResult.Success) {
 						switch (result) {
 							case AssemblyCompression.CompressionResult.EncodingFailed:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -419,7 +419,13 @@ namespace Xamarin.Android.Tasks
 				var key = CompressedAssemblyInfo.GetDictionaryKey (assembly);
 				if (compressedAssembliesInfo.TryGetValue (key, out CompressedAssemblyInfo info) && info != null) {
 					EnsureCompressedAssemblyData (assembly.ItemSpec, info.DescriptorIndex);
-					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly, compressedOutputDir);
+					string assemblyOutputDir;
+					string abiDirectory = assembly.GetMetadata ("AbiDirectory");
+					if (!String.IsNullOrEmpty (abiDirectory))
+						assemblyOutputDir = Path.Combine (compressedOutputDir, abiDirectory);
+					else
+						assemblyOutputDir = compressedOutputDir;
+					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly, assemblyOutputDir);
 					if (result != AssemblyCompression.CompressionResult.Success) {
 						switch (result) {
 							case AssemblyCompression.CompressionResult.EncodingFailed:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true
 			};
-			proj.SetProperty (KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -24,6 +24,18 @@ namespace Xamarin.Android.Build.Tests
 	public partial class BuildTest : BaseTest
 	{
 		[Test]
+		public void CompressedWithoutLinker ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true
+			};
+			proj.SetProperty (KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[Category ("dotnet")]
 		public void BuildBasicApplication ([Values (true, false)] bool isRelease)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
@@ -49,10 +49,15 @@ namespace Xamarin.Android.Tasks
 
 		static readonly ArrayPool<byte> bytePool = ArrayPool<byte>.Shared;
 
-		public static CompressionResult Compress (AssemblyData data)
+		public static CompressionResult Compress (AssemblyData data, string outputDirectory)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));
+
+			if (String.IsNullOrEmpty (outputDirectory))
+				throw new ArgumentException ("must not be null or empty", nameof (outputDirectory));
+
+			Directory.CreateDirectory (outputDirectory);
 
 			var fi = new FileInfo (data.SourcePath);
 			if (!fi.Exists)
@@ -61,7 +66,7 @@ namespace Xamarin.Android.Tasks
 			// 	return CompressionResult.InputTooBig;
 			// }
 
-			data.DestinationPath = $"{data.SourcePath}.lz4";
+			data.DestinationPath = Path.Combine (outputDirectory, $"{Path.GetFileName (data.SourcePath)}.lz4");
 			data.SourceSize = (uint)fi.Length;
 
 			byte[] sourceBytes = null;


### PR DESCRIPTION
Context: d236af54538ef1fe62d0125798cdde78e46dcd8e

Commit d236af54 introduced assembly compression for `Release` builds
with compression output placed in the same directory where the original
assembly resides.  This works well if the linker is enabled for the
project, because all the assemblies are copied to the `obj/` directory,
but if the linker is disabled, some assemblies will be read from their
original path, possibly a system location which is NOT writable by
non-root/non-admin processes.

This commit moves the compressed output location to a subdirectory of
the `obj/` directory for all the input assemblies.