### PR TITLE
[Xamarin.Android.Build.Tasks] redistribute apksigner.jar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,10 @@
     path = external/android-api-docs
     url = https://github.com/xamarin/android-api-docs
     branch = master
+[submodule "external/apksig"]
+    path = external/apksig
+    url = https://android.googlesource.com/platform/tools/apksig
+    branch = platform-tools-30.0.3
 [submodule "external/debugger-libs"]
     path = external/debugger-libs
     url = https://github.com/mono/debugger-libs

--- a/Documentation/release-notes/5032.md
+++ b/Documentation/release-notes/5032.md
@@ -1,0 +1,21 @@
+### Tool and library version updates
+
+#### apksigner from Android SDK Build-Tools 30.0.3 now included
+
+Xamarin.Android now packages its own copy of the
+[`apksigner`][apksigner] executable.  The current included version is
+[aligned with Android SDK Build-Tools 30.0.3][apksigner-30.0.3].
+
+Attempting to use the `apksigner` from Android SDK Build-Tools 30.0
+with Java JDK 8 results in the following error (as mentioned in the
+[Xamarin.Android 11.0 release-notes][xa-11.0]):
+
+    java.lang.UnsupportedClassVersionError: com/android/apksigner/ApkSignerTool has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+
+Using the `apksigner` packaged with Xamarin.Android will allow
+Xamarin.Android to use Android SDK Build-Tools 30.0 along with Java
+JDK 8.
+
+[apksigner]: https://developer.android.com/studio/command-line/apksigner
+[apksigner-30.0.3]: https://android.googlesource.com/platform/tools/apksig/+/refs/tags/platform-tools-30.0.3
+[xa-11.0]: https://docs.microsoft.com/xamarin/android/release-notes/11/11.0#bindings-for-android-11-beta

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -140,6 +140,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.Generato
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.SourceWriter", "external\Java.Interop\src\Xamarin.SourceWriter\Xamarin.SourceWriter.csproj", "{86A8DEFE-7ABB-4097-9389-C249581E243D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "apksigner", "src\apksigner\apksigner.csproj", "{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
@@ -383,6 +385,10 @@ Global
 		{86A8DEFE-7ABB-4097-9389-C249581E243D}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{86A8DEFE-7ABB-4097-9389-C249581E243D}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{86A8DEFE-7ABB-4097-9389-C249581E243D}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -447,6 +453,7 @@ Global
 		{071D9096-65BB-4359-822E-09788439F210} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{86A8DEFE-7ABB-4097-9389-C249581E243D} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apksigner.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.exe"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.pdb"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.exe"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/apksigner.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/apksigner.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	[TPN]
+	class apksigner_google_TPN : ThirdPartyNotice
+	{
+		static readonly Uri    url         = new Uri ("https://android.googlesource.com/platform/tools/apksig/");
+
+		public override string LicenseFile => CommonLicenses.Apache20Path;
+		public override string Name        => "google/apksig";
+		public override Uri    SourceUrl   => url;
+		public override string LicenseText => String.Empty;
+
+		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
+	}
+}

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Steps\Step_ShowEnabledRuntimes.cs" />
     <Compile Include="Steps\Step_ThirdPartyNotices.cs" />
     <Compile Include="ThirdPartyNotices\aapt2.cs" />
+    <Compile Include="ThirdPartyNotices\apksigner.cs" />
     <Compile Include="ThirdPartyNotices\bundletool.cs" />
     <Compile Include="ThirdPartyNotices\dlfcn.cs" />
     <Compile Include="ThirdPartyNotices\Java.Interop.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
@@ -49,8 +49,6 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
       <Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
       <Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
       <Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
-      <Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
-      <Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
       <Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
       <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
       <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -55,12 +55,6 @@ namespace Xamarin.Android.Tasks
 		public string LintToolPath { get; set; }
 
 		[Output]
-		public string ApkSignerJar { get; set; }
-
-		[Output]
-		public bool AndroidUseApkSigner { get; set; }
-
-		[Output]
 		public bool AndroidUseAapt2 { get; set; }
 
 		[Output]
@@ -137,9 +131,6 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			ApkSignerJar = Path.Combine (AndroidSdkBuildToolsBinPath, "lib", ApkSigner);
-			AndroidUseApkSigner = File.Exists (ApkSignerJar);
-
 			if (string.IsNullOrEmpty (Aapt2ToolPath)) {
 				var osBinPath = MonoAndroidHelper.GetOSBinPath ();
 				var aapt2 = Path.Combine (osBinPath, Aapt2);
@@ -204,8 +195,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ($"  {nameof (ZipAlignPath)}: {ZipAlignPath}");
 			Log.LogDebugMessage ($"  {nameof (AndroidSequencePointsMode)}: {AndroidSequencePointsMode}");
 			Log.LogDebugMessage ($"  {nameof (LintToolPath)}: {LintToolPath}");
-			Log.LogDebugMessage ($"  {nameof (ApkSignerJar)}: {ApkSignerJar}");
-			Log.LogDebugMessage ($"  {nameof (AndroidUseApkSigner)}: {AndroidUseApkSigner}");
 			Log.LogDebugMessage ($"  {nameof (AndroidUseAapt2)}: {AndroidUseAapt2}");
 			Log.LogDebugMessage ($"  {nameof (Aapt2Version)}: {Aapt2Version}");
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -274,9 +274,6 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (androidTooling.AndroidSequencePointsMode, "None", "AndroidSequencePointsMode should be None");
 			expected = Path.Combine (androidSdkPath, "tools");
 			Assert.AreEqual (androidTooling.LintToolPath, expected, $"LintToolPath should be {expected}");
-			expected = Path.Combine (androidSdkPath, "build-tools", "26.0.3", "lib", "apksigner.jar");
-			Assert.AreEqual (androidTooling.ApkSignerJar, expected, $"ApkSignerJar should be {expected}");
-			Assert.AreEqual (androidTooling.AndroidUseApkSigner, false, "AndroidUseApkSigner should be false");
 			Assert.AreEqual (validateJavaVersion.JdkVersion, "1.8.0", "JdkVersion should be 1.8.0");
 			Assert.AreEqual (validateJavaVersion.MinimumRequiredJdkVersion, "1.8", "MinimumRequiredJdkVersion should be 1.8");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -440,6 +440,9 @@
     <ProjectReference Include="..\aapt2\aapt2.csproj">
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\apksigner\apksigner.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\bundletool\bundletool.csproj">
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -13,6 +13,7 @@
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
+		<AndroidUseApkSigner Condition=" '$(AndroidUseApkSigner)' == '' ">True</AndroidUseApkSigner>
 		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">True</AndroidUseAapt2>
 		<AndroidPackageNamingPolicy Condition=" '$(AndroidPackageNamingPolicy)' == '' ">LowercaseCrc64</AndroidPackageNamingPolicy>
 		<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' And '$(OS)' != 'Windows_NT' ">False</AndroidUseManagedDesignTimeResourceGenerator>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -653,6 +653,12 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
+	<CreateProperty Value="$(MonoAndroidToolsDirectory)\apksigner.jar">
+		<Output TaskParameter="Value" PropertyName="ApkSignerJar"
+				Condition="'$(ApkSignerJar)' == ''"
+		/>
+	</CreateProperty>
+
 	<CreateProperty Value="$(MonoAndroidToolsDirectory)\manifestmerger.jar">
 		<Output TaskParameter="Value" PropertyName="AndroidManifestMergerJarPath"
 				Condition="'$(AndroidManifestMergerJarPath)' == ''"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -247,8 +247,6 @@ projects. .NET 5 projects will not import this file.
       <Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
       <Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
       <Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
-      <Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
-      <Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
       <Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
       <Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
       <Output TaskParameter="Aapt2ToolPath"               PropertyName="Aapt2ToolPath"               Condition="'$(Aapt2ToolPath)' == ''" />

--- a/src/apksigner/.gitignore
+++ b/src/apksigner/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+build/
+out/
+.classpath
+.project
+.settings/

--- a/src/apksigner/apksigner.csproj
+++ b/src/apksigner/apksigner.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\Configuration.props" />
+
+  <PropertyGroup>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**" />
+    <None Include="build.gradle" />
+    <None Include="build\libs\apksigner.jar" CopyToOutputDirectory="PreserveNewest" Link="apksigner.jar" />
+  </ItemGroup>
+
+  <Target Name="_BuildGradle"
+      BeforeTargets="GetCopyToOutputDirectoryItems"
+      Inputs="$(MSBuildThisFile);build.gradle"
+      Outputs="build\libs\apksigner.jar">
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+  </Target>
+
+  <Target Name="_CleanGradle" BeforeTargets="Clean">
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+  </Target>
+</Project>

--- a/src/apksigner/build.gradle
+++ b/src/apksigner/build.gradle
@@ -1,0 +1,38 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+
+java {
+    ext.javaSourceVer = project.hasProperty('javaSourceVer') ? JavaVersion.toVersion(project.getProperty('javaSourceVer')) : JavaVersion.VERSION_1_8
+    ext.javaTargetVer = project.hasProperty('javaTargetVer') ? JavaVersion.toVersion(project.getProperty('javaTargetVer')) : JavaVersion.VERSION_1_8
+
+    sourceCompatibility = ext.javaSourceVer
+    targetCompatibility = ext.javaTargetVer
+}
+
+repositories {
+    jcenter()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs '../../external/apksig/src/main/java'
+            srcDirs '../../external/apksig/src/apksigner/java'
+        }
+        resources {
+            srcDirs '../../external/apksig/src/main/java'
+            srcDirs '../../external/apksig/src/apksigner/java'
+        }
+    }
+ }
+
+jar {
+    duplicatesStrategy = 'exclude'
+    manifest {
+        attributes 'Main-Class': 'com.android.apksigner.ApkSignerTool'
+    }
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    archiveName 'apksigner.jar'
+}


### PR DESCRIPTION
The Android SDK Build-tools 30.x currently requires JDK 11
in order to use `apksigner.jar`:

	Task "AndroidApkSigner"
	  Task Parameter:ApkSignerJar=C:\Users\dlab14\android-toolchain\sdk\build-tools\30.0.0-rc4\lib\apksigner.jar
	  …
	  Task Parameter:ToolPath=C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25\bin
	  Task Parameter:ManifestFile=obj\Release\android\AndroidManifest.xml
	  C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25\bin\java.exe -jar C:\Users\dlab14\android-toolchain\sdk\build-tools\30.0.0-rc4\lib\apksigner.jar sign --ks "C:\Users\dlab14\AppData\Local\Xamarin\Mono for Android\debug.keystore" --ks-pass pass:android --ks-key-alias androiddebugkey --key-pass pass:android --min-sdk-version 21 --max-sdk-version 29  "C:\A\vs2019xam00000Y-1\_work\1\s\bin\TestRelease\temp\BuildAotApplication AndÜmläüts_x86_64_True_True\bin\Release\UnnamedProject.UnnamedProject-Signed.apk"
	  java.lang.UnsupportedClassVersionError: com/android/apksigner/ApkSignerTool has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	  at java.lang.ClassLoader.defineClass1(Native Method)
	  …
	…\Xamarin.Android.Common.targets(2559,2): error MSB6006: "java.exe" exited with code 1.

Since it is currently unknown when we can install a JDK 11 with Visual
Studio, instead could we compile `apksigner.jar` for Java 1.8
ourselves?

My initial thought was to find `apksigner.jar` on Maven, and we could
simply redistribute it. I could only find `apksig`, which is the
library that drives `apksigner`--not the actual command-line tool.

https://mvnrepository.com/artifact/com.android.tools.build/apksig/4.0.1

If I find the source for this library:

https://android.googlesource.com/platform/tools/apksig/

The source for `apksig` and `apksigner.jar` live in the same git
repository. For now, we can add `apksig` as a submodule and build it
ourselves.

It wasn't too hard to write a gradle script to build all of the
sources into a single, self-contained `apksigner.jar`.

Then I changed the `<ResolveAndroidTooling/>` task so it no longer was
responsible for setting `$(ApkSignerJar)` and `$(AndroidUseApkSigner)`.
I setup these properties in a similar way as we did for aapt2, r8, etc.

In a future PR, I will need to make changes to xamarin/androidtools,
so it can find and use the `apksigner.jar` bundled with
Xamarin.Android.