### PR TITLE
[ci] Install and build with Xcode 11

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -19,7 +19,7 @@ pr:
 variables:
   XA.Jdk8.Folder: jdk-1.8
   XA.Jdk11.Folder: jdk-11
-  XA.Build.MacOSSPool: macOS-10.15
+  XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Android-OSS
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public
   XA.Build.Configuration: Release
   NuGetArtifactName: nupkgs
@@ -37,7 +37,7 @@ stages:
   - job: mac_build
     displayName: Mac Build
     pool:
-      vmImage: $(XA.Build.MacOSSPool)
+      name: $(XA.Build.MacOSSPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -56,6 +56,9 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCoreVersion)
+
+    - script: security unlock-keychain -p $(login-xambot-azure-devops-agent-password)
+      displayName: unlock keychain
 
     - task: provisionator@2
       displayName: Install Xcode

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -58,9 +58,15 @@ stages:
         version: $(DotNetCoreVersion)
 
     - bash: |
-        security create-keychain -p $(login-xambot-azure-devops-agent-password) builder.keychain
-        security default-keychain -s builder.keychain
-        security set-keychain-settings -lut 7200
+        keychains=`security list-keychains`
+        if [[ "$keychains" =~ "\"/Users/${USER}/Library/Keychains/builder.keychain-db\"" ]]; then
+            security unlock-keychain -p $(login-xambot-azure-devops-agent-password) builder.keychain
+        else
+            security create-keychain -p $(login-xambot-azure-devops-agent-password) builder.keychain
+        fi
+        security -v list-keychains -s builder.keychain
+        security -v default-keychain -s builder.keychain
+        security -v set-keychain-settings -lut 7200
       displayName: swap default keychain
 
     - task: provisionator@2
@@ -69,6 +75,16 @@ stages:
         github_token: $(github-pat)
         provisioning_script: $(Build.SourcesDirectory)/build-tools/provisioning/xcode.csx
         provisioning_extra_args: '-v -v -v -v'
+
+    - bash: |
+        keychains=`security list-keychains`
+        if [[ "$keychains" =~ "\"/Users/${USER}/Library/Keychains/builder.keychain-db\"" ]]; then
+            security unlock-keychain -p $(login-xambot-azure-devops-agent-password) builder.keychain
+            security -v delete-keychain builder.keychain
+            security -v default-keychain -s login.keychain
+            security -v list-keychains -s login.keychain
+        fi
+      displayName: restore default keychain
 
     # Prepare and build everything
     - script: >

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -19,11 +19,9 @@ pr:
 variables:
   XA.Jdk8.Folder: jdk-1.8
   XA.Jdk11.Folder: jdk-11
-  XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMacMojaveBuildPool-Android-OSS
+  XA.Build.MacOSSPool: macOS-10.15
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public
-
   XA.Build.Configuration: Release
-
   NuGetArtifactName: nupkgs
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
@@ -39,7 +37,7 @@ stages:
   - job: mac_build
     displayName: Mac Build
     pool:
-      name: $(XA.Build.MacOSSPool)
+      vmImage: $(XA.Build.MacOSSPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -57,8 +57,11 @@ stages:
       parameters:
         version: $(DotNetCoreVersion)
 
-    - script: security unlock-keychain -p $(login-xambot-azure-devops-agent-password)
-      displayName: unlock keychain
+    - bash: |
+        security create-keychain -p $(login-xambot-azure-devops-agent-password) builder.keychain
+        security default-keychain -s builder.keychain
+        security set-keychain-settings -lut 7200
+      displayName: swap default keychain
 
     - task: provisionator@2
       displayName: Install Xcode

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -64,6 +64,7 @@ stages:
       inputs:
         github_token: $(github-pat)
         provisioning_script: $(Build.SourcesDirectory)/build-tools/provisioning/xcode.csx
+        provisioning_extra_args: '-v -v -v -v'
 
     # Prepare and build everything
     - script: >

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -59,6 +59,12 @@ stages:
       parameters:
         version: $(DotNetCoreVersion)
 
+    - task: provisionator@2
+      displayName: Install Xcode
+      inputs:
+        github_token: $(github-pat)
+        provisioning_script: $(Build.SourcesDirectory)/build-tools/provisioning/xcode.csx
+
     # Prepare and build everything
     - script: >
         echo "make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'" &&

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -142,6 +142,14 @@ stages:
         version: $(DotNetCoreVersion)
 
     - script: security list-keychains && echo default `security default-keychain` && echo login `security login-keychain`
+    - template: install-certificates.yml@yaml
+      parameters:
+        DeveloperIdApplication: $(developer-id-application)
+        DeveloperIdInstaller: $(developer-id-installer)
+        IphoneDeveloper: $(iphone-developer)
+        MacDeveloper: $(mac-developer)
+        HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
+    - script: security list-keychains && echo default `security default-keychain` && echo login `security login-keychain`
 
     - task: provisionator@2
       displayName: Install Xcode
@@ -195,14 +203,6 @@ stages:
         targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
 
     # Create installers
-    - template: install-certificates.yml@yaml
-      parameters:
-        DeveloperIdApplication: $(developer-id-application)
-        DeveloperIdInstaller: $(developer-id-installer)
-        IphoneDeveloper: $(iphone-developer)
-        MacDeveloper: $(mac-developer)
-        HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
-
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make create-installers

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -141,7 +141,6 @@ stages:
       parameters:
         version: $(DotNetCoreVersion)
 
-    - script: security list-keychains && echo default `security default-keychain` && echo login `security login-keychain`
     - template: install-certificates.yml@yaml
       parameters:
         DeveloperIdApplication: $(developer-id-application)
@@ -149,7 +148,6 @@ stages:
         IphoneDeveloper: $(iphone-developer)
         MacDeveloper: $(mac-developer)
         HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
-    - script: security list-keychains && echo default `security default-keychain` && echo login `security login-keychain`
 
     - task: provisionator@2
       displayName: Install Xcode

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -141,6 +141,12 @@ stages:
       parameters:
         version: $(DotNetCoreVersion)
 
+    - task: provisionator@2
+      displayName: Install Xcode
+      inputs:
+        github_token: $(github-pat)
+        provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
+
     # Prepare and build everything
     - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -146,6 +146,7 @@ stages:
       inputs:
         github_token: $(github-pat)
         provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
+        provisioning_extra_args: '-v -v -v -v'
 
     # Prepare and build everything
     - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -141,6 +141,8 @@ stages:
       parameters:
         version: $(DotNetCoreVersion)
 
+    - script: security list-keychains && echo default `security default-keychain` && echo login `security login-keychain`
+
     - task: provisionator@2
       displayName: Install Xcode
       inputs:

--- a/build-tools/provisioning/xcode.csx
+++ b/build-tools/provisioning/xcode.csx
@@ -4,7 +4,7 @@ if (IsMac) {
 	if (OSVersion < new Version (MinMacOSVersion))
 		throw new Exception ($"macOS {MinMacOSVersion} or newer is required for Xcode 11.");
 	if (OSVersion >= new Version (MinMacOSVersionForLatestXcode))
-		Item (XreItem.Xcode_11_6_0).XcodeSelect ();
+		Xcode ("11.6.0").XcodeSelect ();
 	else
-		Item (XreItem.Xcode_11_3_1).XcodeSelect ();
+		Xcode ("11.3.1").XcodeSelect ();
 }

--- a/build-tools/provisioning/xcode.csx
+++ b/build-tools/provisioning/xcode.csx
@@ -1,8 +1,9 @@
 if (IsMac) {
 	const string MinMacOSVersion = "10.14.4";
+	const string MinMacOSVersionForLatestXcode = "10.15.2";
 	if (OSVersion < new Version (MinMacOSVersion))
 		throw new Exception ($"macOS {MinMacOSVersion} or newer is required for Xcode 11.");
-	if (OSVersion >= new Version (10.15.2))
+	if (OSVersion >= new Version (MinMacOSVersionForLatestXcode))
 		Item (XreItem.Xcode_11_6_0).XcodeSelect ();
 	else
 		Item (XreItem.Xcode_11_3_1).XcodeSelect ();

--- a/build-tools/provisioning/xcode.csx
+++ b/build-tools/provisioning/xcode.csx
@@ -1,0 +1,9 @@
+if (IsMac) {
+	const string MinMacOSVersion = "10.14.4";
+	if (OSVersion < new Version (MinMacOSVersion))
+		throw new Exception ($"macOS {MinMacOSVersion} or newer is required for Xcode 11.");
+	if (OSVersion >= new Version (10.15.2))
+		Item (XreItem.Xcode_11_6_0).XcodeSelect ();
+	else
+		Item (XreItem.Xcode_11_3_1).XcodeSelect ();
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4907

A new script has been added to manage the Xcode version that we build
against on macOS.  Our three macOS build pools all appear to be using
Mojave agents, and as a result Xcode 11.3.1 will be used.  This script
will support a future migration to Catalina and will use the latest
Xcode currently available (11.6) when building on that macOS version.