### PR TITLE
d16-8 backport for for Preview 3

### DIFF
--- a/Documentation/release-notes/class-libraries-aab.md
+++ b/Documentation/release-notes/class-libraries-aab.md
@@ -1,0 +1,7 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5024](https://github.com/xamarin/xamarin-android/issues/5024):
+  *error XA0119: Using the shared runtime and Android App Bundles at
+  the same time is not currently supported* build error could
+  mistakenly appear for Xamarin.Android class libraries when
+  `$(AndroidPackageFormat)` is set to `aab`.

--- a/Documentation/release-notes/extractNativeLibs.md
+++ b/Documentation/release-notes/extractNativeLibs.md
@@ -1,0 +1,35 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 4986](https://github.com/xamarin/xamarin-android/issues/4986):
+  Updates to Android tooling (`manifest-merger`), caused
+  `//application/@android:extractNativeLibs` to be set to `false` by
+  default. This can cause an undesirable `.apk` file size increase
+  that is more noticeable for Xamarin.Android applications using AOT.
+  Xamarin.Android now sets `extractNativeLibs` to `true` by default.
+
+According to the [Android documentation][extractNativeLibs],
+`extractNativeLibs` affects `.apk` size and install size:
+
+> Whether or not the package installer extracts native libraries from
+> the APK to the filesystem. If set to false, then your native
+> libraries must be page aligned and stored uncompressed in the APK.
+> No code changes are required as the linker loads the libraries
+> directly from the APK at runtime. The default value is "true".
+
+This is a tradeoff that each developer should decide upon on a
+per-application basis. Is a smaller install size at the cost of a
+larger download size preferred?
+
+Since Xamarin.Android now emits `android:extractNativeLibs="true"` by
+default, you can get the opposite behavior with an
+`AndroidManifest.xml` such as:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.hello">
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+    <application android:label="Hello" android:extractNativeLibs="false" />
+</manifest>
+```
+
+[extractNativeLibs]: https://developer.android.com/guide/topics/manifest/application-element

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -42,7 +42,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
       _ValidateLinkMode;
-      _CheckNonIdealConfigurations;
       _SetupDesignTimeBuildForBuild;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -349,6 +349,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations..
+        /// </summary>
+        internal static string XA0119_AOT {
+            get {
+                return ResourceManager.GetString("XA0119_AOT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations..
+        /// </summary>
+        internal static string XA0119_LinkMode {
+            get {
+                return ResourceManager.GetString("XA0119_LinkMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations..
+        /// </summary>
+        internal static string XA0119_LinkTool {
+            get {
+                return ResourceManager.GetString("XA0119_LinkTool", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Assembly &apos;{0}&apos; is using &apos;[assembly: {1}]&apos;, which is no longer supported. Use a newer version of this NuGet package or notify the library author..
         /// </summary>
         internal static string XA0121 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -269,6 +269,18 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</value>
     <comment>The following are literal names and should not be translated: Android App Bundles</comment>
   </data>
+  <data name="XA0119_AOT" xml:space="preserve">
+    <value>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: AOT, Debug, Release.</comment>
+  </data>
+  <data name="XA0119_LinkMode" xml:space="preserve">
+    <value>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: Debug, Release.</comment>
+  </data>
+  <data name="XA0119_LinkTool" xml:space="preserve">
+    <value>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: Debug, Release.</comment>
+  </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Sestavení {0} používá atribut [assembly: {1}], který se už nepodporuje. Použijte novější verzi tohoto balíčku NuGet, nebo to oznamte autorovi knihovny.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Die Assembly "{0}" verwendet das Attribut "[assembly: {1}]", dieses wird nicht mehr unterstützt. Verwenden Sie eine neuere Version dieses NuGet-Pakets, oder benachrichtigen Sie den Bibliotheksautor.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">El ensamblado "{0}" usa "[assembly: {1}]", que ya no se admite. Utilice una versión más reciente de este paquete NuGet o informe al autor de la biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' utilise '[assembly : {1}]', qui n'est plus pris en charge. Utilisez une version plus récente de ce package NuGet ou notifiez l'auteur de la bibliothèque.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">L'assembly '{0}' usa '[assembly: {1}]', che non è più supportato. Usare una versione più recente di questo pacchetto NuGet o inviare una notifica all'autore della libreria.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">アセンブリ '{0}' は、今はサポートされていない '[assembly: {1}]' を使用しています。この NuGet パッケージの新しいバージョンを使用するか、ライブラリの作成者に連絡してください。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' 어셈블리가 더 이상 지원되지 않는 '[assembly: {1}]'을(를) 사용하고 있습니다. 이 NuGet 패키지의 최신 버전을 사용하거나 라이브러리 작성자에게 알리세요.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Zestaw „{0}” korzysta z atrybutu „[assembly: {1}]”, który nie jest już obsługiwany. Użyj nowszej wersji tego pakietu NuGet lub powiadom autora biblioteki.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">O assembly '{0}' está usando '[assembly: {1}]', que não tem mais suporte. Use uma versão mais recente deste pacote NuGet ou notifique o autor da biblioteca.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">Сборка "{0}" использует "[assembly: {1}]", которая больше не поддерживается. Используйте более новую версию этого пакета NuGet или уведомите автора библиотеки.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">'{0}' bütünleştirilmiş kodu artık desteklenmeyen '[assembly: {1}]' kullanıyor. Bu NuGet paketinin daha yeni bir sürümünü kullanın veya bu durumu kitaplık yazarına bildirin.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">程序集“{0}”使用不再受支持的“[assembly: {1}]”。请使用此 NuGet 包的较新版本或通知库作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -187,6 +187,21 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
         <target state="new">Using the shared runtime and Android App Bundles at the same time is not currently supported. Use the shared runtime for Debug configurations and Android App Bundles for Release configurations.</target>
         <note>The following are literal names and should not be translated: Android App Bundles</note>
       </trans-unit>
+      <trans-unit id="XA0119_AOT">
+        <source>Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkMode">
+        <source>Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</source>
+        <target state="new">Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
+      <trans-unit id="XA0119_LinkTool">
+        <source>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</source>
+        <target state="new">Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</target>
+        <note>The following are literal names and should not be translated: Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>
         <target state="translated">組件 '{0}' 正在使用不再受到支援的 '[assembly: {1}]'。請使用此 NuGet 套件的較新版本，或通知程式庫作者。</target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -155,6 +155,19 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void ClassLibraryHasNoWarnings ()
+		{
+			var proj = new XamarinAndroidLibraryProject ();
+			//NOTE: these properties should not affect class libraries at all
+			proj.SetProperty ("AndroidPackageFormat", "aab");
+			proj.SetProperty ("AotAssemblies", "true");
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+			}
+		}
+
+		[Test]
 		public void BuildBasicApplicationWithNuGetPackageConflicts ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2421,7 +2421,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion);
 				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, firstFrameworkVersion)))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -165,6 +165,9 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
 
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				AssertExtractNativeLibs (manifest, extractNativeLibs: false);
+
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
 				AssertEmbeddedDSOs (apk);
@@ -890,6 +893,34 @@ public class Test
 					Assert.IsTrue (b.Build (app), "Build of jar should have succeeded.");
 					string expected = "Failed to add jar entry AndroidManifest.xml from test.jar: the same file already exists in the apk";
 					Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"AndroidManifest.xml for test.jar should have been ignored.");
+				}
+			}
+		}
+
+		[Test]
+		public void ExtractNativeLibsTrue ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				// This combination produces android:extractNativeLibs="false" by default
+				ManifestMerger = "manifestmerger.jar",
+			};
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"23\" />");
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				// We should find extractNativeLibs="true"
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				AssertExtractNativeLibs (manifest, extractNativeLibs: true);
+
+				// All .so files should be compressed
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+					foreach (var entry in zip) {
+						if (entry.FullName.EndsWith (".so")) {
+							AssertCompression (entry, compressed: true);
+						}
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Xml.Linq;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 
@@ -458,6 +459,23 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var exe = IsWindows ? "aapt.exe" : "aapt";
 			return GetPathToLatestBuildTools (exe);
+		}
+
+		/// <summary>
+		/// Asserts that a AndroidManifest.xml file contains the expected //application/@android:extractNativeLibs value.
+		/// </summary>
+		protected void AssertExtractNativeLibs (string manifest, bool extractNativeLibs)
+		{
+			FileAssert.Exists (manifest);
+			using (var stream = File.OpenRead (manifest)) {
+				var doc = XDocument.Load (stream);
+				var element = doc.Root.Element ("application");
+				Assert.IsNotNull (element, $"application element not found in {manifest}");
+				var ns = (XNamespace) "http://schemas.android.com/apk/res/android";
+				var attribute = element.Attribute (ns + "extractNativeLibs");
+				Assert.IsNotNull (attribute, $"android:extractNativeLibs attribute not found in {manifest}");
+				Assert.AreEqual (extractNativeLibs ? "true" : "false", attribute.Value, $"Unexpected android:extractNativeLibs value found in {manifest}");
+			}
 		}
 
 		[SetUp]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -248,8 +248,6 @@ namespace Xamarin.Android.Tasks {
 
 			if (app.Attribute (androidNs + "label") == null && applicationName != null)
 				app.SetAttributeValue (androidNs + "label", applicationName);
-			if (app.Attribute (androidNs + "extractNativeLibs") == null)
-				app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
 
 			var existingTypes = new HashSet<string> (
 				app.Descendants ().Select (a => (string) a.Attribute (attName)).Where (v => v != null));
@@ -405,6 +403,10 @@ namespace Xamarin.Android.Tasks {
 			AddSupportsGLTextures (app);
 			if (UseSharedRuntime && targetSdkVersionValue >= 30)
 				AddQueries (app, targetSdkVersionValue);
+			if (targetSdkVersionValue >= 23) {
+				if (app.Attribute (androidNs + "extractNativeLibs") == null)
+					app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
+			}
 
 			ReorderActivityAliases (log, app);
 			ReorderElements (app);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -248,6 +248,8 @@ namespace Xamarin.Android.Tasks {
 
 			if (app.Attribute (androidNs + "label") == null && applicationName != null)
 				app.SetAttributeValue (androidNs + "label", applicationName);
+			if (app.Attribute (androidNs + "extractNativeLibs") == null)
+				app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
 
 			var existingTypes = new HashSet<string> (
 				app.Descendants ().Select (a => (string) a.Attribute (attName)).Where (v => v != null));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -440,16 +440,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_CheckNonIdealConfigurations">
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and AOT at the same time is not recommended. Use Fast Deployment for Debug configurations and AOT for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_AOT"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True' "
   />
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and the Linker at the same time is not recommended. Use Fast Deployment for Debug configurations and the Linker for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_LinkMode"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkMode)' != 'None' "
   />
-  <Warning Code="XA0119"
-      Text="Using Fast Deployment and a Code Shrinker at the same time is not recommended. Use Fast Deployment for Debug configurations and a Code Shrinker for Release configurations."
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_LinkTool"
       Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkTool)' != '' "
   />
   <AndroidError Code="XA0119"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1238,14 +1238,6 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Package Build -->
 <Target Name="PackageForAndroid"
 	DependsOnTargets="$(_PackageForAndroidDependsOn)" />
-	
-<Target Name="_CheckForObsoleteAssemblies">
-	<PropertyGroup>
-		<_ObsoleteAssemblies>@(ResolvedFrameworkAssemblies)</_ObsoleteAssemblies>
-	</PropertyGroup>
-	<Warning Code="XA1009" Text="OpenTK 0.9.3 is Obsolete. Please upgrade to OpenTK 1.0"
-			Condition="$(_ObsoleteAssemblies.Contains('OpenTK.dll'))" />
-</Target>
 
 <Target Name="_CreatePackageWorkspace">
   <!-- Create our intermediate directory -->
@@ -1415,7 +1407,6 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
 	<_PrepareAssembliesDependsOnTargets>
 		_ResolveAssemblies
-		;_CheckForObsoleteAssemblies
 		;_ResolveSatellitePaths
 		;_CreatePackageWorkspace
 		;_CopyConfigFiles

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -58,7 +58,6 @@ projects. .NET 5 projects will not import this file.
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' And '$(_AndroidIsBindingProject)' != 'True' ">
     <BuildDependsOn>
       _ValidateLinkMode;
-      _CheckNonIdealConfigurations;
       _SetupDesignTimeBuildForBuild;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -46,8 +46,10 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs}\" ");
+				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs.ToString ().ToLowerInvariant ()}\" ");
 				Assert.True (b.Install (proj), "Project should have installed.");
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				AssertExtractNativeLibs (manifest, extractNativeLibs);
 				ClearAdbLogcat ();
 				if (CommercialBuildAvailable)
 					Assert.True (b.RunTarget (proj, "_Run"), "Project should have run.");


### PR DESCRIPTION
These are 5 commits that had conflicts:
* https://github.com/xamarin/xamarin-android/commit/9db3ecbb32baedd528d21a303a080f1b8c904128
* https://github.com/xamarin/xamarin-android/commit/4931eb4451ca88fdfac8dc19795d18b242a54ae9
* https://github.com/xamarin/xamarin-android/commit/1403eec765b14aafc64f97d619d5a143df4cb261
* https://github.com/xamarin/xamarin-android/commit/d94ebbd564b3517618c7d3f7cd027fbeb3824b61
* https://github.com/xamarin/xamarin-android/commit/baa8adad35a2f27dcd57d504013c01ad83577674

One test was modified since the `XamarinAndroidApplicationProject.MinSdkVersion` property is missing.

I used this instead:

```diff
-proj.MinSdkVersion = "23";
+proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"23\" />");
```