### PR TITLE
[C++] fix a handful of compiler warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="XliffTasks" Version="1.0.0-beta.19252.1" PrivateAssets="all" />
+    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20206.1" PrivateAssets="all" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
 

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -660,7 +660,15 @@ ssize_t EmbeddedAssemblies::do_read (int fd, void *buf, size_t count)
 {
 	ssize_t ret;
 	do {
-		ret = ::read (fd, buf, count);
+		ret = ::read (
+			fd,
+			buf,
+#if defined (WINDOWS)
+			static_cast<unsigned int>(count)
+#else
+			count
+#endif
+		);
 	} while (ret < 0 && errno == EINTR);
 
 	return ret;

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1606,13 +1606,13 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		utils.set_world_accessable (counters_path);
 	}
 
-	void *api_dso_handle = nullptr;
+	void *dso_handle = nullptr;
 #if defined (WINDOWS) || defined (APPLE_OS_X)
 	const char *my_location = get_my_location ();
 	if (my_location != nullptr) {
 		simple_pointer_guard<char, false> dso_path (utils.path_combine (my_location, API_DSO_NAME));
 		log_info (LOG_DEFAULT, "Attempting to load %s", dso_path.get ());
-		api_dso_handle = java_interop_lib_load (dso_path.get (), JAVA_INTEROP_LIB_LOAD_GLOBALLY, nullptr);
+		dso_handle = java_interop_lib_load (dso_path.get (), JAVA_INTEROP_LIB_LOAD_GLOBALLY, nullptr);
 #if defined (APPLE_OS_X)
 		delete[] my_location;
 #else   // !defined(APPLE_OS_X)
@@ -1620,14 +1620,14 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 #endif  // defined(APPLE_OS_X)
 	}
 
-	if (api_dso_handle == nullptr) {
+	if (dso_handle == nullptr) {
 		log_info (LOG_DEFAULT, "Attempting to load %s with \"bare\" dlopen", API_DSO_NAME);
-		api_dso_handle = java_interop_lib_load (API_DSO_NAME, JAVA_INTEROP_LIB_LOAD_GLOBALLY, nullptr);
+		dso_handle = java_interop_lib_load (API_DSO_NAME, JAVA_INTEROP_LIB_LOAD_GLOBALLY, nullptr);
 	}
 #endif  // defined(WINDOWS) || defined(APPLE_OS_X)
-	if (api_dso_handle == nullptr)
-		api_dso_handle = androidSystem.load_dso_from_any_directories (API_DSO_NAME, JAVA_INTEROP_LIB_LOAD_GLOBALLY);
-	init_internal_api_dso (api_dso_handle);
+	if (dso_handle == nullptr)
+		dso_handle = androidSystem.load_dso_from_any_directories (API_DSO_NAME, JAVA_INTEROP_LIB_LOAD_GLOBALLY);
+	init_internal_api_dso (dso_handle);
 
 	mono_dl_fallback_register (monodroid_dlopen, monodroid_dlsym, nullptr, nullptr);
 

--- a/src/monodroid/jni/xa-internal-api.cc
+++ b/src/monodroid/jni/xa-internal-api.cc
@@ -10,6 +10,12 @@
 #include "globals.hh"
 #include "xa-internal-api-impl.hh"
 
+#if defined (WINDOWS)
+#define WINDOWS_UNUSED_ARG UNUSED_ARG
+#else
+#define WINDOWS_UNUSED_ARG
+#endif
+
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
 
@@ -21,7 +27,7 @@ int  _monodroid_getifaddrs (struct _monodroid_ifaddrs **ifap);
 void _monodroid_freeifaddrs (struct _monodroid_ifaddrs *ifa);
 
 mono_bool
-MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state (const char *ifname, mono_bool *is_up)
+MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state (WINDOWS_UNUSED_ARG const char *ifname, WINDOWS_UNUSED_ARG mono_bool *is_up)
 {
 #ifdef WINDOWS
 	return FALSE;
@@ -31,7 +37,7 @@ MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state (const c
 }
 
 mono_bool
-MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast)
+MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicast (WINDOWS_UNUSED_ARG const char *ifname, WINDOWS_UNUSED_ARG mono_bool *supports_multicast)
 {
 #ifdef WINDOWS
 	return FALSE;
@@ -41,7 +47,7 @@ MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicas
 }
 
 int
-MonoAndroidInternalCalls_Impl::monodroid_get_dns_servers (void **dns_servers_array)
+MonoAndroidInternalCalls_Impl::monodroid_get_dns_servers (WINDOWS_UNUSED_ARG void **dns_servers_array)
 {
 #ifdef WINDOWS
 	return FALSE;
@@ -51,7 +57,7 @@ MonoAndroidInternalCalls_Impl::monodroid_get_dns_servers (void **dns_servers_arr
 }
 
 int
-MonoAndroidInternalCalls_Impl::monodroid_getifaddrs (struct _monodroid_ifaddrs **ifap)
+MonoAndroidInternalCalls_Impl::monodroid_getifaddrs (WINDOWS_UNUSED_ARG struct _monodroid_ifaddrs **ifap)
 {
 #ifdef WINDOWS
 	return -1;
@@ -61,7 +67,7 @@ MonoAndroidInternalCalls_Impl::monodroid_getifaddrs (struct _monodroid_ifaddrs *
 }
 
 void
-MonoAndroidInternalCalls_Impl::monodroid_freeifaddrs (struct _monodroid_ifaddrs *ifa)
+MonoAndroidInternalCalls_Impl::monodroid_freeifaddrs (WINDOWS_UNUSED_ARG struct _monodroid_ifaddrs *ifa)
 {
 #ifndef WINDOWS
 	::_monodroid_freeifaddrs (ifa);


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/703

This commit fixes a handful of warnings reported by GCC and clang when
building for different platforms.

    monodroid-glue.cc:1609:8: warning: declaration shadows a static data member of 'xamarin::android::internal::MonodroidRuntime' [-Wshadow]
    void *api_dso_handle = nullptr;
                  ^
    monodroid-glue.cc:102:25: note: previous declaration is here
    void *MonodroidRuntime::api_dso_handle = nullptr;

Fix by renaming the local variable.  No functionality changes result
from this fix.

MinGW builds report:

    xa-internal-api.cc: In member function ‘virtual mono_bool xamarin::android::internal::MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state(const char*, mono_bool*)’:
    xa-internal-api.cc:24:86: warning: unused parameter ‘ifname’ [-Wunused-parameter]
       24 | MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state (const char *ifname, mono_bool *is_up)
          |                                                                          ~~~~~~~~~~~~^~~~~~
    xa-internal-api.cc:24:105: warning: unused parameter ‘is_up’ [-Wunused-parameter]
       24 | MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_up_state (const char *ifname, mono_bool *is_up)
          |                                                                                              ~~~~~~~~~~~^~~~~
    xa-internal-api.cc: In member function ‘virtual mono_bool xamarin::android::internal::MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicast(const char*, mono_bool*)’:
    xa-internal-api.cc:34:96: warning: unused parameter ‘ifname’ [-Wunused-parameter]
       34 | MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast)
          |                                                                                    ~~~~~~~~~~~~^~~~~~
    xa-internal-api.cc:34:115: warning: unused parameter ‘supports_multicast’ [-Wunused-parameter]
       34 | MonoAndroidInternalCalls_Impl::monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast)
          |                                                                                                        ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
    xa-internal-api.cc: In member function ‘virtual int xamarin::android::internal::MonoAndroidInternalCalls_Impl::monodroid_get_dns_servers(void**)’:
    xa-internal-api.cc:44:66: warning: unused parameter ‘dns_servers_array’ [-Wunused-parameter]
       44 | MonoAndroidInternalCalls_Impl::monodroid_get_dns_servers (void **dns_servers_array)
          |                                                           ~~~~~~~^~~~~~~~~~~~~~~~~
    xa-internal-api.cc: In member function ‘virtual int xamarin::android::internal::MonoAndroidInternalCalls_Impl::monodroid_getifaddrs(_monodroid_ifaddrs**)’:
    xa-internal-api.cc:54:82: warning: unused parameter ‘ifap’ [-Wunused-parameter]
       54 | MonoAndroidInternalCalls_Impl::monodroid_getifaddrs (struct _monodroid_ifaddrs **ifap)
          |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
    xa-internal-api.cc: In member function ‘virtual void xamarin::android::internal::MonoAndroidInternalCalls_Impl::monodroid_freeifaddrs(_monodroid_ifaddrs*)’:
    xa-internal-api.cc:64:82: warning: unused parameter ‘ifa’ [-Wunused-parameter]
       64 | MonoAndroidInternalCalls_Impl::monodroid_freeifaddrs (struct _monodroid_ifaddrs *ifa)
          |                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~

The fix is to ignore the unused parameters only during Windows builds
by using the C++17 attribute `[[maybe_unused]]`

Another Windows-only warning:

    embedded-assemblies.cc: In static member function ‘static ssize_t xamarin::android::internal::EmbeddedAssemblies::do_read(int, void*, size_t)’:
    embedded-assemblies.cc:663:26: warning: conversion from ‘size_t’ {aka ‘long long unsigned int’} to ‘unsigned int’ may change value [-Wconversion]
      663 |   ret = ::read (fd, buf, count);
          |

It is caused by `read(2)` declared in MinGW headers with the third
parameter using `unsigned int` type instead of the standard `size_t`.
Fixed by casting properly on Windows builds.