### PR TITLE
[xaprepare] Redirect some git messages from stderr to stdout

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Android.Prepare
 {
 	class ProcessRunner : AppObject
 	{
+		public const string StdoutSeverityName = "stdout";
+		public const string StderrSeverityName = "stderr";
+
 		public enum ErrorReasonCode
 		{
 			NotExecutedYet,
@@ -199,7 +202,7 @@ namespace Xamarin.Android.Prepare
 				if (StandardOutputEchoWrapper != null) {
 					AddStandardOutputSink (StandardOutputEchoWrapper);
 				} else if (!defaultStdoutEchoWrapperAdded) {
-					AddStandardOutputSink (new ProcessStandardStreamWrapper { LoggingLevel = EchoStandardOutputLevel, CustomSeverityName = "stdout" });
+					AddStandardOutputSink (new ProcessStandardStreamWrapper { LoggingLevel = EchoStandardOutputLevel, CustomSeverityName = StdoutSeverityName });
 					defaultStdoutEchoWrapperAdded = true;
 				}
 			}
@@ -208,7 +211,7 @@ namespace Xamarin.Android.Prepare
 				if (StandardErrorEchoWrapper != null) {
 					AddStandardErrorSink (StandardErrorEchoWrapper);
 				} else if (defaultStderrEchoWrapper == null) {
-					defaultStderrEchoWrapper = new ProcessStandardStreamWrapper { LoggingLevel = EchoStandardErrorLevel, CustomSeverityName = "stderr" };
+					defaultStderrEchoWrapper = new ProcessStandardStreamWrapper { LoggingLevel = EchoStandardErrorLevel, CustomSeverityName = StderrSeverityName };
 					AddStandardErrorSink (defaultStderrEchoWrapper);
 				}
 			}

--- a/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
@@ -43,8 +43,9 @@ namespace Xamarin.Android.Prepare
 		    DoWrite (value, true);
 	    }
 
-	    protected virtual string PreprocessMessage (string message, ref bool writeLine)
+	    protected virtual string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
 	    {
+		    ignoreLine = false;
 		    return message;
 	    }
 
@@ -53,8 +54,12 @@ namespace Xamarin.Android.Prepare
 		    Action<string, ConsoleColor, bool, string> writer;
 		    ConsoleColor color;
 		    bool showSeverity;
+		    bool ignoreLine;
 
-		    message = PreprocessMessage (message, ref writeLine) ?? String.Empty;
+		    message = PreprocessMessage (message, ref writeLine, out ignoreLine) ?? String.Empty;
+		    if (ignoreLine)
+			    return;
+
 		    switch (LoggingLevel) {
 			    case LogLevel.Error:
 				    color = Log.ErrorColor;

--- a/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
@@ -14,8 +14,9 @@ namespace Xamarin.Android.Prepare
 				LoggingLevel = ProcessStandardStreamWrapper.LogLevel.Message;
 			}
 
-			protected override string PreprocessMessage (string message, ref bool writeLine)
+			protected override string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
 			{
+				ignoreLine = false;
 				// apt-get calls `dpkg` which can't be persuaded to not show any progress and it shows the progress by
 				// writing a line which ends with `0x0D` that is supposed to move the caret to the beginning of the line
 				// which doesn't work with System.Diagnostics.Process because it strips 0x0D and 0x0A before passing the

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
@@ -7,6 +7,26 @@ namespace Xamarin.Android.Prepare
 {
 	partial class GitRunner : ToolRunner
 	{
+		// Redirects git progress output from standard error to standard output so that we show less red on the screen
+		sealed class GitProgressStderrWrapper : ProcessStandardStreamWrapper
+		{
+			public readonly List<string> Messages = new List<string> ();
+
+			protected override string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
+			{
+				ignoreLine = true;
+
+				if (message.Length == 0)
+					return message;
+
+				Messages.Add (message);
+				Log.Instance.MessageLine (message);
+				ignoreLine = true;
+
+				return message;
+			}
+		}
+
 		// These are passed to `git` itself *before* the command
 		static readonly List<string> standardGlobalOptions = new List<string> {
 			"--no-pager"
@@ -28,7 +48,7 @@ namespace Xamarin.Android.Prepare
 			if (String.IsNullOrEmpty (commitRef))
 				throw new ArgumentException ("must not be null or empty", nameof (commitRef));
 
-			var runner = CreateGitRunner (repositoryPath);
+			var runner = CreateGitRunner (repositoryPath, useCustomStderrWrapper: true);
 			runner.AddArgument ("checkout");
 			if (force)
 				runner.AddArgument ("--force");
@@ -48,7 +68,7 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			var runner = CreateGitRunner (repositoryPath);
+			var runner = CreateGitRunner (repositoryPath, useCustomStderrWrapper: true);
 			runner.AddArgument ("fetch");
 			runner.AddArgument ("--all");
 			runner.AddArgument ("--no-recurse-submodules");
@@ -67,7 +87,7 @@ namespace Xamarin.Android.Prepare
 			string parentDir = Path.GetDirectoryName (destinationDirectoryPath);
 			string dirName = Path.GetFileName (destinationDirectoryPath);
 			Utilities.CreateDirectory (parentDir);
-			var runner = CreateGitRunner (parentDir);;
+			var runner = CreateGitRunner (parentDir, useCustomStderrWrapper: true);
 			runner.AddArgument ("clone");
 			runner.AddArgument ("--progress");
 			runner.AddQuotedArgument (url);
@@ -79,7 +99,7 @@ namespace Xamarin.Android.Prepare
 		{
 			string runnerWorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
 
-			var runner = CreateGitRunner (runnerWorkingDirectory);;
+			var runner = CreateGitRunner (runnerWorkingDirectory, useCustomStderrWrapper: true);;
 			runner.AddArgument ("submodule");
 			runner.AddArgument ("update");
 			if (init)
@@ -187,10 +207,17 @@ namespace Xamarin.Android.Prepare
 			return containsHttps;
 		}
 
-		ProcessRunner CreateGitRunner (string? workingDirectory, List<string>? arguments = null)
+		ProcessRunner CreateGitRunner (string? workingDirectory, List<string>? arguments = null, bool useCustomStderrWrapper = false)
 		{
 			var runner = CreateProcessRunner ();
 			runner.WorkingDirectory = workingDirectory;
+			if (useCustomStderrWrapper) {
+				runner.StandardErrorEchoWrapper = new GitProgressStderrWrapper {
+					LoggingLevel = runner.EchoStandardErrorLevel,
+					CustomSeverityName = ProcessRunner.StderrSeverityName,
+				};
+			}
+
 			SetGitArguments (runner, workingDirectory, arguments);
 
 			return runner;
@@ -209,6 +236,11 @@ namespace Xamarin.Android.Prepare
 				);
 			} finally {
 				StopTwiddler ();
+				if (runner.ExitCode != 0 && runner.StandardErrorEchoWrapper is GitProgressStderrWrapper wrapper) {
+					foreach (string message in wrapper.Messages) {
+						Log.ErrorLine (message);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
`git` outputs its progress messages to the standard error stream which
`xaprepare` intercepts and prints on screen in red and in the following
format:

    stderr | Cloning into 'monodroid'...
    stderr | remote: Enumerating objects: 58, done
    stderr | Receiving objects:   0% (1/79000)
    stderr | Receiving objects:   1% (790/79000)
    stderr | Submodule 'external/Java.Interop' (https://github.com/xamarin/java.interop.git) registered for path 'external/Java.Interop'
    stderr | Submodule 'external/android-api-docs' (https://github.com/xamarin/android-api-docs) registered for path 'external/android-api-docs'

This may be confused for an actual error even though it is most
certainly a harmless progress output.  This commit adds code to
intercept the know progress messages and redirect them to standard
output using normal text formatting.

Note: this will work only when English is used!