### PR TITLE
[Xamarin.Android.Build.Tasks] fix enormous string expansion

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -194,12 +194,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_FixupCustomViewsForAapt2"
-    Condition=" '$(_AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' ">
+    Condition=" '$(_AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews->Count())' != '0' ">
   <ItemGroup>
     <_ItemsToFixup Include="@(_CompileResourcesInputs)" Condition=" '@(_ProcessedCustomViews->'%(Identity)')' == '%(Identity)' "/>
   </ItemGroup>
   <Aapt2Compile
-      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ItemsToFixup)' != '' "
+      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ItemsToFixup->Count())' != '0' "
       ContinueOnError="$(DesignTimeBuild)"
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
       DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
@@ -212,7 +212,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ToolExe="$(Aapt2ToolExe)">
     <Output TaskParameter="CompiledResourceFlatFiles" ItemName="_UpdatedFlatFiles" />
   </Aapt2Compile>
-  <Touch Files="$(_AndroidResgenFlagFile)" AlwaysCreate="True" Condition=" '@(_UpdatedFlatFiles)' != '' " />
+  <Touch Files="$(_AndroidResgenFlagFile)" AlwaysCreate="True" Condition=" '@(_UpdatedFlatFiles->Count())' != '0' " />
 </Target>
 
 <Target Name="_CreateBaseApkWithAapt2"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -38,14 +38,14 @@ It is shared between "legacy" binding projects and .NET 5 projects.
 
   <Target Name="ExportJarToXml"
       DependsOnTargets="$(ExportJarToXmlDependsOnTargets)"
-      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar)' != '' Or '@(EmbeddedJar)' != '' ">
+      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' ">
     <PropertyGroup>
       <AllowUnsafeBlocks Condition=" '$(AllowUnsafeBlocks)' != 'true' ">true</AllowUnsafeBlocks>
     </PropertyGroup>
   </Target>
 
   <Target Name="GenerateBindings"
-      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar)' != '' Or '@(EmbeddedJar)' != '' "
+      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' "
       DependsOnTargets="ExportJarToXml;_ResolveMonoAndroidSdks"
       Inputs="$(ApiOutputFile);@(TransformFile);@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildAllProjects)"
       Outputs="$(_GeneratorStampFile)">

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Documentation.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Documentation.targets
@@ -57,7 +57,7 @@ This file is only used by binding projects. .NET 5 can eventually use it, once `
   </Target>
 
   <Target Name="BuildDocumentation"
-      Condition=" '@(JavaDocIndex)' != '' And '$(_JavadocSupported)' == 'True' "
+      Condition=" '@(JavaDocIndex->Count())' != '0' And '$(_JavadocSupported)' == 'True' "
       Inputs="@(JavaDocIndex);@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')"
       Outputs="@(IntermediateAssembly->'$(OutputPath)%(filename).xml')">
     <MDoc

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Wear.targets
@@ -18,7 +18,7 @@ This file is only used by "legacy" Xamarin.Android projects.
   </PropertyGroup>
 
   <Target Name="_PrepareWearApplication"
-      Condition=" $(AndroidApplication) And '@(_AppExtensionReference)' != '' "
+      Condition=" $(AndroidApplication) And '@(_AppExtensionReference->Count())' != '0' "
       DependsOnTargets="_ValidateAndroidPackageProperties">
     <ParseAndroidWearProjectAndManifest ProjectFiles="@(_AppExtensionReference)">
       <Output TaskParameter="ApplicationManifestFile" PropertyName="BundledWearApplicationManifestFile" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -754,7 +754,7 @@ because xbuild doesn't support framework reference assemblies.
 		Files="@(Content)"
 		Code="XA0101"
 		Text="%40(Content) build action is not supported"
-		Condition=" '@(Content)' != '' "
+		Condition=" '@(Content->Count())' != '0' "
 	/>
 </Target>
 
@@ -1008,7 +1008,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>
-	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" Condition=" !Exists ('$(_AndroidResFlagFile)') Or  '@(_ModifiedResources)' != '' Or '@(_AndroidResourceDestRemovedFiles)' != '' " />
+	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" Condition=" !Exists ('$(_AndroidResFlagFile)') Or  '@(_ModifiedResources->Count())' != '0' Or '@(_AndroidResourceDestRemovedFiles->Count())' != '0' " />
 	<ItemGroup>
 		<FileWrites Include="$(_AndroidResFlagFile)" />
 	</ItemGroup>
@@ -1032,7 +1032,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_FindLayoutsForBinding"
-    Condition=" '$(Language)' == 'C#' And ('$(AndroidGenerateLayoutBindings)' == 'True' Or '@(AndroidBoundLayout)' != '') ">
+    Condition=" '$(Language)' == 'C#' And ('$(AndroidGenerateLayoutBindings)' == 'True' Or '@(AndroidBoundLayout->Count())' != '0') ">
   <FindLayoutsToBind
       GenerateLayoutBindings="$(AndroidGenerateLayoutBindings)"
       BoundLayouts="@(AndroidBoundLayout)"
@@ -1068,18 +1068,18 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_IncludeLayoutBindingSources" DependsOnTargets="_GenerateLayoutBindings" Condition=" '$(Language)' == 'C#' ">
-	<ItemGroup Condition=" '@(_LayoutForBinding)' != '' ">
+	<ItemGroup Condition=" '@(_LayoutForBinding->Count())' != '0' ">
 		<Compile Include="$(MSBuildThisFileDirectory)\LayoutBinding$(DefaultLanguageSourceExtension)" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '@(_LayoutForBinding)' != '' ">
+	<ItemGroup Condition=" '@(_LayoutForBinding->Count())' != '0' ">
 		<Compile Include="$(MonoAndroidCodeBehindDir)\%(_LayoutForBinding.LayoutBindingFileName)"
 			Condition="Exists ('$(MonoAndroidCodeBehindDir)\%(_LayoutForBinding.LayoutBindingFileName)')"/>
 		<FileWrites Include="$(MonoAndroidCodeBehindDir)\%(_LayoutForBinding.LayoutBindingFileName)"
 			    Condition="Exists ('$(MonoAndroidCodeBehindDir)\%(_LayoutForBinding.LayoutBindingFileName)')"/>
 	</ItemGroup>
 
-	<ItemGroup Condition=" '@(_LayoutPartialClass)' != '' ">
+	<ItemGroup Condition=" '@(_LayoutPartialClass->Count())' != '0' ">
 	        <Compile Include="$(MonoAndroidCodeBehindDir)\%(_LayoutPartialClass.LayoutPartialClassFileName)"
 			Condition="Exists ('$(MonoAndroidCodeBehindDir)\%(_LayoutPartialClass.LayoutPartialClassFileName)')"/>
 		<FileWrites Include="$(MonoAndroidCodeBehindDir)\%(_LayoutPartialClass.LayoutPartialClassFileName)"
@@ -1218,7 +1218,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="UpdateAndroidInterfaceProxies"
-	Condition="@(AndroidInterfaceDescription) != ''"
+	Condition=" '@(AndroidInterfaceDescription->Count())' != '0' "
 	DependsOnTargets="$(CoreResolveReferencesDependsOn);_RunManagedAidlTool;_AddManagedAidlOutputsToCompile" />
 
 <Target Name="_RunManagedAidlTool">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -94,7 +94,7 @@ This file is used by all project types, including binding projects.
   </Target>
     
   <Target Name="_CreateNativeLibraryArchive"
-      Condition=" '$(AndroidApplication)' != 'true' And '@(EmbeddedNativeLibrary)' != '' "
+      Condition=" '$(AndroidApplication)' != 'true' And '@(EmbeddedNativeLibrary->Count())' != '0' "
       Inputs="@(EmbeddedNativeLibrary)"
       Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
     <CreateNativeLibraryArchive

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -39,7 +39,7 @@
 			If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
 		-->
 		<GetDependsOnNETStandard
-				Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != ''"
+				Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences->Count())' != '0'"
 				References="@(_XACandidateNETStandardReferences)">
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="_XADependsOnNETStandard" />
 		</GetDependsOnNETStandard>


### PR DESCRIPTION
Context: https://github.com/dotnet/msbuild/pull/5553
Context: https://github.com/dotnet/msbuild/issues/5315

I have seen some comically long log messages such as:

    Task "GetDependsOnNETStandard" skipped, due to false condition; ('$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != '') was evaluated as ('true' != 'true' and 'true' != 'true' and '' == '' and 'C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.CSharp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.VisualBasic.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\Microsoft.Win32.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.AppContext.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Buffers.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Concurrent.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Immutable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.NonGeneric.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.Specialized.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Collections.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Annotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.DataAnnotations.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.EventBasedAsync.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.TypeConverter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ComponentModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Configuration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Console.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Core.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.Common.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.DataSetExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Data.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Contracts.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Debug.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.DiagnosticSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.FileVersionInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Process.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.StackTrace.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tools.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.TraceSource.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Diagnostics.Tracing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Drawing.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Dynamic.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Formats.Asn1.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Calendars.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Globalization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.Brotli.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.ZipFile.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Compression.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.DriveInfo.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.Watcher.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.FileSystem.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.IsolatedStorage.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.MemoryMappedFiles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.Pipes.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.UnmanagedMemoryStream.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.IO.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Expressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.Queryable.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Memory.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Http.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.HttpListener.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Mail.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NameResolution.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.NetworkInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Ping.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Requests.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.ServicePoint.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.Sockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebClient.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebHeaderCollection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.Client.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.WebSockets.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Net.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.Vectors.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ObjectModel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.DispatchProxy.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.ILGeneration.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.Lightweight.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Emit.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Metadata.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.TypeExtensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Reflection.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Reader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.ResourceManager.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Resources.Writer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Handles.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.JavaScript.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.InteropServices.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Intrinsics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Loader.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Numerics.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Formatters.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Runtime.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Claims.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Algorithms.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Csp.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.Primitives.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Cryptography.X509Certificates.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.Principal.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.SecureString.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Security.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceModel.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ServiceProcess.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.CodePages.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encoding.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Encodings.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.Json.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Text.RegularExpressions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Channels.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Overlapped.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Dataflow.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Extensions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.Parallel.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Tasks.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Thread.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.ThreadPool.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.Timer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Threading.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.Local.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Transactions.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.ValueTuple.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.HttpUtility.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Web.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Windows.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Linq.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.ReaderWriter.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.Serialization.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.XDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XPath.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlDocument.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.XmlSerializer.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.Xml.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\System.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\WindowsBase.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\mscorlib.dll;C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rc.1.20371.13\ref\net5.0\netstandard.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Java.Interop.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.Export.dll;C:\src\net5-samples\packages\microsoft.android.ref\11.0.100-ci.master.11\ref\net5.0\Mono.Android.dll' != '').

This message is ~18K characters long.

This particular example has been around since PCL support was added
for Xamarin.Android.

There *is* a "fast path" in MSBuild that actually evaluating the
`Condition` will not expand the string when you compare against `''`.
However, the string gets expanded anyway to produce the above log
message! At least it's not getting expanded twice?

The fix is to use `->Count()` instead:

    '@(_XACandidateNETStandardReferences->Count())' != '0'

Which prints a much shorter log message:

    Task "GetDependsOnNETStandard" skipped, due to false condition; ('$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences->Count())' != '0') was evaluated as ('true' != 'true' and 'true' != 'true' and '' == '' and '156' != '0')

I fixed a similar message in Roslyn:

https://github.com/dotnet/roslyn/pull/46445

## Results ##

In a build with no changes:

    > dotnet build .\HelloAndroid\HelloAndroid.csproj -bl -v:quiet

I could see a difference:

    Project "HelloAndroid.csproj" (default targets): (1.024s)
    Project "HelloAndroid.csproj" (default targets): (968ms)

The `<GetDependsOnNETStandard/>` MSBuild task runs 4 times in this
project because it is building for multiple `$(RuntimeIdentifiers)`.

This saved ~56ms in one example, but it might not be noticeable at all
in "legacy" Xamarin.Android.

Down the road I will see if we can drop
`Xamarin.Android.PCLSupport.targets` completely for .NET 6 projects.

I went ahead and fixed any cases of `'@(Foo)' != ''` and updated
`MSBuildBestPractices.md`. The others would not likely be checking
against large item groups, but they could be.