### PR TITLE
[tests] enable One .NET tests for F#

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -63,7 +63,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != FSharp & TestCategory != LibraryProjectZip & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != LibraryProjectZip & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -547,22 +547,18 @@ namespace UnnamedProject
 		[TestCaseSource (nameof (ReleaseLanguage))]
 		public void CheckResourceDesignerIsCreated (bool isRelease, ProjectLanguage language)
 		{
-			//Due to the MSBuild project automatically sorting <ItemGroup />, we can't possibly get the F# projects to build here on Windows
-			//  This API is sorting them: https://github.com/xamarin/xamarin-android/blob/c588bfe07aab224c97996a264579f4d4f18a151c/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs#L117
 			bool isFSharp = language == XamarinAndroidProjectLanguage.FSharp;
-			if (IsWindows && isFSharp) {
-				Assert.Ignore ("Skipping this F# test on Windows.");
-			}
-			if (Builder.UseDotNet && isFSharp) {
-				Assert.Ignore ("Skipping this F# test under 'dotnet'.");
-			}
 
 			var proj = new XamarinAndroidApplicationProject () {
 				Language = language,
 				IsRelease = isRelease,
 			};
+			if (Builder.UseDotNet && isFSharp && isRelease) {
+				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
+				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
+			}
 			proj.SetProperty ("AndroidUseIntermediateDesignerFile", "True");
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				// Intermediate designer file support is not compatible with F# projects using Xamarin.Android.FSharp.ResourceProvider.
 				var outputFile = isFSharp ? Path.Combine (Root, b.ProjectDirectory, "Resources", "Resource.designer" + proj.Language.DefaultDesignerExtension)
@@ -582,21 +578,16 @@ namespace UnnamedProject
 		[TestCaseSource(nameof (ReleaseLanguage))]
 		public void CheckResourceDesignerIsUpdatedWhenReadOnly (bool isRelease, ProjectLanguage language)
 		{
-			//Due to the MSBuild project automatically sorting <ItemGroup />, we can't possibly get the F# projects to build here on Windows
-			//  This API is sorting them: https://github.com/xamarin/xamarin-android/blob/c588bfe07aab224c97996a264579f4d4f18a151c/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs#L117
 			bool isFSharp = language == XamarinAndroidProjectLanguage.FSharp;
-			if (IsWindows && isFSharp) {
-				Assert.Ignore ("Skipping this F# test on Windows.");
-			}
-			if (Builder.UseDotNet && isFSharp) {
-				Assert.Ignore ("Skipping this F# test under 'dotnet'.");
-			}
-
 			var proj = new XamarinAndroidApplicationProject () {
 				Language = language,
 				IsRelease = isRelease,
 			};
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			if (Builder.UseDotNet && isFSharp && isRelease) {
+				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
+				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
+			}
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var designerPath = GetResourceDesignerPath (b, proj);
 				var attr = File.GetAttributes (designerPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -216,6 +216,10 @@ class MemTest {
 				Language = XamarinAndroidProjectLanguage.FSharp,
 				IsRelease = isRelease,
 			};
+			if (Builder.UseDotNet && isRelease) {
+				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
+				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
+			}
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -426,13 +426,13 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
-		public static Package Xamarin_Android_FSharp_ResourceProvider_Runtime = new Package {
+		public static Package Xamarin_Android_FSharp_ResourceProvider = new Package {
 			Id = "Xamarin.Android.FSharp.ResourceProvider",
-			Version = "1.0.0.28",
-			TargetFramework = "monoandroid71",
+			Version = "1.0.1",
+			TargetFramework = "monoandroid81",
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.FSharp.ResourceProvider.Runtime") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.FSharp.ResourceProvider.1.0.0.28\\lib\\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.FSharp.ResourceProvider.1.0.1\\lib\\monoandroid81\\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -86,9 +86,16 @@ namespace Xamarin.ProjectTools
 					// add the stuff needed for FSharp
 					References.Add (new BuildItem.Reference ("System.Numerics"));
 					PackageReferences.Add (KnownPackages.FSharp_Core_Latest);
-					PackageReferences.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider_Runtime);
+					PackageReferences.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider);
 					Sources.Remove (resourceDesigner);
 					OtherBuildItems.Add (new BuildItem.NoActionResource (() => "Resources\\Resource.designer" + Language.DefaultDesignerExtension) { TextContent = () => string.Empty });
+
+					if (Builder.UseDotNet) {
+						this.AddDotNetCompatPackages ();
+
+						// NOTE: workaround for https://github.com/dotnet/sdk/issues/12954
+						SetProperty ("ProduceReferenceAssembly", "false");
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -487,7 +487,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_RemoveLegacyDesigner"
-		Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'true' and '$(ManagedDesignTimeBuild)' != 'true' ">
+		Condition=" '$(Language)' == 'C#' and '$(AndroidUseIntermediateDesignerFile)' == 'true' and '$(ManagedDesignTimeBuild)' != 'true' ">
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
 		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(AndroidResgenFile)' != '' "/>


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider/pull/6

Xamarin.Android.FSharp.ResourceProvider 1.0.1 is now built for
`netstandard2.0` and published to an internal feed.

We should be able to enable F# tests under a `dotnet` context now.

The `_RemoveLegacyDesigner` MSBuild target was running, when it
shouldn't be for F# projects and adding a `Resource.designer.cs`
`@(Compile)` item. I needed to add a `$(Language)` check.

One workaround is for:

https://github.com/dotnet/sdk/issues/12954

We need to set `$(ProduceReferenceAssembly)` to `false` for .NET 5 F#
projects at the moment.