### PR TITLE
[One .NET] fix the GetAndroidDependencies MSBuild target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -136,6 +136,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _GetLibraryImports;
       _ExportJarToXml;
     </ExportJarToXmlDependsOnTargets>
+    <GetAndroidDependenciesDependsOn>
+      _BeforeGetAndroidDependencies;
+      _SetLatestTargetFrameworkVersion;
+      _ResolveSdks;
+      _ResolveAndroidTooling;
+      $(GetAndroidDependenciesDependsOn);
+    </GetAndroidDependenciesDependsOn>
   </PropertyGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Android.Tasks
 
 		public string CommandLineToolsVersion { get; set; }
 
+		public string AndroidApiLevel { get; set; }
+
 		[Required]
 		public string TargetFrameworkVersion { get; set; }
 
@@ -48,7 +50,9 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			var dependencies = new List<ITaskItem> ();
-			var targetApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+			var targetApiLevel = string.IsNullOrEmpty (AndroidApiLevel) ?
+				MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion) :
+				MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (AndroidApiLevel);
 			var manifestApiLevel = DefaultMinSDKVersion;
 			if (File.Exists (ManifestFile.ItemSpec)) {
 				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3262,6 +3262,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void GetDependencyWhenSDKIsMissingTest ([Values (true, false)] bool createSdkDirectory)
 		{
 			var apis = new ApiInfo [] {
@@ -3289,7 +3290,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				builder.Target = "GetAndroidDependencies";
 				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
-				StringAssertEx.Contains ("platforms/android-26", builder.LastBuildOutput, "platforms/android-26 should be a dependency.");
+				int apiLevel = Builder.UseDotNet ? builder.GetMaxInstalledPlatform () : 26;
+				StringAssertEx.Contains ($"platforms/android-{apiLevel}", builder.LastBuildOutput, $"platforms/android-{apiLevel} should be a dependency.");
 				StringAssertEx.Contains ($"build-tools/{buildToolsVersion}", builder.LastBuildOutput, $"build-tools/{buildToolsVersion} should be a dependency.");
 				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2644,7 +2644,7 @@ because xbuild doesn't support framework reference assemblies.
   </PropertyGroup>
 </Target> 
  
-<Target Name="GetAndroidDependencies" DependsOnTargets="_BeforeGetAndroidDependencies;_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
+<Target Name="GetAndroidDependencies" DependsOnTargets="$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
     <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(EnableLLVM)' == 'True'">true</_NdkRequired>
@@ -2652,6 +2652,7 @@ because xbuild doesn't support framework reference assemblies.
   </PropertyGroup>
   <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>
   <CalculateProjectDependencies
+    AndroidApiLevel="$(_AndroidApiLevel)"
     TargetFrameworkVersion="$(TargetFrameworkVersion)"
     CommandLineToolsVersion="$(AndroidCommandLineToolsVersion)"
     ManifestFile="$(_ProjectAndroidManifest)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -144,6 +144,11 @@ projects. .NET 5 projects will not import this file.
       _IncludeNativeSystemLibraries;
       _CheckGoogleSdkRequirements;
     </_PrepareBuildApkDependsOnTargets>
+    <GetAndroidDependenciesDependsOn>
+      _BeforeGetAndroidDependencies;
+      _SetLatestTargetFrameworkVersion;
+      $(GetAndroidDependenciesDependsOn);
+    </GetAndroidDependenciesDependsOn>
   </PropertyGroup>
 
   <!-- Binding projects -->


### PR DESCRIPTION
In a .NET 5+ project, the `GetAndroidDependencies` MSBuild target
would use `$(TargetFrameworkVersion)` (which is 5.0) and always report
that API 21 needs to be installed.

The `<CalculateProjectDependencies/>` MSBuild task should use
`$(_AndroidApiLevel)` if set, and fallback to using
`$(TargetFrameworkVersion)`.

Under .NET 5+, `$(_AndroidApiLevel)` will be set via different targets
running in `$(GetAndroidDependenciesDependsOn)`. `$(_AndroidApiLevel)`
will be blank in legacy projects.

I updated a test so it now passes under a `dotnet` context.