### PR TITLE
[setup-windows] Import Configuration.props earlier

### DIFF
--- a/tools/setup-windows/setup-windows.csproj
+++ b/tools/setup-windows/setup-windows.csproj
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Configuration.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -8,6 +10,4 @@
     <AssemblyName>setup-windows</AssemblyName>
     <OutputPath>$(XamarinAndroidSourcePath)bin\$(Configuration)\bin\</OutputPath>
   </PropertyGroup>
- 
-  <Import Project="..\..\Configuration.props" />
 </Project>


### PR DESCRIPTION
`setup-windows.exe` was being output to:

	xamarin-android\tools\setup-windows\bin\Debug\bin\setup-windows.exe

This caused a little trouble because `setup-windows.exe` currently only
creates the correct symlinks if it is run from:

	xamarin-android\bin\Debug\bin\setup-windows.exe

The trouble was that `Configuration.props` was being imported after the
use of `$(XamarinAndroidSourcePath)`, so `$(XamarinAndroidSourcePath)`
was empty when it was used.

To fix that, move the `Configuration.props` import before the use of
`$(XamarinAndroidSourcePath)`.