### PR TITLE
[build] all desktop Java code should be built with JDK 1.8

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -124,6 +124,8 @@
   <PropertyGroup>
     <JavacSourceVersion>1.8</JavacSourceVersion>
     <JavacTargetVersion>1.8</JavacTargetVersion>
+    <Java8SdkDirectory Condition=" '$(Java8SdkDirectory)' == '' and Exists('$(JavaSdkDirectory)\..\jdk-1.8') ">$([System.IO.Path]::GetFullPath ('$(JavaSdkDirectory)\..\jdk-1.8'))</Java8SdkDirectory>
+    <Java8SdkDirectory Condition=" '$(Java8SdkDirectory)' == '' ">$(JavaSdkDirectory)</Java8SdkDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidMxeFullPath Condition=" '$(AndroidMxeInstallPrefix)' != '' ">$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>

--- a/src/apksigner/apksigner.csproj
+++ b/src/apksigner/apksigner.csproj
@@ -22,7 +22,7 @@
       Outputs="build\libs\apksigner.jar">
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Touch Files="build\libs\apksigner.jar" />
@@ -31,7 +31,7 @@
   <Target Name="_CleanGradle" BeforeTargets="Clean">
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>

--- a/src/manifestmerger/manifestmerger.targets
+++ b/src/manifestmerger/manifestmerger.targets
@@ -18,12 +18,12 @@
       Outputs="$(_Destination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; build $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Copy
@@ -37,7 +37,7 @@
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>

--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -13,7 +13,7 @@
       Outputs="@(_Outputs)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(ProGuardSourceFullPath)\core"
     />
     <MakeDir Directories="$(OutputPath)" />
@@ -39,7 +39,7 @@
     <Delete Files="@(_Outputs)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(ProGuardSourceFullPath)\core"
     />
   </Target>

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -19,7 +19,7 @@
       Outputs="$(_Destination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Copy
@@ -33,7 +33,7 @@
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>


### PR DESCRIPTION
Since c50df1c5, building apps with JDK 1.8 fails with:

    ~/android-toolchain/jdk-1.8/bin/java -jar ./xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/apksigner.jar sign --ks "~/.local/share/Xamarin/Mono for Android/debug.keystore" --ks-pass pass:android --ks-key-alias androiddebugke
        y --key-pass pass:android --min-sdk-version 28 --max-sdk-version 29  ./xamarin/XAPerfTest/bin/Debug/com.xamarin.xaperftest-Signed.apk  (TaskId:206)
        Exception in thread "main" java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer; (TaskId:206)
        at com.android.apksig.internal.util.FileChannelDataSource.copyTo(FileChannelDataSource.java:154) (TaskId:206)
        at com.android.apksig.internal.util.FileChannelDataSource.getByteBuffer(FileChannelDataSource.java:164) (TaskId:206)
        at com.android.apksig.internal.zip.ZipUtils.findZipEndOfCentralDirectoryRecord(ZipUtils.java:181) (TaskId:206)
        at com.android.apksig.internal.zip.ZipUtils.findZipEndOfCentralDirectoryRecord(ZipUtils.java:132) (TaskId:206)
        at com.android.apksig.apk.ApkUtils.findZipSections(ApkUtils.java:55) (TaskId:206)
        at com.android.apksig.ApkSigner.sign(ApkSigner.java:215) (TaskId:206)
        at com.android.apksig.ApkSigner.sign(ApkSigner.java:193) (TaskId:206)
        at com.android.apksigner.ApkSignerTool.sign(ApkSignerTool.java:340) (TaskId:206)
        at com.android.apksigner.ApkSignerTool.main(ApkSignerTool.java:83) (TaskId:206)

I could reproduce this locally by changing `$(JavaSdkDirectory)` to
point to a JDK 1.8 installation:

    xabuild samples/HelloWorld/HelloWorld.csproj -t:SignAndroidPackage -p:JavaSdkDirectory=~/android-toolchain/jdk-1.8

Even though we are effectively building all desktop Java libraries
with `-source 1.8 -target 1.8`, the produced `.jar` files might
*still* fail at runtime. We need to set `JAVA_HOME` so it points to a
JDK 1.8 instance.

The following command-line tools should be built with JDK 1.8:

* apksigner.jar
* manifestmerger.jar
* proguard.jar
* r8.jar

To do this, I created a new `$(Java8SdkDirectory)` MSBuild property to
be used here. It attempts to locate the `..\jdk-1.8` directory, and
falls back to `$(JavaSdkDirectory)` otherwise (for contributors).