### PR TITLE
[runtime] Introduce simple local/stack string classes

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -6,10 +6,6 @@
 #include <ctype.h>
 #include <fcntl.h>
 
-#ifdef ANDROID
-#include <sys/system_properties.h>
-#endif
-
 #if defined (WINDOWS)
 #include <windef.h>
 #include <winbase.h>
@@ -51,11 +47,6 @@ BundledProperty *AndroidSystem::bundled_properties = nullptr;
 #if defined (WINDOWS)
 std::mutex AndroidSystem::readdir_mutex;
 char *AndroidSystem::libmonoandroid_directory_path = nullptr;
-#endif
-
-#if !defined (ANDROID)
-static constexpr uint32_t PROP_NAME_MAX = 32;
-static constexpr uint32_t PROP_VALUE_MAX = 92;
 #endif
 
 #if defined (DEBUG) || !defined (ANDROID)
@@ -207,8 +198,8 @@ AndroidSystem::_monodroid__system_property_get (const char *name, char *sp_value
 		return -1;
 
 	char *buf = nullptr;
-	if (sp_value_len < PROP_VALUE_MAX + 1) {
-		size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, PROP_VALUE_MAX, 1);
+	if (sp_value_len < PROPERTY_VALUE_BUFFER_LEN) {
+		size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, PROPERTY_VALUE_BUFFER_LEN, 1);
 		log_warn (LOG_DEFAULT, "Buffer to store system property may be too small, will copy only %u bytes", sp_value_len);
 		buf = new char [alloc_size];
 	}
@@ -225,12 +216,31 @@ AndroidSystem::_monodroid__system_property_get (const char *name, char *sp_value
 #endif
 
 int
+AndroidSystem::monodroid_get_system_property (const char *name, dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& value)
+{
+	int len = _monodroid__system_property_get (name, value.get (), value.size ());
+	if (len > 0) {
+		// Clumsy, but if we want direct writes to be fast, this is the price we pay
+		value.set_length_after_direct_write (static_cast<size_t>(len));
+		return len;
+	}
+
+	size_t plen;
+	const char *v = lookup_system_property (name, plen);
+	if (v == nullptr)
+		return len;
+
+	value.assign (v, plen);
+	return ADD_WITH_OVERFLOW_CHECK (int, plen, 0);
+}
+
+int
 AndroidSystem::monodroid_get_system_property (const char *name, char **value)
 {
 	if (value)
 		*value = nullptr;
 
-	char  sp_value [PROP_VALUE_MAX+1] = { 0, };
+	char  sp_value [PROPERTY_VALUE_BUFFER_LEN] = { 0, };
 	char *pvalue = sp_value;
 	int len = _monodroid__system_property_get (name, sp_value, sizeof (sp_value));
 
@@ -334,18 +344,20 @@ AndroidSystem::create_update_dir (char *override_dir)
 	log_warn (LOG_DEFAULT, "Creating public update directory: `%s`", override_dir);
 }
 
-char*
-AndroidSystem::get_full_dso_path (const char *base_dir, const char *dso_path, bool &needs_free)
+bool
+AndroidSystem::get_full_dso_path (const char *base_dir, const char *dso_path, dynamic_local_string<SENSIBLE_PATH_MAX>& path)
 {
-	needs_free = false;
 	if (dso_path == nullptr)
-		return nullptr;
+		return false;
 
 	if (base_dir == nullptr || utils.is_path_rooted (dso_path))
 		return const_cast<char*>(dso_path); // Absolute path or no base path, can't do much with it
 
-	needs_free = true;
-	return utils.path_combine (base_dir, dso_path);
+	path.assign (base_dir)
+		.append (MONODROID_PATH_SEPARATOR)
+		.append (dso_path);
+
+	return true;
 }
 
 void*
@@ -375,13 +387,12 @@ AndroidSystem::load_dso_from_specified_dirs (const char **directories, size_t nu
 	if (dso_name == nullptr)
 		return nullptr;
 
-	bool needs_free = false;
-	char *full_path = nullptr;
+	dynamic_local_string<SENSIBLE_PATH_MAX> full_path;
 	for (size_t i = 0; i < num_entries; i++) {
-		full_path = get_full_dso_path (directories [i], dso_name, needs_free);
-		void *handle = load_dso (full_path, dl_flags, false);
-		if (needs_free)
-			delete[] full_path;
+		if (!get_full_dso_path (directories [i], dso_name, full_path)) {
+			continue;
+		}
+		void *handle = load_dso (full_path.get (), dl_flags, false);
 		if (handle != nullptr)
 			return handle;
 	}
@@ -414,43 +425,35 @@ AndroidSystem::load_dso_from_any_directories (const char *name, unsigned int dl_
 	return handle;
 }
 
-char*
-AndroidSystem::get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, bool &needs_free)
+bool
+AndroidSystem::get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, dynamic_local_string<SENSIBLE_PATH_MAX>& path)
 {
-	needs_free = false;
-	char *dso_path = get_full_dso_path (base_dir, dso_name, needs_free);
-	if (utils.file_exists (dso_path))
-		return dso_path;
+	if (get_full_dso_path (base_dir, dso_name, path) && utils.file_exists (path.get ()))
+		return true;
 
-	needs_free = false;
-	delete[] dso_path;
-	return nullptr;
+	return false;
 }
 
-char*
-AndroidSystem::get_full_dso_path_on_disk (const char *dso_name, bool &needs_free)
+bool
+AndroidSystem::get_full_dso_path_on_disk (const char *dso_name, dynamic_local_string<SENSIBLE_PATH_MAX>& path)
 {
-	needs_free = false;
 	if (is_embedded_dso_mode_enabled ())
-		return nullptr;
+		return false;
 
-	char *dso_path = nullptr;
 #ifndef RELEASE
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; i++) {
 		if (AndroidSystem::override_dirs [i] == nullptr)
 			continue;
-		dso_path = get_existing_dso_path_on_disk (AndroidSystem::override_dirs [i], dso_name, needs_free);
-		if (dso_path != nullptr)
-			return dso_path;
+		if (get_existing_dso_path_on_disk (AndroidSystem::override_dirs [i], dso_name, path))
+			return true;
 	}
 #endif
 	for (size_t i = 0; i < app_lib_directories_size; i++) {
-		dso_path = get_existing_dso_path_on_disk (app_lib_directories [i], dso_name, needs_free);
-		if (dso_path != nullptr)
-			return dso_path;
+		if (get_existing_dso_path_on_disk (app_lib_directories [i], dso_name, path))
+			return true;
 	}
 
-	return nullptr;
+	return false;
 }
 
 int
@@ -491,10 +494,10 @@ AndroidSystem::get_max_gref_count_from_system (void)
 		max = 51200;
 	}
 
-	char *override;
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, &override) > 0) {
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> override;
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, override) > 0) {
 		char *e;
-		max       = strtol (override, &e, 10);
+		max       = strtol (override.get (), &e, 10);
 		switch (*e) {
 			case 'k':
 				e++;
@@ -508,10 +511,9 @@ AndroidSystem::get_max_gref_count_from_system (void)
 		if (max < 0)
 			max = INT_MAX;
 		if (*e) {
-			log_warn (LOG_GC, "Unsupported '%s' value '%s'.", Debug::DEBUG_MONO_MAX_GREFC, override);
+			log_warn (LOG_GC, "Unsupported '%s' value '%s'.", Debug::DEBUG_MONO_MAX_GREFC, override.get ());
 		}
 		log_warn (LOG_GC, "Overriding max JNI Global Reference count to %i", max);
-		delete[] override;
 	}
 	return max;
 }

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -3,17 +3,29 @@
 #define __ANDROID_SYSTEM_H
 
 #include <stdint.h>
-#include <stddef.h>
+#include <stdlib.h>
 #include <pthread.h>
 #include <jni.h>
+
+#ifdef ANDROID
+#include <sys/system_properties.h>
+#endif
 
 #include "util.hh"
 #include "cppcompat.hh"
 #include "xamarin-app.hh"
 #include "shared-constants.hh"
 #include "basic-android-system.hh"
+#include "strings.hh"
 
 #include <mono/jit/jit.h>
+
+#if !defined (ANDROID)
+constexpr uint32_t PROP_NAME_MAX = 32;
+constexpr uint32_t PROP_VALUE_MAX = 92;
+#endif
+
+constexpr size_t PROPERTY_VALUE_BUFFER_LEN = PROP_VALUE_MAX + 1;
 
 namespace xamarin::android {
 	class jstring_wrapper;
@@ -44,13 +56,14 @@ namespace xamarin::android::internal
 		void  setup_process_args (jstring_array_wrapper &runtimeApks);
 		void  create_update_dir (char *override_dir);
 		int   monodroid_get_system_property (const char *name, char **value);
+		int   monodroid_get_system_property (const char *name, dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& value);
 		size_t monodroid_get_system_property_from_overrides (const char *name, char ** value);
 		char* get_bundled_app (JNIEnv *env, jstring dir);
 		int   count_override_assemblies ();
 		long  get_gref_gc_threshold ();
 		void* load_dso (const char *path, unsigned int dl_flags, bool skip_exists_check);
 		void* load_dso_from_any_directories (const char *name, unsigned int dl_flags);
-		char* get_full_dso_path_on_disk (const char *dso_name, bool &needs_free);
+		bool get_full_dso_path_on_disk (const char *dso_name, dynamic_local_string<SENSIBLE_PATH_MAX>& path);
 		monodroid_dirent_t* readdir (monodroid_dir_t *dir);
 
 		long get_max_gref_count () const
@@ -117,11 +130,11 @@ namespace xamarin::android::internal
 #if defined (DEBUG) || !defined (ANDROID)
 		size_t  _monodroid_get_system_property_from_file (const char *path, char **value);
 #endif
-		char* get_full_dso_path (const char *base_dir, const char *dso_path, bool &needs_free);
+		bool get_full_dso_path (const char *base_dir, const char *dso_path, dynamic_local_string<SENSIBLE_PATH_MAX>& path);
 		void* load_dso_from_specified_dirs (const char **directories, size_t num_entries, const char *dso_name, unsigned int dl_flags);
 		void* load_dso_from_app_lib_dirs (const char *name, unsigned int dl_flags);
 		void* load_dso_from_override_dirs (const char *name, unsigned int dl_flags);
-		char* get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, bool &needs_free);
+		bool get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, dynamic_local_string<SENSIBLE_PATH_MAX>& path);
 
 #if defined (WINDOWS)
 		struct _wdirent* readdir_windows (_WDIR *dirp);

--- a/src/monodroid/jni/basic-android-system.hh
+++ b/src/monodroid/jni/basic-android-system.hh
@@ -17,7 +17,7 @@ namespace xamarin::android::internal
 	private:
 		// Values correspond to the CPU_KIND_* macros
 		static constexpr const char* android_abi_names[CPU_KIND_X86_64+1] = {
-			"unknown",
+			[0]                 = "unknown",
 			[CPU_KIND_ARM]      = "armeabi-v7a",
 			[CPU_KIND_ARM64]    = "arm64-v8a",
 			[CPU_KIND_MIPS]     = "mips",

--- a/src/monodroid/jni/basic-utilities.cc
+++ b/src/monodroid/jni/basic-utilities.cc
@@ -24,7 +24,7 @@ BasicUtilities::path_combine (const char *path1, const char *path2)
 	if (path2 == nullptr)
 		return strdup_new (path1);
 
-	size_t len = add_with_overflow_check<size_t> (__FILE__, __LINE__, strlen (path1), strlen (path2) + 2);
+	size_t len = ADD_WITH_OVERFLOW_CHECK (size_t, strlen (path1), strlen (path2) + 2);
 	char *ret = new char [len];
 	*ret = '\0';
 
@@ -309,7 +309,7 @@ BasicUtilities::monodroid_strsplit (const char *str, const char *delimiter, size
 
 			if (*str) {
 				size_t toklen = static_cast<size_t>((str - c));
-				size_t alloc_size = add_with_overflow_check<size_t> (__FILE__, __LINE__, toklen, 1);
+				size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, toklen, 1);
 				token = new char [alloc_size];
 				strncpy (token, c, toklen);
 				token [toklen] = '\0';
@@ -377,7 +377,7 @@ BasicUtilities::add_to_vector (char ***vector, size_t size, char *token)
 	if (*vector == nullptr) {
 		*vector = (char **)static_cast<char**>(xmalloc (size * sizeof(*vector)));
 	} else {
-		size_t alloc_size = multiply_with_overflow_check<size_t> (__FILE__, __LINE__, sizeof(*vector), size + 1);
+		size_t alloc_size = MULTIPLY_WITH_OVERFLOW_CHECK (size_t, sizeof(*vector), size + 1);
 		*vector = static_cast<char**>(xrealloc (*vector, alloc_size));
 	}
 

--- a/src/monodroid/jni/basic-utilities.hh
+++ b/src/monodroid/jni/basic-utilities.hh
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <type_traits>
 
 #include <unistd.h>
 
@@ -15,73 +16,13 @@
 #include <dirent.h>
 
 #include "java-interop-util.h"
-
-#if __cplusplus >= 201703L
-#define UNUSED_ARG [[maybe_unused]]
-#else
-#if defined (__GNUC__)
-#define UNUSED_ARG __attribute__((__unused__))
-#else
-#define UNUSED_ARG
-#endif
-#endif
-
-#if WINDOWS
-#define MONODROID_PATH_SEPARATOR      "\\"
-#define MONODROID_PATH_SEPARATOR_CHAR '\\'
-#else
-#define MONODROID_PATH_SEPARATOR      "/"
-#define MONODROID_PATH_SEPARATOR_CHAR '/'
-#endif
-
-#if WINDOWS
-typedef struct _stat monodroid_stat_t;
-#define monodroid_dir_t _WDIR
-typedef struct _wdirent monodroid_dirent_t;
-#else
-typedef struct stat monodroid_stat_t;
-#define monodroid_dir_t DIR
-typedef struct dirent monodroid_dirent_t;
-#endif
-
-#define DEFAULT_DIRECTORY_MODE S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
-
-#if defined (_MSC_VER)
-#define inline __inline
-#define force_inline __forceinline
-#elif defined (__GNUC__)
-#ifndef XA_LIKELY
-#define XA_LIKELY(expr) (__builtin_expect ((expr) != 0, 1))
-#endif
-
-#ifndef XA_UNLIKELY
-#define XA_UNLIKELY(expr) (__builtin_expect ((expr) != 0, 0))
-#endif
-
-#define force_inline inline __attribute__((always_inline))
-#endif
-
-#ifndef force_inline
-#define force_inline inline
-#endif
-
-#ifndef inline
-#define inline inline
-#endif
-
-#ifndef XA_LIKELY
-#define XA_LIKELY(expr) (expr)
-#endif
-
-#ifndef XA_UNLIKELY
-#define XA_UNLIKELY(expr) (expr)
-#endif
+#include "helpers.hh"
+#include "cpp-util.hh"
+#include "platform-compat.hh"
+#include "strings.hh"
 
 namespace xamarin::android
 {
-#define ADD_WITH_OVERFLOW_CHECK(__ret_type__, __a__, __b__) utils.add_with_overflow_check<__ret_type__>(__FILE__, __LINE__, (__a__), (__b__))
-#define MULTIPLY_WITH_OVERFLOW_CHECK(__ret_type__, __a__, __b__) utils.multiply_with_overflow_check<__ret_type__>(__FILE__, __LINE__, (__a__), (__b__))
-
 	class BasicUtilities
 	{
 	public:
@@ -94,7 +35,7 @@ namespace xamarin::android
 		char           **monodroid_strsplit (const char *str, const char *delimiter, size_t max_tokens);
 		char            *monodroid_strdup_printf (const char *format, ...);
 		char            *monodroid_strdup_vprintf (const char *format, va_list vargs);
-		char*            path_combine(const char *path1, const char *path2);
+		char*            path_combine (const char *path1, const char *path2);
 		void             create_public_directory (const char *dir);
 		int              create_directory (const char *pathname, mode_t mode);
 		void             set_world_accessable (const char *path);
@@ -102,6 +43,59 @@ namespace xamarin::android
 		bool             file_exists (const char *file);
 		bool             directory_exists (const char *directory);
 		bool             file_copy (const char *to, const char *from);
+
+
+		// Make sure that `buf` has enough space! This is by design, the methods are supposed to be fast.
+		template<size_t MaxStackSpace, typename TBuffer>
+		void path_combine (TBuffer& buf, const char* path1, const char* path2) noexcept
+		{
+			path_combine (buf, path1, path1 == nullptr ? 0 : strlen (path1), path2, path2 == nullptr ? 0 : strlen (path2));
+		}
+
+		// internal::static_local_string<MaxStackSpace>
+		template<size_t MaxStackSpace, typename TBuffer>
+		void path_combine (TBuffer& buf, const char* path1, size_t path1_len, const char* path2, size_t path2_len) noexcept
+		{
+			assert (path1 != nullptr || path2 != nullptr);
+
+			if (path1 == nullptr) {
+				buf.append (path2);
+				return;
+			}
+
+			if (path2 == nullptr) {
+				buf.append (path1);
+				return;
+			}
+
+			buf.append (path1, path1_len);
+			buf.append (MONODROID_PATH_SEPARATOR, MONODROID_PATH_SEPARATOR_LENGTH);
+			buf.append (path2, path2_len);
+		}
+
+		template<size_t MaxStackSpace>
+		void path_combine (internal::static_local_string<MaxStackSpace>& buf, const char* path1, const char* path2) noexcept
+		{
+			path_combine <MaxStackSpace, decltype(buf)> (buf, path1, path2);
+		}
+
+		template<size_t MaxStackSpace>
+		void path_combine (internal::static_local_string<MaxStackSpace>& buf, const char* path1, size_t path1_len, const char* path2, size_t path2_len) noexcept
+		{
+			path_combine <MaxStackSpace, decltype(buf)> (buf, path1, path1_len, path2, path2_len);
+		}
+
+		template<size_t MaxStackSpace>
+		void path_combine (internal::dynamic_local_string<MaxStackSpace>& buf, const char* path1, const char* path2) noexcept
+		{
+			path_combine <MaxStackSpace, decltype(buf)> (buf, path1, path2);
+		}
+
+		template<size_t MaxStackSpace>
+		void path_combine (internal::dynamic_local_string<MaxStackSpace>& buf, const char* path1, size_t path1_len, const char* path2, size_t path2_len) noexcept
+		{
+			path_combine <MaxStackSpace, decltype(buf)> (buf, path1, path1_len, path2, path2_len);
+		}
 
 		bool ends_with_slow (const char *str, const char *end)
 		{
@@ -137,7 +131,7 @@ namespace xamarin::android
 				return nullptr;
 			}
 
-			size_t alloc_size = add_with_overflow_check<size_t>(__FILE__, __LINE__, len, 1);
+			size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, len, 1);
 			auto ret = new char[alloc_size];
 			memcpy (ret, s, len);
 			ret[len] = '\0';
@@ -154,13 +148,11 @@ namespace xamarin::android
 			return strdup_new (s, strlen (s));
 		}
 
-		// Without <type_traits> it's a little bit open for abuse (bad stuff will happen if
-		// a type different than `char*` is used to specialize the function and we can't
-		// assert this condition on compile time), but we can take that risk since it's
-		// internal, controlled API
-		template<typename StringType = const char*, typename ...Strings>
-		char* string_concat (const char *s1, StringType s2, Strings... strings)
+		template<typename CharType = char, typename ...Strings>
+		char* string_concat (const char *s1, const CharType* s2, Strings... strings)
 		{
+			assert_char_type<CharType> ();
+
 			size_t len = calculate_length (s1, s2, strings...);
 
 			char *ret = new char [len + 1];
@@ -186,67 +178,32 @@ namespace xamarin::android
 #endif // def WINDOWS
 		bool            is_path_rooted (const char *path);
 
-		template<typename Ret, typename P1, typename P2>
-		inline Ret add_with_overflow_check (const char *file, uint32_t line, P1 a, P2 b) const
-		{
-			Ret ret;
-
-			if (XA_UNLIKELY (__builtin_add_overflow (a, b, &ret))) {
-				log_fatal (LOG_DEFAULT, "Integer overflow on addition at %s:%u", file, line);
-				exit (FATAL_EXIT_OUT_OF_MEMORY);
-				return static_cast<Ret>(0);
-			}
-
-			return ret;
-		}
-
-		// Can't use templates as above with add_with_oveflow because of a bug in the clang compiler
-		// shipped with the NDK:
-		//
-		//   https://github.com/android-ndk/ndk/issues/294
-		//   https://github.com/android-ndk/ndk/issues/295
-		//   https://bugs.llvm.org/show_bug.cgi?id=16404
-		//
-		// Using templated parameter types for `a` and `b` would make clang generate that tries to
-		// use 128-bit integers and thus output code that calls `__muloti4` and so linking would
-		// fail
-		//
-		template<typename Ret>
-		inline Ret multiply_with_overflow_check (const char *file, uint32_t line, size_t a, size_t b) const
-		{
-			Ret ret;
-
-			if (XA_UNLIKELY (__builtin_mul_overflow (a, b, &ret))) {
-				log_fatal (LOG_DEFAULT, "Integer overflow on multiplication at %s:%u", file, line);
-				exit (FATAL_EXIT_OUT_OF_MEMORY);
-				return static_cast<Ret>(0);
-			}
-
-			return ret;
-		}
-
-	protected:
-		template<typename StringType = const char*, typename ...Strings>
-		void concatenate_strings_into (UNUSED_ARG size_t len, UNUSED_ARG char *dest)
-		{}
-
-		template<typename StringType = const char*, typename ...Strings>
-		void concatenate_strings_into (size_t len, char *dest, StringType s1, Strings... strings)
-		{
-			strcat (dest, s1);
-			concatenate_strings_into (len, dest, strings...);
-		}
-
-		template<typename StringType = const char*>
-		size_t calculate_length (StringType s)
+		template<typename CharType = char>
+		size_t calculate_length (const CharType* s)
 		{
 			return strlen (s);
 		}
 
-		template<typename StringType = const char*, typename ...Strings>
-		size_t calculate_length (StringType s1, Strings... strings)
+		template<typename CharType = char, typename ...Strings>
+		size_t calculate_length (const CharType* s1, Strings... strings)
 		{
+			assert_char_type<CharType> ();
+
 			return strlen (s1) + calculate_length (strings...);
+		}
+
+	protected:
+		template<typename CharType = char, typename ...Strings>
+		void concatenate_strings_into (UNUSED_ARG size_t len, UNUSED_ARG char *dest)
+		{}
+
+		template<typename CharType = char, typename ...Strings>
+		void concatenate_strings_into (size_t len, char *dest, const CharType* s1, Strings... strings)
+		{
+			assert_char_type<CharType> ();
+
+			strcat (dest, s1);
+			concatenate_strings_into (len, dest, strings...);
 		}
 
 		int make_directory (const char *path, [[maybe_unused]] mode_t mode)
@@ -260,6 +217,12 @@ namespace xamarin::android
 
 	private:
 		void  add_to_vector (char ***vector, size_t size, char *token);
+
+		template<typename CharType>
+		static constexpr void assert_char_type ()
+		{
+			static_assert (std::is_same_v<CharType, char>, "CharType must be an 8-bit character type");
+		}
 	};
 }
 #endif // !__BASIC_UTILITIES_HH

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -6,6 +6,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/assembly.h>
 
+#include "strings.hh"
 #include "xamarin-app.hh"
 
 struct TypeMapHeader;
@@ -98,8 +99,8 @@ namespace xamarin::android::internal {
 		bool zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint16_t& u);
 		bool zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint32_t& u);
 		bool zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint8_t (&sig)[4]);
-		bool zip_read_field (uint8_t* buf, size_t buf_len, size_t index, size_t count, char*& characters);
-		bool zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& buf_offset, uint16_t& compression_method, uint32_t& local_header_offset, uint32_t& file_size, char*& file_name);
+		bool zip_read_field (uint8_t* buf, size_t buf_len, size_t index, size_t count, dynamic_local_string<SENSIBLE_PATH_MAX>& characters);
+		bool zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& buf_offset, uint16_t& compression_method, uint32_t& local_header_offset, uint32_t& file_size, dynamic_local_string<SENSIBLE_PATH_MAX>& file_name);
 
 		const char* get_assemblies_prefix () const
 		{

--- a/src/monodroid/jni/helpers.hh
+++ b/src/monodroid/jni/helpers.hh
@@ -1,0 +1,57 @@
+#ifndef __HELPERS_HH
+#define __HELPERS_HH
+
+#include <cstdint>
+
+#include "java-interop-util.h"
+#include "platform-compat.hh"
+
+namespace xamarin::android
+{
+#define ADD_WITH_OVERFLOW_CHECK(__ret_type__, __a__, __b__) xamarin::android::Helpers::add_with_overflow_check<__ret_type__>(__FILE__, __LINE__, (__a__), (__b__))
+#define MULTIPLY_WITH_OVERFLOW_CHECK(__ret_type__, __a__, __b__) xamarin::android::Helpers::multiply_with_overflow_check<__ret_type__>(__FILE__, __LINE__, (__a__), (__b__))
+
+	class Helpers
+	{
+	public:
+		template<typename Ret, typename P1, typename P2>
+		static force_inline Ret add_with_overflow_check (const char *file, uint32_t line, P1 a, P2 b) noexcept
+		{
+			Ret ret;
+
+			if (XA_UNLIKELY (__builtin_add_overflow (a, b, &ret))) {
+				log_fatal (LOG_DEFAULT, "Integer overflow on addition at %s:%u", file, line);
+				exit (FATAL_EXIT_OUT_OF_MEMORY);
+				return static_cast<Ret>(0);
+			}
+
+			return ret;
+		}
+
+		// Can't use templates as above with add_with_oveflow because of a bug in the clang compiler
+		// shipped with the NDK:
+		//
+		//   https://github.com/android-ndk/ndk/issues/294
+		//   https://github.com/android-ndk/ndk/issues/295
+		//   https://bugs.llvm.org/show_bug.cgi?id=16404
+		//
+		// Using templated parameter types for `a` and `b` would make clang generate that tries to
+		// use 128-bit integers and thus output code that calls `__muloti4` and so linking would
+		// fail
+		//
+		template<typename Ret>
+		static force_inline Ret multiply_with_overflow_check (const char *file, uint32_t line, size_t a, size_t b) noexcept
+		{
+			Ret ret;
+
+			if (XA_UNLIKELY (__builtin_mul_overflow (a, b, &ret))) {
+				log_fatal (LOG_DEFAULT, "Integer overflow on multiplication at %s:%u", file, line);
+				exit (FATAL_EXIT_OUT_OF_MEMORY);
+				return static_cast<Ret>(0);
+			}
+
+			return ret;
+		}
+	};
+}
+#endif // __HELPERS_HH

--- a/src/monodroid/jni/jni-wrappers.hh
+++ b/src/monodroid/jni/jni-wrappers.hh
@@ -4,7 +4,7 @@
 
 #include <assert.h>
 #include <jni.h>
-#include <stddef.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1,5 +1,8 @@
-#include <stdlib.h>
-#include <stdarg.h>
+#include <array>
+#include <cstdlib>
+#include <cstdarg>
+#include <memory>
+
 #include <jni.h>
 #include <time.h>
 #include <stdio.h>
@@ -84,6 +87,7 @@
 #endif
 
 #include "cpp-util.hh"
+#include "strings.hh"
 
 #include "java-interop-dlfcn.h"
 
@@ -164,16 +168,14 @@ MonodroidRuntime::setup_bundled_app (const char *dso_name)
 		log_info (LOG_DEFAULT, "bundle app: embedded DSO mode");
 		libapp = androidSystem.load_dso_from_any_directories (dso_name, dlopen_flags);
 	} else {
-		bool needs_free = false;
 		log_info (LOG_DEFAULT, "bundle app: normal mode");
-		char *bundle_path = androidSystem.get_full_dso_path_on_disk (dso_name, needs_free);
-		log_info (LOG_DEFAULT, "bundle_path == %s", bundle_path ? bundle_path : "<nullptr>");
-		if (bundle_path == nullptr)
+		dynamic_local_string<SENSIBLE_PATH_MAX> bundle_path;
+		if (!androidSystem.get_full_dso_path_on_disk (dso_name, bundle_path)) {
+			log_info (LOG_DEFAULT, "bundle %s not found on filesystem", dso_name);
 			return;
-		log_info (LOG_BUNDLE, "Attempting to load bundled app from %s", bundle_path);
-		libapp = androidSystem.load_dso (bundle_path, dlopen_flags, true);
-		if (needs_free)
-			delete[] bundle_path;
+		}
+		log_info (LOG_BUNDLE, "Attempting to load bundled app from %s", bundle_path.get ());
+		libapp = androidSystem.load_dso (bundle_path.get (), dlopen_flags, true);
 	}
 
 	if (libapp == nullptr) {
@@ -298,29 +300,42 @@ MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, [[maybe_unused]
 
 	const char *culture = reinterpret_cast<const char*> (mono_assembly_name_get_culture (aname));
 	const char *name    = reinterpret_cast<const char*> (mono_assembly_name_get_name (aname));
-	char *pname_raw_ptr;
+	size_t culture_len;
 
-	if (culture != nullptr && *culture != '\0')
-		pname_raw_ptr = utils.path_combine (culture, name);
+	if (culture != nullptr)
+		culture_len = strlen (culture);
 	else
-		pname_raw_ptr = utils.strdup_new (name);
+		culture_len = 0;
+	size_t name_len = strlen (name);
 
-	simple_pointer_guard<char[]> pname (pname_raw_ptr);
+	static_local_string<SENSIBLE_PATH_MAX> pname (name_len + culture_len);
+	if (culture_len > 0)
+		pname.append (culture, culture_len);
+	pname.append (name, name_len);
 
-	constexpr const char *format_none = "%s" MONODROID_PATH_SEPARATOR "%s";
-	constexpr const char *format_dll  = "%s" MONODROID_PATH_SEPARATOR "%s.dll";
+	constexpr char dll_extension[] = ".dll";
+	constexpr size_t dll_extension_len = sizeof(dll_extension) - 1;
+
+	bool is_dll = utils.ends_with (name, dll_extension);
+	size_t file_name_len = pname.length () + 1;
+	if (!is_dll)
+		file_name_len += dll_extension_len;
 
 	for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
 		override_dir = androidSystem.get_override_dir (oi);
 		if (override_dir == nullptr || !utils.directory_exists (override_dir))
 			continue;
 
-		const char *format = utils.ends_with (name, ".dll") ? format_none : format_dll;
-		simple_pointer_guard<char, false> fullpath (utils.monodroid_strdup_printf (format, override_dir, pname.get ()));
+		size_t override_dir_len = strlen (override_dir);
+		static_local_string<SENSIBLE_PATH_MAX> fullpath (override_dir_len + file_name_len);
+		utils.path_combine (fullpath, override_dir, override_dir_len, pname.get (), pname.length ());
+		if (!is_dll) {
+			fullpath.append (dll_extension, dll_extension_len);
+		}
 
-		log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", static_cast<const char*>(fullpath));
-		if (utils.file_exists (fullpath))
-			result = mono_assembly_open_full (fullpath, nullptr, 0);
+		log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", fullpath.get ());
+		if (utils.file_exists (fullpath.get ()))
+			result = mono_assembly_open_full (fullpath.get (), nullptr, 0);
 		if (result != nullptr) {
 			// TODO: register .mdb, .pdb file
 			break;
@@ -338,13 +353,16 @@ bool
 MonodroidRuntime::should_register_file ([[maybe_unused]] const char *filename)
 {
 #ifndef RELEASE
+	size_t filename_len = strlen (filename) + 1; // includes space for path separator
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
 		const char *odir = androidSystem.get_override_dir (i);
 		if (odir == nullptr)
 			continue;
 
-		simple_pointer_guard<char[]> p (utils.path_combine (odir, filename));
-		bool  exists  = utils.file_exists (p);
+		size_t odir_len = strlen (odir);
+		static_local_string<SENSIBLE_PATH_MAX> p (odir_len + filename_len);
+		utils.path_combine (p, odir, odir_len, filename, filename_len);
+		bool  exists  = utils.file_exists (p.get ());
 
 		if (exists) {
 			log_info (LOG_ASSEMBLY, "should not register '%s' as it exists in the override directory '%s'", filename, odir);
@@ -506,104 +524,108 @@ MonodroidRuntime::parse_gdb_options ()
 }
 
 #if defined (DEBUG) && !defined (WINDOWS)
-int
-MonodroidRuntime::parse_runtime_args (char *runtime_args, RuntimeOptions *options)
+bool
+MonodroidRuntime::parse_runtime_args (dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> &runtime_args, RuntimeOptions *options)
 {
-	char **args, **ptr;
+	if (runtime_args.length () == 0) {
+		log_warn (LOG_DEFAULT, "runtime args empty");
+		return true;
+	}
 
-	if (runtime_args == nullptr)
-		return 1;
+	constexpr char   ARG_DEBUG[]                   = "debug";
+	constexpr size_t ARG_DEBUG_LENGTH              = sizeof(ARG_DEBUG) - 1;
+	constexpr char   ARG_TIMEOUT[]                 = "timeout=";
+	constexpr size_t ARG_TIMEOUT_LENGTH            = sizeof(ARG_TIMEOUT) - 1;
+	constexpr char   ARG_SERVER[]                  = "server=";
+	constexpr size_t ARG_SERVER_LENGTH             = sizeof(ARG_SERVER) - 1;
+	constexpr char   ARG_LOGLEVEL[]                = "loglevel=";
+	constexpr size_t ARG_LOGLEVEL_LENGTH           = sizeof(ARG_LOGLEVEL) - 1;
 
-	options->timeout_time = 0;
-
-	args = utils.monodroid_strsplit (runtime_args, ",", 0);
-
-	for (ptr = args; ptr && *ptr; ptr++) {
-		const char *arg = *ptr;
-
-		if (!strncmp (arg, "debug", 5)) {
+	bool ret = true;
+	string_segment token;
+	while (runtime_args.next_token (',', token)) {
+		if (token.starts_with (ARG_DEBUG, ARG_DEBUG_LENGTH)) {
 			char *host = nullptr;
 			int sdb_port = 1000, out_port = -1;
 
-			options->debug = 1;
+			options->debug = true;
 
-			if (arg[5] == '=') {
-				const char *sep, *endp;
+			if (token.has_at ('=', ARG_DEBUG_LENGTH)) {
+				constexpr size_t arg_name_length = ARG_DEBUG_LENGTH + 1; // Includes the '='
 
-				arg += 6;
-				sep = strchr (arg, ':');
-				if (sep != nullptr) {
-					size_t arg_len = static_cast<size_t>(sep - arg);
-					size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, arg_len, 1);
-					host = new char [alloc_size];
-					memset (host, 0x00, alloc_size);
-					strncpy (host, arg, arg_len);
-					arg = sep+1;
+				static_local_string<SMALL_STRING_PARSE_BUFFER_LEN> hostport (token.length () - arg_name_length);
+				hostport.assign (token.start () + arg_name_length, token.length () - arg_name_length);
 
-					sdb_port = (int) strtol (arg, const_cast<char**> (&endp), 10);
-					if (endp == arg) {
-						log_error (LOG_DEFAULT, "Invalid --debug argument.");
-						continue;
-					} else if (*endp == ':') {
-						arg = endp+1;
-						out_port = (int) strtol (arg, const_cast<char**> (&endp), 10);
-						if ((endp == arg) || (*endp != '\0')) {
-							log_error (LOG_DEFAULT, "Invalid --debug argument.");
-							continue;
-						}
-					} else if (*endp != '\0') {
-						log_error (LOG_DEFAULT, "Invalid --debug argument.");
-						continue;
+				string_segment address;
+				size_t field = 0;
+				while (field < 3 && hostport.next_token (':', address)) {
+					switch (field) {
+						case 0: // host
+							if (address.empty ()) {
+								log_error (LOG_DEFAULT, "Invalid --debug argument for the host field (empty string)");
+							} else {
+								host = utils.strdup_new (address.start (), address.length ());
+							}
+							break;
+
+						case 1: // sdb_port
+							if (!address.to_integer (sdb_port)) {
+								log_error (LOG_DEFAULT, "Invalid --debug argument for the sdb_port field");
+							}
+							break;
+
+						case 2: // out_port
+							if (!address.to_integer (out_port)) {
+								log_error (LOG_DEFAULT, "Invalid --debug argument for the sdb_port field");
+							}
+							break;
 					}
+					field++;
 				}
-			} else if (arg[5] != '\0') {
+			} else if (!token.has_at ('\0', ARG_DEBUG_LENGTH)) {
 				log_error (LOG_DEFAULT, "Invalid --debug argument.");
+				ret = false;
 				continue;
 			}
 
-			if (!host)
-				host = utils.strdup_new ("10.0.2.2");
-
 			if (sdb_port < 0 || sdb_port > USHRT_MAX) {
 				log_error (LOG_DEFAULT, "Invalid SDB port value %d", sdb_port);
+				ret = false;
 				continue;
 			}
 
 			if (out_port > USHRT_MAX) {
 				log_error (LOG_DEFAULT, "Invalid output port value %d", out_port);
+				ret = false;
 				continue;
 			}
+
+			if (host == nullptr)
+				host = utils.strdup_new ("10.0.2.2");
 
 			options->host = host;
 			options->sdb_port = static_cast<uint16_t>(sdb_port);
 			options->out_port = out_port == -1 ? 0 : static_cast<uint16_t>(out_port);
-		} else if (!strncmp (arg, "timeout=", 8)) {
-			char *endp;
-
-			arg += sizeof ("timeout");
-			options->timeout_time = strtoll (arg, &endp, 10);
-			if ((endp == arg) || (*endp != '\0'))
+		} else if (token.starts_with (ARG_TIMEOUT, ARG_TIMEOUT_LENGTH)) {
+			if (!token.to_integer (options->timeout_time, ARG_TIMEOUT_LENGTH)) {
 				log_error (LOG_DEFAULT, "Invalid --timeout argument.");
-			continue;
-		} else if (!strncmp (arg, "server=", 7)) {
-			arg += sizeof ("server");
-			options->server = *arg == 'y' || *arg == 'Y';
-			continue;
-		} else if (!strncmp (arg, "loglevel=", 9)) {
-			char *endp;
-
-			arg += sizeof ("loglevel");
-			options->loglevel = static_cast<int>(strtol (arg, &endp, 10));
-			if ((endp == arg) || (*endp != '\0'))
+				ret = false;
+			}
+		} else if (token.starts_with (ARG_SERVER, ARG_SERVER_LENGTH)) {
+			options->server = token.has_at ('y', ARG_SERVER_LENGTH) || token.has_at ('Y', ARG_SERVER_LENGTH);
+		} else if (token.starts_with (ARG_LOGLEVEL, ARG_LOGLEVEL_LENGTH)) {
+			if (!token.to_integer (options->loglevel, ARG_LOGLEVEL_LENGTH)) {
 				log_error (LOG_DEFAULT, "Invalid --loglevel argument.");
+				ret = false;
+			}
 		} else {
-				log_error (LOG_DEFAULT, "Unknown runtime argument: '%s'", arg);
-			continue;
+			static_local_string<SMALL_STRING_PARSE_BUFFER_LEN> arg (token);
+			log_error (LOG_DEFAULT, "Unknown runtime argument: '%s'", arg.get ());
+			ret = false;
 		}
 	}
 
-	utils.monodroid_strfreev (args);
-	return 1;
+	return ret;
 }
 #endif  // def DEBUG && !WINDOWS
 
@@ -618,17 +640,16 @@ MonodroidRuntime::set_debug_options (void)
 }
 
 void
-MonodroidRuntime::mono_runtime_init ([[maybe_unused]] char *runtime_args)
+MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& runtime_args)
 {
 #if defined (DEBUG) && !defined (WINDOWS)
 	RuntimeOptions options;
 	int64_t cur_time;
-	memset(&options, 0, sizeof (options));
 
 	cur_time = time (nullptr);
 
 	if (!parse_runtime_args (runtime_args, &options)) {
-		log_error (LOG_DEFAULT, "Failed to parse runtime args: '%s'", runtime_args);
+		log_error (LOG_DEFAULT, "Failed to parse runtime args: '%s'", runtime_args.get ());
 	} else if (options.debug && cur_time > options.timeout_time) {
 		log_warn (LOG_DEBUGGER, "Not starting the debugger as the timeout value has been reached; current-time: %lli  timeout: %lli", cur_time, options.timeout_time);
 	} else if (options.debug && cur_time <= options.timeout_time) {
@@ -743,16 +764,15 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] char *runtime_args)
 		}
 	}
 
-	char *prop_val;
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> prop_val;
 	/* Additional runtime arguments passed to mono_jit_parse_options () */
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_RUNTIME_ARGS_PROPERTY, &prop_val) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_RUNTIME_ARGS_PROPERTY, prop_val) > 0) {
 		char **ptr;
 
-		log_warn (LOG_DEBUGGER, "passing '%s' as extra arguments to the runtime.\n", prop_val);
+		log_warn (LOG_DEBUGGER, "passing '%s' as extra arguments to the runtime.\n", prop_val.get ());
 
-		char **args = utils.monodroid_strsplit (prop_val, " ", 0);
+		char **args = utils.monodroid_strsplit (prop_val.get (), " ", 0);
 		int argc = 0;
-		delete[] prop_val;
 
 		for (ptr = args; *ptr; ptr++)
 			argc ++;
@@ -796,7 +816,7 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] char *runtime_args)
 MonoDomain*
 MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool is_root_domain)
 {
-	size_t user_assemblies_count   = 0;;
+	size_t user_assemblies_count   = 0;
 
 	gather_bundled_assemblies (runtimeApks, &user_assemblies_count);
 
@@ -812,8 +832,16 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 		domain = mono_jit_init_version (const_cast<char*> ("RootDomain"), const_cast<char*> ("mobile"));
 	} else {
 		MonoDomain* root_domain = mono_get_root_domain ();
-		simple_pointer_guard<char[], false> domain_name = utils.monodroid_strdup_printf ("MonoAndroidDomain%d", android_api_level);
-		domain = utils.monodroid_create_appdomain (root_domain, domain_name, /*shadow_copy:*/ 1, /*shadow_directory:*/ androidSystem.get_override_dir (0));
+
+		constexpr char DOMAIN_NAME[] = "MonoAndroidDomain";
+		constexpr size_t DOMAIN_NAME_LENGTH = sizeof(DOMAIN_NAME) - 1;
+		constexpr size_t DOMAIN_NAME_TOTAL_SIZE = DOMAIN_NAME_LENGTH + MAX_INTEGER_DIGIT_COUNT_BASE10;
+
+		static_local_string<DOMAIN_NAME_TOTAL_SIZE + 1> domain_name (DOMAIN_NAME_TOTAL_SIZE);
+		domain_name.append (DOMAIN_NAME);
+		domain_name.append (android_api_level);
+
+		domain = utils.monodroid_create_appdomain (root_domain, domain_name.get (), /*shadow_copy:*/ 1, /*shadow_directory:*/ androidSystem.get_override_dir (0));
 	}
 
 	if constexpr (is_running_on_desktop) {
@@ -858,57 +886,6 @@ MonodroidRuntime::LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int ve
 	java_System_identityHashCode = env->GetStaticMethodID (java_System, "identityHashCode", "(Ljava/lang/Object;)I");
 
 	return 1;
-}
-
-int
-MonodroidRuntime::get_display_dpi (float *x_dpi, float *y_dpi)
-{
-	if (!x_dpi) {
-		log_error (LOG_DEFAULT, "Internal error: x_dpi parameter missing in get_display_dpi");
-		return -1;
-	}
-
-	if (!y_dpi) {
-		log_error (LOG_DEFAULT, "Internal error: y_dpi parameter missing in get_display_dpi");
-		return -1;
-	}
-
-	MonoDomain *domain = nullptr;
-	if (runtime_GetDisplayDPI == nullptr) {
-		domain = mono_get_root_domain ();
-		MonoAssembly *assm = utils.monodroid_load_assembly (domain, "Mono.Android");;
-
-		MonoImage *image = nullptr;
-		if (assm != nullptr)
-			image = mono_assembly_get_image  (assm);
-
-		MonoClass *environment = nullptr;
-		if (image != nullptr)
-			environment = utils.monodroid_get_class_from_image (domain, image, "Android.Runtime", "AndroidEnvironment");
-
-		if (environment != nullptr)
-			runtime_GetDisplayDPI = mono_class_get_method_from_name (environment, "GetDisplayDPI", 2);
-	}
-
-	if (!runtime_GetDisplayDPI) {
-		*x_dpi = DEFAULT_X_DPI;
-		*y_dpi = DEFAULT_Y_DPI;
-		return 0;
-	}
-
-	void* args [] = {
-		x_dpi,
-		y_dpi,
-	};
-
-	MonoObject *exc = nullptr;
-	utils.monodroid_runtime_invoke (domain != nullptr ? domain : mono_get_root_domain (), runtime_GetDisplayDPI, nullptr, args, &exc);
-	if (exc != nullptr) {
-		*x_dpi = DEFAULT_X_DPI;
-		*y_dpi = DEFAULT_Y_DPI;
-	}
-
-	return 0;
 }
 
 inline void
@@ -1245,11 +1222,19 @@ MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, [[m
 	else
 		basename_part = (char*)name;
 
-	simple_pointer_guard<char[]> basename = utils.string_concat ("libaot-", basename_part);
-	h = androidSystem.load_dso_from_any_directories (basename, dl_flags);
+	constexpr char LIBAOT_PREFIX[] = "libaot-";
+	constexpr size_t LIBAOT_PREFIX_SIZE = sizeof(LIBAOT_PREFIX);
+
+	size_t base_len = strlen (basename_part);
+	size_t len = base_len + LIBAOT_PREFIX_SIZE; // includes the trailing \0
+	static_local_string<PATH_MAX> basename (len);
+
+	basename.append (LIBAOT_PREFIX).append (basename_part);
+
+	h = androidSystem.load_dso_from_any_directories (basename.get (), dl_flags);
 
 	if (h != nullptr && XA_UNLIKELY (utils.should_log (LOG_ASSEMBLY)))
-		log_info_nocheck (LOG_ASSEMBLY, "Loaded AOT image '%s'", static_cast<const char*>(basename));
+		log_info_nocheck (LOG_ASSEMBLY, "Loaded AOT image '%s'", basename.get ());
 
 	if (name_needs_free) {
 		delete[] name;
@@ -1288,145 +1273,175 @@ MonodroidRuntime::set_environment_variable_for_directory (const char *name, jstr
 }
 
 inline void
-MonodroidRuntime::create_xdg_directory (jstring_wrapper& home, const char *relativePath, const char *environmentVariableName)
+MonodroidRuntime::create_xdg_directory (jstring_wrapper& home, size_t home_len, const char *relativePath, size_t relative_path_len, const char *environmentVariableName)
 {
-	simple_pointer_guard<char> dir = utils.path_combine (home.get_cstr (), relativePath);
-	log_info (LOG_DEFAULT, "Creating XDG directory: %s", static_cast<char*>(dir));
-	int rv = utils.create_directory (dir, DEFAULT_DIRECTORY_MODE);
+	static_local_string<SENSIBLE_PATH_MAX> dir (home_len + relative_path_len);
+	utils.path_combine (dir, home.get_cstr (), home_len, relativePath, relative_path_len);
+	log_info (LOG_DEFAULT, "Creating XDG directory: %s", dir.get ());
+	int rv = utils.create_directory (dir.get (), DEFAULT_DIRECTORY_MODE);
 	if (rv < 0 && errno != EEXIST)
-		log_warn (LOG_DEFAULT, "Failed to create XDG directory %s. %s", static_cast<char*>(dir), strerror (errno));
+		log_warn (LOG_DEFAULT, "Failed to create XDG directory %s. %s", dir.get (), strerror (errno));
 	if (environmentVariableName)
-		setenv (environmentVariableName, dir, 1);
+		setenv (environmentVariableName, dir.get (), 1);
 }
 
 inline void
 MonodroidRuntime::create_xdg_directories_and_environment (jstring_wrapper &homeDir)
 {
-	create_xdg_directory (homeDir, ".local/share", "XDG_DATA_HOME");
-	create_xdg_directory (homeDir, ".config", "XDG_CONFIG_HOME");
+	size_t home_len = strlen (homeDir.get_cstr ());
+
+	constexpr char XDG_DATA_HOME[] = "XDG_DATA_HOME";
+	constexpr char HOME_PATH[] = ".local/share";
+	constexpr size_t HOME_PATH_LEN = sizeof(HOME_PATH) - 1;
+	create_xdg_directory (homeDir, home_len, HOME_PATH, HOME_PATH_LEN, XDG_DATA_HOME);
+
+	constexpr char XDG_CONFIG_HOME[] = "XDG_CONFIG_HOME";
+	constexpr char CONFIG_PATH[] = ".config";
+	constexpr size_t CONFIG_PATH_LEN = sizeof(CONFIG_PATH) - 1;
+	create_xdg_directory (homeDir, home_len, CONFIG_PATH, CONFIG_PATH_LEN, XDG_CONFIG_HOME);
 }
 
 #if DEBUG
 void
 MonodroidRuntime::set_debug_env_vars (void)
 {
-	char *value;
-
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_ENV_PROPERTY, &value) == 0)
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> value;
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_ENV_PROPERTY, value) == 0)
 		return;
 
-	char **args = utils.monodroid_strsplit (value, "|", 0);
-	delete[] value;
+	auto log_envvar = [](const char *name, const char *v) {
+		log_debug (LOG_DEFAULT, "Env variable '%s' set to '%s'.", name, v);
+	};
 
-	for (char **ptr = args; ptr && *ptr; ptr++) {
-		char *arg = *ptr;
-		char *v = strchr (arg, '=');
-		if (v) {
-			*v = '\0';
-			++v;
-		} else {
+	string_segment arg_token;
+	while (value.next_token ('|', arg_token)) {
+		static_local_string<SMALL_STRING_PARSE_BUFFER_LEN> arg (arg_token.length ());
+		arg.assign (arg_token.start (), arg_token.length ());
+
+		ssize_t idx = arg.index_of ('=');
+		size_t index = static_cast<size_t>(idx);
+		if (idx < 0 || index == arg.length () - 1) {
+			// ’name’ or ’name=’
 			constexpr char one[] = "1";
-			v = const_cast<char*> (one);
+			if (index == arg.length () - 1) {
+				arg[index] = '\0';
+			}
+			setenv (arg.get (), one, 1);
+			log_envvar (arg.get (), one);
+		} else if (index == 0) {
+			// ’=value’
+			log_warn (LOG_DEFAULT, "Attempt to set environment variable without specifying name: '%s'", arg.get ());
+		} else {
+			// ’name=value’
+			arg[index] = '\0';
+			const char *v = arg.get () + idx + 1;
+			setenv (arg.get (), v, 1);
+			log_envvar (arg.get (), v);
 		}
-		setenv (arg, v, 1);
-		log_info (LOG_DEFAULT, "Env variable '%s' set to '%s'.", arg, v);
 	}
-	utils.monodroid_strfreev (args);
 }
 #endif /* DEBUG */
 
 inline void
 MonodroidRuntime::set_trace_options (void)
 {
-	char *value;
-
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_TRACE_PROPERTY, &value) == 0)
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> value;
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_TRACE_PROPERTY, value) == 0)
 		return;
 
-	mono_jit_set_trace_options (value);
-	delete[] value;
+	mono_jit_set_trace_options (value.get ());
 }
 
 inline void
 MonodroidRuntime::set_profile_options ()
 {
-	constexpr const char mlpd_ext[] = "mlpd";
-	constexpr const char aot_ext[] = "aotprofile";
+	// We want to avoid dynamic allocation, thus let’s create a buffer that can take both the property value and a
+	// path without allocation
+	dynamic_local_string<SENSIBLE_PATH_MAX + PROPERTY_VALUE_BUFFER_LEN> value;
+	{
+		dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> prop_value;
+		if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, prop_value) == 0)
+			return;
 
-	constexpr const char output_arg[] = "output=";
-	constexpr const size_t output_arg_len = sizeof(output_arg) - 1;
+		value.assign (prop_value.get (), prop_value.length ());
+	}
 
-	char *value;
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, &value) == 0)
-		return;
+	constexpr char OUTPUT_ARG[] = "output=";
+	constexpr size_t OUTPUT_ARG_LEN = sizeof(OUTPUT_ARG) - 1;
 
-	char *output = nullptr;
-	char *delimiter = strchr (value, ',');
-	while (delimiter != nullptr) {
-		char *arg = delimiter + 1;
-		if (*arg == '\0') {
-			break;
-		}
+	ssize_t colon_idx = value.index_of (':');
+	size_t start_index = colon_idx < 0 ? 0 : static_cast<size_t>(colon_idx + 1);
+	dynamic_local_string<SENSIBLE_PATH_MAX> output_path;
+	bool have_output_arg = false;
+	string_segment param;
 
-		if (strncmp (arg, output_arg, output_arg_len) != 0) {
-			delimiter = strchr (arg, ',');
+	while (value.next_token (start_index, ',', param)) {
+		dynamic_local_string<SENSIBLE_PATH_MAX> temp;
+		temp.assign (param.start (), param.length ());
+		if (!param.starts_with (OUTPUT_ARG, OUTPUT_ARG_LEN) || param.length () == OUTPUT_ARG_LEN) {
 			continue;
 		}
 
-		arg += output_arg_len;
-		if (*arg == '\0') {
-			break; // empty...
-		}
-
-		delimiter = strchr (arg, ',');
-		if (delimiter == nullptr) {
-			output = utils.strdup_new (arg);
-		} else {
-			output = utils.strdup_new (arg, static_cast<size_t>(delimiter - arg));
-		}
+		output_path.assign (param.start () + OUTPUT_ARG_LEN, param.length () - OUTPUT_ARG_LEN);
+		have_output_arg = true;
 		break;
 	}
 
-	if (output == nullptr) {
-		const char* col = strchr (value, ':');
-		char *extension;
-		bool  extension_needs_free = false;
+	if (!have_output_arg) {
+		constexpr char   MLPD_EXT[] = "mlpd";
+		constexpr size_t MLPD_EXT_LEN = sizeof(MLPD_EXT) - 1;
+		constexpr char   AOT_EXT[] = "aotprofile";
+		constexpr size_t AOT_EXT_LEN = sizeof(AOT_EXT) - 1;
+		constexpr char   COV_EXT[] = "xml";
+		constexpr size_t COV_EXT_LEN = sizeof(COV_EXT) - 1;
+		constexpr char   LOG_PREFIX[] = "log:";
+		constexpr size_t LOG_PREFIX_LENGTH = sizeof(LOG_PREFIX) - 1;
+		constexpr char   AOT_PREFIX[] = "aot:";
+		constexpr size_t AOT_PREFIX_LENGTH = sizeof(AOT_PREFIX) - 1;
+		constexpr char   DEFAULT_PREFIX[] = "default:";
+		constexpr size_t DEFAULT_PREFIX_LENGTH = sizeof(DEFAULT_PREFIX) - 1;
+		constexpr char   COVERAGE_PREFIX[] = "coverage:";
+		constexpr size_t COVERAGE_PREFIX_LENGTH = sizeof(COVERAGE_PREFIX) - 1;
+		constexpr char   PROFILE_FILE_NAME_PREFIX[] = "profile.";
+		constexpr size_t PROFILE_FILE_NAME_PREFIX_LEN = sizeof(PROFILE_FILE_NAME_PREFIX) - 1;
 
-		if ((col != nullptr && strncmp (value, "log:", 4) == 0) || strcmp (value, "log") == 0)
-			extension = const_cast<char*>(mlpd_ext);
-		else if ((col != nullptr && !strncmp (value, "aot:", 4)) || !strcmp (value, "aot"))
-			extension = const_cast<char*>(aot_ext);
-		else if ((col != nullptr && strncmp (value, "default:", 8) == 0) || strcmp (value, "default") == 0)
-			extension = const_cast<char*>(mlpd_ext);
-		else {
-			size_t len = col != nullptr ? static_cast<size_t>(col - value) : strlen (value);
-			size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, len, 1);
-			extension = new char [alloc_size];
-			strncpy (extension, value, len);
-			extension [len] = '\0';
-			extension_needs_free = true;
+		size_t length_adjust = colon_idx >= 1 ? 0 : 1;
+
+		output_path
+			.assign (androidSystem.get_override_dir (0))
+			.append (MONODROID_PATH_SEPARATOR)
+			.append (PROFILE_FILE_NAME_PREFIX, PROFILE_FILE_NAME_PREFIX_LEN);
+
+		if (value.starts_with (LOG_PREFIX, LOG_PREFIX_LENGTH - length_adjust)) {
+			output_path.append (MLPD_EXT, MLPD_EXT_LEN);
+		} else if (value.starts_with (AOT_PREFIX, AOT_PREFIX_LENGTH - length_adjust)) {
+			output_path.append (AOT_EXT, AOT_EXT_LEN);
+		} else if (value.starts_with (DEFAULT_PREFIX, DEFAULT_PREFIX_LENGTH - length_adjust)) {
+			output_path.append (MLPD_EXT, MLPD_EXT_LEN);
+		} else if (value.starts_with (COVERAGE_PREFIX, COVERAGE_PREFIX_LENGTH - length_adjust)) {
+			output_path.append (COV_EXT, COV_EXT_LEN);
+		} else {
+			size_t len = colon_idx < 0 ? value.length () : static_cast<size_t>(colon_idx + 1);
+			output_path.append (value.get (), len);
 		}
 
-		output = utils.string_concat (androidSystem.get_override_dir (0), MONODROID_PATH_SEPARATOR, "profile.", extension);
-		char *ovalue = utils.string_concat (value, col == nullptr ? ":" : ",", output_arg, output);
-
-		if (extension_needs_free)
-			delete[] extension;
-		delete[] value;
-		value = ovalue;
+		if (colon_idx < 0)
+			value.append (":");
+		else
+			value.append (",");
+		value
+			.append (OUTPUT_ARG, OUTPUT_ARG_LEN)
+			.append (output_path.get (), output_path.length ());
 	}
 
 	/*
 	 * libmono-profiler-log.so profiler won't overwrite existing files.
 	 * Remove it For Great Justice^H^H^H to preserve my sanity!
 	 */
-	unlink (output);
+	unlink (output_path.get ());
 
-	log_warn (LOG_DEFAULT, "Initializing profiler with options: %s", value);
-	debug.monodroid_profiler_load (androidSystem.get_runtime_libdir (), value, output);
-
-	delete[] value;
-	delete[] output;
+	log_warn (LOG_DEFAULT, "Initializing profiler with options: %s", value.get ());
+	debug.monodroid_profiler_load (androidSystem.get_runtime_libdir (), value.get (), output_path.get ());
 }
 
 /*
@@ -1672,10 +1687,11 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)) && !(log_timing_categories & LOG_TIMING_BARE)) {
 		mono_counters_enable (static_cast<int>(XA_LOG_COUNTERS));
 
-		simple_pointer_guard<char[]> counters_path (utils.path_combine (androidSystem.get_override_dir (0), "counters.txt"));
+		dynamic_local_string<SENSIBLE_PATH_MAX> counters_path;
+		utils.path_combine (counters_path, androidSystem.get_override_dir (0), "counters.txt");
 		log_info_nocheck (LOG_TIMING, "counters path: %s", counters_path.get ());
-		counters = utils.monodroid_fopen (counters_path, "a");
-		utils.set_world_accessable (counters_path);
+		counters = utils.monodroid_fopen (counters_path.get (), "a");
+		utils.set_world_accessable (counters_path.get ());
 	}
 
 	void *dso_handle = nullptr;
@@ -1746,8 +1762,8 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		mono_set_use_llvm (true);
 	}
 
-	char *runtime_args = nullptr;
-	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_EXTRA_PROPERTY, &runtime_args);
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> runtime_args;
+	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_EXTRA_PROPERTY, runtime_args);
 
 #if TRACE
 	__android_log_print (ANDROID_LOG_INFO, "*jonp*", "debug.mono.extra=%s", runtime_args);
@@ -1769,8 +1785,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	jstring_array_wrapper assembliesPaths (env);
 	/* the first assembly is used to initialize the AppDomain name */
 	create_and_initialize_domain (env, klass, runtimeApks, assemblies, nullptr, assembliesPaths, loader, /*is_root_domain:*/ true, /*force_preload_assemblies:*/ false);
-
-	delete[] runtime_args;
 
 	// Install our dummy exception handler on Desktop
 	if constexpr (is_running_on_desktop) {
@@ -1865,7 +1879,7 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 {
 	timing_period total_time;
 
-	char *type = nullptr;
+	dynamic_local_string<SENSIBLE_TYPE_NAME_LENGTH> type;
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
@@ -1875,10 +1889,10 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
-		type = utils.strdup_new (mt_ptr);
+		type.assign (mt_ptr, strlen (mt_ptr));
 		env->ReleaseStringUTFChars (managedType, mt_ptr);
 
-		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type);
+		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type.get ());
 	}
 
 	int methods_len = env->GetStringLength (methods);
@@ -1912,8 +1926,7 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 
 		Timing::info (total_time, "Runtime.register: end time");
 
-		dump_counters ("## Runtime.register: type=%s\n", type);
-		delete[] type;
+		dump_counters ("## Runtime.register: type=%s\n", type.get ());
 	}
 }
 

--- a/src/monodroid/jni/platform-compat.hh
+++ b/src/monodroid/jni/platform-compat.hh
@@ -1,0 +1,68 @@
+#ifndef __PLATFORM_COMPAT_HH
+#define __PLATFORM_COMPAT_HH
+
+#include <cstdint>
+
+#if __cplusplus >= 201703L
+#define UNUSED_ARG [[maybe_unused]]
+#else
+#if defined (__GNUC__)
+#define UNUSED_ARG __attribute__((__unused__))
+#else // !__GNUC__
+#define UNUSED_ARG
+#endif // __GNUC__
+#endif // __cplusplus >= 201703L
+
+#if WINDOWS
+constexpr char MONODROID_PATH_SEPARATOR[] = "\\";
+constexpr char MONODROID_PATH_SEPARATOR_CHAR = '\\';
+#else // !WINDOWS
+constexpr char MONODROID_PATH_SEPARATOR[] = "/";
+constexpr char MONODROID_PATH_SEPARATOR_CHAR = '/';
+#endif // WINDOWS
+constexpr size_t MONODROID_PATH_SEPARATOR_LENGTH = sizeof(MONODROID_PATH_SEPARATOR) - 1;
+
+#if WINDOWS
+typedef struct _stat monodroid_stat_t;
+#define monodroid_dir_t _WDIR
+typedef struct _wdirent monodroid_dirent_t;
+#else // !WINDOWS
+typedef struct stat monodroid_stat_t;
+#define monodroid_dir_t DIR
+typedef struct dirent monodroid_dirent_t;
+#endif // WINDOWS
+
+#define DEFAULT_DIRECTORY_MODE S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
+
+#if defined (_MSC_VER)
+#define inline __inline
+#define force_inline __forceinline
+#elif defined (__GNUC__)
+#ifndef XA_LIKELY
+#define XA_LIKELY(expr) (__builtin_expect ((expr) != 0, 1))
+#endif
+
+#ifndef XA_UNLIKELY
+#define XA_UNLIKELY(expr) (__builtin_expect ((expr) != 0, 0))
+#endif
+
+#define force_inline inline __attribute__((always_inline))
+#endif // _MSV_VER
+
+#ifndef force_inline
+#define force_inline inline
+#endif
+
+#ifndef inline
+#define inline inline
+#endif
+
+#ifndef XA_LIKELY
+#define XA_LIKELY(expr) (expr)
+#endif
+
+#ifndef XA_UNLIKELY
+#define XA_UNLIKELY(expr) (expr)
+#endif
+
+#endif // __PLATFORM_COMPAT_HH

--- a/src/monodroid/jni/strings.hh
+++ b/src/monodroid/jni/strings.hh
@@ -1,0 +1,775 @@
+#ifndef __STRINGS_HH
+#define __STRINGS_HH
+
+#include <array>
+#include <cstring>
+#include <cerrno>
+#include <limits>
+#include <type_traits>
+#include <unistd.h>
+
+#include "platform-compat.hh"
+#include "logger.hh"
+#include "helpers.hh"
+
+namespace xamarin::android::internal
+{
+	constexpr size_t SENSIBLE_TYPE_NAME_LENGTH = 128;
+	constexpr size_t SENSIBLE_PATH_MAX = 256;
+	// 64-bit unsigned or 64-bit signed with sign
+	constexpr size_t MAX_INTEGER_DIGIT_COUNT_BASE10 = 21;
+
+#if DEBUG
+	constexpr bool BoundsCheck = true;
+#else
+	constexpr bool BoundsCheck = false;
+#endif
+
+	class string_segment
+	{
+	public:
+		force_inline bool initialized () const noexcept
+		{
+			return !_fresh;
+		}
+
+		force_inline const char* start () const noexcept
+		{
+			return _start;
+		}
+
+		force_inline size_t length () const noexcept
+		{
+			return _length;
+		}
+
+		force_inline bool empty () const noexcept
+		{
+			return length () == 0;
+		}
+
+		force_inline bool equal (const char *s) const noexcept
+		{
+			if (s == nullptr)
+				return false;
+
+			return equal (s, strlen (s));
+		}
+
+		force_inline bool equal (const char *s, size_t s_length) const noexcept
+		{
+			if (s == nullptr)
+				return false;
+
+			if (!can_access (s_length)) {
+				return false;
+			}
+
+			if (length () != s_length) {
+				return false;
+			}
+
+			if (length () == 0) {
+				return true;
+			}
+
+			return memcmp (_start, s, length ()) == 0;
+		}
+
+		force_inline bool starts_with (const char *s) const noexcept
+		{
+			if (s == nullptr)
+				return false;
+
+			return starts_with (s, strlen (s));
+		}
+
+		force_inline bool starts_with (const char *s, size_t s_length) const noexcept
+		{
+			if (s == nullptr || !can_access (s_length)) {
+				return false;
+			}
+
+			if (length () < s_length) {
+				return false;
+			}
+
+			return memcmp (start (), s, s_length) == 0;
+		}
+
+		template<size_t Size>
+		force_inline bool starts_with (const char (&s)[Size]) const noexcept
+		{
+			return starts_with (s, Size);
+		}
+
+		force_inline bool has_at (const char ch, size_t index) const noexcept
+		{
+			if (!can_access (index)) {
+				return false;
+			}
+
+			return start ()[index] == ch;
+		}
+
+		force_inline ssize_t find (const char ch, size_t start_index) const noexcept
+		{
+			if (!can_access (start_index)) {
+				return -1;
+			}
+
+			while (start_index <= length ()) {
+				if (start ()[start_index] == ch) {
+					return static_cast<ssize_t>(start_index);
+				}
+				start_index++;
+			}
+
+			return -1;
+		}
+
+		template<typename T>
+		force_inline bool to_integer (T &val, size_t start_index = 0, int base = 10) const noexcept
+		{
+			static_assert (std::is_integral_v<T>);
+			constexpr T min = std::numeric_limits<T>::min ();
+			constexpr T max = std::numeric_limits<T>::max ();
+			using integer = typename std::conditional<std::is_signed_v<T>, int64_t, uint64_t>::type;
+
+			if (length () == 0) {
+				return false;
+			}
+
+			if (!can_access (start_index)) {
+				log_error (LOG_DEFAULT, "Cannot convert string to integer, index %u is out of range", start_index);
+				return false;
+			}
+
+			// FIXME: this is less than ideal... we shouldn't need another buffer here
+			size_t slen = length () - start_index;
+			char s[slen + 1];
+
+			memcpy (s, start () + start_index, slen);
+			s[slen] = '\0';
+
+			integer ret;
+			char *endp;
+			bool out_of_range;
+			errno = 0;
+			if constexpr (std::is_signed_v<T>) {
+				ret = strtoll (s, &endp, base);
+				out_of_range = ret < min || ret > max;
+			} else {
+				ret = strtoull (s, &endp, base);
+				out_of_range = ret > max;
+			}
+
+			if (out_of_range || errno == ERANGE) {
+				log_error (LOG_DEFAULT, "Value %s is out of range of this type (%lld..%llu)", s, static_cast<int64_t>(min), static_cast<uint64_t>(max));
+				return false;
+			}
+
+			if (endp == s) {
+				log_error (LOG_DEFAULT, "Value %s does not represent a base %d integer", s, base);
+				return false;
+			}
+
+			if (*endp != '\0') {
+				log_error (LOG_DEFAULT, "Value %s has non-numeric characters at the end", s);
+				return false;
+			}
+
+			val = static_cast<T>(ret);
+			return true;
+		}
+
+	private:
+		force_inline bool can_access (size_t index) const noexcept
+		{
+			if (XA_UNLIKELY (!initialized () || start () == nullptr)) {
+				return false;
+			}
+
+			if (index > length ())
+				return false;
+
+			return true;
+		}
+
+	protected:
+		size_t       _last_index = 0;
+		bool         _fresh = true;
+		const char  *_start = nullptr;
+		size_t       _length = 0;
+
+		template<size_t MaxStackSize, typename TStorage, typename TChar> friend class string_base;
+	};
+
+	template<size_t MaxStackSize, bool HasResize, typename T = char>
+	class local_storage
+	{
+		protected:
+		using LocalStoreArray = std::array<T, MaxStackSize>;
+
+	public:
+		static constexpr bool has_resize = HasResize;
+
+	public:
+		explicit local_storage (size_t size) noexcept
+		{
+			static_assert (MaxStackSize > 0, "MaxStackSize must be more than 0");
+			init_store (size < MaxStackSize ? MaxStackSize : size);
+		}
+
+		virtual ~local_storage ()
+		{
+			free_store ();
+		}
+
+		T* get () noexcept
+		{
+			return allocated_store == nullptr ? local_store.data () : allocated_store;
+		}
+
+		const T* get () const noexcept
+		{
+			return allocated_store == nullptr ? local_store.data () : allocated_store;
+		}
+
+		size_t size () const noexcept
+		{
+			return store_size;
+		}
+
+	protected:
+		force_inline void init_store (size_t new_size) noexcept
+		{
+			if (new_size > MaxStackSize) {
+				allocated_store = new T[new_size];
+			} else {
+				allocated_store = nullptr;
+			}
+			store_size = new_size;
+		}
+
+		force_inline void free_store () noexcept
+		{
+			if (allocated_store == nullptr)
+				return;
+			delete[] allocated_store;
+		}
+
+		force_inline LocalStoreArray& get_local_store () noexcept
+		{
+			return local_store;
+		}
+
+		force_inline T* get_allocated_store () noexcept
+		{
+			return allocated_store;
+		}
+
+	private:
+		size_t store_size;
+		LocalStoreArray local_store;
+		T* allocated_store;
+	};
+
+	// This class is meant to provide a *very* thin veneer (by design) over space allocated for *local* buffers - that
+	// is one which are not meant to survive the exit of the function they are created in.  The idea is that the caller
+	// knows the size of the buffer they need and they want to put the buffer on stack, if it doesn't exceed a certain
+	// value, or dynamically allocate memory if more is needed.  Even though the class could be used on its own, it's
+	// really meant to be a base for more specialized buffers.  There are not many safeguards, by design - the code is
+	// meant to be performant.  This is the reason why the size is static throughout the life of the object, so that we
+	// can perform as few checks as possible.
+
+	template <size_t MaxStackSize, typename T> using static_local_storage_base = local_storage<MaxStackSize, false, T>;
+
+	template<size_t MaxStackSize, typename T = char>
+	class static_local_storage final : public static_local_storage_base<MaxStackSize, T>
+	{
+		using base = static_local_storage_base<MaxStackSize, T>;
+
+	public:
+		explicit static_local_storage (size_t initial_size) noexcept
+			: base (initial_size)
+		{}
+	};
+
+	template <size_t MaxStackSize, typename T> using dynamic_local_storage_base = local_storage<MaxStackSize, true, T>;
+
+	template<size_t MaxStackSize, typename T = char>
+	class dynamic_local_storage final : public dynamic_local_storage_base<MaxStackSize, T>
+	{
+		using base = dynamic_local_storage_base<MaxStackSize, T>;
+
+	public:
+		explicit dynamic_local_storage (size_t initial_size = 0) noexcept
+			: base (initial_size)
+		{}
+
+		//
+		// If `new_size` is smaller than the current size and the dynamic store is allocated, data WILL NOT be
+		// preserved.
+		//
+		// If `new_size` is bigger than the current size bigger than MaxStackSize, data will be copied to the new
+		// dynamically allocated store
+		//
+		// If `new_size` is smaller or equal to `MaxStackSize`, no changes are made unless dynamic store was allocated,
+		// in which case it will be freed
+		//
+		void resize (size_t new_size) noexcept
+		{
+			size_t old_size = base::size ();
+
+			if (new_size == old_size) {
+				return;
+			}
+
+			if (new_size <= MaxStackSize) {
+				new_size = MaxStackSize;
+				base::free_store ();
+				return;
+			}
+
+			if (new_size < old_size) {
+				base::free_store ();
+				base::init_store (new_size);
+				return;
+			}
+
+			T* old_allocated_store = base::get_allocated_store ();
+			base::init_store (new_size);
+
+			T* new_allocated_store = base::get_allocated_store ();
+			if (old_allocated_store != nullptr) {
+				std::memcpy (new_allocated_store, old_allocated_store, old_size);
+				delete[] old_allocated_store;
+				return;
+			}
+
+			std::memcpy (new_allocated_store, base::get_local_store ().data (), MaxStackSize);
+		}
+	};
+
+	template<size_t MaxStackSize, typename TStorage, typename TChar = char>
+	class string_base
+	{
+	protected:
+		static constexpr TChar NUL = '\0';
+		static constexpr TChar ZERO = '0';
+
+	public:
+		explicit string_base (size_t initial_size = 0)
+			: buffer (initial_size)
+		{
+			// Currently we care only about `char`, maybe in the future we'll add support for `wchar` (if needed)
+			static_assert (std::is_same_v<TChar, char>, "TChar must be an 8-bit character type");
+
+			clear ();
+		}
+
+		explicit string_base (const string_segment &token)
+			: string_base (token.initialized () ? token.length () : 0)
+		{
+			if (token.initialized ())
+				assign (token.start (), token.length ());
+		}
+
+		force_inline size_t length () const noexcept
+		{
+			return idx;
+		}
+
+		force_inline bool empty () const noexcept
+		{
+			return length () == 0;
+		}
+
+		force_inline void set_length (size_t new_length) noexcept
+		{
+			if (new_length >= buffer.size ()) {
+				return;
+			}
+
+			idx = new_length;
+			terminate ();
+		}
+
+		force_inline void clear () noexcept
+		{
+			set_length (0);
+			buffer.get ()[0] = NUL;
+		}
+
+		force_inline void terminate () noexcept
+		{
+			buffer.get ()[idx] = NUL;
+		}
+
+		force_inline string_base& append (const TChar* s, size_t length) noexcept
+		{
+			if (s == nullptr || length == 0)
+				return *this;
+
+			resize_for_extra (length);
+			if constexpr (BoundsCheck) {
+				ensure_have_extra (length);
+			}
+
+			std::memcpy (buffer.get () + idx, s, length);
+			idx += length;
+			buffer.get ()[idx] = NUL;
+
+			return *this;
+		}
+
+		template<size_t Size>
+		force_inline string_base& append (const char (&s)[Size]) const noexcept
+		{
+			return append (s, Size);
+		}
+
+		force_inline string_base& append (const char *s) noexcept
+		{
+			if (s == nullptr)
+				return *this;
+
+			return append (s, strlen (s));
+		}
+
+		force_inline string_base& append (int16_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (buffer.get (), i);
+			return *this;
+		}
+
+		force_inline string_base& append (uint16_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (i);
+			return *this;
+		}
+
+		force_inline string_base& append (int32_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (i);
+			return *this;
+		}
+
+		force_inline string_base& append (uint32_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (i);
+			return *this;
+		}
+
+		force_inline string_base& append (int64_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (i);
+			return *this;
+		}
+
+		force_inline string_base& append (uint64_t i) noexcept
+		{
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			append_integer (i);
+			return *this;
+		}
+
+		force_inline string_base& assign (const TChar* s, size_t length) noexcept
+		{
+			idx = 0;
+			return append (s, length);
+		}
+
+		force_inline string_base& assign (const TChar* s) noexcept
+		{
+			if (s == nullptr)
+				return *this;
+
+			return assign (s, strlen (s));
+		}
+
+		template<size_t Size>
+		force_inline string_base& assign (const char (&s)[Size]) const noexcept
+		{
+			return assign (s, Size);
+		}
+
+		force_inline string_base& assign (const TChar* s, size_t offset, size_t count) noexcept
+		{
+			if (s == nullptr)
+				return *this;
+
+			if constexpr (BoundsCheck) {
+				size_t slen = strlen (s);
+				if (offset + count > slen) {
+					log_fatal (LOG_DEFAULT, "Attempt to assign data from a string exceeds the source string length");
+					exit (1);
+				}
+			}
+
+			return assign (s + offset, count);
+		}
+
+		force_inline bool next_token (size_t start_index, const TChar separator, string_segment& token) const noexcept
+		{
+			size_t index;
+			if (token._fresh) {
+				token._fresh = false;
+				token._last_index = start_index;
+				index = start_index;
+			} else {
+				index = token._last_index + 1;
+			}
+
+			token._start = nullptr;
+			token._length = 0;
+			if (token._last_index + 1 >= buffer.size ()) {
+				return false;
+			}
+
+			const TChar *start = buffer.get () + index;
+			const TChar *p = start;
+			while (*p != NUL) {
+				if (*p == separator) {
+					break;
+				}
+				p++;
+				index++;
+			}
+
+			token._last_index = *p == NUL ? buffer.size () : index;
+			token._start = start;
+			token._length = static_cast<size_t>(p - start);
+
+			return true;
+		}
+
+		force_inline bool next_token (const char separator, string_segment& token) const noexcept
+		{
+			return next_token (0, separator, token);
+		}
+
+		force_inline ssize_t index_of (const TChar ch) const noexcept
+		{
+			const TChar *p = buffer.get ();
+			while (p != nullptr && *p != NUL) {
+				if (*p == ch) {
+					return static_cast<ssize_t>(p - buffer.get ());
+				}
+				p++;
+			}
+
+			return -1;
+		}
+
+		force_inline bool starts_with (const TChar *s, size_t s_length) noexcept
+		{
+			if (s == nullptr || s_length == 0 || s_length > buffer.size ())
+				return false;
+
+			return memcmp (buffer.get (), s, s_length) == 0;
+		}
+
+		force_inline bool starts_with (const char* s) const noexcept
+		{
+			if (s == nullptr)
+				return false;
+
+			return starts_with (s, strlen (s));
+		}
+
+		force_inline void set_length_after_direct_write (size_t new_length) noexcept
+		{
+			set_length (new_length);
+			terminate ();
+		}
+
+		force_inline void set_at (size_t index, const TChar ch) noexcept
+		{
+			ensure_valid_index (index);
+			TChar *p = buffer + index;
+			if (*p == NUL) {
+				return;
+			}
+
+			*p = ch;
+		}
+
+		force_inline const TChar get_at (size_t index) const noexcept
+		{
+			ensure_valid_index (index);
+			return buffer.get () + index;
+		}
+
+		force_inline TChar& get_at (size_t index) noexcept
+		{
+			ensure_valid_index (index);
+			return *(buffer.get () + index);
+		}
+
+		force_inline const TChar* get () const noexcept
+		{
+			return buffer.get ();
+		}
+
+		force_inline TChar* get () noexcept
+		{
+			return buffer.get ();
+		}
+
+		force_inline size_t size () const noexcept
+		{
+			return buffer.size ();
+		}
+
+		char operator[] (size_t index) const noexcept
+		{
+			return get_at (index);
+		}
+
+		char& operator[] (size_t index) noexcept
+		{
+			return get_at (index);
+		}
+
+	protected:
+		template<typename Integer>
+		force_inline void append_integer (Integer i) noexcept
+		{
+			static_assert (std::is_integral_v<Integer>);
+
+			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			if constexpr (BoundsCheck) {
+				ensure_have_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			}
+
+			if (i == 0) {
+				constexpr char zero[] = "0";
+				constexpr size_t zero_len = sizeof(zero) - 1;
+
+				append (zero, zero_len);
+				return;
+			}
+
+			TChar temp_buf[MAX_INTEGER_DIGIT_COUNT_BASE10 + 1];
+			TChar *p = temp_buf + MAX_INTEGER_DIGIT_COUNT_BASE10;
+			*p = NUL;
+			TChar *end = p;
+
+			uint32_t x;
+			if constexpr (sizeof(Integer) > 4) {
+				uint64_t y;
+
+				if constexpr (std::is_signed_v<Integer>) {
+					y = static_cast<uint64_t>(i > 0 ? i : -i);
+				} else {
+					y = static_cast<uint64_t>(i);
+				}
+				while (y > std::numeric_limits<uint32_t>::max ()) {
+					*--p = (y % 10) + ZERO;
+					y /= 10;
+				}
+				x = static_cast<uint32_t>(y);
+			} else {
+				if constexpr (std::is_signed_v<Integer>) {
+					x = static_cast<uint32_t>(i > 0 ? i : -i);
+				} else {
+					x = static_cast<uint32_t>(i);
+				}
+			}
+
+			while (x > 0) {
+				*--p = (x % 10) + ZERO;
+				x /= 10;
+			}
+
+			if constexpr (std::is_signed_v<Integer>) {
+				if (i < 0)
+					*--p = '-';
+			}
+
+			append (p, static_cast<size_t>(end - p));
+		}
+
+		force_inline void ensure_valid_index (size_t access_index) const noexcept
+		{
+			if (XA_LIKELY (access_index < idx && access_index < buffer.size ())) {
+				return;
+			}
+
+			log_fatal (
+				LOG_DEFAULT,
+				"Index %u is out of range (0 - %u)",
+				access_index, idx
+			);
+			exit (1);
+		}
+
+		force_inline void ensure_have_extra (size_t length) noexcept
+		{
+			size_t needed_space = ADD_WITH_OVERFLOW_CHECK (size_t, length, idx + 1);
+			if (needed_space > buffer.size ()) {
+				log_fatal (
+					LOG_DEFAULT,
+					"Attempt to store too much data in a buffer (capacity: %u; exceeded by: %u)",
+					buffer.size (), (idx + length) - buffer.size ()
+				);
+				exit (1);
+			}
+		}
+
+		force_inline void resize_for_extra (size_t needed_space) noexcept
+		{
+			if constexpr (TStorage::has_resize) {
+				size_t required_space = ADD_WITH_OVERFLOW_CHECK (size_t, needed_space, idx + 1);
+				size_t current_size = buffer.size ();
+				if (required_space > current_size) {
+					size_t new_size = ADD_WITH_OVERFLOW_CHECK (size_t, current_size, (current_size / 2));
+					new_size = ADD_WITH_OVERFLOW_CHECK (size_t, new_size, required_space);
+					buffer.resize (new_size);
+				}
+			}
+		}
+
+	private:
+		size_t   idx;
+		TStorage buffer;
+	};
+
+	template<size_t MaxStackSize, typename TChar = char>
+	class static_local_string : public string_base<MaxStackSize, static_local_storage<MaxStackSize, TChar>, TChar>
+	{
+		using base = string_base<MaxStackSize, static_local_storage<MaxStackSize, TChar>, TChar>;
+
+	public:
+		explicit static_local_string (size_t initial_size) noexcept
+			: base (initial_size)
+		{}
+
+		explicit static_local_string (const string_segment &token) noexcept
+			: base (token)
+		{}
+	};
+
+	template<size_t MaxStackSize, typename TChar = char>
+	class dynamic_local_string : public string_base<MaxStackSize, dynamic_local_storage<MaxStackSize, TChar>, TChar>
+	{
+		using base = string_base<MaxStackSize, dynamic_local_storage<MaxStackSize, TChar>, TChar>;
+
+	public:
+		explicit dynamic_local_string (size_t initial_size = 0)
+			: base (initial_size)
+		{}
+
+		explicit dynamic_local_string (const string_segment &token) noexcept
+			: base (token)
+		{}
+	};
+}
+#endif // __STRINGS_HH


### PR DESCRIPTION
This commit introduces a couple of top-level classes to work with
strings allocated either on stack or from the heap, which are always
released when leaving the scope.  The classes allocate string buffer on
stack if the size doesn't exceed a certain maximum value (provided as a
template parameter) or, if the space needed is more than size of the
on-stack buffer, allocate memory from heap as necessary.  If we choose
the stack allocation size correctly, this has the advantage of being
very quick since no calls are necessary for (de)allocation of memory -
it's either part of the function prolog/epilog where appropriate stack
for local variables space is reserved, or part of a scope setup which
operation also isn't expensive.

Two introduced classes are `static_local_string` and
`dynamic_local_string`.  The former is useful in situations when we know
the string size beforehand and we know it will never exceed that size.
The class doesn't support resizing of the buffer.  The latter adds the
ability to extend the available space, possibly transfering data from
the stack to a dynamically allocated buffer.

Both classes derive from a single base class which can be configured to
use any kind of memory storage implementation, if it's needed in the
future.

= Performance changes (app Displayed Time)

Device:
  - Model: **Pixel 3 XL**
  - Native architecture: **arm64-v8a**
  - SDK version: **29**

== Release
Release performance borders on the statistical error, but it is still
slightly better (on slower devices it will be more pronounced):

| Before  | After   | Δ        | Notes                          |
| ------- | ------- | -------- | ------------------------------ |
| 859.000 | 862.800 | +0.44% ✗ | preload enabled; 32-bit build  |
| 853.400 | 851.800 | -0.19% ✓ | preload disabled; 32-bit build |
| 867.600 | 852.200 | -1.78% ✓ | preload enabled; 64-bit build  |
| 855.000 | 858.000 | +0.35% ✗ | preload disabled; 64-bit build |

== Debug
Debug performance has bigger gains because the runtime does much more
parsing and string processing than the Release one:

| Before   | After    | Δ        | Notes                          |
| -------- | -------- | -------- | ------------------------------ |
| 1124.700 | 1113.400 | -1.00% ✓ | preload enabled; 32-bit build  |
| 1120.500 | 1114.200 | -0.56% ✓ | preload disabled; 32-bit build |
| 1122.700 | 1123.000 | +0.03% ✗ | preload enabled; 64-bit build  |
| 1113.700 | 1112.100 | -0.14% ✓ | preload disabled; 64-bit build |
