### PR TITLE
[One .NET] fix designer MSBuild targets/tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -104,7 +104,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       ToolPath="$(JavaToolPath)"
       JavaOptions="$(JavaOptions)"
       ManifestMergerJarPath="$(AndroidManifestMergerJarPath)"
-      AndroidManifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
+      AndroidManifest="$(IntermediateOutputPath)AndroidManifest.xml"
       OutputManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
       LibraryManifestFiles="@(ExtractedManifestDocuments)"
       ManifestPlaceholders="$(AndroidManifestPlaceholders)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -41,6 +41,10 @@ namespace Xamarin.Android.Tasks
 			var output = new Dictionary<Guid, ITaskItem> ();
 
 			foreach (var assembly in InputAssemblies) {
+				if (!File.Exists (assembly.ItemSpec)) {
+					Log.LogDebugMessage ($"Skipping non-existent dependency '{assembly.ItemSpec}'.");
+					continue;
+				}
 				using (var pe = new PEReader (File.OpenRead (assembly.ItemSpec))) {
 					var reader = pe.GetMetadataReader ();
 					var module = reader.GetModuleDefinition ();


### PR DESCRIPTION
All of the `DesignerTests` were failing under a `dotnet` context...

The first issue is that the main app assembly might not exist during
the `SetupDependenciesForDesigner` MSBuild target. This target can run
before a build has been run at all.

So I brought the same `File.Exists()` check over from the
`<FilterAssemblies/>` MSBuild target to the `<ProcessAssemblies/>`
MSBuild target:

https://github.com/xamarin/xamarin-android/blob/0907f09f9c2073522adb66d717c2726be3712208/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs#L38-L41

This allows `SetupDependenciesForDesigner` to complete successfully.

Secondly, some of the `AndroidX` libraries pull in this setting:

    <PropertyGroup>
      <AndroidManifestMerger Condition=" '$(AndroidManifestMerger)' == '' ">manifestmerger.jar</AndroidManifestMerger>
    </PropertyGroup>

https://github.com/xamarin/AndroidX/blob/64e60fe32d4b112d6db4abab60ded1f9f931a3a0/source/AndroidXTargets.cshtml#L32-L34

This uncovered a bug when using `manifestmerger.jar` in the designer.
We had the wrong file being passed in:

```xml
<ManifestMerger
    ...
    AndroidManifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
    OutputManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
```

`AndroidManifest` should be `$(IntermediateOutputPath)AndroidManifest.xml`,
as it is in the `_GenerateJavaStubs` MSBuild target.

Now all the `DesignerTests` pass under a `dotnet` context.