### PR TITLE
[Xamarin.Android.Build.Tests] Import regression tests from job 1

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1103,7 +1103,7 @@ stages:
   condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['RunAllTests'], true))
   jobs:
 
-  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
+  # Check - "Xamarin.Android (Regression Tests Mac-1)"
   - job: integrated_regression_mac_1
     displayName: Mac-1
     pool:
@@ -1119,7 +1119,7 @@ stages:
       parameters:
         node_id: 1
 
-  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
+  # Check - "Xamarin.Android (Regression Tests Mac-2)"
   - job: integrated_regression_mac_2
     displayName: Mac-2
     pool:
@@ -1135,23 +1135,7 @@ stages:
       parameters:
         node_id: 2
 
-  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
-  - job: integrated_regression_mac_3
-    displayName: Mac-3
-    pool:
-      name: VSEng-Xamarin-Mac-Devices
-      demands:
-      - android
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - template: yaml-templates/run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 3
-
-  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
+  # Check - "Xamarin.Android (Regression Tests Windows-1)"
   - job: integrated_regression_Win_1
     displayName: Windows-1
     pool:
@@ -1173,7 +1157,7 @@ stages:
 
     - template: remove-visualstudio.yml@yaml
 
-  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
+  # Check - "Xamarin.Android (Regression Tests Windows-2)"
   - job: integrated_regression_Win_2
     displayName: Windows-2
     pool:
@@ -1192,28 +1176,6 @@ stages:
     - template: yaml-templates\run-integrated-regression-tests.yaml
       parameters:
         node_id: 2
-
-    - template: remove-visualstudio.yml@yaml
-
-  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
-  - job: integrated_regression_Win_3
-    displayName: Windows-3
-    pool:
-      name: VSEng-Xamarin-Win-XMA
-      demands:
-      - android
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    variables:
-      XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
-    steps:
-    - template: remove-visualstudio.yml@yaml
-
-    - template: yaml-templates\run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 3
 
     - template: remove-visualstudio.yml@yaml
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -90,13 +90,6 @@ steps:
       testRunTitle: Smoke Tests on Device
       nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Fast Deploy Tests
-      nunitConsoleExtraArgs: --where "cat == FastDevTests"
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
   - template: run-nunit-tests.yaml
     parameters:

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -90,15 +90,6 @@ steps:
       testRunTitle: Smoke Tests on Device
       nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Debug Tests
-      nunitConsoleExtraArgs: --where "cat == DebuggerTests"
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-
   - template: run-nunit-tests.yaml
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -94,13 +94,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Smoke Tests
-      nunitConsoleExtraArgs: --where "cat == RegressionTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Installer Tests
       nunitConsoleExtraArgs: --where "cat == InstallationTests"
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -94,13 +94,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Installer Tests
-      nunitConsoleExtraArgs: --where "cat == InstallationTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Fast Deploy Tests
       nunitConsoleExtraArgs: --where "cat == FastDevTests"
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -94,14 +94,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Wearable Tests
-      nunitConsoleExtraArgs: --where "cat == Wearable"
-
-- ${{ if eq(parameters.node_id, 2) }}:
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Incremental Build Tests
       nunitConsoleExtraArgs: --where "cat == BuildPerformance"
 
@@ -112,7 +104,7 @@ steps:
       testRunTitle: AOT Tests
       nunitConsoleExtraArgs: --where "cat == AotSupport"
 
-- ${{ if eq(parameters.node_id, 3) }}:
+- ${{ if eq(parameters.node_id, 2) }}:
   - template: run-nunit-tests.yaml
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -94,13 +94,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Linker Tests
-      nunitConsoleExtraArgs: --where "cat == LinkerTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Wearable Tests
       nunitConsoleExtraArgs: --where "cat == Wearable"
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -396,7 +396,11 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyPass", Uri.EscapeDataString (pass));
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningStorePass", Uri.EscapeDataString (pass));
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, perAbiApk);
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			if (perAbiApk) {
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "arm64-v8a", "x86_64");
+			} else {
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 				Assert.IsTrue (b.Build (proj), "First build failed");
@@ -412,6 +416,17 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 					using (var zip = ZipHelper.OpenZip (apk)) {
 						Assert.IsTrue (zip.Any (e => e.FullName == "META-INF/MANIFEST.MF"), $"APK file `{apk}` is not signed! It is missing `META-INF/MANIFEST.MF`.");
 					}
+				}
+
+				// Make sure the APKs have unique version codes
+				if (perAbiApk) {
+					int armManifestCode = GetVersionCodeFromIntermediateManifest (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "armeabi-v7a", "AndroidManifest.xml"));
+					int x86ManifestCode = GetVersionCodeFromIntermediateManifest (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "x86", "AndroidManifest.xml"));
+					int arm64ManifestCode = GetVersionCodeFromIntermediateManifest (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "arm64-v8a", "AndroidManifest.xml"));
+					int x86_64ManifestCode = GetVersionCodeFromIntermediateManifest (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "x86_64", "AndroidManifest.xml"));
+					var versionList = new List<int> { armManifestCode, x86ManifestCode, arm64ManifestCode, x86_64ManifestCode };
+					Assert.True (versionList.Distinct ().Count () == versionList.Count,
+						$"APK version codes were not unique - armeabi-v7a: {armManifestCode}, x86: {x86ManifestCode}, arm64-v8a: {arm64ManifestCode}, x86_64: {x86_64ManifestCode}");
 				}
 
 				var item = proj.AndroidResources.First (x => x.Include () == "Resources\\values\\Strings.xml");
@@ -431,6 +446,18 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 						Assert.IsTrue (zip.Any (e => e.FullName == "META-INF/MANIFEST.MF"), $"APK file `{apk}` is not signed! It is missing `META-INF/MANIFEST.MF`.");
 					}
 				}
+			}
+
+			int GetVersionCodeFromIntermediateManifest (string manifestFilePath)
+			{
+				var doc = XDocument.Load (manifestFilePath);
+				var versionCode = doc.Descendants ()
+					.Where (e => e.Name == "manifest")
+					.Select (m => m.Attribute ("{http://schemas.android.com/apk/res/android}versionCode")).FirstOrDefault ();
+
+				if (!int.TryParse (versionCode?.Value, out int parsedCode))
+					Assert.Fail ($"Unable to parse 'versionCode' value from manifest content: {File.ReadAllText (manifestFilePath)}.");
+				return parsedCode;
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/QualityAssurance/pull/3639

This is an initial effort to migrate non duplicated and relevant tests
from QualityAssurance into xamarin-android.  The majority of test
categories that ran in the first regression test job have been audited,
and a few tests have been imported while the rest have been removed.
The remaining regression test categories that were ran as part of the
first and second regression test jobs have been merged, and the third
job has been removed.