### PR TITLE
[Xamarin.Android.Build.Tasks] Use writable dirs for compression (#4924)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -322,6 +322,7 @@ namespace Xamarin.Android.Tasks
 			bool use_shared_runtime = String.Equals (UseSharedRuntime, "true", StringComparison.OrdinalIgnoreCase);
 			string sourcePath;
 			AssemblyCompression.AssemblyData compressedAssembly = null;
+			string compressedOutputDir = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (ApkOutputPath), "..", "lz4"));
 
 			int count = 0;
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
@@ -420,7 +421,13 @@ namespace Xamarin.Android.Tasks
 
 				if (compressedAssembliesInfo.TryGetValue (Path.GetFileName (assembly.ItemSpec), out CompressedAssemblyInfo info) && info != null) {
 					EnsureCompressedAssemblyData (assembly.ItemSpec, info.DescriptorIndex);
-					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly);
+					string assemblyOutputDir;
+					string abiDirectory = assembly.GetMetadata ("AbiDirectory");
+					if (!String.IsNullOrEmpty (abiDirectory))
+						assemblyOutputDir = Path.Combine (compressedOutputDir, abiDirectory);
+					else
+						assemblyOutputDir = compressedOutputDir;
+					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly, assemblyOutputDir);
 					if (result != AssemblyCompression.CompressionResult.Success) {
 						switch (result) {
 							case AssemblyCompression.CompressionResult.EncodingFailed:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -42,6 +42,18 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void CompressedWithoutLinker ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true
+			};
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkMode, AndroidLinkMode.None.ToString ());
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[Category ("SmokeTests")]
 		public void BuildBasicApplicationReleaseProfiledAot ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyCompression.cs
@@ -49,10 +49,15 @@ namespace Xamarin.Android.Tasks
 
 		static readonly ArrayPool<byte> bytePool = ArrayPool<byte>.Shared;
 
-		public static CompressionResult Compress (AssemblyData data)
+		public static CompressionResult Compress (AssemblyData data, string outputDirectory)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));
+
+			if (String.IsNullOrEmpty (outputDirectory))
+				throw new ArgumentException ("must not be null or empty", nameof (outputDirectory));
+
+			Directory.CreateDirectory (outputDirectory);
 
 			var fi = new FileInfo (data.SourcePath);
 			if (!fi.Exists)
@@ -61,7 +66,7 @@ namespace Xamarin.Android.Tasks
 			// 	return CompressionResult.InputTooBig;
 			// }
 
-			data.DestinationPath = $"{data.SourcePath}.lz4";
+			data.DestinationPath = Path.Combine (outputDirectory, $"{Path.GetFileName (data.SourcePath)}.lz4");
 			data.SourceSize = (uint)fi.Length;
 
 			byte[] sourceBytes = null;


### PR DESCRIPTION
Context: d236af54538ef1fe62d0125798cdde78e46dcd8e

Commit d236af54 introduced assembly compression for `Release` builds
with compression output placed in the same directory where the original
assembly resides.  This works well if the linker is enabled for the
project because all the assemblies are copied to the `obj/` directory,
but if the linker is disabled, some assemblies will be read from their
original path, possibly a system location which is NOT writable by
non-root/non-admin processes:

	# Ensure dir holding `Mono.Android.dll` isn't writable
	$ chmod 555 bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v11.0

	# Build samples/HelloWorld w/ linking disabled
	$ bin/Debug/bin/xabuild /restore /t:SignAndroidPackage /v:diag \
		/p:AndroidLinkMode=None /p:Configuration=Release \
		samples/HelloWorld/*.csproj
	…
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019: System.UnauthorizedAccessException: Access to the path "…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v11.0/Mono.Android.dll.lz4" is denied.
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options)
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share)
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at System.IO.File.Open (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share)
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at Xamarin.Android.Tasks.AssemblyCompression.Compress (Xamarin.Android.Tasks.AssemblyCompression+AssemblyData data)
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at Xamarin.Android.Tasks.BuildApk.<AddAssemblies>g__CompressAssembly|138_1 (Microsoft.Build.Framework.ITaskItem assembly, Xamarin.Android.Tasks.BuildApk+<>c__DisplayClass138_0& )
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at Xamarin.Android.Tasks.BuildApk.AddAssemblies (Xamarin.Android.Tasks.ZipArchiveEx apk, System.Boolean debug, System.Boolean compress, System.Collections.Generic.IDictionary`2[TKey,TValue] compressedAssembliesInfo)
	…/Xamarin.Android.Common.targets(2181,3): error XABLD7019:   at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi (System.String[] supportedAbis, System.String apkInputPath, System.String apkOutputPath, System.Boolean debug, System.Boolean compress, System.Collections.Generic.IDictionary`2[TKey,TValue] compressedAssembliesInfo)

This commit moves the compressed output location to a subdirectory of
the `obj/` directory for all the input assemblies.

Co-authored-by: Jonathan Peppers <jonathan.peppers@gmail.com>