### PR TITLE
Fix nullable annotation on JavaCast

### DIFF
--- a/src/Mono.Android/Android.Runtime/Extensions.cs
+++ b/src/Mono.Android/Android.Runtime/Extensions.cs
@@ -6,7 +6,7 @@ namespace Android.Runtime {
 
 	public static class Extensions {
 
-		[return: NotNullIfNotNull("instance")]
+		[return: NotNullIfNotNull ("instance")]
 		public static TResult? JavaCast<TResult> (this IJavaObject? instance)
 			where TResult : class, IJavaObject
 		{

--- a/src/Mono.Android/Android.Runtime/Extensions.cs
+++ b/src/Mono.Android/Android.Runtime/Extensions.cs
@@ -6,8 +6,8 @@ namespace Android.Runtime {
 
 	public static class Extensions {
 
-		[return: MaybeNull]
-		public static TResult JavaCast<TResult> (this IJavaObject? instance)
+		[return: NotNullIfNotNull("instance")]
+		public static TResult? JavaCast<TResult> (this IJavaObject? instance)
 			where TResult : class, IJavaObject
 		{
 			return Java.Interop.JavaObjectExtensions.JavaCast<TResult>(instance);

--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -45,8 +45,8 @@ namespace Java.Interop {
 			return instance is JavaDictionary<K,V> ? (JavaDictionary<K,V>) instance : new JavaDictionary<K,V> (instance);
 		}
 
-		[return: MaybeNull]
-		public static TResult JavaCast<TResult> (this IJavaObject? instance)
+		[return: NotNullIfNotNull ("instance")]
+		public static TResult? JavaCast<TResult> (this IJavaObject? instance)
 			where TResult : class, IJavaObject
 		{
 			return _JavaCast<TResult> (instance);
@@ -60,6 +60,9 @@ namespace Java.Interop {
 
 			if (instance is TResult)
 				return (TResult) instance;
+
+			if (instance.Handle == IntPtr.Zero)
+				throw new ObjectDisposedException (instance.GetType ().FullName);
 
 			Type resultType = typeof (TResult);
 			if (resultType.IsClass) {


### PR DESCRIPTION
Assuming `JavaCast<TResult>` never returns null except when its input is null, this annotation conveys the idea so C# realizes that given a non-null input, a non-null output will come out, thereby avoiding compiler warnings in calling code caused by the addition of the less precise nullable annotations added earlier.