### PR TITLE
[ci] Use main branch of yaml-templates

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/master
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
     type: github


### PR DESCRIPTION
The default yaml-templates branch is now `main`, we should track this
going forward.