### PR TITLE
[tests] fix ClassLibraryHasNoWarnings test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -161,7 +161,7 @@ namespace Xamarin.Android.Build.Tests
 			//NOTE: these properties should not affect class libraries at all
 			proj.SetProperty ("AndroidPackageFormat", "aab");
 			proj.SetProperty ("AotAssemblies", "true");
-			using (var b = CreateApkBuilder ()) {
+			using (var b = CreateDllBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
 			}


### PR DESCRIPTION
This was failing with:

    Xamarin.Android.Common.targets(2107,3): error XABBA7024: Xamarin.Tools.Zip.ZipIOException: Error occured while reading obj\Debug\android\bin\base.zip
        at Xamarin.Tools.Zip.ZipArchive.Open(String path, FileMode mode, String defaultExtractionDir, Boolean strictConsistencyChecks, IPlatformOptions options) in /Users/runner/work/1/s/ZipArchive.cs:line 273
        at Xamarin.Android.Tasks.ZipArchiveEx..ctor(String archive, FileMode filemode)
        at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo)
        at Xamarin.Android.Tasks.BuildApk.RunTask()
        at Xamarin.Android.Tasks.AndroidTask.Execute()

But this shouldn't run at all for a class library?

The test was accidentally calling `CreateApkBuilder` instead of
`CreateDllBuilder`, so it was running the `SignAndroidPackage` MSBuild
target by default.