### PR TITLE
[tests] standardize on SetAndroidSupportedAbis in MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -950,7 +950,7 @@ namespace UnamedProject
 		public void BuildMkBundleApplicationReleaseAllAbi ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ("temp/BuildMkBundleApplicationReleaseAllAbi", false)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				foreach (var abi in new string [] { "armeabi-v7a", "x86" }) {
@@ -986,7 +986,7 @@ namespace UnamedProject
 				AotAssemblies = true,
 			};
 			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
+			proj.SetAndroidSupportedAbis (supportedAbis);
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
 			bool checkMinLlvmPath = enableLLVM && (supportedAbis == "armeabi-v7a" || supportedAbis == "x86");
 			if (checkMinLlvmPath) {
@@ -1055,7 +1055,7 @@ namespace UnamedProject
 				AotAssemblies = true,
 			};
 			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
+			proj.SetAndroidSupportedAbis (supportedAbis);
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
 			using (var b = CreateApkBuilder (path)) {
 				if (!b.CrossCompilerAvailable (supportedAbis))
@@ -2027,8 +2027,8 @@ namespace App1
 				IsRelease = isRelease,
 				AotAssemblies = aotAssemblies
 			};
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			var abis = new [] { "armeabi-v7a", "x86" };
+			proj.SetAndroidSupportedAbis (abis);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "MonoSymbolArchive", monoSymbolArchive);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", debugType);
@@ -2138,7 +2138,7 @@ namespace App1
 				}
 			};
 			proj.SetProperty ("TargetFrameworkVersion", "v7.1");
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("int count = 1;", @"int count = 1;
 Mono.Data.Sqlite.SqliteConnection connection = null;
 Mono.Unix.UnixFileInfo fileInfo = null;");
@@ -2196,7 +2196,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 					},
 				}
 			};
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.ThrowOnBuildFailure = false;
@@ -4219,7 +4219,7 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var environment = b.Output.GetIntermediaryPath (Path.Combine ("__environment__.txt"));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -241,7 +241,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			var supportedAbis = new string [] { "armeabi-v7a", "arm64-v8a" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", supportedAbis));
+			proj.SetAndroidSupportedAbis (supportedAbis);
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildWithTlsProvider_{androidTlsProvider}_{isRelease}_{expected}"))) {
 				proj.SetProperty ("AndroidTlsProvider", androidTlsProvider);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -234,6 +234,7 @@ public class TestMe {
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void ResolveNativeLibrariesInManagedReferences ([Values(true, false)] bool useShortFileNames)
 		{
 			var lib = new XamarinAndroidLibraryProject () {
@@ -310,6 +311,7 @@ namespace Lib2
 							new BuildItem.ProjectReference (@"..\Lib2\Lib2.csproj", "Lib2", lib2.ProjectGuid),
 						}
 					};
+					app.SetAndroidSupportedAbis ("armeabi-v7a");
 					app.SetProperty (app.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 					using (var builder = CreateApkBuilder (Path.Combine (path, "App"))) {
 						builder.Verbosity = LoggerVerbosity.Diagnostic;
@@ -1165,14 +1167,17 @@ namespace Lib2
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void ChangeSupportedAbis ()
 		{
 			var proj = new XamarinFormsAndroidApplicationProject ();
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a");
 			using (var b = CreateApkBuilder ()) {
 				b.Build (proj);
 
-				var parameters = new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
+				var parameters = Builder.UseDotNet ?
+					new [] { $"{KnownProperties.RuntimeIdentifier}=android.21-x86" } :
+					new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
 				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -431,7 +431,7 @@ namespace Bug12935
 			proj.SetProperty ("Foo", "1");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, seperateApk);
 			if (!string.IsNullOrEmpty (abis))
-				proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, abis);
+				proj.SetAndroidSupportedAbis (abis);
 			if (!string.IsNullOrEmpty (versionCodePattern))
 				proj.SetProperty (proj.ReleaseProperties, "AndroidVersionCodePattern", versionCodePattern);
 			else

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -35,8 +35,8 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty (proj.ReleaseProperties, "MonoSymbolArchive", monoSymbolArchive);
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, "true");
-			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidPackageFormat", packageFormat);
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ()) {
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
@@ -137,7 +137,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.PackageReferences.Add(KnownPackages.SQLitePCLRaw_Core);
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
-			proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "x86");
+			proj.SetAndroidSupportedAbis ("x86");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : "so");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
@@ -321,7 +321,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyPass", pass);
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningStorePass", pass);
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, perAbiApk);
-			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 				Assert.IsTrue (b.Build (proj), "First build failed");
@@ -375,7 +375,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
 			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, true);
-			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				if (!b.TargetFrameworkExists (proj.TargetFrameworkVersion))
 					Assert.Ignore ($"Skipped as {proj.TargetFrameworkVersion} not available.");
@@ -565,7 +565,7 @@ namespace App1
 			}
 		}
 	}";
-			app.SetProperty (KnownProperties.AndroidSupportedAbis, "x86;armeabi-v7a");
+			app.SetAndroidSupportedAbis ("x86", "armeabi-v7a");
 			var expectedFiles = new string [] {
 				"Java.Interop.dll",
 				"Mono.Android.dll",

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Build.Tests
 			AssertHasDevices ();
 
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			var port = 9000 + new Random ().Next (1000);
 			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());
 			proj.AndroidManifest = string.Format (PermissionManifest, proj.PackageName);

--- a/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
-				proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;arm64-v8a;x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
 			} else {
 				proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"23\" />");
 			}

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -69,8 +69,7 @@ namespace Xamarin.Android.Build.Tests
 			//NOTE: this is here to enable adb shell run-as
 			app.AndroidManifest = app.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 			app.SetProperty (app.ReleaseProperties, "AndroidPackageFormat", "aab");
-			var abis = new string [] { "armeabi-v7a", "arm64-v8a", "x86" };
-			app.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			app.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
 			app.SetProperty ("AndroidBundleConfigurationFile", "buildConfig.json");
 
 			libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName), cleanupOnDispose: true);

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -41,8 +41,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
-				var abis = new string [] { "armeabi-v7a", "x86" };
-				proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
@@ -71,8 +70,7 @@ namespace Xamarin.Android.Build.Tests
 				ProjectName = "MyApp",
 			};
 			if (!CommercialBuildAvailable) {
-				var abis = new string [] { "armeabi-v7a", "x86" };
-				app.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+				app.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
 			app.SetDefaultTargetDevice ();
 
@@ -164,8 +162,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = false,
 				AndroidFastDeploymentType = fastDevType,
 			};
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			proj.SetProperty (KnownProperties.AndroidUseSharedRuntime, useSharedRuntime.ToString ());
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
@@ -319,8 +316,7 @@ namespace ${ROOT_NAMESPACE} {
 				EmbedAssembliesIntoApk = embedAssemblies,
 				AndroidFastDeploymentType = fastDevType
 			};
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			if (allowDeltaInstall)
 				proj.SetProperty (KnownProperties._AndroidAllowDeltaInstall, "true");
 			proj.SetDefaultTargetDevice ();

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			proj = new XamarinFormsAndroidApplicationProject ();
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			var mainPage = proj.Sources.First (x => x.Include () == "MainPage.xaml.cs");
 			var source = mainPage.TextContent ().Replace ("InitializeComponent ();", @"InitializeComponent ();
 			Console.WriteLine ($""TimeZoneInfo={TimeZoneInfo.Local.DisplayName}"");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -35,8 +35,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease) {
-				var abis = new string [] { "armeabi-v7a", "x86" };
-				proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
@@ -65,8 +64,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease) {
-				var abis = new string [] { "armeabi-v7a", "x86" };
-				proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
@@ -106,8 +104,7 @@ namespace Xamarin.Android.Build.Tests
 			AssertHasDevices ();
 
 			var proj = new XamarinAndroidApplicationProject ();
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var builder = CreateApkBuilder ()) {
 				// Use the default debug.keystore XA generates
 				Assert.IsTrue (builder.Install (proj), "first install should succeed.");
@@ -136,8 +133,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
 			};
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (builder.Build (proj));
@@ -204,8 +200,8 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, "DebugType", "none");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidUseSharedRuntime", false);
 			proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			var abis = new [] { "armeabi-v7a", "x86" };
+			proj.SetAndroidSupportedAbis (abis);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false, false)) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				if (RunAdbCommand ("shell pm list packages Mono.Android.DebugRuntime").Trim ().Length != 0)
@@ -258,7 +254,7 @@ namespace Xamarin.Android.Build.Tests
 				AndroidUseSharedRuntime = false,
 				EmbedAssembliesIntoApk = true,
 			};
-			proj.SetProperty (proj.DebugProperties, KnownProperties.AndroidSupportedAbis, abi);
+			proj.SetAndroidSupportedAbis (abi);
 
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.ThrowOnBuildFailure = false;
@@ -301,8 +297,7 @@ namespace Xamarin.Android.Build.Tests
 				//Now toggle FastDev to OFF
 				proj.AndroidUseSharedRuntime = false;
 				proj.EmbedAssembliesIntoApk = true;
-				var abis = new string [] { "armeabi-v7a", "x86" };
-				proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 
 				Assert.IsTrue (builder.Install (proj), "Second install should have succeeded.");
 
@@ -395,8 +390,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetProperty ("AndroidSigningStorePass", password);
 				proj.SetProperty ("AndroidSigningKeyPass", password);
 			}
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			proj.SetProperty ("AndroidKeyStore", androidKeyStore);
 			proj.SetProperty ("AndroidSigningKeyStore", "test.keystore");
 			proj.SetProperty ("AndroidSigningKeyAlias", "mykey");

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -115,8 +115,7 @@ namespace UnnamedProject
 			}
 		}
 	}";
-			var abis = new string [] { "armeabi-v7a", "x86" };
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			proj.SetProperty (KnownProperties.AndroidUseSharedRuntime, useSharedRuntime.ToString ());
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();


### PR DESCRIPTION
Using `ProjectExtensions.SetAndroidSupportedAbis()` sets either
`$(RuntimeIdentifiers)` or `$(AndroidSupportedAbis)` when appropriate.

Most tests should not do something like this going forward:

    proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", supportedAbis));

And instead, simply do this:

    proj.SetAndroidSupportedAbis (supportedAbis);

This fixes many tests under the `dotnet` context, but I just enabled a
couple for now.