### PR TITLE
[tests] BuildLibraryWhichUsesResources should be NonParallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1905,6 +1905,7 @@ namespace App1
 		}
 
 		[Test]
+		[NonParallelizable] // fails on NuGet restore
 		[Category ("dotnet")]
 		/// <summary>
 		/// Reference https://bugzilla.xamarin.com/show_bug.cgi?id=29568


### PR DESCRIPTION
Context: https://build.azdo.io/3947655

Since 396aca1c switched the
`Xamarin.Android.Build.Tests.BuildTest.BuildLibraryWhichUsesResources`
test to use AndroidX, it has been randomly failing with:

    (Restore target) ->
      /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(124,5): error : Could not find file '/Users/runner/work/1/s/packages/xamarin.androidx.migration/1.0.0.1/c0hredtr.mkk'.

I think this is happening because the test is parameterized and
AndroidX has a large dependency tree.

`[NonParallelizable]` should solve the issue.