### PR TITLE
[xaprepare] add retry logic for downloading files

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/DownloadStatus.cs
+++ b/build-tools/xaprepare/xaprepare/Application/DownloadStatus.cs
@@ -32,10 +32,7 @@ namespace Xamarin.Android.Prepare
 			updater = updaterCallback;
 		}
 
-		public void Start ()
-		{
-			watch.Start ();
-		}
+		public void Start () => watch.Restart ();
 
 		public void Update (ulong bytesRead)
 		{


### PR DESCRIPTION
Context: https://build.azdo.io/3979030

Sometimes I've seen random network failures on CI such as:

    Download progress: 80.87% (2.29 GB at 1.91 GB/s)
    Download progress: 80.87% (2.29 GB at 16 KB/s)
    Step Xamarin.Android.Prepare.Step_Android_SDK_NDK failed: Failed to download https://dl.google.com/android/repository/android-2.3.3_r02.zip: Remote prematurely closed connection.
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_Android_SDK_NDK failed: Failed to download https://dl.google.com/android/repository/android-2.3.3_r02.zip: Remote prematurely closed connection. ---> System.InvalidOperationException: Failed to download
        at Mono.Net.Security.AsyncProtocolRequest.ProcessOperation (System.Threading.CancellationToken cancellationToken) [0x000e3] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
        at Mono.Net.Security.AsyncProtocolRequest.StartOperation (System.Threading.CancellationToken cancellationToken) [0x0008b] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
        at Mono.Net.Security.MobileAuthenticatedStream.StartOperation (Mono.Net.Security.MobileAuthenticatedStream+OperationType type, Mono.Net.Security.AsyncProtocolRequest asyncRequest, System.Threading.CancellationToken cancellationToken) [0x0024b] in <25c939f74d6540b5ab92a1c4b8117ce9>:0
        at System.Net.Http.HttpConnection.ReadAsync (System.Memory`1[T] destination) [0x000f0] in <e2e2419f6ef64d67b19d45b8a4ed7ab6>:0
        at System.Net.Http.HttpConnection+ContentLengthReadStream.ReadAsync (System.Memory`1[T] buffer, System.Threading.CancellationToken cancellationToken) [0x00109] in <e2e2419f6ef64d67b19d45b8a4ed7ab6>:0
        at System.Net.Http.HttpConnection+HttpContentReadStream.Read (System.Byte[] buffer, System.Int32 offset, System.Int32 count) [0x00024] in <e2e2419f6ef64d67b19d45b8a4ed7ab6>:0
        at Xamarin.Android.Prepare.Utilities.DoDownload (System.IO.FileStream fs, System.IO.Stream webStream, Xamarin.Android.Prepare.DownloadStatus status) [0x0003a] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.Utilities.Download (System.Uri url, System.String targetFile, Xamarin.Android.Prepare.DownloadStatus status) [0x00243] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.StepWithDownloadProgress.Download (Xamarin.Android.Prepare.Context context, System.Uri url, System.String destinationFilePath, System.String descriptiveName, System.String fileName, Xamarin.Android.Prepare.DownloadStatus downloadStatus) [0x000f2] in <d82a2cecb8f042159be4226f7f31f532>:0
        --- End of inner exception stack trace ---
        at Xamarin.Android.Prepare.StepWithDownloadProgress.Download (Xamarin.Android.Prepare.Context context, System.Uri url, System.String destinationFilePath, System.String descriptiveName, System.String fileName, Xamarin.Android.Prepare.DownloadStatus downloadStatus) [0x00181] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.Step_Android_SDK_NDK.Execute (Xamarin.Android.Prepare.Context context) [0x0052a] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.Step.Run (Xamarin.Android.Prepare.Context context) [0x00079] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.Scenario.Run (Xamarin.Android.Prepare.Context context, Xamarin.Android.Prepare.Log log) [0x000e7] in <d82a2cecb8f042159be4226f7f31f532>:0
        --- End of inner exception stack trace ---
        at Xamarin.Android.Prepare.Scenario.Run (Xamarin.Android.Prepare.Context context, Xamarin.Android.Prepare.Log log) [0x0014b] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.Context.Execute () [0x000ee] in <d82a2cecb8f042159be4226f7f31f532>:0
        at Xamarin.Android.Prepare.App.Run (System.String[] args) [0x00802] in <d82a2cecb8f042159be4226f7f31f532>:0

I think adding some simple retry logic would avoid us having to
restart as many builds.

I made the `Utilities.Download` method retry 5 times, with a 1 second
delay between failures.

For the timing on retries to work, I also needed to make
`DownloadStatus.Start()` call `Stopwatch.Restart()`.