### PR TITLE
[runtime] Use the "none" option for C++'s standard library

### DIFF
--- a/build-tools/scripts/cmake-common.props
+++ b/build-tools/scripts/cmake-common.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_CmakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM=$(NinjaPath)</_CmakeCommonFlags>
-    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_STL="system" -DANDROID_CPP_FEATURES="" -DANDROID_TOOLCHAIN=clang -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
+    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_STL="none" -DANDROID_CPP_FEATURES="no-rtti no-exceptions" -DANDROID_TOOLCHAIN=clang -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
   </PropertyGroup>
 </Project>

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -143,6 +143,7 @@ if(STRIP_DEBUG)
 endif()
 
 if(ENABLE_NDK)
+  include_directories(${CMAKE_SYSROOT}/usr/include/c++/v1/)
   include_directories(${LZ4_INCLUDE_DIR})
   add_definitions("-DHAVE_LZ4")
   add_definitions("-DPLATFORM_ANDROID")

--- a/src/monodroid/jni/cppcompat.hh
+++ b/src/monodroid/jni/cppcompat.hh
@@ -14,14 +14,17 @@
 #define HAVE_WORKING_MUTEX 1
 #endif
 
+// We can't use <mutex> on Android because it requires linking libc++ into the rutime, see below.
 #if !defined (ANDROID)
 #include <type_traits>
 #include <mutex> // Also declares `lock_guard` even if it doesn't declare `mutex`
 #endif
 
-// Since Android doesn't currently have any standard C++ library
-// and we don't want to use any implementation of it shipped in
-// source form with the NDK (for space reasons), this header will
+// Android NDK currently provides a build of libc++ which we cannot link into Xamarin.Android runtime because it would
+// expose libc++ symbols which would conflict with a version of libc++ potentially included in a mixed
+// native/Xamarin.Android application.
+//
+// Until we can figure out a way to take full advantage of the STL, this header will
 // contain implementations of certain C++ standard functions, classes
 // etc we want to use despite lack of the STL.
 //
@@ -30,15 +33,6 @@
 namespace std
 {
 #if defined (ANDROID)
-	template <typename T> struct remove_reference      { using type = T; };
-	template <typename T> struct remove_reference<T&>  { using type = T; };
-	template <typename T> struct remove_reference<T&&> { using type = T; };
-
-	template<typename T> typename remove_reference<T>::type&& move (T&& arg) noexcept
-	{
-		return static_cast<typename remove_reference<decltype(arg)>::type&&>(arg);
-	}
-
 	template<typename TMutex>
 	class lock_guard
 	{

--- a/src/monodroid/jni/new_delete.cc
+++ b/src/monodroid/jni/new_delete.cc
@@ -22,7 +22,7 @@ operator new (size_t size)
 }
 
 void*
-operator new (size_t size, const std::nothrow_t&)
+operator new (size_t size, const std::nothrow_t&) noexcept
 {
 	return do_alloc (size);
 }
@@ -34,7 +34,7 @@ operator new[] (size_t size)
 }
 
 void*
-operator new[] (size_t size, const std::nothrow_t&)
+operator new[] (size_t size, const std::nothrow_t&) noexcept
 {
 	return do_alloc (size);
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4949
Context: https://github.com/xamarin/xamarin-android/pull/4952
Context: https://github.com/android/ndk/issues/744

Xamarin.Android uses the "system" version of the C++ standard
library (which is, in reality, a very basic stub containing only weak
definitions of the `new` and `delete` operator functions) in order to
avoid possible conflicts with Xamarin.Android applications which could
make use of their own version of the C++ standard library. The conflict
would arise from the fact that the `libc++` library shipped with the
current versions of Android NDK is built in a way that would expose a
large number of its symbols which would conflict with any other `libc++`
used by the application.

Additionally, linking `libc++` into Xamarin.Android runtime would result
in a binary 4-6 times bigger than what we currently ship (when linking
statically) or by 6.2MB if the shared library version of `libc++` were
used.

The "system" version of `libstdc++` is deprecated in favor of `libc++`
and may be removed from the NDK in a near future.  In order to prepare
for this we need to switch to one of the supported STL implementations.
The static and dynamic linking options are not viable, as described
above, which leaves us with the `none` STL option.  However, using this
variety causes Android NDK's cmake toolchain to pass the `-nostdlib++
-nostdinc++` options to the compiler.  The first of them doesn't affect
us, since we don't use any types from the `libc++` library, but the
second of them causes the standard C++ files, which we do use, to not be
found.  This commit enables the `none` STL variety and works around the
`-nostdinc++` flag by detecting and specifying the include path to the
standard C++ headers manually on the command line.