### PR TITLE
[One .NET] fix design-time builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
+		[Category ("SmokeTests"), Category ("dotnet")]
 		public void DesignTimeBuild ([Values(false, true)] bool isRelease, [Values (false, true)] bool useManagedParser, [Values (false, true)] bool useAapt2)
 		{
 			var regEx = new Regex (@"(?<type>([a-zA-Z_0-9])+)\slibrary_name=(?<value>([0-9A-Za-z])+);", RegexOptions.Compiled | RegexOptions.Multiline );
@@ -939,6 +939,7 @@ namespace Lib1 {
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void BuildAppWithManagedResourceParser()
 		{
 			var path = Path.Combine ("temp", "BuildAppWithManagedResourceParser");
@@ -978,6 +979,7 @@ namespace Lib1 {
 
 		[Test]
 		[NonParallelizable]
+		[Category ("dotnet")]
 		public void BuildAppWithManagedResourceParserAndLibraries ()
 		{
 			int maxBuildTimeMs = 10000;
@@ -1021,6 +1023,9 @@ namespace Lib1 {
 				},
 			};
 			appProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
+			if (Builder.UseDotNet) {
+				appProj.AddDotNetCompatPackages ();
+			}
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, libProj.ProjectName), false, false)) {
 				libBuilder.AutomaticNuGetRestore = false;
 				Assert.IsTrue (libBuilder.RunTarget (libProj, "Restore"), "Library project should have restored.");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -487,7 +487,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	>
 </Target>
 
-<Target Name="_RemoveLegacyDesigner" Condition="'$(AndroidUseIntermediateDesignerFile)' == 'True'">
+<Target Name="_RemoveLegacyDesigner"
+		Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'true' and '$(ManagedDesignTimeBuild)' != 'true' ">
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
 		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(AndroidResgenFile)' != '' "/>
@@ -563,6 +564,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</_OnResolveMonoAndroidSdks>
 	<_ResolveMonoAndroidSdksDependsOn>
 		GetReferenceAssemblyPaths;
+		_ResolveSdks;
+		_ResolveAndroidTooling;
 		$(_ResolveMonoAndroidSdksDependsOn);
 	</_ResolveMonoAndroidSdksDependsOn>
 </PropertyGroup>


### PR DESCRIPTION
Design-time builds were not working as expected under a `dotnet`
context, mostly due to differences in build ordering.

`dotnet` design-time builds would fail with:

    Xamarin.Android.Common.targets(577,2): Could not locate MonoAndroid SDK.

Reviewing the `_ResolveMonoAndroidSdks` MSBuild target, it depends on
values that the `_ResolveSdks` provides.

After updating `$(_ResolveMonoAndroidSdksDependsOn)` to include
`_ResolveSdks`, I hit:

    Xamarin.Android.Common.targets(716,2): error MSB4044: The "GetAndroidDefineConstants" task was not given a value for the required parameter "AndroidApiLevel".

`$(_AndroidApiLevel)` was blank, which is provided by the
`_ResolveAndroidTooling` target.

After updating `$(_ResolveMonoAndroidSdksDependsOn)` again, I hit:

    CSC error CS2001: Source file 'C:\src\xamarin-android\bin\TestDebug\temp\BuildAppWithManagedResourceParser\App1\obj\Release\Resource.designer.cs' could not be found.

It turns out using `$(AndroidUseIntermediateDesignerFile)` breaks
design-time builds. We set this by default for .NET 5+. The fix here
was to make the `_RemoveLegacyDesigner` target not run when
`$(ManagedDesignTimeBuild)` is true.

After these changes, I could add the `dotnet` category to a few tests
around design-time builds.