### PR TITLE
[Microsoft.Android.Sdk] use net5.0-android $(TargetFramework)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ logcat-*.txt
 apk-sizes-*.txt
 *.rawproto
 *.binlog
-src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
-src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BundledVersions.props
+*.ProjectImports.zip
 *~
 external/monodroid/
 external/mono/

--- a/Configuration.props
+++ b/Configuration.props
@@ -20,6 +20,8 @@
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/api-xml-adjuster/Makefile` -->
     <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v4.4</AndroidFirstFrameworkVersion>
     <AndroidFirstApiLevel Condition="'$(AndroidFirstApiLevel)' == ''">19</AndroidFirstApiLevel>
+    <!-- The min API level supported by Microsoft.Android.Sdk, should refactor/remove when this value is the same as $(AndroidFirstApiLevel) -->
+    <AndroidMinimumDotNetApiLevel Condition="'$(AndroidMinimumDotNetApiLevel)' == ''">21</AndroidMinimumDotNetApiLevel>
     <AndroidFirstPlatformId Condition="'$(AndroidFirstPlatformId)' == ''">$(AndroidFirstApiLevel)</AndroidFirstPlatformId>
     <_IsRunningNuGetRestore Condition="$(RestoreTaskAssemblyFile.EndsWith('NuGet.exe', StringComparison.InvariantCultureIgnoreCase))">True</_IsRunningNuGetRestore>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->

--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -206,7 +206,7 @@ The following instructions can be used for early preview testing.
 ```xml
 <Project Sdk="Microsoft.Android.Sdk/10.0.100">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-android</TargetFramework>
     <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
@@ -1,0 +1,83 @@
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	/// <summary>
+	/// Generates Microsoft.Android.Sdk.SupportedPlatforms.props
+	/// Similar to: https://github.com/dotnet/sdk/blob/18ee4eac8b3abe6d554d2e0c39d8952da0f23ce5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSupportedTargetPlatforms.props
+	/// </summary>
+	public class GenerateSupportedPlatforms : Task
+	{
+		/// <summary>
+		/// A list of AndroidApiInfo.xml files produced by Mono.Android.targets
+		/// </summary>
+		[Required]
+		public string [] AndroidApiInfo { get; set; }
+
+		/// <summary>
+		/// The output file to generate
+		/// </summary>
+		[Required]
+		public string OutputFile { get; set; }
+
+		/// <summary>
+		/// $(AndroidMinimumDotNetApiLevel) from Configuration.props
+		/// </summary>
+		[Required]
+		public int MinimumApiLevel { get; set; }
+
+		public override bool Execute ()
+		{
+			if (AndroidApiInfo.Length == 0) {
+				Log.LogError ("This task requires at least one AndroidApiInfo.xml file!");
+				return false;
+			}
+
+			var versions = new AndroidVersions (
+				AndroidApiInfo.Select (d => Path.GetDirectoryName (d)));
+			var settings = new XmlWriterSettings {
+				OmitXmlDeclaration = true,
+				Indent = true,
+			};
+			using (var writer = XmlWriter.Create (OutputFile, settings)) {
+
+				writer.WriteComment ($@"
+***********************************************************************************************
+{Path.GetFileName (OutputFile)}
+
+Specifies the supported Android platform versions for this SDK.
+
+***********************************************************************************************
+");
+				writer.WriteStartElement ("Project");
+
+				writer.WriteStartElement ("PropertyGroup");
+				writer.WriteStartElement ("TargetPlatformVersion");
+				writer.WriteAttributeString ("Condition", " '$(TargetPlatformVersion)' == '' ");
+				writer.WriteString (versions.MaxStableVersion.ApiLevel.ToString ());
+				writer.WriteEndElement (); // </TargetPlatformVersion>
+				writer.WriteEndElement (); // </PropertyGroup>
+
+				writer.WriteStartElement ("ItemGroup");
+				foreach (AndroidVersion version in versions.InstalledBindingVersions
+						.Where (v => v.ApiLevel >= MinimumApiLevel)
+						.OrderBy (v => v.ApiLevel)) {
+					writer.WriteStartElement ("AndroidSdkSupportedTargetPlatform");
+					writer.WriteAttributeString ("Include", version.ApiLevel.ToString ());
+					writer.WriteEndElement (); // </AndroidSdkSupportedTargetPlatform>
+				}
+				writer.WriteStartElement ("SdkSupportedTargetPlatform");
+				writer.WriteAttributeString ("Condition", " '$(TargetPlatformIdentifier)' == 'Android' ");
+				writer.WriteAttributeString ("Include", "@(AndroidSdkSupportedTargetPlatform)");
+
+				writer.WriteEndDocument (); // </Project>
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -27,7 +27,7 @@ variables:
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3
+  DotNetCorePreviewVersion: 5.0.100-rc.2.20459.1
 
 stages:
 - stage: mac_stage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -52,7 +52,7 @@ variables:
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-preview.7.20307.3
+  DotNetCorePreviewVersion: 5.0.100-rc.2.20459.1
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019

--- a/src/Xamarin.Android.Build.Tasks/.gitignore
+++ b/src/Xamarin.Android.Build.Tasks/.gitignore
@@ -1,2 +1,4 @@
+/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BundledVersions.props
+/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.SupportedPlatforms.props
 /Xamarin.Android.Common.props
 /Xamarin.Android.BuildInfo.txt

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -19,9 +19,13 @@
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <PropertyGroup>
+    <TargetPlatformSupported Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">true</TargetPlatformSupported>
+  </PropertyGroup>
 
   <!-- Default item includes (globs and implicit references) -->
   <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
+  <Import Project="Microsoft.Android.Sdk.SupportedPlatforms.props" />
   <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -73,7 +73,7 @@ $@"{{
 		public XASdkProject (string outputType = "Exe")
 		{
 			Sdk = $"Microsoft.Android.Sdk/{SdkVersion}";
-			TargetFramework = "net5.0";
+			TargetFramework = "net5.0-android";
 
 			TargetSdkVersion = AndroidSdkResolver.GetMaxInstalledPlatform ().ToString ();
 			PackageName = PackageName ?? string.Format ("{0}.{0}", ProjectName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -26,7 +26,7 @@ namespace Xamarin.ProjectTools
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
 
 			if (Builder.UseDotNet) {
-				SetProperty ("TargetFramework", "net5.0");
+				SetProperty ("TargetFramework", "net5.0-android");
 				SetProperty ("EnableDefaultItems", "false");
 				SetProperty ("AppendTargetFrameworkToOutputPath", "false");
 				SetProperty ("AppendRuntimeIdentifierToOutputPath", "false");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateProfile" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateSupportedPlatforms" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)"      TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)"      TaskName="Xamarin.Android.BuildTools.PrepTasks.Which" />
@@ -10,6 +11,10 @@
   <PropertyGroup>
     <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
     <_GeneratedProfileClass>$(MSBuildThisFileDirectory)$(IntermediateOutputPath)Profile.g.cs</_GeneratedProfileClass>
+    <ResolveReferencesDependsOn>
+      $(ResolveReferencesDependsOn);
+      _GenerateSupportedPlatforms;
+    </ResolveReferencesDependsOn>
     <BuildDependsOn>
       _CopyNDKTools;
       _GenerateXACommonProps;
@@ -265,6 +270,21 @@
         DestinationFile="Xamarin.Android.Common.props"
         Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@NDK_ARMEABI_V7_API@=$(AndroidNdkApiLevel_ArmV7a);@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a);@NDK_X86_API@=$(AndroidNdkApiLevel_X86);@NDK_X86_64_API@=$(AndroidNdkApiLevel_X86_64);@BUNDLETOOL_VERSION@=$(XABundleToolVersion)">
     </ReplaceFileContents>
+  </Target>
+  <Target Name="_FindAndroidApiInfo">
+    <ItemGroup>
+      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\*\AndroidApiInfo.xml" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_GenerateSupportedPlatforms"
+      DependsOnTargets="_FindAndroidApiInfo"
+      Inputs="$(BootstrapTasksAssembly);$(MSBuildThisFile);@(_AndroidApiInfo)"
+      Outputs="Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.SupportedPlatforms.props">
+    <GenerateSupportedPlatforms
+        AndroidApiInfo="@(_AndroidApiInfo)"
+        MinimumApiLevel="$(AndroidMinimumDotNetApiLevel)"
+        OutputFile="Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.SupportedPlatforms.props"
+    />
   </Target>
   <Target Name="_GenerateProfileClass"
       BeforeTargets="CoreCompile"

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTestsDotNet.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTestsDotNet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-android</TargetFramework>
     <RootNamespace>Xamarin.Android.Tests.CodeBehindBuildTests</RootNamespace>
     <OutputType>Exe</OutputType>
     <AndroidGenerateLayoutBindings>True</AndroidGenerateLayoutBindings>

--- a/tests/CodeBehind/CommonSampleLibrary/CommonSampleLibraryDotNet.csproj
+++ b/tests/CodeBehind/CommonSampleLibrary/CommonSampleLibraryDotNet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Android.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-android</TargetFramework>
     <RootNamespace>CommonSampleLibrary</RootNamespace>
     <AssemblyName>CommonSampleLibrary</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
After bumping to .NET 5.0.100-rc.2.20458.11, we can now use:

    <TargetFramework>net5.0-android</TargetFramework>

On the first try, this failed with:

    error NETSDK1139: The target platform identifier android was not recognized.

Our SDK needs to specify:

    <TargetPlatformSupported Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">true</TargetPlatformSupported>

After doing this, everything seemed to work as before.

I updated tests so they will use `net5.0-android` going forward.

## @(SdkSupportedTargetPlatform) ##

A second part of this change is the need to fill out
`$(TargetPlatformVersion)`, `@(AndroidSdkSupportedTargetPlatform)`,
and `@(SdkSupportedTargetPlatform)` similar to:

https://github.com/dotnet/sdk/blob/c43785736edc8d4bc927df3b557c1609d028cd93/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.WindowsSdkSupportedTargetPlatforms.props

Using this data, the dotnet/sdk will run the
`GenerateTargetPlatformDefineConstants` MSBuild target:

https://github.com/dotnet/sdk/blob/a0e17b2b5d2ec75c16e1083b1f926a258126c73a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L188-L198

This fills out `$(DefineConstants)` with `ANDROID;ANDROID21;...;ANDROID30`.