### PR TITLE
[build] fix '(Attempt N)' listed twice on artifacts

### DIFF
--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -15,4 +15,4 @@ steps:
 - template: publish-artifact.yaml
   parameters:
     displayName: upload build and test results
-    artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)
+    artifactName: ${{ parameters.artifactName }}


### PR DESCRIPTION
I accidentally put the extra label twice in 5bcd2d9d:

    Test Results - MSBuild - Mac-2 - Legacy (Attempt 2) (Attempt 2)

This was because `publish-artifact.yaml` has:

    - task: PublishPipelineArtifact@1
      displayName: ${{ parameters.displayName }}
      inputs:
        artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)
        targetPath: ${{ parameters.targetPath }}
      condition: ${{ parameters.condition }}

*and* `upload-results.yaml` has:

    - template: publish-artifact.yaml
      parameters:
        displayName: upload build and test results
        artifactName: ${{ parameters.artifactName }} $(UploadAttemptSuffix)

We need to remove `$(UploadAttemptSuffix)` from `upload-results.yaml`.