### PR TITLE
[One .NET] remove libsqlite3_xamarin.so from Microsoft.Android.Runtime

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -39,7 +39,6 @@ projects that use the Microsoft.Android framework in .NET 5.
       <_AndroidRuntimePackAssets Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.debug.so" />
       <_AndroidRuntimePackAssets Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.release.so" />
       <_AndroidRuntimePackAssets Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib\$(AndroidABI)\libxa-internal-api.so" />
-      <_AndroidRuntimePackAssets Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib\$(AndroidABI)\libsqlite3_xamarin.so" />
       <_AndroidRuntimePackAssets Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib\$(AndroidABI)\libxamarin-debug-app-helper.so" />
       <FrameworkListFileClass Include="@(_AndroidRuntimePackAssets->'%(Filename)%(Extension)')" Profile="Android" />
     </ItemGroup>


### PR DESCRIPTION
`libsqlite3_xamarin.so` is needed for `Mono.Data.Sqlite.dll`, which
does not currently exist in a One .NET world.

`libsqlite3_xamarin.so` is currently included in the
`Microsoft.Android.Runtime` pack:

    runtimes\android.21-arm\lib\net5.0\Java.Interop.dll
    runtimes\android.21-arm\lib\net5.0\Mono.Android.dll
    runtimes\android.21-arm\lib\net5.0\Mono.Android.Export.dll
    runtimes\android.21-arm\native\libmono-android.debug.so
    runtimes\android.21-arm\native\libmono-android.release.so
    runtimes\android.21-arm\native\libxa-internal-api.so
    runtimes\android.21-arm\native\libsqlite3_xamarin.so
    runtimes\android.21-arm\native\libxamarin-debug-app-helper.so

The way things are currently working, every native library in this
package is added to every app.

This library adds ~641KB per architecture:

       Size   Compressed  Name
    ------- ------------  ------------------------
    1320836       641411  lib\x86\libsqlite3_xamarin.so

`libsqlite3_xamarin.so` seems to just be extra space at the moment.
Let's remove it.

There is probably a need to add a build warning for
`Mono.Data.Sqlite.dll`, but that can be done in the future.