### PR TITLE
[xabuild] fixes for MSBuild 16.7.x

### DIFF
--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -36,17 +36,16 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" GeneratePathProperty="true">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
           and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
     <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll" Condition=" '$(OS)' == 'Windows_NT' " >
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(MSBuildToolsPath)\System.*.dll"
-        Exclude="$(MSBuildToolsPath)\System.Buffers.dll"
-        Condition=" '$(OS)' == 'Windows_NT' " >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/App.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/App.config
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="1.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.6.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\*.cs">
       <Link>Utilities\%(FileName).cs</Link>
     </Compile>
+    <None Include="..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\App.config" Link="App.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/xabuild/App.config
+++ b/tools/xabuild/App.config
@@ -14,12 +14,50 @@
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="1.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.6.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -31,6 +31,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildToolsPath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4872
Context: https://docs.microsoft.com/dotnet/framework/configure-apps/redirect-assembly-versions

On Windows, since installing VS 16.7 `xabuild` fails on any project with:

    error XACML7028: System.IO.FileNotFoundException: Could not load file or assembly 'System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
    error XACML7028: File name: 'System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
    error XACML7028:    at Xamarin.Tools.Zip.ZipArchive.stream_callback(IntPtr state, IntPtr data, UInt64 len, SourceCommand cmd)
    error XACML7028:    at Xamarin.Tools.Zip.Native.zip_source_function(IntPtr source, zip_source_callback callback, IntPtr user_data)
    error XACML7028:    at Xamarin.Tools.Zip.ZipArchive.AddStream(Stream stream, String archivePath, EntryPermissions permissions, CompressionMethod compressionMethod, Boolean overwriteExisting, Nullable`1 modificationTime) in /Users/runner/runners/2.165.0/work/1/s/ZipArchive.cs:line 327
    error XACML7028:    at Xamarin.Tools.Zip.ZipArchive.AddFile(String sourcePath, String archivePath, EntryPermissions permissions, CompressionMethod compressionMethod, Boolean overwriteExisting) in /Users/runner/runners/2.165.0/work/1/s/ZipArchive.cs:line 405
    error XACML7028:    at Xamarin.Android.Tasks.ZipArchiveEx.AddFiles(String folder, String folderInArchive, CompressionMethod method)
    error XACML7028:    at Xamarin.Android.Tasks.ZipArchiveEx.AddDirectory(String folder, String folderInArchive, CompressionMethod method)
    error XACML7028:    at Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive.<>c__DisplayClass39_0.<RunTask>b__1(String f)
    error XACML7028:    at Xamarin.Android.Tools.Files.ArchiveZipUpdate(String target, Action`1 archiver)
    error XACML7028:    at Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive.RunTask()
    error XACML7028:    at Xamarin.Android.Tasks.AndroidTask.Execute()

Looking at `MSBuild.exe.config`, there are some new assembly binding
redirects we need to bring over.

I took these changes directly from:

    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe.config

I changed the version number range to `99.9.9.9`, so that things will
still work on *older* MSBuild versions.

Unfortunately, two test projects need similar fixes:

* `Xamarin.Android.Build.Tests`
* `MSBuildDeviceIntegration`

They fail with errors such as:

    System.IO.FileLoadException : Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
        at System.MemoryExtensions.AsSpan(String text)
        at Microsoft.Build.Evaluation.Expander`2.Function`1.ExtractPropertyFunction(String expressionFunction, IElementLocation elementLocation, Object propertyValue, UsedUninitializedProperties usedUnInitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertyBody(String propertyBody, Object propertyValue, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveTypedAndEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.ExpandIntoStringLeaveEscaped(String expression, ExpanderOptions options, IElementLocation elementLocation)
        at Microsoft.Build.Evaluation.ToolsetReader.ExpandPropertyUnescaped(ToolsetPropertyDefinition property, Expander`2 expander)
        at Microsoft.Build.Evaluation.ToolsetReader.EvaluateAndSetProperty(ToolsetPropertyDefinition property, PropertyDictionary`1 properties, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& toolsPath, String& binPath, Expander`2& expander)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadToolset(ToolsetPropertyDefinition toolsVersion, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadEachToolset(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadToolsets(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& msBuildOverrideTasksPath, String& defaultOverrideToolsVersion)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadAllToolsets(Dictionary`2 toolsets, ToolsetRegistryReader registryReader, ToolsetConfigurationReader configurationReader, PropertyDictionary`1 environmentProperties, PropertyDictionary`1 globalProperties, ToolsetDefinitionLocations locations)
        at Microsoft.Build.Evaluation.ProjectCollection.InitializeToolsetCollection(ToolsetRegistryReader registryReader, ToolsetConfigurationReader configReader)
        at Microsoft.Build.Evaluation.ProjectCollection..ctor(IDictionary`2 globalProperties, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, Int32 maxNodeCount, Boolean onlyLogCriticalEvents, Boolean loadProjectsReadOnly)
        at Microsoft.Build.Evaluation.ProjectCollection.get_GlobalProjectCollection()
        at Microsoft.Build.Construction.ProjectRootElement.Create()
        at Xamarin.ProjectTools.DotNetXamarinProject.Construct() in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\DotNetXamarinProject.cs:line 97
        at Xamarin.ProjectTools.XamarinAndroidCommonProject.Construct() in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Android\XamarinAndroidCommonProject.cs:line 77
        at Xamarin.ProjectTools.DotNetXamarinProject.SaveProject() in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\DotNetXamarinProject.cs:line 129
        at Xamarin.ProjectTools.XamarinProject.Save(Boolean saveProject) in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\XamarinProject.cs:line 222
        at Xamarin.ProjectTools.ProjectBuilder.Save(XamarinProject project, Boolean doNotCleanupOnUpdate, Boolean saveProject) in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\ProjectBuilder.cs:line 44
        at Xamarin.ProjectTools.ProjectBuilder.Build(XamarinProject project, Boolean doNotCleanupOnUpdate, String[] parameters, Boolean saveProject, Dictionary`2 environmentVariables) in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\ProjectBuilder.cs:line 66
        at Xamarin.Android.Build.Tests.BuildTest.KotlinServiceLoader(String packageFormat) in C:\Source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\BuildTest.cs:line 4215

Binding redirects are needed for
`System.Runtime.CompilerServices.Unsafe` and `System.Buffers` -- the
same ones used in `MSBuild.exe.config`.

I added new `App.config` files and a minimal set of redirects for
these two test projects.

The only other fix, is to keep things working on older MSBuild
versions on Windows, we need to explicitly reference:

    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
    <PackageReference Include="System.ValueTuple" Version="4.5.0" />

This way we use the newer versions of these libraries on older MSBuild
versions. Otherwise, the `Windows - Build and Smoke Test` phase fails
on CI with errors similar to above.