### PR TITLE
[Xamarin.Android.Build.Tasks] Fix <InstallAndroidDependencies/>

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@5784a746112babd9ef801e0a6bc3fe2694bdf64c
+xamarin/monodroid:master@b12a3e8d57a5bdbdc8e829b8f2de80f3cf51e89f
 mono/mono:2020-02@83105ba22461455f4343d6bb14976eba8b0b3f39

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -18,21 +18,23 @@ namespace Xamarin.Android.Build.Tests
 		public void InstallAndroidDependenciesTest ()
 		{
 			AssertCommercialBuild ();
-			if (IsWindows) {
-				// TODO: we need: https://github.com/xamarin/android-sdk-installer/pull/450
-				Assert.Ignore ("InstallAndroidDependencies currently fails on Windows");
-			}
 			var old = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
 			try {
 				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
 				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", sdkPath);
+				if (Directory.Exists (sdkPath))
+					Directory.Delete (sdkPath, true);
+				Directory.CreateDirectory (sdkPath);
 				var proj = new XamarinAndroidApplicationProject ();
 				using (var b = CreateApkBuilder ()) {
+					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;
 					b.Target = "InstallAndroidDependencies";
 					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "InstallAndroidDependencies should have succeeded.");
 					b.Target = defaultTarget;
-					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+					Assert.IsTrue (b.Build (proj, true), "build should have succeeded.");
+					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"Output Property: _AndroidSdkDirectory={sdkPath}"), "_AndroidSdkDirectory was not set to new SDK path.");
+					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"JavaPlatformJarPath={sdkPath}"), "JavaPlatformJarPath did not contain new SDK path.");
 				}
 			} finally {
 				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", old);


### PR DESCRIPTION
Context: xamarin/android-sdk-installer#450
Changes: https://github.com/xamarin/android-sdk-installer/compare/c6c12db0...2b4d1a6
Changes: https://github.com/xamarin/monodroid/compare/5784a746...b12a3e8d

A fix for the `<InstallAndroidDependencies/>` target has been brought in
via the `android-sdk-installer` bump in xamarin/monodroid@b12a3e8.

The `<InstallAndroidDependencies/>` test previously had issues due to
clean up logic in the test framework that partially deleted the newly
provisioned Android SDK on a subsequent build.  I believe that we've
been seeing successful results for this test because the subsequent
build in the test would fall back to a different Android SDK that was
already on disk.  The test has been improved by asserting that the newly
installed Android SDK is used during the subsequent build.