### PR TITLE
[Microsoft.Cpp.Android] fix for app bundles and C++ projects

### DIFF
--- a/Documentation/release-notes/cpp-aab.md
+++ b/Documentation/release-notes/cpp-aab.md
@@ -1,0 +1,6 @@
+#### C++ projects
+
+* [GitHub Issue 4998](https://github.com/xamarin/xamarin-android/issues/4998):
+  *Files under lib/ must have .so extension, found 'lib/x86/gdbserver'.* build error
+  prevented building app bundles for projects with references to Android C++ library
+  projects.

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Microsoft.Cpp.Android.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Microsoft.Cpp.Android.targets
@@ -70,7 +70,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
         
         <ItemGroup Condition="'@(NativeLibraryPaths)' != ''">
             <AndroidNativeLibrary Include="@(NativeLibraryPaths)"
-                                  Condition="'%(Extension)' == '.so' Or '%(FileName)' == 'gdbserver'">
+                                  Condition="'%(Extension)' == '.so' Or ('$(AndroidIncludeDebugSymbols)' == 'true' And '$(AndroidPackageFormat)' != 'aab' And '%(FileName)' == 'gdbserver')">
                 <Abi>$(NativeLibraryAbi)</Abi>
             </AndroidNativeLibrary>
             <Content Include="@(NativeLibraryPaths)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4998
Context: https://github.com/luminixinc/XamarinAndroidNativeDebugTest

The above C++ project fails to build when using
`$(AndroidPackageFormat)` = `aab` with:

    Files under lib/ must have .so extension, found 'lib/x86/gdbserver'.

Reviewing `Microsoft.Cpp.Android.targets`, it adds `gdbserver` to the
`@(AndroidNativeLibrary)` item group.

`bundletool` fails on any non-`.so` files added to the `lib` directory:

https://github.com/google/bundletool/blob/ae0fc0162fd80d92ef8f4ef4527c066f0106942f/src/main/java/com/android/tools/build/bundletool/validation/BundleFilesValidator.java#L97-L103

This should probably only be done for debug builds. We should only
include this file when `$(AndroidIncludeDebugSymbols)` is `true`
and `$(AndroidPackageFormat)` is not `aab`.