### PR TITLE
[tests] fix Aapt2DaemonInstances on 4 core machines

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -23,6 +23,9 @@ namespace Xamarin.Android.Tasks {
 
 		private static readonly int DefaultMaxAapt2Daemons = 6;
 		protected Dictionary<string, string> resource_name_case_map;
+
+		protected virtual int ProcessorCount => Environment.ProcessorCount;
+
 		public int DaemonMaxInstanceCount { get; set; }
 
 		public bool DaemonKeepInDomain { get; set; }
@@ -67,7 +70,7 @@ namespace Xamarin.Android.Tasks {
 			// Must register on the UI thread!
 			// We don't want to use up ALL the available cores especially when 
 			// running in the IDE. So lets cap it at DefaultMaxAapt2Daemons (6).
-			int maxInstances = Math.Min (Environment.ProcessorCount-1, DefaultMaxAapt2Daemons);
+			int maxInstances = Math.Min (ProcessorCount - 1, DefaultMaxAapt2Daemons);
 			if (DaemonMaxInstanceCount == 0)
 				DaemonMaxInstanceCount = maxInstances;
 			else

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Android.Build.Tests
 			files.Add (CreateTaskItemForResourceFile (resPath, "values", "strings.xml"));
 			for (int i = 0; i < numLayouts; i++)
 				files.Add (CreateTaskItemForResourceFile (resPath, "layout", $"main{i}.xml"));
-			var task = new Aapt2Compile {
+			var task = new Aapt2CompileWithProcessorCount (processorCount: 8) {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
 				ResourcesToCompile = files.ToArray (),
@@ -109,6 +109,13 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (expectedMax, daemon.MaxInstances, $"Expected {expectedMax} but was {daemon.MaxInstances}");
 			Assert.AreEqual (expectedInstances, daemon.CurrentInstances, $"Expected {expectedInstances} but was {daemon.CurrentInstances}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		class Aapt2CompileWithProcessorCount : Aapt2Compile
+		{
+			protected override int ProcessorCount { get; }
+
+			public Aapt2CompileWithProcessorCount (int processorCount) => ProcessorCount = processorCount;
 		}
 
 		[Test]


### PR DESCRIPTION
Context: https://build.azdo.io/3974634

Several of the `Aapt2DaemonInstances` tests can fail with:

    Expected 6 but was 3
    Expected: 6
    But was:  3

It seems like this is happening randomly, and we think the reason is
that some macOS CI machines only have 4 processors/cores.

To solve this:

* I moved the `Environment.ProcessorCount` call to a `virtual`
  property.
* The test overrides the value to 8, so the test will pass on any
  machine.

I verified that if you change the value to 4, the test fails in the
same way we are seeing on CI.