### PR TITLE
[One .NET] fixes for satellite assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -57,7 +57,6 @@ _ResolveAssemblies MSBuild target.
     <ProcessAssemblies
         InputAssemblies="@(_ResolvedAssemblyFiles)"
         ResolvedSymbols="@(_ResolvedSymbolFiles)"
-        IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
         UseSharedRuntime="$(AndroidUseSharedRuntime)"
         LinkMode="$(AndroidLinkMode)">
       <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
@@ -111,10 +110,10 @@ _ResolveAssemblies MSBuild target.
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
     <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' ">
-      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')" />
-      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'%(IntermediateLinkerOutput)')" />
-      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'%(IntermediateLinkerOutput)')" />
-      <_ResolvedSymbols             Include="@(ResolvedSymbols->'%(IntermediateLinkerOutput)')" />
+      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
+      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
+      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
+      <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
       <_ShrunkAssemblies            Include="@(_ResolvedAssemblies)" />
       <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
       <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -421,9 +421,9 @@ namespace Xamarin.Android.Tasks
 				if (compressedAssembliesInfo.TryGetValue (key, out CompressedAssemblyInfo info) && info != null) {
 					EnsureCompressedAssemblyData (assembly.ItemSpec, info.DescriptorIndex);
 					string assemblyOutputDir;
-					string abiDirectory = assembly.GetMetadata ("AbiDirectory");
-					if (!String.IsNullOrEmpty (abiDirectory))
-						assemblyOutputDir = Path.Combine (compressedOutputDir, abiDirectory);
+					string subDirectory = assembly.GetMetadata ("DestinationSubDirectory");
+					if (!String.IsNullOrEmpty (subDirectory))
+						assemblyOutputDir = Path.Combine (compressedOutputDir, subDirectory);
 					else
 						assemblyOutputDir = compressedOutputDir;
 					AssemblyCompression.CompressionResult result = AssemblyCompression.Compress (compressedAssembly, assemblyOutputDir);
@@ -494,11 +494,13 @@ namespace Xamarin.Android.Tasks
 		string GetAssemblyPath (ITaskItem assembly, bool frameworkAssembly)
 		{
 			var assembliesPath = AssembliesPath;
-			var abiDirectory = assembly.GetMetadata ("AbiDirectory");
-			if (!string.IsNullOrEmpty (abiDirectory)) {
-				assembliesPath += abiDirectory + "/";
-			}
-			if (!frameworkAssembly && SatelliteAssembly.TryGetSatelliteCultureAndFileName (assembly.ItemSpec, out var culture, out _)) {
+			var subDirectory = assembly.GetMetadata ("DestinationSubDirectory");
+			if (!string.IsNullOrEmpty (subDirectory)) {
+				assembliesPath += subDirectory.Replace ('\\', '/');
+				if (!assembliesPath.EndsWith ("/", StringComparison.Ordinal)) {
+					assembliesPath += "/";
+				}
+			} else if (!frameworkAssembly && SatelliteAssembly.TryGetSatelliteCultureAndFileName (assembly.ItemSpec, out var culture, out _)) {
 				assembliesPath += culture + "/";
 			}
 			return assembliesPath;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -34,9 +34,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ProjectFile { get; set; }
 
-		[Required]
-		public string IntermediateAssemblyDirectory { get; set; }
-
 		public string ProjectAssetFile { get; set; }
 
 		public string TargetMoniker { get; set; }
@@ -141,7 +138,7 @@ namespace Xamarin.Android.Tasks
 				} else {
 					resolvedUserAssemblies.Add (assembly);
 				}
-				assembly.SetMetadata ("IntermediateLinkerOutput", Path.Combine (IntermediateAssemblyDirectory, Path.GetFileName (assembly.ItemSpec)));
+				assembly.SetDestinationSubPath ();
 			}
 			ResolvedAssemblies = resolvedAssemblies.ToArray ();
 			ResolvedSymbols = resolvedSymbols.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -142,9 +142,11 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsTrue (zip.ContainsEntry ($"lib/{abi}/libmonodroid.so"), "libmonodroid.so should exist.");
 					Assert.IsTrue (zip.ContainsEntry ($"lib/{abi}/libmonosgen-2.0.so"), "libmonosgen-2.0.so should exist.");
 					if (rids.Length > 1) {
-						Assert.IsTrue (zip.ContainsEntry ($"assemblies/{abi}/System.Private.CoreLib.dll"), "System.Private.CoreLib.dll should exist.");
+						var entry = $"assemblies/{abi}/System.Private.CoreLib.dll";
+						Assert.IsTrue (zip.ContainsEntry (entry), $"{entry} should exist.");
 					} else {
-						Assert.IsTrue (zip.ContainsEntry ("assemblies/System.Private.CoreLib.dll"), "System.Private.CoreLib.dll should exist.");
+						var entry = "assemblies/System.Private.CoreLib.dll";
+						Assert.IsTrue (zip.ContainsEntry (entry), $"{entry} should exist.");
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssemblyInfo.cs
@@ -27,12 +27,14 @@ namespace Xamarin.Android.Tasks
 
 		public static string GetDictionaryKey (ITaskItem assembly)
 		{
-			var key = Path.GetFileName (assembly.ItemSpec);
-			var abiDirectory = assembly.GetMetadata ("AbiDirectory");
-			if (!string.IsNullOrEmpty (abiDirectory)) {
-				key = abiDirectory + "/" + key;
+			// Prefer %(DestinationSubPath) if set
+			var path = assembly.GetMetadata ("DestinationSubPath");
+			if (!string.IsNullOrEmpty (path)) {
+				return path;
 			}
-			return key;
+			// MSBuild sometimes only sets %(DestinationSubDirectory)
+			var subDirectory = assembly.GetMetadata ("DestinationSubDirectory");
+			return Path.Combine (subDirectory, Path.GetFileName (assembly.ItemSpec));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
@@ -239,5 +239,17 @@ namespace Xamarin.Android.Tasks
 			var targetfile = FixupResourceFilename (file, resourceDir, resourceNameCaseMap);
 			log.LogCodedWarning (code, file: targetfile, lineNumber: 0, message: message);
 		}
+
+		/// <summary>
+		/// Sets the default value for %(DestinationSubPath) if it is not already set
+		/// </summary>
+		public static void SetDestinationSubPath (this ITaskItem assembly)
+		{
+			if (string.IsNullOrEmpty (assembly.GetMetadata ("DestinationSubPath"))) {
+				var directory = assembly.GetMetadata ("DestinationSubDirectory");
+				var path = Path.Combine (directory, Path.GetFileName (assembly.ItemSpec));
+				assembly.SetMetadata ("DestinationSubPath", path);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1382,11 +1382,11 @@ because xbuild doesn't support framework reference assemblies.
     DependsOnTargets="_LinkAssembliesNoShrinkInputs"
     Condition="'$(AndroidLinkMode)' == 'None'"
     Inputs="@(ResolvedAssemblies);$(_AndroidBuildPropertiesCache)"
-    Outputs="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')">
+    Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')">
   <LinkAssembliesNoShrink
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
-      DestinationFiles="@(ResolvedAssemblies->'%(IntermediateLinkerOutput)')"
+      DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"
       Deterministic="$(Deterministic)"
   />
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -282,7 +282,6 @@ projects. .NET 5 projects will not import this file.
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         ProjectAssetFile="$(ProjectLockFile)"
         TargetMoniker="$(NuGetTargetMoniker)"
-        IntermediateAssemblyDirectory="$(MonoAndroidIntermediateAssemblyDir)"
         ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
       <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />
       <Output TaskParameter="ResolvedUserAssemblies" ItemName="ResolvedUserAssemblies" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5040

In trying to enable our F# MSBuild tests, one fails with:

    GenerateCompressedAssembliesNativeSourceFiles
        Xamarin.Android.Common.targets(1933,3): error XAGCANSF7004: System.ArgumentException: An item with the same key has already been added. Key: [FSharp.Core.resources.dll, Xamarin.Android.Tasks.CompressedAssemblyInfo]
        at System.Collections.Generic.TreeSet`1.AddIfNotPresent(T item)
        at System.Collections.Generic.SortedDictionary`2.Add(TKey key, TValue value)
        at Xamarin.Android.Tasks.GenerateCompressedAssembliesNativeSourceFiles.GenerateCompressedAssemblySources()
        at Xamarin.Android.Tasks.GenerateCompressedAssembliesNativeSourceFiles.RunTask()
        at Xamarin.Android.Tasks.AndroidTask.Execute()

Looking at some of the item groups earlier:

    C:\src\xamarin-android\packages\xamarin.android.fsharp.resourceprovider\1.0.1\lib\monoandroid81\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll
        ...
        DestinationSubPath = Xamarin.Android.FSharp.ResourceProvider.Runtime.dll
        ...
    C:\src\xamarin-android\packages\fsharp.core\4.7.2\lib\netstandard2.0\cs\FSharp.Core.resources.dll
        ...
        DestinationSubDirectory = cs\
        DestinationSubPath = cs\FSharp.Core.resources.dll
        ...
    C:\src\xamarin-android\packages\fsharp.core\4.7.2\lib\netstandard2.0\de\FSharp.Core.resources.dll
        ...
        DestinationSubDirectory = de\
        DestinationSubPath = de\FSharp.Core.resources.dll
        ...

Two instances of `FSharp.Core.resources.dll` is causing the above
exception. Should we be using the `%(DestinationSubDirectory)` and
`%(DestinationSubPath)` item metadata?

Currently, we have some behavior for architecture-specific .NET
assemblies:

* `%(AbiDirectory)` is set for x86, armeabi-v7a, etc.
* `%(IntermediateLinkerOutput)` is set to a full path taking
  `%(AbiDirectory)` into account.

To clean things up here, we should just use
`%(DestinationSubDirectory)` coming from dotnet/sdk and
`%(DestinationSubPath)` and remove the item data that we invented.

Other changes:

* Usage of `%(AbiDirectory)` can use `%(DestinationSubDirectory)` or
  `%(DestinationSubPath)` where appropriate.
* Any usage of `%(IntermediateLinkerOutput)` can use
  `$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)`
  instead.
* The `<ResolveAssemblies/>` (legacy) and `<ProcessAssemblies/>`
  MSBuild tasks no longer need the `IntermediateAssemblyDirectory`
  property.