### PR TITLE
[Xamarin.Android.Build.Tasks] <BuildApk/> should check compression

### DIFF
--- a/Documentation/release-notes/5001.md
+++ b/Documentation/release-notes/5001.md
@@ -1,0 +1,8 @@
+#### Application and library build and deployment
+
+* [Developer Community 1144021][0] and
+  [GitHub Issue 4990](https://github.com/xamarin/xamarin-android/issues/4990):
+  *ADB0010: [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]*
+  build error could prevent apps from being deployed after `AndroidManifest.xml` changes.
+
+[0]: https://developercommunity.visualstudio.com/content/problem/1144021/vs-1670-compile-and-archive-issues.html

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -129,13 +129,29 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public bool SkipExistingFile (string file, string fileInArchive)
+		public bool SkipExistingFile (string file, string fileInArchive, CompressionMethod compressionMethod)
 		{
 			if (!zip.ContainsEntry (fileInArchive)) {
 				return false;
 			}
-			var lastWrite = File.GetLastWriteTimeUtc (file);
 			var entry = zip.ReadEntry (fileInArchive);
+			switch (compressionMethod) {
+				case CompressionMethod.Unknown:
+					// If incoming value is Unknown, don't check anything
+					break;
+				case CompressionMethod.Default:
+					// For Default, existing entries could have CompressionMethod.Deflate
+					// Only compare against CompressionMethod.Store
+					if (entry.CompressionMethod == CompressionMethod.Store)
+						return false;
+					break;
+				default:
+					// Other values can just compare CompressionMethod
+					if (entry.CompressionMethod != compressionMethod)
+						return false;
+					break;
+			}
+			var lastWrite = File.GetLastWriteTimeUtc (file);
 			return WithoutMilliseconds (lastWrite) <= WithoutMilliseconds (entry.ModificationTime);
 		}
 


### PR DESCRIPTION
Fixes: https://feedback.devdiv.io/1144021
Fixes: https://github.com/xamarin/xamarin-android/issues/4990

If you deploy an app with `android:extractNativeLibs="true"` (most of
the time the default when omitted).

Then change it to `android:extractNativeLibs="false"` and deploy again
you get a deploy error:

    ADB0010: Mono.AndroidTools.InstallFailedException: Failure [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]

Looking at the resulting `.apk` file, the native libraries are
compressed when they shouldn't be. A `Rebuild` solves the issue.

In 1c4727cb, the changes to the `<BuildApk/>` for better incremental
build performance did not take into account what happens if the
compression mode changes for zip entries.

There are two cases:

1. We are copying entries produced by `aapt` from `packaged_resources`
   to the `.apk` file. This needs to check if the `CompressedSize`
   matches or not.
2. We are adding entries from disk. This needs to check the if
   `CompressionMode` matches in the existing entry.

The only hangup is usage of `CompressionMode.Default`, as it generates
entries with `CompressionMode.Deflate`. We can check against
`CompressionMode.Store` in this case.

I added tests around these scenarios.