### PR TITLE
[build] PackDotNet target to simplify .NET 6 development

### DIFF
--- a/Before.Xamarin.Android.sln.targets
+++ b/Before.Xamarin.Android.sln.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\DotNet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\ImportExportDocs.targets" />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\PrepareWindows.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RunTests.targets" />

--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -72,6 +72,37 @@ and Windows (.vsix) installer files can be built with:
 Commercial installers will be created by this command if the
 `make prepare-external-git-dependencies` command was ran before building.
 
+# Creating .NET 6 NuGet packages
+
+Once `make all` or `make jenkins` have completed, you can build the .NET 6
+packages with:
+
+    make pack-dotnet
+
+Several `.nupkg` files will be output in `./bin/BuildDebug/nupkgs/`, you
+can use these with a `nuget.config` such as:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="local-xa" value="/full/path/to/bin/BuildDebug/nupkgs" />
+  </packageSources>
+</configuration>
+```
+
+Then use a `global.json` for the locally built version of the packages:
+
+```json
+{
+    "msbuild-sdks": {
+            "Microsoft.Android.Sdk": "11.0.100-ci.master.11"
+    }
+}
+```
+
+See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
 
 # Building Unit Tests
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -87,6 +87,38 @@ So for example:
 [windows_path]: https://www.java.com/en/download/help/path.xml
 [set_alias]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-alias?view=powershell-6
 
+# Creating .NET 6 NuGet packages
+
+Once `Xamarin.Android.sln` is built, you can build the .NET 6 packages
+with:
+
+    msbuild Xamarin.Android.sln /t:PackDotNet
+
+Several `.nupkg` files will be output in `.\bin\BuildDebug\nupkgs\`, you
+can use these with a `nuget.config` such as:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="local-xa" value="C:\full\path\to\bin\BuildDebug\nupkgs" />
+  </packageSources>
+</configuration>
+```
+
+Then use a `global.json` for the locally built version of the packages:
+
+```json
+{
+    "msbuild-sdks": {
+            "Microsoft.Android.Sdk": "11.0.100-ci.master.11"
+    }
+}
+```
+
+See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
+
 # Building Unit Tests
 
 Once `msbuild Xamarin.Android.sln` has completed, the unit tests may

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ endif
 all-tests::
 	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
 
+pack-dotnet::
+	$(call MSBUILD_BINLOG,pack-dotnet,$(_SLN_BUILD)) $(MSBUILD_FLAGS) Xamarin.Android.sln /t:PackDotNet
+
 install::
 	@if [ ! -d "bin/$(CONFIGURATION)" ]; then \
 		echo "run 'make all' before you execute 'make install'!"; \

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -1,0 +1,16 @@
+<Project>
+  <Target Name="PackDotNet">
+    <PropertyGroup>
+      <_TopDir>$(MSBuildThisFileDirectory)..\..\</_TopDir>
+    </PropertyGroup>
+    <MSBuild Projects="$(_TopDir)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <MSBuild Projects="$(_TopDir)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild Projects="$(_TopDir)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
+    <!-- Clean up old, previously restored packages -->
+    <ItemGroup>
+      <_OldPackages Include="$(_TopDir)packages\microsoft.android.*\**\*.nupkg" />
+      <_DirectoriesToRemove Include="%(_OldPackages.RootDir)%(_OldPackages.Directory)" />
+    </ItemGroup>
+    <RemoveDir Directories="@(_DirectoriesToRemove)" />
+  </Target>
+</Project>


### PR DESCRIPTION
When working on .NET 6, I use the following powershell function for my
"developer loop":

    function pack-xa-nugets([string] $configuration = 'Debug')
    {
        & msbuild $xa\build-tools\xa-prep-tasks\xa-prep-tasks.csproj
        & msbuild $xa\Xamarin.Android.sln -p:DisableApiCompatibilityCheck=true
        & msbuild /t:CreateAllPacks build-tools/create-packs/Microsoft.Android.Sdk.proj
        Remove-Item -r $xa\packages\microsoft.android.* -ErrorAction SilentlyContinue
    }

The steps here are:

1. Build `xa-prep-tasks.csproj` so the `_CreateVersion` MSBuild target
   can run and update git versioning information:

https://github.com/xamarin/xamarin-android/blob/9c880983914e2dbc3f384dea16b5351696732682/build-tools/xa-prep-tasks/xa-prep-tasks.targets#L4

2. Build `Xamarin.Android.sln`.

3. Run `CreateAllPacks`, to create all the `.nupkg` files.

4. Delete any previously extracted files in `packages/microsoft.android.*`

Step 4 is particularly important for sanity. Otherwise, I have
attempted to build a project, but NuGet did not extract the new
`.nupkg` files because their versions were the same!

Because no one else has this script, I ported it to MSBuild to it can
live this in repo and work on all platforms.

On Windows:

    msbuild Xamarin.Android.sln /t:PackDotNet

On macOS:

    make pack-dotnet

Down the road we could improve this workflow further by copying files
directly. The `PackDotNet` target currently takes about 40 seconds on
my Windows desktop machine.

Other naming suggestions welcome.