### PR TITLE
[Xamarin.Android.Tools.Aidl] Fix `Map` marshaling

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -48,7 +48,7 @@
       </NUnitTarget>
     </ItemGroup>
     <Exec
-        Command="$(_NUnit) $(NUNIT_EXTRA) %(NUnitTarget.Identity) $(_Test) --labels=all --result=&quot;TestResult-%(NUnitTarget.TestFilename).xml;format=nunit2&quot; %(NUnitTarget.NUnitOutput)"
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(NUnitTarget.Identity) $(_Test) --labels=all --result=&quot;TestResult-%(NUnitTarget.TestFilename).xml&quot; %(NUnitTarget.NUnitOutput)"
         WorkingDirectory="$(_TopDir)"
         IgnoreStandardErrorWarningFormat="true"
         ContinueOnError="ErrorAndContinue"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AidlTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AidlTest.cs
@@ -25,6 +25,22 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void ListAndMap ()
+		{
+			string aidl = @"
+import android.os;
+import android.view;
+import android.animation;
+
+interface Test {
+	void arrayList(inout List list);
+	void map(inout Map m);
+}
+";
+			TestAidl ($"temp/AidlTest.{nameof (ListAndMap)}", aidl);
+		}
+
+		[Test]
 		public void NamespaceResolution ()
 		{
 			string aidl = @"

--- a/src/Xamarin.Android.Tools.Aidl/CSharpCodeGenerator.cs
+++ b/src/Xamarin.Android.Tools.Aidl/CSharpCodeGenerator.cs
@@ -452,7 +452,7 @@ namespace Xamarin.Android.Tools.Aidl
 				return String.Format ("{0} = (global::Android.Runtime.JavaList) {1}.ReadArrayList ((global::Java.Lang.ClassLoader) null);", arg, parcel);
 			case "Map":
 			case "Android.Runtime.JavaDictionary":
-				return String.Format ("{0} = {1}.ReadHashMap ();", arg, parcel);
+				return String.Format ("{0} = (global::Android.Runtime.JavaDictionary) {1}.ReadHashMap ((global::Java.Lang.ClassLoader) null);", arg, parcel);
 			case "Android.OS.IParcelable":
 				return String.Format ("{0} = {1}.ReadInt () != 0 ? ({2}) global::Android.OS.Bundle.Creator.CreateFromParcel ({1}) : null;", arg, parcel, ToOutputTypeName (csname));
 			case "Android.OS.IBinder":
@@ -513,10 +513,10 @@ namespace Xamarin.Android.Tools.Aidl
 						return String.Format ("{1}.ReadTypedList ({0}, {2}.Creator);", arg, parcel, ToOutputTypeName (name_cache.ToCSharp (type.GenericArguments [0])));
 					}
 				}
-				return String.Format ("{0} = {1}.ReadList ();", arg, parcel);
+				return String.Format ("{1}.ReadList ({0}, (global::Java.Lang.ClassLoader) null);", arg, parcel);
 			case "Map":
 			case "Android.Runtime.JavaDictionary":
-				return String.Format ("{0} = {1}.ReadMap ();", arg, parcel);
+				return String.Format ("{1}.ReadMap ({0}, (global::Java.Lang.ClassLoader) null);", arg, parcel);
 			case "Android.OS.IBinder":
 				return String.Format ("{0} = {1}.ReadStrongBinder ();", arg, parcel);
 			case "Android.OS.IBinder []":


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1597

`Xamarin.Android.Tools.Aidl.CSharpCodeGenerator` didn't properly
support unmarshaling the `Map` type, e.g. given a `Test.aidl` file
with the Build action `@(AndroidInterfaceDescription)`:

	import java.util;

	interface Test {
	    void arrayList(inout List list);
	    void map(inout Map m);
	}

the build would fail with:

	obj/Debug/aidl/Test.cs(57,17): error CS7036: There is no argument given that corresponds to the required formal parameter 'loader' of 'Parcel.ReadHashMap(ClassLoader)'
	obj/Debug/aidl/Test.cs(98,21): error CS7036: There is no argument given that corresponds to the required formal parameter 'outVal' of 'Parcel.ReadList(IList, ClassLoader)'
	obj/Debug/aidl/Test.cs(118,18): error CS7036: There is no argument given that corresponds to the required formal parameter 'outVal' of 'Parcel.ReadMap(IDictionary, ClassLoader)'

in which the lines 56-57 are:

	Android.Runtime.JavaDictionary arg0 = default (Android.Runtime.JavaDictionary);
	arg0 = data.ReadHashMap ();	// error CS7036

Lines 94-98 are:

	__data.WriteInterfaceToken (descriptor);
	__data.WriteList (list);
	remote.Transact (ITestStub.TransactionArrayList, __data, __reply, 0);
	__reply.ReadException ();
	list = __reply.ReadList ();	// error CS7036

Lines 114-118 are:

	__data.WriteInterfaceToken (descriptor);
	__data.WriteMap (m);
	remote.Transact (ITestStub.TransactionMap, __data, __reply, 0);
	__reply.ReadException ();
	m = __reply.ReadMap (); 	// error CS7036

Fix `Map` marshaling and update `List` marshaling for `inout` and `out`
parameters, so that `data.ReadHashMap()` appropriately passes `null`
for the `ClassLoader` parameter:

	arg0 = (global::Android.Runtime.JavaDictionary) data.ReadHashMap ((global::Java.Lang.ClassLoader) null);

and `inout`/`out` parameters use the appropriate `Parcel.Read*()`
methods:

	__reply.ReadList (list, (global::Java.Lang.ClassLoader) null);
	__reply.ReadMap (m, (global::Java.Lang.ClassLoader) null);

Note: to run the unit test fixture for *just* the AIDL tests, use:

	msbuild Xamarin.Android.sln /t:RunNUnitTests /p:Test=Xamarin.Android.Build.Tests.AidlTest

The `RunNUnitTests` target has been updated so that it works as intended.