### PR TITLE
[.editorconfig] Do not trim trailing spaces in .resx files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,10 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+# RESX files
+[*.resx]
+trim_trailing_whitespace = false
+
 # JSON files
 [*.json]
 indent_style = space


### PR DESCRIPTION
For contributors using Visual Studio Code with the EditorConfig
extension, manual edits to `.resx` files would cause trailing spaces to
be trimmed from all lines of the files on each file save.  This
conflicted with edits made using the Visual Studio `.resx` resource
editor because in that editor, each file save creates a new file that
includes trailing spaces in the explanatory `Microsoft ResX Schema` XML
comment.

Adjust the `.editorconfig` file to disable automatic trimming of
trailing spaces from `.resx` files.  Contributors will now need to trim
trailing spaces by hand for any changed lines and avoid changing
trailing spaces for any other lines.