### PR TITLE
[tests] multi-target MSBuildDeviceIntegration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
     "nxunitExplorer.nunit": "packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe",
     "nxunitExplorer.modules": [
-        "bin/TestDebug/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll",
+        "bin/TestDebug/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll",
         "bin/TestDebug/net472/Xamarin.Android.Build.Tests.dll",
         "bin/TestDebug/Xamarin.Android.Build.Tests.Commercial.dll",
-        "bin/TestRelease/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll",
+        "bin/TestRelease/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll",
     ],
     "cmake.configureOnOpen": false
 }

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -62,7 +62,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger'
   NUnit.NumberOfTestWorkers: 4
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 
@@ -704,7 +704,7 @@ stages:
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: MSBuildDeviceIntegration Smoke - macOS
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll
         nunitConsoleExtraArgs: --where "cat == SmokeTests"
         testResultsFile: TestResult-MSBuildDeviceIntegrationSmoke-$(XA.Build.Configuration).xml
 
@@ -835,70 +835,19 @@ stages:
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'MSBuildDevice')))
   jobs:
-  # Check - "Xamarin.Android (MSBuild Emulator Tests macOS)"
-  - job: mac_msbuilddevice_tests
-    displayName: macOS
-    pool: $(HostedMac)
-    timeoutInMinutes: 150
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - template: yaml-templates/setup-test-environment.yaml
+  # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - Legacy)"
+  - template: yaml-templates/run-msbuild-device-tests.yaml
+    parameters:
+      job_name: mac_msbuilddevice_tests
+      job_suffix: Legacy
 
-    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
-      displayName: install emulator
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: build check-boot-times.csproj
-      inputs:
-        solution: build-tools/check-boot-times/check-boot-times.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/build-check-boot-times.binlog
-      continueOnError: true
-
-    - task: MSBuild@1
-      displayName: Run check-boot-times
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/run-check-boot-times.binlog
-      continueOnError: true
-
-    - task: MSBuild@1
-      displayName: start emulator
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
-
-    - template: yaml-templates/run-nunit-tests.yaml
-      parameters:
-        testRunTitle: MSBuildDeviceIntegration On Device - macOS
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
-        nunitConsoleExtraArgs: --where "cat != TimeZoneInfo && cat != SmokeTests"
-        testResultsFile: TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
-
-    - task: MSBuild@1
-      displayName: shut down emulator
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /t:AcquireAndroidTarget,ReleaseAndroidTarget
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
-      condition: always()
-
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: Test Results - MSBuild With Emulator - macOS
-
-    - template: yaml-templates/fail-on-issue.yaml
+  # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
+  - template: yaml-templates/run-msbuild-device-tests.yaml
+    parameters:
+      job_name: mac_dotnetdevice_tests
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      target_framework: 'netcoreapp3.1'
 
 - stage: designer_tests
   displayName: Designer Tests

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -1,0 +1,77 @@
+# Runs MSBuild tests against a device running on macOS
+
+parameters:
+  job_name: ''
+  job_suffix: ''
+  nunit_categories: ''
+  target_framework: 'net472'
+
+jobs:
+  - job: ${{ parameters.job_name }}
+    displayName: MSBuild With Emulator - macOS - ${{ parameters.job_suffix }}
+    pool: $(HostedMac)
+    timeoutInMinutes: 150
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    variables:
+      UseDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}
+    steps:
+    - template: setup-test-environment.yaml
+
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - ${{ if eq(parameters.job_suffix, 'Legacy') }}:
+      - task: MSBuild@1
+        displayName: build check-boot-times.csproj
+        inputs:
+          solution: build-tools/check-boot-times/check-boot-times.csproj
+          configuration: $(XA.Build.Configuration)
+          msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/build-check-boot-times.binlog
+        continueOnError: true
+
+      - task: MSBuild@1
+        displayName: Run check-boot-times
+        inputs:
+          solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+          configuration: $(XA.Build.Configuration)
+          msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/run-check-boot-times.binlog
+        continueOnError: true
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - template: run-nunit-tests.yaml
+      parameters:
+        useDotNet: $(UseDotNet)
+        testRunTitle: MSBuildDeviceIntegration On Device - macOS - ${{ parameters.job_suffix }}
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
+        nunitConsoleExtraArgs: --where "cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
+        dotNetTestExtraArgs: --filter "TestCategory != TimeZoneInfo & TestCategory != SmokeTests ${{ parameters.nunit_categories }}"
+        testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - template: upload-results.yaml
+      parameters:
+        artifactName: Test Results - MSBuild With Emulator - macOS - ${{ parameters.job_suffix }}
+
+    - template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     - template: run-nunit-tests.yaml
       parameters:
         testRunTitle: TimeZoneInfoTests On Device - macOS
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll
         nunitConsoleExtraArgs: --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrectNode${{ parameters.node_id }}"
         testResultsFile: TestResult-TimeZoneInfoTests-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
 

--- a/build-tools/scripts/NUnitReferences.projitems
+++ b/build-tools/scripts/NUnitReferences.projitems
@@ -5,4 +5,9 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="$(NUnitConsoleVersion)" />
     <PackageReference Include="NUnit3TestAdapter"   Version="3.16.1" />
   </ItemGroup>
+  <!-- Required packages for .NET Core -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -16,12 +16,6 @@
     </Reference>
   </ItemGroup>
 
-  <!-- Required packages for .NET Core -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj" />
     <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks.csproj" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -282,7 +282,11 @@ namespace Xamarin.ProjectTools
 				args.Append ("build ");
 			args.AppendFormat ("{0} /t:{1} {2}",
 					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
-			if (AutomaticNuGetRestore && restore && !UseDotNet) {
+			if (UseDotNet) {
+				if (!AutomaticNuGetRestore) {
+					args.Append (" --no-restore");
+				}
+			} else if (AutomaticNuGetRestore && restore) {
 				args.Append (" /restore");
 			}
 			if (MaxCpuCount != null) {

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Xamarin.Android.Build.Tests</RootNamespace>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration</OutputPath>
+    <OutputPath>..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration\</OutputPath>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.targets
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.targets
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_RemapAssemblies" AfterTargets="Build">
+  <Target Name="_RemapAssemblies"
+      AfterTargets="Build"
+      Condition=" '$(TargetFramework)' != '' ">
     <ItemGroup>
-      <_Source Include="..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration\Mono.Debugging.Soft.dll">
+      <_Source Include="$(OutputPath)Mono.Debugging.Soft.dll">
         <From>Mono.Cecil</From>
-        <To>..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration\Xamarin.Android.Cecil.dll</To>
+        <To>$(OutputPath)Xamarin.Android.Cecil.dll</To>
       </_Source>
-      <_Source Include="..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration\Mono.Debugger.Soft.dll">
+      <_Source Include="$(OutputPath)Mono.Debugger.Soft.dll">
         <From>Mono.Cecil</From>
-        <To>..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration\Xamarin.Android.Cecil.dll</To>
+        <To>$(OutputPath)Xamarin.Android.Cecil.dll</To>
       </_Source>
     </ItemGroup>
     <Copy SourceFiles="..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Cecil.dll"
-        DestinationFolder="..\..\bin\Test$(Configuration)\MSBuildDeviceIntegration" />
+        DestinationFolder="$(OutputPath)" />
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; %(_Source.From) &quot;%(_Source.To)&quot;"
     />

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
@@ -36,8 +36,13 @@ namespace UnnamedProject
 			try
 			{
 				var asm = typeof(Library1.SomeClass).Assembly;
+				// TODO: ILLink removing .ctor: https://github.com/mono/linker/issues/1633
+#if NET
+				Android.Util.Log.Info(TAG, $"[PASS] Able to use 'typeof({typeof(Library1.SomeClass)})'.");
+#else
 				var o = Activator.CreateInstance(asm.GetType("Library1.SomeClass"));
 				Android.Util.Log.Info(TAG, $"[PASS] Able to create instance of '{o.GetType().Name}'.");
+#endif
 			}
 			catch (Exception ex)
 			{
@@ -111,7 +116,9 @@ namespace UnnamedProject
 			Android.Util.Log.Info(TAG, cldt.TryAccessNonXmlPreservedMethodOfLinkerModeFullClass());
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug21578.MulticastOption_ShouldNotBeStripped());
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug21578.MulticastOption_ShouldNotBeStripped2());
+#if !NET
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug35195.AttemptCreateTable());
+#endif
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug36250.SerializeSearchRequestWithDictionary());
 
 			Android.Util.Log.Info(TAG, "All regression tests completed.");

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -5,7 +5,7 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Category ("UsesDevice")]
+	[Category ("UsesDevice"), Category ("AOT")]
 	public class AotProfileTests : DeviceTest
 	{
 

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2")]
 	public class BundleToolTests : BaseTest
 	{
+		static readonly string [] Abis = new [] { "armeabi-v7a", "arm64-v8a", "x86" };
 		XamarinAndroidLibraryProject lib;
 		XamarinAndroidApplicationProject app;
 		ProjectBuilder libBuilder, appBuilder;
@@ -69,7 +70,7 @@ namespace Xamarin.Android.Build.Tests
 			//NOTE: this is here to enable adb shell run-as
 			app.AndroidManifest = app.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 			app.SetProperty (app.ReleaseProperties, "AndroidPackageFormat", "aab");
-			app.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
+			app.SetAndroidSupportedAbis (Abis);
 			app.SetProperty ("AndroidBundleConfigurationFile", "buildConfig.json");
 
 			libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName), cleanupOnDispose: true);
@@ -118,23 +119,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var baseZip = Path.Combine (intermediate, "android", "bin", "base.zip");
 			var contents = ListArchiveContents (baseZip);
-			var expectedFiles = new [] {
+			var expectedFiles = new List<string> {
 				"dex/classes.dex",
-				"lib/arm64-v8a/libmono-btls-shared.so",
-				"lib/arm64-v8a/libmonodroid.so",
-				"lib/arm64-v8a/libmono-native.so",
-				"lib/arm64-v8a/libmonosgen-2.0.so",
-				"lib/arm64-v8a/libxamarin-app.so",
-				"lib/armeabi-v7a/libmono-btls-shared.so",
-				"lib/armeabi-v7a/libmonodroid.so",
-				"lib/armeabi-v7a/libmono-native.so",
-				"lib/armeabi-v7a/libmonosgen-2.0.so",
-				"lib/armeabi-v7a/libxamarin-app.so",
-				"lib/x86/libmono-btls-shared.so",
-				"lib/x86/libmonodroid.so",
-				"lib/x86/libmono-native.so",
-				"lib/x86/libmonosgen-2.0.so",
-				"lib/x86/libxamarin-app.so",
 				"manifest/AndroidManifest.xml",
 				"res/drawable-hdpi-v4/icon.png",
 				"res/drawable-mdpi-v4/icon.png",
@@ -145,19 +131,45 @@ namespace Xamarin.Android.Build.Tests
 				"resources.pb",
 				"root/assemblies/Java.Interop.dll",
 				"root/assemblies/Mono.Android.dll",
-				"root/assemblies/mscorlib.dll",
-				"root/assemblies/System.Core.dll",
-				"root/assemblies/System.dll",
-				"root/assemblies/System.Runtime.Serialization.dll",
 				"root/assemblies/Localization.dll",
 				"root/assemblies/es/Localization.resources.dll",
 				"root/assemblies/UnnamedProject.dll",
-				//These are random files from Google Play Services .jar/.aar files
-				"root/build-data.properties",
-				"root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt",
-				"root/error_prone/Annotations.gwt.xml",
-				"root/protobuf.meta",
 			};
+			if (Builder.UseDotNet) {
+				expectedFiles.Add ("root/assemblies/System.Console.dll");
+				expectedFiles.Add ("root/assemblies/System.IO.FileSystem.dll");
+				expectedFiles.Add ("root/assemblies/System.Linq.dll");
+				expectedFiles.Add ("root/assemblies/System.Net.Http.dll");
+
+				//These are random files from Google Play Services .aar files
+				expectedFiles.Add ("root/play-services-base.properties");
+				expectedFiles.Add ("root/play-services-basement.properties");
+				expectedFiles.Add ("root/play-services-maps.properties");
+				expectedFiles.Add ("root/play-services-tasks.properties");
+			} else {
+				expectedFiles.Add ("root/assemblies/mscorlib.dll");
+				expectedFiles.Add ("root/assemblies/System.Core.dll");
+				expectedFiles.Add ("root/assemblies/System.dll");
+				expectedFiles.Add ("root/assemblies/System.Runtime.Serialization.dll");
+
+				//These are random files from Google Play Services .aar files
+				expectedFiles.Add ("root/build-data.properties");
+				expectedFiles.Add ("root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt");
+				expectedFiles.Add ("root/error_prone/Annotations.gwt.xml");
+				expectedFiles.Add ("root/protobuf.meta");
+			}
+			foreach (var abi in Abis) {
+				expectedFiles.Add ($"lib/{abi}/libmonodroid.so");
+				expectedFiles.Add ($"lib/{abi}/libmonosgen-2.0.so");
+				expectedFiles.Add ($"lib/{abi}/libxamarin-app.so");
+				if (Builder.UseDotNet) {
+					expectedFiles.Add ($"lib/{abi}/libSystem.IO.Compression.Native.so");
+					expectedFiles.Add ($"lib/{abi}/libSystem.Native.so");
+				} else {
+					expectedFiles.Add ($"lib/{abi}/libmono-native.so");
+					expectedFiles.Add ($"lib/{abi}/libmono-btls-shared.so");
+				}
+			}
 			foreach (var expected in expectedFiles) {
 				CollectionAssert.Contains (contents, expected, $"`{baseZip}` did not contain `{expected}`");
 			}
@@ -169,23 +181,8 @@ namespace Xamarin.Android.Build.Tests
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.aab");
 			FileAssert.Exists (aab);
 			var contents = ListArchiveContents (aab);
-			var expectedFiles = new [] {
+			var expectedFiles = new List<string> {
 				"base/dex/classes.dex",
-				"base/lib/arm64-v8a/libmono-btls-shared.so",
-				"base/lib/arm64-v8a/libmonodroid.so",
-				"base/lib/arm64-v8a/libmono-native.so",
-				"base/lib/arm64-v8a/libmonosgen-2.0.so",
-				"base/lib/arm64-v8a/libxamarin-app.so",
-				"base/lib/armeabi-v7a/libmono-btls-shared.so",
-				"base/lib/armeabi-v7a/libmonodroid.so",
-				"base/lib/armeabi-v7a/libmono-native.so",
-				"base/lib/armeabi-v7a/libmonosgen-2.0.so",
-				"base/lib/armeabi-v7a/libxamarin-app.so",
-				"base/lib/x86/libmono-btls-shared.so",
-				"base/lib/x86/libmonodroid.so",
-				"base/lib/x86/libmono-native.so",
-				"base/lib/x86/libmonosgen-2.0.so",
-				"base/lib/x86/libxamarin-app.so",
 				"base/manifest/AndroidManifest.xml",
 				"base/native.pb",
 				"base/res/drawable-hdpi-v4/icon.png",
@@ -197,20 +194,46 @@ namespace Xamarin.Android.Build.Tests
 				"base/resources.pb",
 				"base/root/assemblies/Java.Interop.dll",
 				"base/root/assemblies/Mono.Android.dll",
-				"base/root/assemblies/mscorlib.dll",
-				"base/root/assemblies/System.Core.dll",
-				"base/root/assemblies/System.dll",
-				"base/root/assemblies/System.Runtime.Serialization.dll",
 				"base/root/assemblies/Localization.dll",
 				"base/root/assemblies/es/Localization.resources.dll",
 				"base/root/assemblies/UnnamedProject.dll",
 				"BundleConfig.pb",
-				//These are random files from Google Play Services .jar/.aar files
-				"base/root/build-data.properties",
-				"base/root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt",
-				"base/root/error_prone/Annotations.gwt.xml",
-				"base/root/protobuf.meta",
 			};
+			if (Builder.UseDotNet) {
+				expectedFiles.Add ("base/root/assemblies/System.Console.dll");
+				expectedFiles.Add ("base/root/assemblies/System.IO.FileSystem.dll");
+				expectedFiles.Add ("base/root/assemblies/System.Linq.dll");
+				expectedFiles.Add ("base/root/assemblies/System.Net.Http.dll");
+
+				//These are random files from Google Play Services .aar files
+				expectedFiles.Add ("base/root/play-services-base.properties");
+				expectedFiles.Add ("base/root/play-services-basement.properties");
+				expectedFiles.Add ("base/root/play-services-maps.properties");
+				expectedFiles.Add ("base/root/play-services-tasks.properties");
+			} else {
+				expectedFiles.Add ("base/root/assemblies/mscorlib.dll");
+				expectedFiles.Add ("base/root/assemblies/System.Core.dll");
+				expectedFiles.Add ("base/root/assemblies/System.dll");
+				expectedFiles.Add ("base/root/assemblies/System.Runtime.Serialization.dll");
+
+				//These are random files from Google Play Services .aar files
+				expectedFiles.Add ("base/root/build-data.properties");
+				expectedFiles.Add ("base/root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt");
+				expectedFiles.Add ("base/root/error_prone/Annotations.gwt.xml");
+				expectedFiles.Add ("base/root/protobuf.meta");
+			}
+			foreach (var abi in Abis) {
+				expectedFiles.Add ($"base/lib/{abi}/libmonodroid.so");
+				expectedFiles.Add ($"base/lib/{abi}/libmonosgen-2.0.so");
+				expectedFiles.Add ($"base/lib/{abi}/libxamarin-app.so");
+				if (Builder.UseDotNet) {
+					expectedFiles.Add ($"base/lib/{abi}/libSystem.IO.Compression.Native.so");
+					expectedFiles.Add ($"base/lib/{abi}/libSystem.Native.so");
+				} else {
+					expectedFiles.Add ($"base/lib/{abi}/libmono-native.so");
+					expectedFiles.Add ($"base/lib/{abi}/libmono-btls-shared.so");
+				}
+			}
 			foreach (var expected in expectedFiles) {
 				CollectionAssert.Contains (contents, expected, $"`{aab}` did not contain `{expected}`");
 			}

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Android.Build.Tests
 		};
 #pragma warning restore 414
 
-		[Test]
+		[Test, Category ("Debugger")]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
 		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool activityStarts)
 		{
@@ -275,7 +275,7 @@ namespace ${ROOT_NAMESPACE} {
 		};
 #pragma warning restore 414
 
-		[Test, Category ("SmokeTests")]
+		[Test, Category ("SmokeTests"), Category ("Debugger")]
 		[TestCaseSource (nameof(DebuggerTestCases))]
 		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall)
 		{
@@ -287,8 +287,7 @@ namespace ${ROOT_NAMESPACE} {
 				AndroidFastDeploymentType = fastDevType
 			};
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
-			if (allowDeltaInstall)
-				proj.SetProperty (KnownProperties._AndroidAllowDeltaInstall, "true");
+			proj.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);

--- a/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[NonParallelizable] //These tests deploy to devices
+	[Category ("DotNetIgnore")] // .csproj files are legacy projects that won't build under dotnet
 	public class DeleteBinObjTest : DeviceTest
 	{
 		const string BaseUrl = "https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/";

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -106,8 +106,8 @@ namespace Xamarin.Android.Build.Tests
 				library2.AndroidUseAapt2 =
 				app.AndroidUseAapt2 = useAapt2;
 			app.LayoutMain = app.LayoutMain.Replace ("@string/hello", "@string/hello_me");
-			using (var l1 = CreateApkBuilder (Path.Combine ("temp", TestName, library.ProjectName)))
-			using (var l2 = CreateApkBuilder (Path.Combine ("temp", TestName, library2.ProjectName)))
+			using (var l1 = CreateDllBuilder (Path.Combine ("temp", TestName, library.ProjectName)))
+			using (var l2 = CreateDllBuilder (Path.Combine ("temp", TestName, library2.ProjectName)))
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
 				b.ThrowOnBuildFailure = false;
 				string apiLevel;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -187,7 +187,12 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty (proj.ReleaseProperties, "Optimize", false);
 			proj.SetProperty (proj.ReleaseProperties, "DebugType", "none");
-			proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
+			if (Builder.UseDotNet) {
+				// NOTE: in .NET 6, EmbedAssembliesIntoApk=true by default for Release builds
+				proj.SetProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk", "false");
+			} else {
+				proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
+			}
 			var abis = new [] { "armeabi-v7a", "x86" };
 			proj.SetAndroidSupportedAbis (abis);
 			using (var builder = CreateApkBuilder ()) {

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunSimpleBuild ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 
@@ -123,6 +124,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void SimpleInstallAndUninstall ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 
@@ -141,6 +143,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void SkipFastDevAlreadyInstalledFile ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 
@@ -210,6 +213,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunResourceChange ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 
@@ -244,6 +248,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunFastDevTypemaps ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 
@@ -271,6 +276,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunNativeLibrary ([Values ("dx", "d8")] string dexTool)
 		{
+			AssertDexToolSupported (dexTool);
 			AssertCommercialBuild ();
 			AssertHasDevices ();
 

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -19,29 +19,25 @@ namespace Xamarin.Android.Build.Tests
 			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
-				/* activityStarts */     true,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
-				/* activityStarts */     true,
 			},
 			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies:Dexes",
-				/* activityStarts */     true,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
-				/* activityStarts */     true,
 			},
 		};
 #pragma warning restore 414
 
 		[Test]
 		[TestCaseSource (nameof (MonoAndroidExportTestCases))]
-		public void MonoAndroidExportReferencedAppStarts (bool embedAssemblies, string fastDevType, bool activityStarts)
+		public void MonoAndroidExportReferencedAppStarts (bool embedAssemblies, string fastDevType)
 		{
 			AssertCommercialBuild ();
 			AssertHasDevices ();
@@ -98,7 +94,8 @@ namespace UnnamedProject
 			}
 		}
 	}";
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			//TODO: x86_64 is a workaround in .NET 6 for: https://github.com/xamarin/monodroid/issues/1136
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -43,10 +43,20 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		void Profile (ProjectBuilder builder, Action<ProjectBuilder> action, [CallerMemberName] string caller = null)
+		void Profile (ProjectBuilder builder, Action<ProjectBuilder> action, bool additionalTimeForSigning, [CallerMemberName] string caller = null)
 		{
 			if (!csv_values.TryGetValue (caller, out int expected)) {
 				Assert.Fail ($"No timeout value found for a key of {caller}");
+			}
+
+			if (Builder.UseDotNet) {
+				//TODO: there is currently a slight performance regression in .NET 6
+				expected += 500;
+
+				//NOTE: some tests run `dotnet build`, which would sign the .apk
+				if (additionalTimeForSigning) {
+					expected += 500;
+				}
 			}
 
 			action (builder);
@@ -85,24 +95,31 @@ namespace Xamarin.Android.Build.Tests
 			return duration.TotalMilliseconds;
 		}
 
-		ProjectBuilder CreateBuilderWithoutLogFile (string directory = null)
+		ProjectBuilder CreateBuilderWithoutLogFile (string directory = null, bool isApp = true)
 		{
-			var builder = CreateApkBuilder (directory);
+			var builder = isApp ? CreateApkBuilder (directory) : CreateDllBuilder (directory);
 			builder.BuildLogFile = null;
 			builder.Verbosity = LoggerVerbosity.Quiet;
 			return builder;
+		}
+
+		XamarinAndroidApplicationProject CreateApplicationProject ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetAndroidSupportedAbis ("x86"); // Use a single ABI
+			return proj;
 		}
 
 		[Test]
 		[Retry (2)]
 		public void Build_From_Clean_DontIncludeRestore ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.MainActivity = proj.DefaultMainActivity;
+			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
+				builder.AutomaticNuGetRestore = false;
 				builder.Target = "Build";
 				builder.Restore (proj);
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -110,14 +127,15 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_No_Changes ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity;
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile no changes
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: false);
 
 				// Change C# and build
 				proj.MainActivity += $"{Environment.NewLine}//comment";
@@ -125,7 +143,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Build (proj);
 
 				// Profile no changes
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: false);
 			}
 		}
 
@@ -133,16 +151,17 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_CSharp_Change ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity;
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile C# change
 				proj.MainActivity += $"{Environment.NewLine}//comment";
 				proj.Touch ("MainActivity.cs");
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: false);
 			}
 		}
 
@@ -150,15 +169,16 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_AndroidResource_Change ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile AndroidResource change
 				proj.LayoutMain += $"{Environment.NewLine}<!--comment-->";
 				proj.Touch ("Resources\\layout\\Main.axml");
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -175,28 +195,27 @@ namespace Xamarin.Android.Build.Tests
 			lib.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\foo.bar") {
 				BinaryContent = () => bytes,
 			});
-			var proj = new XamarinAndroidApplicationProject () {
-				ProjectName = "App1",
-				References = {
-					new BuildItem.ProjectReference ("..\\Library1\\Library1.csproj"),
-				},
-			};
+			var proj = CreateApplicationProject ();
+			proj.ProjectName = "App1";
+			proj.References.Add (new BuildItem.ProjectReference ("..\\Library1\\Library1.csproj"));
 			rnd.NextBytes (bytes);
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\foo.bar") {
 				BinaryContent = () => bytes,
 			});
-			using (var libBuilder = CreateBuilderWithoutLogFile (Path.Combine ("temp", TestName, lib.ProjectName)))
+			using (var libBuilder = CreateBuilderWithoutLogFile (Path.Combine ("temp", TestName, lib.ProjectName), isApp: false))
 			using (var builder = CreateBuilderWithoutLogFile (Path.Combine ("temp", TestName, proj.ProjectName))) {
 				builder.Target = "Build";
 				libBuilder.Build (lib);
 				builder.Build (proj);
+				libBuilder.AutomaticNuGetRestore =
+					builder.AutomaticNuGetRestore = false;
 
 				rnd.NextBytes (bytes);
 				lib.Touch ("Assets\\foo.bar");
 				libBuilder.Build (lib);
 				builder.Target = "SignAndroidPackage";
 				// Profile AndroidAsset change
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: false);
 			}
 		}
 
@@ -204,11 +223,11 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_Designer_Change ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.MainActivity = proj.DefaultMainActivity;
+			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Change AndroidResource & run SetupDependenciesForDesigner
 				proj.LayoutMain += $"{Environment.NewLine}<!--comment-->";
@@ -217,7 +236,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.RunTarget (proj, "SetupDependenciesForDesigner", parameters: parameters);
 
 				// Profile AndroidResource change
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -226,18 +245,19 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_JLO_Change ()
 		{
 			var className = "Foo";
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {
 				TextContent = () => $"class {className} : Java.Lang.Object {{}}"
 			});
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile Java.Lang.Object rename
 				className = "Foo2";
 				proj.Touch ("Foo.cs");
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -245,15 +265,16 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_AndroidManifest_Change ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile AndroidManifest.xml change
 				proj.AndroidManifest += $"{Environment.NewLine}<!--comment-->";
 				proj.Touch ("Properties\\AndroidManifest.xml");
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -261,16 +282,17 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (2)]
 		public void Build_CSProj_Change ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile .csproj change
 				proj.Sources.Add (new BuildItem ("None", "Foo.txt") {
 					TextContent = () => "Bar",
 				});
-				Profile (builder, b => b.Build (proj));
+				Profile (builder, b => b.Build (proj), additionalTimeForSigning: true);
 			}
 		}
 
@@ -313,14 +335,11 @@ namespace Xamarin.Android.Build.Tests
 			} else if (produceReferenceAssembly) {
 				caller += "_RefAssembly";
 			}
-			var app = new XamarinFormsAndroidApplicationProject {
-				ProjectName = "MyApp",
-				Sources = {
-					new BuildItem.Source ("Foo.cs") {
-						TextContent = () => "public class Foo : Bar { }"
-					},
-				}
-			};
+			var app = CreateApplicationProject ();
+			app.ProjectName = "MyApp";
+			app.Sources.Add (new BuildItem.Source ("Foo.cs") {
+				TextContent = () => "public class Foo : Bar { }"
+			});
 			//NOTE: this will skip a 382ms <VerifyVersionsTask/> from the support library
 			app.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
 
@@ -344,7 +363,7 @@ namespace Xamarin.Android.Build.Tests
 			lib.SetProperty ("ProduceReferenceAssembly", produceReferenceAssembly.ToString ());
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
 
-			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var libBuilder = CreateBuilderWithoutLogFile (Path.Combine (path, lib.ProjectName), isApp: false))
 			using (var appBuilder = CreateBuilderWithoutLogFile (Path.Combine (path, app.ProjectName))) {
 				libBuilder.Build (lib);
 				appBuilder.Target = "Build";
@@ -362,9 +381,9 @@ namespace Xamarin.Android.Build.Tests
 				lib.Touch ("MyPage.xaml");
 				libBuilder.Build (lib, doNotCleanupOnUpdate: true);
 				if (install) {
-					Profile (appBuilder, b => b.Install (app, doNotCleanupOnUpdate: true), caller);
+					Profile (appBuilder, b => b.Install (app, doNotCleanupOnUpdate: true), additionalTimeForSigning: false, caller);
 				} else {
-					Profile (appBuilder, b => b.Build (app, doNotCleanupOnUpdate: true), caller);
+					Profile (appBuilder, b => b.Build (app, doNotCleanupOnUpdate: true), additionalTimeForSigning: false, caller);
 				}
 			}
 		}
@@ -377,17 +396,17 @@ namespace Xamarin.Android.Build.Tests
 			AssertCommercialBuild (); // This test will fail without Fast Deployment
 			AssertHasDevices ();
 
-			var proj = new XamarinAndroidApplicationProject () {
-				PackageName = "com.xamarin.install_csharp_change"
-			};
+			var proj = CreateApplicationProject ();
+			proj.PackageName = "com.xamarin.install_csharp_change";
 			proj.MainActivity = proj.DefaultMainActivity;
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Install (proj);
+				builder.AutomaticNuGetRestore = false;
 
 				// Profile C# change
 				proj.MainActivity += $"{Environment.NewLine}//comment";
 				proj.Touch ("MainActivity.cs");
-				Profile (builder, b => b.Install (proj));
+				Profile (builder, b => b.Install (proj), additionalTimeForSigning: false);
 			}
 		}
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("Debugger")]
 		public void DotNetDebug ()
 		{
 			AssertCommercialBuild ();

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_DeviceTestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\MSBuildDeviceIntegration\MSBuildDeviceIntegration.dll" />
+    <_DeviceTestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\MSBuildDeviceIntegration\net472\MSBuildDeviceIntegration.dll" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This builds `MSBuildDeviceIntegration.csproj` for `netcoreapp3.1`, and
adds a new test job for the `MSBuild Emulator Tests` stage.

I added `[Category]` as needed for tests when running under a `dotnet`
context.

Other fixes:

* `PerformanceTest` now builds all projects for a single ABI. This
  reduces the time spent in `<ProcessAssemblies/>`. I also added a
  500ms buffer for a `dotnet` context and an additional 500ms if the
  test would now sign the `.apk` during `dotnet build`.
* If `AutomaticNuGetRestore` is `false`, `dotnet build` needs to pass
  `--no-restore`. This improves `PerformanceTest` times.
* `BundleToolTests` needed many file paths updated.
* Ensure that `AssertDexToolSupported (dexTool)` is called to ignore
  tests using an `$(AndroidDexTool)` of `dx`.
* The MSBuild tests using `mono/debugger-libs` do not appear to work
  in .NET 6, added a new `Debugger` category to ignore for now.
* A few specific tests are marked `[Category("DotNetIgnore")]` with an
  explanation for each.
* The `CustomLinkDescriptionPreserve` test needed to exclude code
  relying on `sqlite-net-pcl` as using PCLs do not appear to work in
  .NET 6.