### PR TITLE
[build] bump to .NET 5.0.100-rc.1.20365.11

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -52,7 +52,7 @@ variables:
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3
+  DotNetCorePreviewVersion: 5.0.100-rc.1.20365.11
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019


### PR DESCRIPTION
Context: https://github.com/dotnet/installer

This is still a "master" build, they are just using the `rc1` name after `preview7`.

This may break some tests using Xamarin.Forms, we'll see what happens.