### PR TITLE
[Xamarin.Android.Build.Tasks] _CheckNonIdealConfigurations only runs for apps

### DIFF
--- a/Documentation/release-notes/class-libraries-aab.md
+++ b/Documentation/release-notes/class-libraries-aab.md
@@ -1,0 +1,7 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5024](https://github.com/xamarin/xamarin-android/issues/5024):
+  *error XA0119: Using the shared runtime and Android App Bundles at
+  the same time is not currently supported* build error could
+  mistakenly appear for Xamarin.Android class libraries when
+  `$(AndroidPackageFormat)` is set to `aab`.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -69,7 +69,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
       _ValidateLinkMode;
-      _CheckNonIdealConfigurations;
       _SetupDesignTimeBuildForBuild;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -155,6 +155,19 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void ClassLibraryHasNoWarnings ()
+		{
+			var proj = new XamarinAndroidLibraryProject ();
+			//NOTE: these properties should not affect class libraries at all
+			proj.SetProperty ("AndroidPackageFormat", "aab");
+			proj.SetProperty ("AotAssemblies", "true");
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+			}
+		}
+
+		[Test]
 		public void BuildBasicApplicationWithNuGetPackageConflicts ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -58,7 +58,6 @@ projects. .NET 5 projects will not import this file.
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' And '$(_AndroidIsBindingProject)' != 'True' ">
     <BuildDependsOn>
       _ValidateLinkMode;
-      _CheckNonIdealConfigurations;
       _SetupDesignTimeBuildForBuild;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5024

Building a class library with `$(AndroidPackageFormat)` set to `aab`
fails with:

    error XA0119: Using the shared runtime and Android App Bundles at the same time is not currently supported.
        Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.

In 5d8bc5c1, we upgraded this message from a warning to an error.
Unfortunately, this error is being emitted for class libraries as
well as apps!

You could easily hit the issue running MSBuild command-line:

    msbuild Foo.Android.csproj -p:Configuration=Release -p:AndroidPackageFormat=aab

If `Foo.Android.csproj` referenced a Xamarin.Android class library, it
would have the global `$(AndroidPackageFormat)` property set. Class
libraries also appear to have `$(AndroidUseSharedRuntime)` set by
default when omitted.

Looking through the `_CheckNonIdealConfigurations` MSBuild target, all
of the warnings & errors it emits only apply to Xamarin.Android
*application* projects:

* `'$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True'`
* `'$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkMode)' != 'None'`
* `'$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkTool)' != ''`
* `'$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidPackageFormat)' == 'aab'`
* `'$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8'`
* `'$(AndroidDexTool)' == 'dx' and '$(UsingAndroidNETSdk)' != 'true'`
* `'$(AndroidDexTool)' == 'dx' and '$(UsingAndroidNETSdk)' == 'true'`

I think we can simply omit `_CheckNonIdealConfigurations` from
`$(BuildDependsOn)` in class library projects.

`$(AndroidUseSharedRuntime)` is being removed in #4672, so we probably
don't need to change its default value for class libraries.

I could reproduce this issue pretty easily in a unit test.