### PR TITLE
[Xamarin.Android.Build.Task] emit android:extractNativeLibs="true" by default

### DIFF
--- a/Documentation/release-notes/extractNativeLibs.md
+++ b/Documentation/release-notes/extractNativeLibs.md
@@ -1,0 +1,35 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 4986](https://github.com/xamarin/xamarin-android/issues/4986):
+  Updates to Android tooling (`manifest-merger`), caused
+  `//application/@android:extractNativeLibs` to be set to `false` by
+  default. This can cause an undesirable `.apk` file size increase
+  that is more noticeable for Xamarin.Android applications using AOT.
+  Xamarin.Android now sets `extractNativeLibs` to `true` by default.
+
+According to the [Android documentation][extractNativeLibs],
+`extractNativeLibs` affects `.apk` size and install size:
+
+> Whether or not the package installer extracts native libraries from
+> the APK to the filesystem. If set to false, then your native
+> libraries must be page aligned and stored uncompressed in the APK.
+> No code changes are required as the linker loads the libraries
+> directly from the APK at runtime. The default value is "true".
+
+This is a tradeoff that each developer should decide upon on a
+per-application basis. Is a smaller install size at the cost of a
+larger download size preferred?
+
+Since Xamarin.Android now emits `android:extractNativeLibs="true"` by
+default, you can get the opposite behavior with an
+`AndroidManifest.xml` such as:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.hello">
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+    <application android:label="Hello" android:extractNativeLibs="false" />
+</manifest>
+```
+
+[extractNativeLibs]: https://developer.android.com/guide/topics/manifest/application-element

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Xml.Linq;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 
@@ -476,6 +477,23 @@ namespace Xamarin.Android.Build.Tests
 				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
 			}
 			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
+		}
+
+		/// <summary>
+		/// Asserts that a AndroidManifest.xml file contains the expected //application/@android:extractNativeLibs value.
+		/// </summary>
+		protected void AssertExtractNativeLibs (string manifest, bool extractNativeLibs)
+		{
+			FileAssert.Exists (manifest);
+			using (var stream = File.OpenRead (manifest)) {
+				var doc = XDocument.Load (stream);
+				var element = doc.Root.Element ("application");
+				Assert.IsNotNull (element, $"application element not found in {manifest}");
+				var ns = (XNamespace) "http://schemas.android.com/apk/res/android";
+				var attribute = element.Attribute (ns + "extractNativeLibs");
+				Assert.IsNotNull (attribute, $"android:extractNativeLibs attribute not found in {manifest}");
+				Assert.AreEqual (extractNativeLibs ? "true" : "false", attribute.Value, $"Unexpected android:extractNativeLibs value found in {manifest}");
+			}
 		}
 
 		[SetUp]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -248,6 +248,8 @@ namespace Xamarin.Android.Tasks {
 
 			if (app.Attribute (androidNs + "label") == null && applicationName != null)
 				app.SetAttributeValue (androidNs + "label", applicationName);
+			if (app.Attribute (androidNs + "extractNativeLibs") == null)
+				app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
 
 			var existingTypes = new HashSet<string> (
 				app.Descendants ().Select (a => (string) a.Attribute (attName)).Where (v => v != null));

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -46,8 +46,10 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs}\" ");
+				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs.ToString ().ToLowerInvariant ()}\" ");
 				Assert.True (b.Install (proj), "Project should have installed.");
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				AssertExtractNativeLibs (manifest, extractNativeLibs);
 				ClearAdbLogcat ();
 				if (CommercialBuildAvailable)
 					Assert.True (b.RunTarget (proj, "_Run"), "Project should have run.");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4986
Context: https://github.com/xamarin/xamarin-android/commit/86737ca159d851f2743c01ffdf66428df07082b5
Context: https://android.googlesource.com/platform/tools/base/+/fd2ac00ab76dfdececce5a25cb7ad23b2b6f5d29%5E%21

When we bumped `manifest-merger` from 26.5.0 to 27.0.0, it started
emitting this in `AndroidManifest.xml` when `minSdkVersion` is 23 or
higher:

    <application android:extractNativeLibs="false">

When *omitted* this value defaults to `true`, meaning that native
libraries are compressed in `.apk` files and extracted to disk on
installation.

When `extractNativeLibs` is `false`, native libraries are
*uncompressed* in `.apk` files and loaded directly from the `.apk`.
This saves on install size at the cost of larger `.apk` size. This
behavior is only supported on API 23 devices and higher.

The Android docs say:

> The default value is "true". However, when building your app using
> Android Gradle plugin 3.6.0 or higher, this property is set to
> "false" by default.

Ignoring the related bugs caused by this behavior:

* https://github.com/xamarin/xamarin-android/commit/bf657e815b200e57098725c0ad963d70e881ea69
* https://github.com/xamarin/xamarin-android/commit/8828fef1331490352da15f1f43d7f4e3d7ccf220

The new `manifest-merger` will implicitly make `.apk` files larger. In
the case of a customer using AOT, an app grew from 24MB to 60MB!

To solve this:

* If not specified in apps' `Properties\AndroidManifest.xml`, we will
  emit `android:extractNativeLibs="true"` by default.

This way Xamarin.Android applications will have consistent behavior.
Developers can set `extractNativeLibs="false"` if they prefer that
behavior.

This behavior also works fine on an API 19 emulator, since
`extractNativeLibs="true"` is already the default and seems to be
ignored.