### PR TITLE
[Xamarin.Android.Build.Tasks] emit extractNativeLibs only for 23+

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2465,9 +2465,11 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
+				TargetSdkVersion = null,
+				MinSdkVersion = null,
 			};
 			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion);
 				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, firstFrameworkVersion)))

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -248,8 +248,6 @@ namespace Xamarin.Android.Tasks {
 
 			if (app.Attribute (androidNs + "label") == null && applicationName != null)
 				app.SetAttributeValue (androidNs + "label", applicationName);
-			if (app.Attribute (androidNs + "extractNativeLibs") == null)
-				app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
 
 			var existingTypes = new HashSet<string> (
 				app.Descendants ().Select (a => (string) a.Attribute (attName)).Where (v => v != null));
@@ -405,6 +403,10 @@ namespace Xamarin.Android.Tasks {
 			AddSupportsGLTextures (app);
 			if (UseSharedRuntime && targetSdkVersionValue >= 30)
 				AddQueries (app, targetSdkVersionValue);
+			if (targetSdkVersionValue >= 23) {
+				if (app.Attribute (androidNs + "extractNativeLibs") == null)
+					app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
+			}
 
 			ReorderActivityAliases (log, app);
 			ReorderElements (app);


### PR DESCRIPTION
Context: https://build.azdo.io/3997245
Context: https://github.com/xamarin/xamarin-android/pull/5034
Context: https://android.googlesource.com/platform/tools/base/+/fd2ac00ab76dfdececce5a25cb7ad23b2b6f5d29%5E%21

This test was failing with an `aapt2` error:

    AndroidManifest.xml(8): error APT2260: attribute android:extractNativeLibs not found.
    Xamarin.Android.Aapt2.targets(226,3): error APT2067: failed processing manifest.

I think this is passing on master, because projects generated by tests
emit this by default:

    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />

If we switch the test back to:

    <uses-sdk />

I can reproduce the error...

Playing with the values in `<uses-sdk/>`, `aapt2` emits this error
unless `android:targetSdkVersion` is >= 23. `android:minSdkVersion`
does not appear to affect anything.

1403eec7 was incomplete, it needs to also make the same check before
emitting `extractNativeLibs="true"` by default. We leave the value
as-is for older API levels.