### PR TITLE
[xaprepare] CGManifest.json generation

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -8,6 +8,7 @@
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)XABuildConfig.cs" Condition="Exists('$(BootstrapOutputDirectory)XABuildConfig.cs')" />
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)*.binlog" />
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)prepare*.log" />
+    <_BuildStatusFiles Include="$(BootstrapOutputDirectory)*.json" />
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)*.mk" />
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)*.projitems" />
     <_BuildStatusFiles Include="$(BootstrapOutputDirectory)*.cmake" />

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -239,6 +239,8 @@ stages:
         artifactName: $(NuGetArtifactName)
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
+    - task: ComponentGovernanceComponentDetection@0
+
     - template: yaml-templates/upload-results.yaml
       parameters:
         solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -239,8 +239,6 @@ stages:
         artifactName: $(NuGetArtifactName)
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
-    - task: ComponentGovernanceComponentDetection@0
-
     - template: yaml-templates/upload-results.yaml
       parameters:
         solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Android.Prepare
 			AddRequiredOSSpecificSteps (true);
 			Steps.Add (new Step_InstallMonoRuntimes ());
 			Steps.Add (new Step_Get_Windows_Binutils ());
+			Steps.Add (new Step_GenerateCGManifest ());
 
 			AddRequiredOSSpecificSteps (false);
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateCGManifest.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateCGManifest.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Xamarin.Android.Prepare
+{
+	partial class Step_GenerateCGManifest : Step
+	{
+		static readonly HashSet<string> DevelopmentDependencies = new HashSet<string> (StringComparer.OrdinalIgnoreCase) {
+			"7-Zip.CommandLine",
+			"icsharpcode/NRefactory",
+			"Kajabity.Tools.Java",
+			"Mono.Linq.Expressions",
+			"mono/debugger-libs",
+			"Newtonsoft.Json",
+			"System.CommandLine",
+			"Xamarin.Forms",
+			"xunit",
+			"xunit.abstractions",
+			"xunit.analyzers",
+			"xunit.assert",
+			"xunit.core",
+			"xunit.extensibility.core",
+			"xunit.extensibility.execution",
+			"xunit.runner.utility",
+
+			// ???
+			"Microsoft.Build",
+			"Microsoft.Build.Framework",
+			"Microsoft.Build.Tasks.Core",
+			"Microsoft.Build.Utilities.Core",
+			"Microsoft.VisualStudio.CoreUtility",
+			"Microsoft.VisualStudio.Imaging",
+			"Microsoft.VisualStudio.OLE.Interop",
+			"Microsoft.VisualStudio.Shell.15.0",
+			"Microsoft.VisualStudio.Shell.Framework",
+			"Microsoft.VisualStudio.Shell.Interop",
+			"Microsoft.VisualStudio.Shell.Interop.8.0",
+			"Microsoft.VisualStudio.Shell.Interop.9.0",
+			"Microsoft.VisualStudio.TextManager.Interop",
+			"Microsoft.VisualStudio.TextManager.Interop.8.0",
+			"Microsoft.VisualStudio.Threading",
+			"Microsoft.VisualStudio.Utilities",
+			"Microsoft.VisualStudio.Validation",
+			"Microsoft.VSSDK.BuildTools",
+		};
+
+		public Step_GenerateCGManifest ()
+			: base ("Generate CGManifest.json")
+		{}
+
+		protected override async Task<bool> Execute (Context context)
+		{
+			var nugets              = MSBuildPackageReferenceInfo.GetPackageReferences ();
+			var git                 = new GitRunner (context);
+			var gitSubmoduleInfo    = await git.ConfigList (new[]{"--blob", "HEAD:.gitmodules"});
+			var gitSubmoduleStatus  = await git.SubmoduleStatus ();
+			var gitSubmodules       = GitSubmoduleInfo.GetGitSubmodules (gitSubmoduleInfo, gitSubmoduleStatus);
+
+			var cgManifestEntries   = ((IEnumerable<CGManifestEntry>) nugets).Concat (gitSubmodules)
+				.OrderBy (e => e.Name);
+
+			var jsonPath    = Path.Combine (Configurables.Paths.BuildBinDir, "CGManifest.json");
+			using var json  = File.CreateText (jsonPath);
+
+			json.WriteLine ("{");
+			json.WriteLine ("    \"Registrations\": [");
+
+			var properties = new Dictionary<string, string> ();
+
+			bool first = true;
+
+			foreach (var entry in cgManifestEntries) {
+				if (first) {
+					first   = false;
+				} else {
+					json.WriteLine (",");
+				}
+
+				WriteComponent (json, entry, properties);
+			}
+
+			json.WriteLine ();
+			json.WriteLine ("    ]");
+			json.WriteLine ("}");
+
+			return true;
+		}
+
+		void WriteComponent (TextWriter json, CGManifestEntry entry, Dictionary<string, string> properties)
+		{
+			string dev = DevelopmentDependencies.Contains (entry.Name)
+				? "true"
+				: "false";
+
+			properties.Clear ();
+			entry.FillComponentProperties (properties);
+
+			json.WriteLine ($"        {{");
+			json.WriteLine ($"            \"Component\": {{");
+			json.WriteLine ($"                \"Type\": \"{entry.Type.ToLowerInvariant ()}\",");
+			json.WriteLine ($"                \"{entry.Type}\": {{");
+			bool firstProp = true;
+			foreach (var key in properties.Keys.OrderBy (p => p, StringComparer.OrdinalIgnoreCase)) {
+				var value = properties [key];
+				if (firstProp) {
+					firstProp = false;
+				} else {
+					json.WriteLine (",");
+				}
+				json.Write ($"                    \"{key}\": \"{value}\"");
+			}
+			json.WriteLine ();
+			json.WriteLine ($"                }}");
+			json.WriteLine ($"            }},");
+			json.WriteLine ($"            \"DevelopmentDependency\":{dev}");
+			json.Write     ($"        }}");
+		}
+	}
+
+	abstract class CGManifestEntry {
+
+		public  abstract    string  Name {get;}
+		public  abstract    string  Type {get;}
+
+		public  abstract    void    FillComponentProperties (Dictionary<string, string> properties);
+
+		protected CGManifestEntry ()
+		{
+		}
+	}
+
+	sealed class GitSubmoduleInfo : CGManifestEntry {
+
+		public  override    string      Name {
+			get {
+				const string github = "github.com/";
+				int i = RepositoryUrl.IndexOf (github, StringComparison.OrdinalIgnoreCase);
+				if (i >= 0)
+					return RepositoryUrl.Substring (i + github.Length);
+				return RepositoryUrl;
+			}
+		}
+
+		public  override    string      Type    => "Git";
+
+		public  string      RepositoryUrl   {get; private set;}
+		public  string      CommitHash      {get; private set;}
+
+		GitSubmoduleInfo ()
+		{
+		}
+
+		public override void FillComponentProperties (Dictionary<string, string> properties)
+		{
+			properties ["RepositoryUrl"]    = RepositoryUrl;
+			properties ["CommitHash"]       = CommitHash;
+		}
+
+		const string Submodule = "submodule.external/";
+
+		public static IEnumerable<GitSubmoduleInfo> GetGitSubmodules (List<string> config, List<string> submoduleStatus)
+		{
+			string? entryId = null;
+			string? path = null;
+			string? url = null;
+
+			foreach (var line in config) {
+				if (!line.StartsWith (Submodule, StringComparison.Ordinal))
+					continue;
+
+				string? id = GetSubmoduleId (line);
+				if (id != entryId) {
+					if (url != null && path != null)
+						yield return CreateSubmoduleInfo (url, path);
+
+					entryId = id;
+					path    = null;
+					url     = null;
+				}
+
+				const string Path   = ".path=";
+				const string Url    = ".url=";
+				const string Git    = ".git";
+
+				int pathIndex   = line.IndexOf (Path, StringComparison.Ordinal);
+				if (pathIndex > 0) {
+					path        = line.Substring (pathIndex + Path.Length);
+					continue;
+				}
+
+				int urlIndex    = line.IndexOf (Url, StringComparison.Ordinal);
+				if (urlIndex > 0) {
+					int start   = urlIndex + Url.Length;
+					int count   = line.Length - start;
+					if (line.EndsWith (Git, StringComparison.Ordinal))
+						count -= Git.Length;
+					url         = line.Substring (start, count);
+					continue;
+				}
+			}
+
+			if (url != null && path != null)
+				yield return CreateSubmoduleInfo (url, path);
+
+			GitSubmoduleInfo CreateSubmoduleInfo (string url, string path)
+			{
+				string? hash = null;
+				foreach (var e in submoduleStatus) {
+					int pi  = e.IndexOf (path, StringComparison.OrdinalIgnoreCase);
+					if (pi < 1 || e [pi - 1] != ' ')
+						continue;
+					hash    = e.Substring (1, pi - 2);
+					break;
+				}
+				return new GitSubmoduleInfo () {
+					RepositoryUrl   = url,
+					CommitHash      = hash,
+				};
+			}
+		}
+
+		static string? GetSubmoduleId (string line)
+		{
+			int eq = line.IndexOf ('=');
+			if (eq < 0)
+				return null;
+			int lastDot = line.LastIndexOf ('.', eq);
+			return line.Substring (Submodule.Length, lastDot - Submodule.Length);
+		}
+	}
+
+	sealed class MSBuildPackageReferenceInfo : CGManifestEntry {
+
+		string name;
+
+		public  override    string      Name    => name;
+		public  override    string      Type    => "Nuget";
+
+		public  string      Version {get; private set;}
+
+		MSBuildPackageReferenceInfo (string name, string version)
+		{
+			this.name = name;
+			Version = version;
+		}
+
+		public override void FillComponentProperties (Dictionary<string, string> properties)
+		{
+			properties ["Name"]     = Name;
+			properties ["Version"]  = Version;
+		}
+
+		static  readonly    XNamespace      MSBuildXmlns    = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
+
+		public static IEnumerable<MSBuildPackageReferenceInfo> GetPackageReferences ()
+		{
+			var files = Directory.EnumerateFiles (BuildPaths.XamarinAndroidSourceRoot, "*.csproj", SearchOption.AllDirectories)
+				.Concat (Directory.EnumerateFiles (BuildPaths.XamarinAndroidSourceRoot, "*.targets", SearchOption.AllDirectories))
+				.Concat (Directory.EnumerateFiles (BuildPaths.XamarinAndroidSourceRoot, "*.projitems", SearchOption.AllDirectories))
+				;
+			var packages    = new Dictionary<string, HashSet<string>> ();
+			var versions    = new Dictionary<string, HashSet<string>> ();
+			foreach (var file in files) {
+				var contents            = File.ReadAllText (file);
+				if (contents.IndexOf ("PackageReference", StringComparison.Ordinal) < 0 ||
+						contents.IndexOf ("PropertyGroup", StringComparison.Ordinal) < 0)
+					continue;
+				var proj                = XDocument.Parse (contents);
+				var packageReferences   = proj.Elements (MSBuildXmlns + "Project")
+					.Elements (MSBuildXmlns + "ItemGroup")
+					.Elements (MSBuildXmlns + "PackageReference");
+				foreach (var packageReference in packageReferences) {
+					var name    = (string?) packageReference.Attribute ("Include");
+					var version = (string?) packageReference.Attribute ("Version") ??
+						packageReference.Element (MSBuildXmlns+"Version")?.Value;
+					if (name == null || version == null)
+						continue;
+					if (!packages.TryGetValue (name, out var v)) {
+						packages.Add (name, v = new HashSet<string> ());
+					}
+					v.Add (version);
+				}
+				var properties  = proj.Elements (MSBuildXmlns + "Project")
+					.Elements (MSBuildXmlns + "PropertyGroup")
+					.Elements ();
+				foreach (var property in properties) {
+					var name = $"$({property.Name.LocalName})";
+					if (!property.Name.LocalName.EndsWith ("Version", StringComparison.Ordinal))
+						continue;
+					if (!versions.TryGetValue (name, out var v)) {
+						versions.Add (name, v = new HashSet<string> ());
+					}
+					v.Add (property.Value.Trim ());
+				}
+			}
+
+			foreach (var package in packages) {
+				string name = package.Key;
+				foreach (var version in package.Value) {
+					if (version.Length > 0 && version [0] != '$') {
+						yield return new MSBuildPackageReferenceInfo (name, version);
+						continue;
+					}
+					if (!versions.TryGetValue (version, out var propertyVersions))
+						continue;
+					foreach (var propertyVersion in propertyVersions) {
+						yield return new MSBuildPackageReferenceInfo (name, propertyVersion);
+					}
+				}
+			}
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
@@ -75,6 +75,31 @@ namespace Xamarin.Android.Prepare
 			return await RunGit (runner, $"clone-{dirName}");
 		}
 
+		public async Task<List<string>?> SubmoduleStatus (string? workingDirectory = null)
+		{
+			string runnerWorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
+
+			var runner = CreateGitRunner (runnerWorkingDirectory);;
+			runner.AddArgument ("submodule");
+			runner.AddArgument ("status");
+
+			var lines = new List<string> ();
+
+			bool success = await RunTool (
+				() => {
+					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
+						outputSink.LineCallback = (string line) => lines.Add (line);
+						return runner.Run ();
+					}
+				}
+			);
+
+			if (!success)
+				return null;
+
+			return lines;
+		}
+
 		public async Task<bool> SubmoduleUpdate (string? workingDirectory = null, bool init = true, bool recursive = true)
 		{
 			string runnerWorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
@@ -155,6 +180,31 @@ namespace Xamarin.Android.Prepare
 				return null;
 
 			return parserState.Entries;
+		}
+
+		public async Task<List<string>?> ConfigList (string[] fileOptions, string? workingDirectory = null)
+		{
+			var runner = CreateGitRunner (workingDirectory);
+			runner.AddArgument ("config");
+			foreach (var opt in fileOptions)
+				runner.AddArgument (opt);
+			runner.AddArgument ("--list");
+
+			var lines = new List<string> ();
+
+			bool success = await RunTool (
+				() => {
+					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
+						outputSink.LineCallback = (string line) => lines.Add (line);
+						return runner.Run ();
+					}
+				}
+			);
+
+			if (!success)
+				return null;
+
+			return lines;
 		}
 
 		public async Task<bool> IsRepoUrlHttps (string workingDirectory)

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Steps\Step_BuildMingwDependencies.cs" />
     <Compile Include="Steps\Step_DownloadMonoArchive.cs" />
     <Compile Include="Steps\Step_DownloadNuGet.cs" />
+    <Compile Include="Steps\Step_GenerateCGManifest.cs" />
     <Compile Include="Steps\Step_GenerateFiles.cs" />
     <Compile Include="Steps\Step_Get_Windows_Binutils.cs" />
     <Compile Include="Steps\Step_InstallJetBrainsOpenJDK.cs" />


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1139601
Fixes: https://dev.azure.com/devdiv/DevDiv/_componentGovernance/112013/alert/3185600?typeId=1016455

Context: https://docs.opensource.microsoft.com/tools/cg/cgmanifest.html
Context: https://github.com/xamarin/xamarin-macios/commit/32c4999822da706e0d374c253b76a293ba80cd8a

For a variety of "sanity and security" reasons, we need to better
integrate with "Component Governance", which "detects open source [used]
and alerts you to whether it has security vulnerabilities…".

Much of Component Governance is automagic, scanning the source tree
before and after the build occurs -- meaning it can scan NuGet
dependencies & such which are "in tree" after `make prepare` -- but it
can't have "insight" into the *meaning* of certain dependencies.

Consider the [7-Zip.CommandLine][0] NuGet package: we use this *only*
to build the xamarin-android repo itself; it is not redistributed.
However, it gets flagged by Component Governance due to LGPL-2 use.

There is a way to tell Component Governance that a file isn't
redistributed: provide a [`CGManifest.json` file][1] and set the
`DevelopmentDependency` to `true`.

Update `xaprepare` so that it (manually) "knows" which packages are
Development Dependencies, by listing their names in
`Step_GenerateCGManifest.DevelopmentDependencies`, and then scan the
build tree for NuGet package references and Git submodule info, so
that an appropriate `CGManifest.json` file can be generated.

[0]: https://www.nuget.org/packages/7-Zip.CommandLine/
[1]: https://docs.opensource.microsoft.com/tools/cg/cgmanifest.html