### PR TITLE
[build] add attempt # for designer tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -955,12 +955,11 @@ stages:
         flattenFolders: true
       condition: always()
 
-    - task: PublishPipelineArtifact@1
-      displayName: upload designer binlogs
-      inputs:
+    - template: yaml-templates/publish-artifact.yaml
+      parameters:
+        displayName: upload designer binlogs
         artifactName: Test Results - Designer - macOS
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
-      condition: always()
 
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
@@ -1034,12 +1033,11 @@ stages:
         flattenFolders: true
       condition: always()
 
-    - task: PublishPipelineArtifact@1
-      displayName: upload designer binlogs
-      inputs:
+    - template: yaml-templates/publish-artifact.yaml
+      parameters:
+        displayName: upload designer binlogs
         artifactName: Test Results - Designer - Windows
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
-      condition: always()
 
 - stage: dotnet_tests
   displayName: One .NET Tests

--- a/build-tools/automation/yaml-templates/publish-artifact.yaml
+++ b/build-tools/automation/yaml-templates/publish-artifact.yaml
@@ -1,0 +1,20 @@
+parameters:
+  displayName: upload artifacts
+  artifactName: artifact
+  targetPath: $(Build.ArtifactStagingDirectory)
+  condition: always()
+
+steps:
+# Add the "(Attempt X)" for retries, but leave the initial run blank
+- powershell: |
+    $UploadAttemptSuffix = If ($(System.JobAttempt) -gt 1) {"(Attempt $(System.JobAttempt))"} Else {""}
+    Write-Host "##vso[task.setvariable variable=UploadAttemptSuffix;]$UploadAttemptSuffix"
+  displayName: Set upload artifact name
+  condition: ${{ parameters.condition }}
+
+- task: PublishPipelineArtifact@1
+  displayName: ${{ parameters.displayName }}
+  inputs:
+    artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)
+    targetPath: ${{ parameters.targetPath }}
+  condition: ${{ parameters.condition }}

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -12,16 +12,7 @@ steps:
     msbuildArguments: /restore /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
   condition: always()
 
-# Add the "(Attempt X)" for retries, but leave the initial run blank
-- powershell: |
-    $UploadAttemptSuffix = If ($(System.JobAttempt) -gt 1) {"(Attempt $(System.JobAttempt))"} Else {""}
-    Write-Host "##vso[task.setvariable variable=UploadAttemptSuffix;]$UploadAttemptSuffix"
-  displayName: Set upload artifact name
-  condition: always()
-
-- task: PublishPipelineArtifact@1
-  displayName: upload build and test results
-  inputs:
+- template: publish-artifact.yaml
+  parameters:
+    displayName: upload build and test results
     artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)
-    targetPath: $(Build.ArtifactStagingDirectory)
-  condition: always()


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4000236&view=logs&j=db00894d-3ef4-5d97-073c-254fbd613a41&t=2d91500b-42fa-5f4d-9c78-a0a207f1288c&l=2042

A re-run of the designer tests will fail with:

    ##[error]Artifact Test Results - Designer - macOS already exists for build 4000236.

All of our other calls to `PublishPipelineArtifact` go through the
steps in `upload-results.yaml`. I moved the logic that sets
`$(UploadAttemptSuffix)` so that it can be used by the designer tests
as well.