### PR TITLE
[Xamarin.Android.Build.Tasks] fix for lint.jar and @(LibraryProjectZip)

### DIFF
--- a/Documentation/release-notes/4982.md
+++ b/Documentation/release-notes/4982.md
@@ -1,0 +1,5 @@
+#### Binding projects
+
+* [GitHub Issue 4565](https://github.com/xamarin/xamarin-android/issues/4565):
+  *Missing class: com.android.tools.lint...* build error could prevent apps from
+  consuming custom binding libraries for `.AAR` files.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -69,10 +69,13 @@ namespace Xamarin.Android.Tasks
 					string tmpname = Path.Combine (Path.GetTempPath (), "monodroid_import_" + Guid.NewGuid ().ToString ());
 					try {
 						Directory.CreateDirectory (tmpname);
-						var archive = ZipArchive.Open (p, FileMode.Open);
-						archive.ExtractAll (tmpname);
+						bool isAar = p.EndsWith (".aar", StringComparison.OrdinalIgnoreCase);
+						using (var archive = ZipArchive.Open (p, FileMode.Open)) {
+							var skipCallback = isAar ? Files.ShouldSkipEntryInAar : default (Func<string, bool>);
+							Files.ExtractAll (archive, tmpname, skipCallback: skipCallback);
+						}
 
-						if (!CopyLibraryContent (tmpname, p.EndsWith (".aar", StringComparison.OrdinalIgnoreCase)))
+						if (!CopyLibraryContent (tmpname, isAar))
 							return false;
 					} finally {
 						Directory.Delete (tmpname, true);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -382,18 +382,7 @@ namespace Xamarin.Android.Tasks
 							return entryFullName;
 						}, deleteCallback: (fileToDelete) => {
 							return !jars.ContainsKey (fileToDelete);
-						}, skipCallback: (entryFullName) => {
-							// AAR files may contain other jars not needed for compilation
-							// See: https://developer.android.com/studio/projects/android-library.html#aar-contents
-							if (!entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase))
-								return false;
-							if (entryFullName == "classes.jar" ||
-									entryFullName.StartsWith ("libs/", StringComparison.OrdinalIgnoreCase) ||
-									entryFullName.StartsWith ("libs\\", StringComparison.OrdinalIgnoreCase))
-								return false;
-							// This could be `lint.jar` or `api.jar`, etc.
-							return true;
-						});
+						}, skipCallback: Files.ShouldSkipEntryInAar);
 
 						if (Directory.Exists (importsDir) && aarHash != stampHash) {
 							Log.LogDebugMessage ($"Saving hash to {stamp}, changes: {updated}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -573,5 +573,37 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 				Assert.IsNotNull (error, "Build should have failed with XA1019.");
 			}
 		}
+
+		[Test]
+		[Category ("LibraryProjectZip")]
+		public void LibraryProjectZipWithLint ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidBindingProject () {
+				ProjectName = "BindingsProject",
+				AndroidClassParser = "class-parse",
+				Jars = {
+					new AndroidItem.LibraryProjectZip ("fragment-1.2.2.aar") {
+						WebContent = "https://maven.google.com/androidx/fragment/fragment/1.2.2/fragment-1.2.2.aar"
+					}
+				},
+				MetadataXml = @"<metadata><remove-node path=""/api/package[@name='androidx.fragment.app']/interface[@name='FragmentManager.OpGenerator']"" /></metadata>"
+			};
+			var app = new XamarinAndroidApplicationProject () {
+				ProjectName = "App",
+				IsRelease = true,
+				LinkTool = "r8",
+				References = { new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid) }
+			};
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName), cleanupAfterSuccessfulBuild: false))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
+				Assert.IsTrue (appBuilder.Build (app), "App build should have succeeded.");
+				StringAssertEx.DoesNotContain ("warning : Missing class: com.android.tools.lint.detector.api.Detector", appBuilder.LastBuildOutput, "Build output should contain no warnings about com.android.tools.lint.detector.api.Detector");
+				var libraryProjects = Path.Combine (Root, appBuilder.ProjectDirectory, app.IntermediateOutputPath, "lp");
+				Assert.IsFalse (Directory.EnumerateFiles (libraryProjects, "lint.jar", SearchOption.AllDirectories).Any (),
+					"`lint.jar` should not be extracted!");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -366,6 +366,23 @@ namespace Xamarin.Android.Tools
 			return updated;
 		}
 
+		/// <summary>
+		/// Callback that can be used in combination with ExtractAll for extracting .aar files
+		/// </summary>
+		public static bool ShouldSkipEntryInAar (string entryFullName)
+		{
+			// AAR files may contain other jars not needed for compilation
+			// See: https://developer.android.com/studio/projects/android-library.html#aar-contents
+			if (!entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase))
+				return false;
+			if (entryFullName == "classes.jar" ||
+					entryFullName.StartsWith ("libs/", StringComparison.OrdinalIgnoreCase) ||
+					entryFullName.StartsWith ("libs\\", StringComparison.OrdinalIgnoreCase))
+				return false;
+			// This could be `lint.jar` or `api.jar`, etc.
+			return true;
+		}
+
 		public static string HashString (string s)
 		{
 			var bytes = Encoding.UTF8.GetBytes (s);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4565
Context: https://github.com/xamarin/xamarin-android/issues/4565#issuecomment-668341395

In f230b87c, I fixed `lint.jar` from being included in apps from the
`@(AndroidAarLibrary)` item group. Unfortunately, this did not fix the
scenario for `@(LibraryProjectZip)` in binding projects!

I moved the `skipCallback` used in the
`<ResolveLibraryProjectImports/>` to a common place in the `Files`
class so it can also be used by the `<CreateLibraryResourceArchive/>`
MSBuild task.  We need to use this for `.aar` files *only*, because
`.zip` files could be *any* format.

I brought over Brendan's test that reproduces the bug as well.