### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore Hidden Files for AndroidResources.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -1,21 +1,21 @@
-// 
+//
 // AndroidUpdateResDir.cs
-//  
+//
 // Author:
 //       Michael Hutchinson <mhutchinson@novell.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -40,10 +40,10 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public ITaskItem[] ResourceFiles { get; set; }
-		
+
 		[Required]
 		public string IntermediateDir { get; set; }
-		
+
 		public string Prefixes { get; set; }
 
 		public bool LowercaseFilenames { get; set; }
@@ -51,13 +51,13 @@ namespace Xamarin.Android.Tasks
 		public string ProjectDir { get; set; }
 
 		public string AndroidLibraryFlatFilesDirectory { get; set; }
-		
+
 		[Output]
 		public ITaskItem[] IntermediateFiles { get; set; }
 
 		[Output]
 		public ITaskItem [] ResolvedResourceFiles { get; set; }
-		
+
 		[Output]
 		public string ResourceNameCaseMap { get; set; }
 
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var intermediateFiles = new List<ITaskItem> ();
 			var resolvedFiles = new List<ITaskItem> ();
-			
+
 			string[] prefixes = Prefixes != null ? Prefixes.Split (';') : null;
 			if (prefixes != null) {
 				for (int i = 0; i < prefixes.Length; i++) {
@@ -82,6 +82,9 @@ namespace Xamarin.Android.Tasks
 				var item = ResourceFiles [i];
 
 				if (Directory.Exists (item.ItemSpec))
+					continue;
+
+				if (MonoAndroidHelper.IsHiddenFile (item.ItemSpec))
 					continue;
 				//compute the target path
 				string rel;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Tasks
 			}
 			Process p = new Process ();
 			p.StartInfo = psi;
-			
+
 			p.OutputDataReceived += onOutput;
 			p.ErrorDataReceived += onError;
 			p.Start ();
@@ -213,7 +213,7 @@ namespace Xamarin.Android.Tasks
 		{
 			return filePaths.Select (p => new FileInfo (p)).ToArray ().Distinct (new MonoAndroidHelper.SizeAndContentFileComparer ()).Select (f => f.FullName).ToArray ();
 		}
-		
+
 		public static IEnumerable<string> GetDuplicateFileNames (IEnumerable<string> fullPaths, string [] excluded)
 		{
 			var files = fullPaths.Select (full => Path.GetFileName (full)).Where (f => excluded == null || !excluded.Contains (f, StringComparer.OrdinalIgnoreCase)).ToArray ();
@@ -222,7 +222,7 @@ namespace Xamarin.Android.Tasks
 					if (String.Compare (files [i], files [j], StringComparison.OrdinalIgnoreCase) == 0)
 						yield return files [i];
 		}
-		
+
 		public static bool IsEmbeddedReferenceJar (string jar)
 		{
 			return jar.StartsWith ("__reference__");
@@ -289,7 +289,7 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrWhiteSpace (rid)) {
 				lib_abi = RuntimeIdentifierToAbi (rid);
 			}
-			
+
 			if (!string.IsNullOrWhiteSpace (lib_abi))
 				return lib_abi;
 
@@ -334,6 +334,12 @@ namespace Xamarin.Android.Tasks
 				}
 				return false;
 			}
+		}
+
+		public static bool IsHiddenFile (string file)
+		{
+			FileAttributes fa = File.GetAttributes (file);
+			return (fa & FileAttributes.Hidden) == FileAttributes.Hidden;
 		}
 
 		public static bool IsForceRetainedAssembly (string assembly)
@@ -512,7 +518,7 @@ namespace Xamarin.Android.Tasks
 		}
 
 #if MSBUILD
-		internal static IEnumerable<ITaskItem> GetFrameworkAssembliesToTreatAsUserAssemblies (ITaskItem[] resolvedAssemblies) 
+		internal static IEnumerable<ITaskItem> GetFrameworkAssembliesToTreatAsUserAssemblies (ITaskItem[] resolvedAssemblies)
 		{
 			var ret = new List<ITaskItem> ();
 			foreach (ITaskItem item in resolvedAssemblies) {
@@ -645,7 +651,7 @@ namespace Xamarin.Android.Tasks
 
 		/// <summary>
 		/// Converts .NET 5 RIDs to Android ABIs or an empty string if no match.
-		/// 
+		///
 		/// Known RIDs:
 		/// "android.21-arm64" -> "arm64-v8a"
 		/// "android.21-arm"   -> "armeabi-v7a"


### PR DESCRIPTION
We should not be processing hidden files for `AndroidResorce`
items. They can cause issue with the build since aapt2 will
ignore these kinds of file by default.

We might get into a situation where becaue `aapt2` does NOT
create an expected file our targets don't build incrementally.
This can happen is `aapt2` just flat out ignores the file.