### PR TITLE
[build] fix incremental build for apksigner.jar

### DIFF
--- a/src/apksigner/apksigner.csproj
+++ b/src/apksigner/apksigner.csproj
@@ -25,6 +25,7 @@
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
+    <Touch Files="build\libs\apksigner.jar" />
   </Target>
 
   <Target Name="_CleanGradle" BeforeTargets="Clean">


### PR DESCRIPTION
In c50df1c5, I made a small mistake in building `apksigner`.

Locally, I noticed my machine is in a state where `apksigner` is built
on any incremental build:

    Input file "apksigner.csproj" is newer than output file "build\libs\apksigner.jar".
    Exec
        ...
        > Task :compileJava UP-TO-DATE
        > Task :processResources UP-TO-DATE
        > Task :classes UP-TO-DATE
        > Task :jar UP-TO-DATE
        BUILD SUCCESSFUL in 3s
        3 actionable tasks: 3 up-to-date

To fix this, we need a `<Touch/>` MSBuild task call to ensure the
timestamp on `apksigner.jar` is updated even if gradle doesn't do any
work.

Now things are working properly:

    Skipping target "_BuildGradle" because all output files are up-to-date with respect to the input files.
    Input files: apksigner.csproj;build.gradle
    Output files: build\libs\apksigner.jar

This saves ~3.294s on incremental builds of `Xamarin.Android.sln`.