### PR TITLE
[tests] bump to stable AndroidX packages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1138,6 +1138,7 @@ namespace Lib2
 			var proj = new XamarinFormsAndroidApplicationProject ();
 			proj.PackageReferences.Add (KnownPackages.AndroidXMigration);
 			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);
+			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompatResources);
 			proj.PackageReferences.Add (KnownPackages.AndroidXBrowser);
 			proj.PackageReferences.Add (KnownPackages.AndroidXMediaRouter);
 			proj.PackageReferences.Add (KnownPackages.AndroidXLegacySupportV4);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -296,61 +296,71 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidXMigration = new Package {
 			Id = "Xamarin.AndroidX.Migration",
-			Version = "1.0.0-rc1",
+			Version = "1.0.6.1",
 			TargetFramework = "MonoAndroid10",
 		};
 		public static Package AndroidXAppCompat = new Package {
 			Id = "Xamarin.AndroidX.AppCompat",
-			Version = "1.1.0-rc1",
+			Version = "1.1.0",
 			TargetFramework = "MonoAndroid10",
 		};
 		public static Package AndroidXBrowser = new Package {
 			Id = "Xamarin.AndroidX.Browser",
-			Version = "1.0.0-rc1",
+			Version = "1.0.0",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Browser") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Browser.1.0.0-rc1\\lib\\MonoAndroid90\\Xamarin.AndroidX.Browser.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Browser.1.0.0\\lib\\MonoAndroid90\\Xamarin.AndroidX.Browser.dll"
 				},
 			}
 		};
 		public static Package AndroidXMediaRouter = new Package {
 			Id = "Xamarin.AndroidX.MediaRouter",
-			Version = "1.1.0-rc1",
+			Version = "1.1.0",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.MediaRouter") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.MediaRouter.1.1.0-rc1\\lib\\MonoAndroid90\\Xamarin.AndroidX.MediaRouter.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.MediaRouter.1.1.0\\lib\\MonoAndroid90\\Xamarin.AndroidX.MediaRouter.dll"
 				},
 			}
 		};
 		public static Package AndroidXLegacySupportV4 = new Package {
 			Id = "Xamarin.AndroidX.Legacy.Support.V4",
-			Version = "1.0.0-rc1",
+			Version = "1.0.0",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Legacy.Support.V4") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Legacy.Support.V4.1.0.0-rc1\\lib\\MonoAndroid90\\Xamarin.AndroidX.Legacy.Support.V4.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Legacy.Support.V4.1.0.0\\lib\\MonoAndroid90\\Xamarin.AndroidX.Legacy.Support.V4.dll"
 				},
 			}
 		};
 		public static Package AndroidXLifecycleLiveData = new Package {
 			Id = "Xamarin.AndroidX.Lifecycle.LiveData",
-			Version = "2.1.0-rc1",
+			Version = "2.1.0",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Lifecycle.LiveData") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Lifecycle.LiveData.2.1.0-rc1\\lib\\MonoAndroid90\\Xamarin.AndroidX.Lifecycle.LiveData.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Lifecycle.LiveData.2.1.0\\lib\\MonoAndroid90\\Xamarin.AndroidX.Lifecycle.LiveData.dll"
+				},
+			}
+		};
+		public static Package AndroidXAppCompatResources = new Package {
+			Id = "Xamarin.AndroidX.AppCompat.AppCompatResources",
+			Version = "1.1.0.1",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.AndroidX.AppCompat.AppCompatResources") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.AppCompat.AppCompatResources.1.1.0.1\\lib\\MonoAndroid90\\Xamarin.AndroidX.AppCompat.AppCompatResources.dll"
 				},
 			}
 		};
 		public static Package XamarinGoogleAndroidMaterial = new Package {
 			Id = "Xamarin.Google.Android.Material",
-			Version = "1.0.0-rc1",
+			Version = "1.0.0",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Google.Android.Material") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Google.Android.Material.1.0.0-rc1\\lib\\MonoAndroid90\\Xamarin.Google.Android.Material.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Google.Android.Material.1.0.0\\lib\\MonoAndroid90\\Xamarin.Google.Android.Material.dll"
 				},
 			}
 		};


### PR DESCRIPTION
The `AndroidXMigration` test was failing under a `dotnet` context:

    error NU1605: Detected package downgrade: Xamarin.AndroidX.Lifecycle.LiveData from 2.1.0 to 2.1.0-rc1. Reference the package directly from the project to select a different version.
        UnnamedProject -> Xamarin.Forms 4.5.0.617 -> Xamarin.AndroidX.Lifecycle.LiveData (>= 2.1.0)
        UnnamedProject -> Xamarin.AndroidX.Lifecycle.LiveData (>= 2.1.0-rc1)
    error NU1605: Detected package downgrade: Xamarin.Google.Android.Material from 1.0.0 to 1.0.0-rc1. Reference the package directly from the project to select a different version.
        UnnamedProject -> Xamarin.Forms 4.5.0.617 -> Xamarin.Google.Android.Material (>= 1.0.0)
        UnnamedProject -> Xamarin.Google.Android.Material (>= 1.0.0-rc1)
    error NU1605: Detected package downgrade: Xamarin.AndroidX.Legacy.Support.V4 from 1.0.0 to 1.0.0-rc1. Reference the package directly from the project to select a different version.
        UnnamedProject -> Xamarin.Forms 4.5.0.617 -> Xamarin.AndroidX.Legacy.Support.V4 (>= 1.0.0)
        UnnamedProject -> Xamarin.AndroidX.Legacy.Support.V4 (>= 1.0.0-rc1)
    error NU1605: Detected package downgrade: Xamarin.AndroidX.Browser from 1.0.0 to 1.0.0-rc1. Reference the package directly from the project to select a different version.
        UnnamedProject -> Xamarin.Forms 4.5.0.617 -> Xamarin.AndroidX.Browser (>= 1.0.0)
        UnnamedProject -> Xamarin.AndroidX.Browser (>= 1.0.0-rc1)

Updating to AndroidX.Migration 1.0.6.1 solves this issue. Let's go
ahead and update *all* the `-rc1` packages to use stable versions.

I also needed to update some file paths in the tests when `ILLink` is
used for linking.