### PR TITLE
[Xamarin.Android.Build.Tasks] AndroidAsset changes should update .apk

### DIFF
--- a/Documentation/release-notes/5051.md
+++ b/Documentation/release-notes/5051.md
@@ -1,0 +1,7 @@
+#### Application and library build and deployment
+
+  * [Developer Community 1157593][0]: Fixes an issue where modifying
+    `@(AndroidAsset)` files would require a `Rebuild` to see the
+    changes reflected in the Android application build output.
+
+[0]: https://developercommunity.visualstudio.com/content/problem/1157593/apk-is-not-rebuild-when-androidasset-changes.html

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1099,10 +1099,6 @@ because xbuild doesn't support framework reference assemblies.
       $(_UpdateAndroidResgenInputs);
       @(_ModifiedResources);
     </_UpdateAndroidResgenInputs>
-    <_CreateBaseApkInputs>
-      $(_CreateBaseApkInputs);
-      @(_ModifiedResources);
-    </_CreateBaseApkInputs>
   </PropertyGroup>
 </Target>
 
@@ -1613,10 +1609,30 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
+<Target Name="_CreateBaseApkInputs">
+  <PropertyGroup>
+    <_CreateBaseApkInputs>
+      $(_CreateBaseApkInputs);
+      $(MSBuildAllProjects);
+      $(IntermediateOutputPath)android\AndroidManifest.xml;
+      @(_ModifiedResources);
+      @(_AndroidAssetsDest);
+      $(_AcwMapFile);
+      $(_AndroidBuildPropertiesCache);
+    </_CreateBaseApkInputs>
+  </PropertyGroup>
+</Target>
+
 <Target Name="_PrepareCreateBaseApk"
+    DependsOnTargets="_CreateBaseApkInputs"
     Inputs="$(_CreateBaseApkInputs)"
     Outputs="$(_PackagedResources)"
   >
+  <!--
+    NOTE: these steps need to be in a separate target, so variables
+    pass through to <CallTarget/> in _CreateBaseApk. (MSBuild bug)
+  -->
+
   <!-- Create a temporary directory to work in, or else R.java will always get updated -->
   <CreateTemporaryDirectory>
     <Output TaskParameter="TemporaryDirectory" PropertyName="AaptTemporaryDirectory" />
@@ -1645,14 +1661,6 @@ because xbuild doesn't support framework reference assemblies.
 		UpdateAndroidAssets;
 		$(_AfterCreateBaseApkDependsOnTargets);
 	</_CreateBaseApkDependsOnTargets>
-	<_CreateBaseApkInputs>
-		$(MSBuildAllProjects)
-		;$(IntermediateOutputPath)android\AndroidManifest.xml
-		;@(_AndroidResourceDest)
-		;@(_AndroidAssetsDest)
-		;$(_AcwMapFile)
-		;$(_AndroidBuildPropertiesCache)
-	</_CreateBaseApkInputs>
 </PropertyGroup>
 
 <Target Name="_CreateBaseApk"


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/1157593/apk-is-not-rebuild-when-androidasset-changes.html
Fixes: https://feedback.devdiv.io/1157593

An incremental build after `@(AndroidAsset)` file changes did not
actually make it to the `.apk` file.

I could reproduce this easily in a sample app doing something like:

    using (var reader = new StreamReader (Assets.Open ("foo.txt"))) {
        var textView = FindViewById<TextView> (Resource.Id.textView1);
        textView.Text = reader.ReadToEnd ();
    }

Edits to `foo.txt` would not show on screen, unless I did a `Rebuild`
or edited an `@(AndroidResource)` file!

Reviewing the inputs to the `_CreateBaseApk` MSBuild target:

    <PropertyGroup>
        <_CreateBaseApkInputs>
            $(MSBuildAllProjects)
            ;$(IntermediateOutputPath)android\AndroidManifest.xml
            ;@(_AndroidResourceDest)
            ;@(_AndroidAssetsDest)
            ;$(_AcwMapFile)
            ;$(_AndroidBuildPropertiesCache)
        </_CreateBaseApkInputs>
    </PropertyGroup>

At the time MSBuild properties are evaluated, item groups do not exist
yet. Item groups are only evaluated in a future pass.

Any of the item groups above are blank: `@(_AndroidResourceDest)` and
`@(_AndroidAssetsDest)`.

The only reason this currently works at all, is this target:

    <Target Name="_IncludeModifiedFilesInUpdateAndroidResgenInputs">
      <PropertyGroup>
        <!-- .. -->
        <_CreateBaseApkInputs>
          $(_CreateBaseApkInputs);
          @(_ModifiedResources);
        </_CreateBaseApkInputs>
      </PropertyGroup>
    </Target>

`@(_ModifiedResources)` enables resource changes to trigger properly,
but `@(AndroidAsset)` changes would not.

Looking through all of this, it seems we should clean things up:

* Don't define `$(_CreateBaseApkInputs)` as a top-level
  `<PropertyGroup/>` at all. Only define it inside a `<Target/>`.
* `_PrepareCreateBaseApk` has some logic to workaround properties not
  passing through `<CallTarget/>`. I added a comment for future self.
* A new `_CreateBaseApkInputs` target can set
  `$(_CreateBaseApkInputs)`, including Android assets.