### PR TITLE
[One .NET] fix build ordering & BuildItem.Deleted

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -77,6 +77,7 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CreateNativeLibraryArchive;
       _AddAndroidEnvironmentToCompile;
       _CheckForContent;
+      _RemoveLegacyDesigner;
       _ValidateAndroidPackageProperties;
       $(BuildDependsOn);
     </BuildDependsOn>
@@ -87,10 +88,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
 
   <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
   <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">
-    <ResolveReferencesDependsOn>
+    <CoreResolveReferencesDependsOn>
       _SeparateAppExtensionReferences;
       $(ResolveReferencesDependsOn);
       _AddAndroidCustomMetaData;
+    </CoreResolveReferencesDependsOn>
+    <ResolveReferencesDependsOn>
+      $(CoreResolveReferencesDependsOn);
       UpdateAndroidInterfaceProxies;
       UpdateAndroidResources;
       AddBindingsToCompile;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -22,12 +22,13 @@
 
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
+  <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
 
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.Core.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.AssemblyResolution.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Linker.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.NuGet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Publish.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
@@ -59,6 +59,8 @@ namespace Xamarin.ProjectTools
 
 		static void AppendBuildItem (StringBuilder sb, BuildItem bi)
 		{
+			if (bi.Deleted)
+				return;
 			sb.Append ($"\t\t<{bi.BuildAction} ");
 			if (bi.Include != null) sb.Append ($"Include=\"{bi.Include ()}\" ");
 			if (bi.Update != null) sb.Append ($"Update=\"{bi.Update ()}\" ");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -754,10 +754,6 @@ because xbuild doesn't support framework reference assemblies.
       EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)" />
 </Target>
 
-<Target Name="_CheckTargetFramework">
-	<Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
-</Target>
-
 <Target Name="_CheckForContent">
 	<LogWarningsForFiles
 		Files="@(Content)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -193,6 +193,10 @@ projects. .NET 5 projects will not import this file.
   <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies"               AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
+  <Target Name="_CheckTargetFramework">
+    <Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
+  </Target>
+
   <Target Name="_GetReferenceAssemblyPaths">
     <GetReferenceAssemblyPaths
         TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"


### PR DESCRIPTION
The `AndroidUpdateResourcesTest.CheckFilesAreRemoved` test was failing
with:

    Resources\values\Theme.xml error XA2001: Source file 'Resources\values\Theme.xml' could not be found.

When looking through logs, I noticed lots of differences in build
ordering from legacy projects.

1. `$(BuildDependsOn)` ordering - In legacy projects
   `ImplicitlyExpandDesignTimeFacades` is listed last, while it was in
   the middle for .NET 5+ projects.

This was caused by the ordering of `<Import/>`.
`Microsoft.Android.Sdk.BuildOrder.targets` needs to be imported before
`Xamarin.Android.Common.targets`.

2. `$(BuildDependsOn)` also listed these targets in legacy projects:

    _CheckTargetFramework;
    _RemoveLegacyDesigner;

`_CheckTargetFramework` is not needed, but it needs to be moved to
`Xamarin.Android.Legacy.targets`.

`_RemoveLegacyDesigner` should be listed in `$(BuildDependsOn)`.

3. `_UpdateAndroidResources` had different values for `DependsOnTargets`.

In c87ef952, I removed `$(CoreResolveReferencesDependsOn)` to just
simplify things. It turns out `_UpdateAndroidResources` uses this
property. I put things back the way they were.

After fixing the build ordering, the test still failed.

Then I noticed the *actual* cause to the failing test... There were
additional `@(AndroidResource)` items in the `.csproj` file.
`BuildItem.Deleted` wasn't being checked when short-form `.csproj`
files are generated. We should omit build items with this flag set.

After doing this, we can run a couple additional tests under `dotnet`
context.