### PR TITLE
[Microsoft.Android.Sdk] fix %(AndroidSkip*) item metadata

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -60,10 +60,20 @@ _ResolveAssemblies MSBuild target.
         IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
         UseSharedRuntime="$(AndroidUseSharedRuntime)"
         LinkMode="$(AndroidLinkMode)">
-      <Output TaskParameter="OutputAssemblies" ItemName="ResolvedAssemblies" />
+      <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
       <Output TaskParameter="ResolvedSymbols"  ItemName="ResolvedSymbols" />
-      <Output TaskParameter="ShrunkAssemblies" ItemName="_ShrunkAssemblies" />
+      <Output TaskParameter="ShrunkAssemblies" ItemName="_ProcessedShrunkAssemblies" />
     </ProcessAssemblies>
+    <AppendCustomMetadataToItemGroup
+        Inputs="@(_ProcessedAssemblies)"
+        MetaDataItems="@(AndroidCustomMetaDataForReferences)">
+      <Output TaskParameter="Output" ItemName="ResolvedAssemblies" />
+    </AppendCustomMetadataToItemGroup>
+    <AppendCustomMetadataToItemGroup
+        Inputs="@(_ProcessedShrunkAssemblies)"
+        MetaDataItems="@(AndroidCustomMetaDataForReferences)">
+      <Output TaskParameter="Output" ItemName="_ShrunkAssemblies" />
+    </AppendCustomMetadataToItemGroup>
     <ItemGroup>
       <ResolvedFrameworkAssemblies
           Include="@(ResolvedAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -212,6 +212,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("dotnet")]
 		public void CheckMetadataSkipItemsAreProcessedCorrectly ()
 		{
 			var packages = new List<Package> () {


### PR DESCRIPTION
The `CheckMetadataSkipItemsAreProcessedCorrectly` test was failing
under a `dotnet` context due to item metadata missing, such as:

    <AndroidSkipAddToPackage>True</AndroidSkipAddToPackage>
    <AndroidSkipJavaStubGeneration>True</AndroidSkipJavaStubGeneration>
    <AndroidSkipResourceExtraction>True</AndroidSkipResourceExtraction>

These metadata support AndroidX.Migration, and they are completely
missing from the item groups generated in
`Microsoft.Android.Sdk.AssemblyResolution.targets`.

After the `<ProcessAssemblies/>` MSBuild task is called, we should
call `<AppendCustomMetadataToItemGroup/>` to populate the missing
metadata.

The `CheckMetadataSkipItemsAreProcessedCorrectly` test now passes.