### PR TITLE
[LibZipSharp] Bump to Version 1.0.20

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -114,7 +114,7 @@
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>
     <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
-    <LibZipSharpVersion>1.0.10</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.20</LibZipSharpVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -22,7 +22,6 @@ override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/aapt2.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libwinpthread-1.dll
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll
-	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.so
 
 	dh_install
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -399,4 +399,7 @@
     />
   </Target>
 
+  <Target Name="_Remove32BitLinux" Condition="Exists ('$(OutputPath)lib32\libzip.so')" AfterTargets="CopyFilesToOutputDirectory">
+    <Delete Files="$(OutputPath)lib32\libzip.so" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes the issue with a native crash on windows. 
The actual patch for libzip can be found at [https://github.com/nih-at/libzip/pull/202](https://github.com/nih-at/libzip/pull/202).
However LibZipSharp is currently applying that patch manually via [https://github.com/xamarin/LibZipSharp/pull/67](https://github.com/xamarin/LibZipSharp/pull/67) to fix the issue in v1.7.3 of libzip. This is because the fix might not land for a while.