### PR TITLE
[Xamarin.Android.Build.Tasks] localization for _CheckNonIdealConfigurations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -349,6 +349,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations..
+        /// </summary>
+        internal static string XA0119_AOT {
+            get {
+                return ResourceManager.GetString("XA0119_AOT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations..
+        /// </summary>
+        internal static string XA0119_LinkMode {
+            get {
+                return ResourceManager.GetString("XA0119_LinkMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations..
+        /// </summary>
+        internal static string XA0119_LinkTool {
+            get {
+                return ResourceManager.GetString("XA0119_LinkTool", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Assembly &apos;{0}&apos; is using &apos;[assembly: {1}]&apos;, which is no longer supported. Use a newer version of this NuGet package or notify the library author..
         /// </summary>
         internal static string XA0121 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -269,6 +269,18 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</value>
     <comment>The following are literal names and should not be translated: Android App Bundles</comment>
   </data>
+  <data name="XA0119_AOT" xml:space="preserve">
+    <value>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: AOT, Debug, Release.</comment>
+  </data>
+  <data name="XA0119_LinkMode" xml:space="preserve">
+    <value>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: Debug, Release.</comment>
+  </data>
+  <data name="XA0119_LinkTool" xml:space="preserve">
+    <value>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: Debug, Release.</comment>
+  </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Sestavení {0} používá atribut [assembly: {1}], který se už nepodporuje. Použijte novější verzi tohoto balíčku NuGet, nebo to oznamte autorovi knihovny.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Die Assembly "{0}" verwendet das Attribut "[assembly: {1}]", dieses wird nicht mehr unterstützt. Verwenden Sie eine neuere Version dieses NuGet-Pakets, oder benachrichtigen Sie den Bibliotheksautor.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">El ensamblado "{0}" usa "[assembly: {1}]", que ya no se admite. Utilice una versión más reciente de este paquete NuGet o informe al autor de la biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' utilise '[assembly : {1}]', qui n'est plus pris en charge. Utilisez une version plus récente de ce package NuGet ou notifiez l'auteur de la bibliothèque.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' usa '[assembly: {1}]', che non è più supportato. Usare una versione più recente di questo pacchetto NuGet o inviare una notifica all'autore della libreria.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">アセンブリ '{0}' は、今はサポートされていない '[assembly: {1}]' を使用しています。この NuGet パッケージの新しいバージョンを使用するか、ライブラリの作成者に連絡してください。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' 어셈블리가 더 이상 지원되지 않는 '[assembly: {1}]'을(를) 사용하고 있습니다. 이 NuGet 패키지의 최신 버전을 사용하거나 라이브러리 작성자에게 알리세요.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Zestaw „{0}” korzysta z atrybutu „[assembly: {1}]”, który nie jest już obsługiwany. Użyj nowszej wersji tego pakietu NuGet lub powiadom autora biblioteki.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">O assembly '{0}' está usando '[assembly: {1}]', que não tem mais suporte. Use uma versão mais recente deste pacote NuGet ou notifique o autor da biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Сборка "{0}" использует "[assembly: {1}]", которая больше не поддерживается. Используйте более новую версию этого пакета NuGet или уведомите автора библиотеки.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' bütünleştirilmiş kodu artık desteklenmeyen '[assembly: {1}]' kullanıyor. Bu NuGet paketinin daha yeni bir sürümünü kullanın veya bu durumu kitaplık yazarına bildirin.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">程序集“{0}”使用不再受支持的“[assembly: {1}]”。请使用此 NuGet 包的较新版本或通知库作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">組件 '{0}' 正在使用不再受到支援的 '[assembly: {1}]'。請使用此 NuGet 套件的較新版本，或通知程式庫作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -439,16 +439,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations">
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and AOT at the same time is not recommended. Use Fast Deployment for Debug configurations and AOT for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_AOT"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True' "
   />
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and the Linker at the same time is not recommended. Use Fast Deployment for Debug configurations and the Linker for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_LinkMode"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkMode)' != 'None' "
   />
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and a Code Shrinker at the same time is not recommended. Use Fast Deployment for Debug configurations and a Code Shrinker for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_LinkTool"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkTool)' != '' "
   />
   <AndroidError Code="XA0119"


### PR DESCRIPTION
Some of the warning messages in the `_CheckNonIdealConfigurations`
MSBuild target were written before we had localization support in
Xamarin.Android.Build.Tasks.

This brings the messages over to `Resources.resx`, so we can get them
localized.