### PR TITLE
[Xamarin.Android.Build.Tasks] fix C# 8.0 support by default

### DIFF
--- a/Documentation/release-notes/csharp-8.md
+++ b/Documentation/release-notes/csharp-8.md
@@ -1,0 +1,5 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5049](https://github.com/xamarin/xamarin-android/issues/5049):
+  *Feature 'XYZ' is not available in C# 7.3. Please use language version 8.0 or greater.*
+  build error could prevent projects from using C# 8.0 language features.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -44,7 +44,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v5.0</TargetFrameworkVersion>
-    <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
+    <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
     <_AndroidIsBindingProject>True</_AndroidIsBindingProject>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -28,7 +28,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
         <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
-        <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
+        <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5049
Context: https://github.com/dotnet/roslyn/commit/12f1b8f6c17c0bcd271525b5f4db0f621944c49d#diff-125e2d8c52dd9033f9b248f79f78c3f8
Context: https://github.com/dotnet/roslyn/pull/44911#discussion_r477418327

The `BuildTest.CSharp8Features` test was failing for me locally where
I have Visual Studio 2019 16.7.2 installed:

    Foo.cs(1,23): error CS8370: Feature 'using declarations' is not available in C# 7.3. Please use language version 8.0 or greater.

After review, it appears that a change in Roslyn's MSBuild targets
removed `$(MaxSupportedLangVersion)` and made the property private:
`$(_MaxSupportedLangVersion)`.

After some discussion around C# 9.0:

* It is unknown if C# 9.0 will be supported by mono/mono/2020-02. Some
  features like covariant return types and function pointers require
  runtime changes.
* Using a build of .NET 5 rc1, `$(LangVersion)` is already being set
  to `9.0` by default.

We should just change the current behavior of:

    <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>

And change it to:

    <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>

This matches what Roslyn's default behavior is:

https://github.com/dotnet/roslyn/blob/1aeda2e94fb9371b96d4bfd94b074860064ec3d2/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets#L6-L21

.NET 5+ projects should be unaffected by this change, as they do not
import `Xamarin.Android.CSharp.targets`.

If at some point, mono/mono/2020-02 fully supports C# we can bump this
value. Users can opt into `9.0` on their own if desired.

`BuildTest.CSharp8Features` now passes for me locally.