### PR TITLE
[One .NET] populate @(ResolvedSymbols)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -45,6 +45,7 @@ _ResolveAssemblies MSBuild target.
     </MSBuild>
     <ItemGroup>
       <_ResolvedAssemblyFiles Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' " />
+      <_ResolvedSymbolFiles   Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.pdb' " />
       <_UnusedConfigFiles     Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.config' " />
     </ItemGroup>
     <AndroidWarning
@@ -55,10 +56,12 @@ _ResolveAssemblies MSBuild target.
     />
     <ProcessAssemblies
         InputAssemblies="@(_ResolvedAssemblyFiles)"
+        ResolvedSymbols="@(_ResolvedSymbolFiles)"
         IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
         UseSharedRuntime="$(AndroidUseSharedRuntime)"
         LinkMode="$(AndroidLinkMode)">
       <Output TaskParameter="OutputAssemblies" ItemName="ResolvedAssemblies" />
+      <Output TaskParameter="ResolvedSymbols"  ItemName="ResolvedSymbols" />
       <Output TaskParameter="ShrunkAssemblies" ItemName="_ShrunkAssemblies" />
     </ProcessAssemblies>
     <ItemGroup>
@@ -102,6 +105,7 @@ _ResolveAssemblies MSBuild target.
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')" />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'%(IntermediateLinkerOutput)')" />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'%(IntermediateLinkerOutput)')" />
+      <_ResolvedSymbols             Include="@(ResolvedSymbols->'%(IntermediateLinkerOutput)')" />
       <_ShrunkAssemblies            Include="@(_ResolvedAssemblies)" />
       <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
       <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />
@@ -110,6 +114,7 @@ _ResolveAssemblies MSBuild target.
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies)" />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies)" />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+      <_ResolvedSymbols             Include="@(ResolvedSymbols)" />
       <_ShrunkFrameworkAssemblies
           Include="@(_ShrunkAssemblies)"
           Condition=" '%(_ShrunkAssemblies.FrameworkAssembly)' == 'true' "


### PR DESCRIPTION
The `@(ResolvedSymbols)` and `@(_ResolvedSymbols)` MSBuild item group
are currently populated in `Xamarin.Android.Legacy.targets`.

Since a) nothing used these item groups and b) no test failed, I
didn't implement these item groups for .NET 5+.

After reviewing some of the existing code:

* https://github.com/xamarin/monodroid/blob/3d84feddd5517b2ca2322ddc68eef454c60fa9ca/tools/msbuild/Tasks/InstallPackageAssemblies.cs#L191-L194
* https://github.com/xamarin/xamarin-android/blob/0907f09f9c2073522adb66d717c2726be3712208/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs#L342-L353

It seems like we *should* actually use these item groups, instead of
relying on `File.Exists()` checks. Additionally, the new fast
deployment system is using item groups.

I was able to look for `.pdb` files within `@(ResolvedFileToPublish)`.
The only complication is the `<ProcessAssemblies/>` MSBuild task needs
to remove duplicate `.pdb` files. It also needs to set the
`%(AbiDirectory)` and `%(IntermediateLinkerOutput)` item metadata.

After this change, a "Hello World" app has these values:

    ResolvedSymbols
        obj\Release\net5.0\android.21-arm\linked\UnnamedProject.pdb
            IntermediateLinkerOutput = obj\Release\net5.0\android.21-arm\android\assets\UnnamedProject.pdb
    _ResolvedSymbols
        obj\Release\net5.0\android.21-arm\linked\UnnamedProject.pdb
            IntermediateLinkerOutput = obj\Release\net5.0\android.21-arm\android\assets\UnnamedProject.pdb

Down the road, we should make changes to the `<BuildApk/>` MSBuild
task to use this item group.