### PR TITLE
[Xamarin.Android.Build.Tasks] fix for `aapt compile` and .DS_Store

### DIFF
--- a/Documentation/release-notes/5071.md
+++ b/Documentation/release-notes/5071.md
@@ -1,0 +1,8 @@
+#### Application and library build and deployment
+
+  * [Developer Community 1141659][0]: Starting in Xamarin.Android
+    11.0, the *Updating Resources...* build step could get stuck
+    indefinitely if `.DS_Store` or any file starting with `.` was
+    included in the project with the **AndroidResource** Build Action.
+
+[0]: https://developercommunity.visualstudio.com/content/problem/1141659/android-build-process-never-stops.html

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Tasks {
 		protected long RunAapt (string [] args, string outputFile)
 		{
 			LogDebugMessage ($"Executing {string.Join (" ", args)}");
-			long jobid = daemon.QueueCommand (args, outputFile);
+			long jobid = daemon.QueueCommand (args, outputFile, CancellationToken);
 			jobs.Add (jobid);
 			return jobid;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -117,6 +117,10 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string baseFileName = LowercaseFilenames ? rel.ToLowerInvariant () : rel;
+				if (Path.GetFileName (baseFileName).StartsWith (".", StringComparison.Ordinal)) {
+					Log.LogDebugMessage ($"Skipping ignored file: {baseFileName}");
+					continue;
+				}
 				if (Path.GetExtension (baseFileName) == ".axml")
 					baseFileName = Path.ChangeExtension (baseFileName, ".xml");
 				if (baseFileName != rel)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1376,5 +1376,25 @@ namespace UnnamedProject
 				Assert.Fail ($"aapt log message was not found: {aaptCommand}");
 			}
 		}
+
+		[Test]
+		public void InvalidFilenames ()
+		{
+			BuildItem CreateItem (string include) =>
+				new AndroidItem.AndroidResource (include) {
+					TextContent = () => "",
+				};
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.foo"));
+			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.git"));
+			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.svn"));
+			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.DS_Store"));
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+				b.Output.AssertTargetIsSkipped ("_CompileResources");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/content/problem/1141659/android-build-process-never-stops.html
Context: https://feedback.devdiv.io/1141659

If you add the following file to a project:

    <AndroidResource Include="Resources\drawable\.DS_Store" />

It can just be an empty file.

The `<Aapt2Compile/>` MSBuild task will block indefinitely with:

    Executing compile -o C:\src\xamarin-android\samples\HelloWorld\obj\Debug\110\flat\ C:\src\xamarin-android\samples\HelloWorld\obj\Debug\110\res\drawable\.ds_store

In VS for Mac, the "stop" button will not stop the build either.
Clicking this button has no effect. At the command-line, Ctrl+C works
properly.

The above `aapt2 compile` command does not error and does not output
any files.

At first I found this code:

    const char * const gDefaultIgnoreAssets =
        "!.svn:!.git:!.ds_store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~";

https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/master/tools/aapt/AaptAssets.cpp#61

So I tested the following paths in a project:

* Resources\raw\.git
* Resources\raw\.svn
* Resources\raw\.DS_Store
* Resources\raw\picasa.ini
* Resources\raw\Thumbs.db
* Resources\raw\foo - with FileAttributes.Hidden

Only the files that started with an actual `.` character caused the
problem. All the other examples worked fine. This let me to realize I
was reading the wrong source code.

The skipping behavior is here:

    // Skip hidden input files
    if (file::IsHidden(path)) {
      continue;
    }

https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/master/tools/aapt2/cmd/Compile.cpp#652

Which simply checks for the `.` character:

    bool IsHidden(const android::StringPiece& path) {
      return util::StartsWith(GetFilename(path), ".");
    }

https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/master/tools/aapt2/util/Files.cpp#174

The following loop will block forever in this case:

    // wait for the file we expect to be created. There can be a delay between
    // the daemon saying "Done" and the file finally being written to disk.
    if (!string.IsNullOrEmpty (job.OutputFile) && !errored) {
        while (!File.Exists (job.OutputFile)) {
            Thread.Sleep (10);
        }
    }

Two things to fix here:

1. Cancellation: the outermost `AsyncTask.CancellationToken` as well
   as the `CancellationTokenSource` need to have
   `ThrowIfCancellationRequested ()` called within the `while` loop.

2. Let's make the `<AndroidComputeResPaths/>` MSBuild task check for
   these files and skip them silently (but log a message).

I would not say these changes fix DevCom 1141659, as the root cause is
that VS for Mac adds `.DS_Store` files to a project when using the
`Select files to add from folder` dialog.