### PR TITLE
[tests] emit <uses-sdk/> & use Xamarin.Forms 4.7

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Android.Build.Tests
 		public void InstallAndroidDependenciesTest ()
 		{
 			AssertCommercialBuild ();
+			// We need to grab the latest API level *before* changing env vars
+			var apiLevel = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			var old = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
 			try {
 				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
@@ -25,7 +27,9 @@ namespace Xamarin.Android.Build.Tests
 				if (Directory.Exists (sdkPath))
 					Directory.Delete (sdkPath, true);
 				Directory.CreateDirectory (sdkPath);
-				var proj = new XamarinAndroidApplicationProject ();
+				var proj = new XamarinAndroidApplicationProject {
+					TargetSdkVersion = apiLevel.ToString (),
+				};
 				using (var b = CreateApkBuilder ()) {
 					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;
@@ -78,6 +82,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				TargetFrameworkVersion = "v8.0",
+				TargetSdkVersion = "26",
 				UseLatestPlatformSdk = false,
 			};
 			var parameters = new string [] {
@@ -90,7 +95,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Target = "GetAndroidDependencies";
 				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
-				int apiLevel = Builder.UseDotNet ? builder.GetMaxInstalledPlatform () : 26;
+				int apiLevel = Builder.UseDotNet ? AndroidSdkResolver.GetMaxInstalledPlatform () : 26;
 				StringAssertEx.Contains ($"platforms/android-{apiLevel}", builder.LastBuildOutput, $"platforms/android-{apiLevel} should be a dependency.");
 				StringAssertEx.Contains ($"build-tools/{buildToolsVersion}", builder.LastBuildOutput, $"build-tools/{buildToolsVersion} should be a dependency.");
 				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");
@@ -112,6 +117,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				TargetFrameworkVersion = "v8.0",
+				TargetSdkVersion = "26",
 				UseLatestPlatformSdk = false,
 			};
 			var parameters = new string [] {
@@ -125,7 +131,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Target = "GetAndroidDependencies";
 				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
-				int apiLevel = Builder.UseDotNet ? builder.GetMaxInstalledPlatform () : 26;
+				int apiLevel = Builder.UseDotNet ? AndroidSdkResolver.GetMaxInstalledPlatform () : 26;
 				StringAssertEx.Contains ($"platforms/android-{apiLevel}", builder.LastBuildOutput, $"platforms/android-{apiLevel} should be a dependency.");
 				StringAssertEx.Contains ($"build-tools/{buildToolsVersion}", builder.LastBuildOutput, $"build-tools/{buildToolsVersion} should be a dependency.");
 				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1105,6 +1105,8 @@ namespace Lib1 {
 			var path = Path.Combine ("temp", TestName);
 			var proj = new XamarinAndroidApplicationProject () {
 				TargetFrameworkVersion = "v8.0",
+				TargetSdkVersion = "26",
+				MinSdkVersion = null,
 				UseLatestPlatformSdk = false,
 				IsRelease = true,
 				OtherBuildItems = {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1131,6 +1131,7 @@ namespace Lib2
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		[NonParallelizable]
 		public void AndroidXMigrationBug ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿using System;
+﻿﻿﻿using System;
 using System.Linq;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -427,6 +427,7 @@ namespace Bug12935
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
+				MinSdkVersion = null,
 			};
 			proj.SetProperty ("Foo", "1");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, seperateApk);
@@ -847,9 +848,9 @@ class TestActivity : Activity { }"
 			var proj = new XamarinAndroidApplicationProject {
 				AndroidUseSharedRuntime = true,
 				EmbedAssembliesIntoApk = false,
+				TargetSdkVersion = "30",
 			};
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
-			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:targetSdkVersion=\"30\" />");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -154,10 +154,7 @@ namespace Xamarin.Android.Build.Tests
 					items.Add (new TaskItem (file));
 				}
 			}
-			int platform = 0;
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			var outputFile = Path.Combine (path, "resources.apk");
 			var task = new Aapt2Link {
 				BuildEngine = engine,
@@ -435,10 +432,7 @@ namespace Xamarin.Android.Build.Tests
 			var archives = new List<ITaskItem>();
 			CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
 			var outputFile = Path.Combine (path, "resources.apk");
-			int platform = 0;
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			var task = new Aapt2Link {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
@@ -478,12 +472,9 @@ namespace Xamarin.Android.Build.Tests
 			var archives = new List<ITaskItem>();
 			CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
 			var outputFile = Path.Combine (path, "resources.apk");
-			int platform = 0;
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			string emitids = Path.Combine (path, "emitids.txt");
 			string Rtxt = Path.Combine (path, "R.txt");
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
 			var task = new Aapt2Link {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -486,10 +486,7 @@ int xml myxml 0x7f140000
 			};
 			
 			Assert.IsTrue (aapt2Compile.Execute (), $"Aapt2 Compile should have succeeded. {string.Join (" ", errors.Select (x => x.Message))}");
-			int platform = 0;
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			string resPath = Path.Combine (Root, path, "res");
 			string rTxt = Path.Combine (Root, path, "R.txt");
 			var aapt2Link = new Aapt2Link {
@@ -556,10 +553,7 @@ int xml myxml 0x7f140000
 			File.WriteAllText (Path.Combine (Root, path, "foo.map"), @"a\nb");
 			Directory.CreateDirectory (Path.Combine (Root, path, "java"));
 			string resPath = Path.Combine (Root, path, "res");
-			int platform = 0;
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			var aapt = new Aapt () {
 				BuildEngine = engine,
@@ -644,10 +638,7 @@ int xml myxml 0x7f140000
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			TaskLoggingHelper loggingHelper = new TaskLoggingHelper (engine, nameof (ManagedResourceParser));
 			string resPath = Path.Combine (Root, path, "res");
-			int platform = 0;
-			using (var b = new Builder ()) {
-				platform = b.GetMaxInstalledPlatform ();
-			}
+			int platform = AndroidSdkResolver.GetMaxInstalledPlatform ();
 			var flagFile = Path.Combine (Root, path, "AndroidResgen.flag");
 			var lp = new string [] { Path.Combine (Root, path, "lp", "res") };
 			Stopwatch sw = new Stopwatch ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -419,7 +419,7 @@ namespace Xamarin.Android.Build.Tests {
 			var proj = new XamarinAndroidApplicationProject {
 				UseLatestPlatformSdk = false,
 			};
-			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:targetSdkVersion=\"19\" />");
+			proj.TargetSdkVersion = "19";
 			using (var b = CreateApkBuilder ()) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -77,5 +77,25 @@ namespace Xamarin.ProjectTools
 				return Directory.Exists (path) ? path : null;
 			}
 		}
+
+		static int? maxInstalled;
+
+		public static int GetMaxInstalledPlatform ()
+		{
+			if (maxInstalled != null)
+				return maxInstalled.Value;
+
+			string sdkPath = GetAndroidSdkPath ();
+			foreach (var dir in Directory.EnumerateDirectories (Path.Combine (sdkPath, "platforms"))) {
+				int version;
+				string v = Path.GetFileName (dir).Replace ("android-", "");
+				if (!int.TryParse (v, out version))
+					continue;
+				if (version < maxInstalled)
+					continue;
+				maxInstalled = version;
+			}
+			return maxInstalled ?? 0;
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -222,9 +222,14 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
-		public static Package XamarinForms_4_5_0_617 = new Package {
+		public static Package XamarinForms_4_7_0_1142 = new Package {
 			Id = "Xamarin.Forms",
-			Version = "4.5.0.617",
+			Version = "4.7.0.1142",
+			TargetFramework = "MonoAndroid10.0",
+		};
+		public static Package XamarinFormsMaps_4_7_0_1142 = new Package {
+			Id = "Xamarin.Forms.Maps",
+			Version = "4.7.0.1142",
 			TargetFramework = "MonoAndroid10.0",
 		};
 		/* additional packages for XForms 4.5 on NET5 */
@@ -301,12 +306,12 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidXAppCompat = new Package {
 			Id = "Xamarin.AndroidX.AppCompat",
-			Version = "1.1.0",
+			Version = "1.1.0.1",
 			TargetFramework = "MonoAndroid10",
 		};
 		public static Package AndroidXBrowser = new Package {
 			Id = "Xamarin.AndroidX.Browser",
-			Version = "1.0.0",
+			Version = "1.2.0.1",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Browser") {
@@ -316,7 +321,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidXMediaRouter = new Package {
 			Id = "Xamarin.AndroidX.MediaRouter",
-			Version = "1.1.0",
+			Version = "1.1.0.1",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.MediaRouter") {
@@ -326,7 +331,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidXLegacySupportV4 = new Package {
 			Id = "Xamarin.AndroidX.Legacy.Support.V4",
-			Version = "1.0.0",
+			Version = "1.0.0.1",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Legacy.Support.V4") {
@@ -336,7 +341,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidXLifecycleLiveData = new Package {
 			Id = "Xamarin.AndroidX.Lifecycle.LiveData",
-			Version = "2.1.0",
+			Version = "2.2.0.1",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.AndroidX.Lifecycle.LiveData") {
@@ -354,9 +359,19 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+		public static Package AndroidXWorkRuntime = new Package {
+			Id = "Xamarin.AndroidX.Work.Runtime",
+			Version = "2.3.4.3",
+			TargetFramework = "MonoAndroid90",
+			References = {
+				new BuildItem.Reference("Xamarin.AndroidX.Work.Runtime") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Work.Runtime.2.3.4.3\\lib\\MonoAndroid90\\Xamarin.AndroidX.Work.Runtime.dll"
+				}
+			}
+		};
 		public static Package XamarinGoogleAndroidMaterial = new Package {
 			Id = "Xamarin.Google.Android.Material",
-			Version = "1.0.0",
+			Version = "1.0.0.1",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Google.Android.Material") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			if (Builder.UseDotNet) {
-				PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
+				PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
 				this.AddDotNetCompatPackages ();
 			} else {
 				PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -15,7 +15,11 @@ namespace Xamarin.ProjectTools
 
 		public XamarinFormsMapsApplicationProject ()
 		{
-			PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_0_0_425677);
+			if (Builder.UseDotNet) {
+				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_7_0_1142);
+			} else {
+				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_0_0_425677);
+			}
 			MainActivity = MainActivity.Replace ("//${AFTER_FORMS_INIT}", "Xamarin.FormsMaps.Init (this, savedInstanceState);");
 			//NOTE: API_KEY metadata just has to *exist*
 			AndroidManifest = AndroidManifest.Replace ("</application>", "<meta-data android:name=\"com.google.android.maps.v2.API_KEY\" android:value=\"\" /></application>");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
@@ -43,7 +43,7 @@ namespace Xamarin.ProjectTools
 		public XamarinFormsXASdkProject (string outputType = "Exe")
 			: base (outputType)
 		{
-			PackageReferences.Add (KnownPackages.XamarinForms_4_5_0_617);
+			PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
 			this.AddDotNetCompatPackages ();
 
 			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -200,22 +200,6 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public int GetMaxInstalledPlatform ()
-		{
-			string sdkPath = AndroidSdkResolver.GetAndroidSdkPath ();
-			int result = 0;
-			foreach (var dir in Directory.EnumerateDirectories (Path.Combine (sdkPath, "platforms"))) {
-				int version;
-				string v = Path.GetFileName (dir).Replace ("android-", "");
-				if (!int.TryParse (v, out version))
-					continue;
-				if (version < result)
-					continue;
-				result = version;
-			}
-			return result;
-		}
-
 		static string GetApiLevelFromInfoPath (string androidApiInfo)
 		{
 			if (!File.Exists (androidApiInfo))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/AndroidManifest.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0"
     package="${PACKAGENAME}"
   >
-  <uses-sdk />
+  ${USES_SDK}
   <application android:label="${PROJECT_NAME}">
   </application>
 </manifest>

--- a/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
@@ -40,7 +40,8 @@ namespace Xamarin.Android.Build.Tests
 			if (isRelease || !CommercialBuildAvailable) {
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
 			} else {
-				proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"23\" />");
+				proj.MinSdkVersion = "23";
+				proj.TargetSdkVersion = null;
 			}
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
 $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -288,7 +288,7 @@ namespace Xamarin.Android.Build.Tests
 				};
 				var directorylist = string.Empty;
 				foreach (var dir in overrideDirs) {
-					var listing = RunAdbCommand ($"shell ls {dir}");
+					var listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls {dir}");
 					if (!listing.Contains ("No such file or directory"))
 						directorylist += listing;
 				}
@@ -303,7 +303,7 @@ namespace Xamarin.Android.Build.Tests
 
 				directorylist = string.Empty;
 				foreach (var dir in overrideDirs) {
-					var listing = RunAdbCommand ($"shell ls {dir}");
+					var listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls {dir}");
 					if (!listing.Contains ("No such file or directory"))
 						directorylist += listing;
 				}

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -55,7 +55,11 @@ namespace Xamarin.Android.Build.Tests
 			AssertHasDevices ();
 
 			XASdkProject proj;
-			proj = new XASdkProject ();
+			proj = new XASdkProject {
+				//TODO: targetSdkVersion="30" causes a crash on startup in .NET 5
+				MinSdkVersion = null,
+				TargetSdkVersion = null,
+			};
 			proj.SetRuntimeIdentifier (DeviceAbi);
 
 			var relativeProjDir = Path.Combine ("temp", TestName);


### PR DESCRIPTION
Context: https://github.com/xamarin/net6-samples/commit/571e1c0f94737271c2ea43b25ad3e2b508e72b5f

Xamarin.Forms 4.7.x is required to solve a crash on startup in .NET 5+.
We should bump to Xamarin.Forms 4.7 in our MSBuild tests. This requires
some additional AndroidX packages to be bumped.

However, after doing this I got build warnings such as:

    warning XA1006: Android API level 30 is higher than the targetSdkVersion (28). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.

The project has a `AndroidManifest.xml` with an empty `<uses-sdk/>`
element, but `obj\Debug\android\AndroidManifest.xml` has 28 listed.
The projects that the MSBuild tests generate have an empty
`<uses-sdk/>` by default.

So where does `targetSdkVersion="28"` come from?

The `Xamarin.AndroidX.Media` NuGet package brings in:

    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
        package="androidx.media" >
        <uses-sdk
            android:minSdkVersion="14"
            android:targetSdkVersion="28" />
    ...

This is coming directly from the `.aar` file via:

https://maven.google.com/androidx/media/media/1.1.0/media-1.1.0.aar

Why do our MSBuild tests even have an `AndroidManifest.xml` file with
an empty `<uses-sdk/>`? It seems like almost no developer would do
this--the templates have been defining `minSdkVersion` and
`targetSdkVersion` for a long time.

To address how the MSBuild tests work:

* Move `Builder.GetMaxInstalledPlatform` to `AndroidSdkResolver`, so
  it can be a `static` method. Add simple caching so we don't query
  the file system so much.
* Add `TargetSdkVersion` and `MinSdkVersion` properties to
  `XamarinAndroidApplicationProject`.
* The new properties impact `<uses-sdk/>` accordingly. You can set
  them to `""` or `null` to omit them from `AndroidManifest.xml`.

Now our MSBuild tests will default to use:

    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />

...until we add another new API level.

The impacted MSBuild tests will now pass under a `dotnet` context.