### PR TITLE
[Xamarin.Android.Build.Tasks] Fix CollectNonEmptyDirectories to handle file collisions.

### DIFF
--- a/Documentation/release-notes/5038.md
+++ b/Documentation/release-notes/5038.md
@@ -1,0 +1,10 @@
+#### Fix CollectNonEmptyDirectories to handle file collisions.
+
+- [GitHub PR 5038](https://github.com/xamarin/xamarin-android/pull/5038):
+  Aapt2 would fail with missing resources when using ResizetizerNT and
+  `google-services.json` together.
+
+      error APT2260: resource drawable/icon (aka com.some.package:drawable/icon) not found.
+      error APT2061: failed linking file resources.
+
+  This is because they were both using the same file to track the directory contents. The build system has now been updated to ensure each resource directory has its own unique cache file.

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -83,6 +83,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <Output TaskParameter="LibraryResourceFiles" ItemName="_LibraryResourceFiles" />
     <Output TaskParameter="LibraryResourceFiles" ItemName="_CompileResourcesInputs" />
   </CollectNonEmptyDirectories>
+  <ItemGroup>
+    <FileWrites Include="@(_LibraryResourceDirectories->'%(FilesCache)')" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_ConvertResourcesCases"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks {
-	
+
 	public class CollectNonEmptyDirectories : AndroidTask {
 		public override string TaskPrefix => "CNE";
 
@@ -39,13 +39,14 @@ namespace Xamarin.Android.Tasks {
 					continue;
 				}
 				string stampFile = directory.GetMetadata ("StampFile");
+				string directoryHash = Files.HashString (directory.ItemSpec);
 				if (string.IsNullOrEmpty (stampFile)) {
 					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
 						// If inside the `lp` directory
 						stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
 					} else {
 						// Otherwise use a hashed stamp file
-						stampFile = Path.Combine (StampDirectory, Files.HashString (directory.ItemSpec) + ".stamp");
+						stampFile = Path.Combine (StampDirectory, $"{directoryHash}.stamp");
 					}
 				}
 
@@ -53,18 +54,25 @@ namespace Xamarin.Android.Tasks {
 				bool.TryParse (directory.GetMetadata (ResolveLibraryProjectImports.AndroidSkipResourceProcessing), out generateArchive);
 
 				IEnumerable<string> files;
-				string fileCache = Path.Combine (directory.ItemSpec, "..", "files.cache");
+				string filesCache = directory.GetMetadata ("FilesCache");
+				if (string.IsNullOrEmpty (filesCache)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
+						filesCache = Path.Combine (directory.ItemSpec, "..", "files.cache");
+					} else {
+						filesCache = Path.Combine (directory.ItemSpec, "..", $"{directoryHash}-files.cache");
+					}
+				}
 				DateTime lastwriteTime = File.Exists (stampFile) ? File.GetLastWriteTimeUtc (stampFile) : DateTime.MinValue;
-				DateTime cacheLastWriteTime = File.Exists (fileCache) ? File.GetLastWriteTimeUtc (fileCache) : DateTime.MinValue;
+				DateTime cacheLastWriteTime = File.Exists (filesCache) ? File.GetLastWriteTimeUtc (filesCache) : DateTime.MinValue;
 
-				if (File.Exists (fileCache) && cacheLastWriteTime >= lastwriteTime) {
-					Log.LogDebugMessage ($"Reading cached Library resources list from  {fileCache}");
-					files = File.ReadAllLines (fileCache);
+				if (File.Exists (filesCache) && cacheLastWriteTime >= lastwriteTime) {
+					Log.LogDebugMessage ($"Reading cached Library resources list from  {filesCache}");
+					files = File.ReadAllLines (filesCache);
 				} else {
-					if (!File.Exists (fileCache))
-						Log.LogDebugMessage ($"Cached Library resources list {fileCache} does not exist.");
+					if (!File.Exists (filesCache))
+						Log.LogDebugMessage ($"Cached Library resources list {filesCache} does not exist.");
 					else
-						Log.LogDebugMessage ($"Cached Library resources list {fileCache} is out of date.");
+						Log.LogDebugMessage ($"Cached Library resources list {filesCache} is out of date.");
 					if (generateArchive) {
 						files = new string[1] { stampFile };
 					} else {
@@ -73,8 +81,8 @@ namespace Xamarin.Android.Tasks {
 				}
 
 				if (files.Any ()) {
-					if (!File.Exists (fileCache) || cacheLastWriteTime < lastwriteTime)
-						File.WriteAllLines (fileCache, files, Encoding.UTF8);
+					if (!File.Exists (filesCache) || cacheLastWriteTime < lastwriteTime)
+						File.WriteAllLines (filesCache, files, Encoding.UTF8);
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {
 						{"FileFound", files.First () },
 					});
@@ -85,11 +93,17 @@ namespace Xamarin.Android.Tasks {
 					} else {
 						Log.LogDebugMessage ($"%(StampFile) already set: {stampFile}");
 					}
+					if (string.IsNullOrEmpty (directory.GetMetadata ("FilesCache"))) {
+						taskItem.SetMetadata ("FilesCache", filesCache);
+					} else {
+						Log.LogDebugMessage ($"%(FilesCache) already set: {filesCache}");
+					}
 					output.Add (taskItem);
 					foreach (var file in files) {
 						var fileTaskItem = new TaskItem (file, new Dictionary<string, string> () {
 							{ "ResourceDirectory", directory.ItemSpec },
 							{ "StampFile", generateArchive ? stampFile : file },
+							{ "FilesCache", filesCache},
 							{ "Hash", stampFile },
 							{ "_ArchiveDirectory", Path.Combine (directory.ItemSpec, "..", "flat" + Path.DirectorySeparatorChar) },
 							{ "_FlatFile", generateArchive ?  $"{Path.GetFileNameWithoutExtension (stampFile)}.flata"  : Monodroid.AndroidResource.CalculateAapt2FlatArchiveFileName (file) },


### PR DESCRIPTION
Context https://github.com/Redth/ResizetizerNT/issues/23

The `CollectNonEmptyDirectories` task is responsible for
creating a cache file `files.cache`. This file contains
a list of all the resource files for that particular
directory.

We hit a problem when using `ResizetizerNT` and a
`google-services.json` file where the `files.cache` for
one would be overwritten by the other.  This is because of
a simple assuption within the Task itself. That if the
"directory" was not in the Intermediate `lp` directory
(for libraries) then we could just create the `files.cache`
file in the parent directory. This woud be the root of
the `IntermediateOutputPath`.

The problem with `ResizetizerNT` and `google-services.json` is that
they are BOTH outside of the `lp` directory. They also only create
a directory structure which is one level deep. So `..` will ALWAYS
end up in the `IntermediateOutputPath`. The other issue is that they
were both using the same file name. #facepalm.

The `files.cache` should instead be handled in the same manner as
the `stamp` file. In that if the file is NOT in the `lp` directory
we should use a unique filename. In this case we can use the same
technique and use the directory hash. This way the two directories
do not collide with each other.