### PR TITLE
[csproj] Convert non-managed projects to SDK-style "Microsoft.Build.NoTargets" projects.

### DIFF
--- a/build-tools/proprietary/proprietary.csproj
+++ b/build-tools/proprietary/proprietary.csproj
@@ -1,24 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets" >
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D93CAC27-3893-42A3-99F1-2BCA72E186F4}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <CopyBuildOutputToOutputDirectory>False</CopyBuildOutputToOutputDirectory>
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
   </PropertyGroup>
+
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
-  <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      PrepareForRun;
-    </BuildDependsOn>
-  </PropertyGroup>
   <Import Project="proprietary.targets" />
 </Project>

--- a/build-tools/proprietary/proprietary.targets
+++ b/build-tools/proprietary/proprietary.targets
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="proprietary.projitems" />
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)">
+  <Target Name="_BuildProprietary" BeforeTargets="Build">
     <Warning
         Condition=" '$(XAIncludeProprietaryBits)' == 'True' "
         Text="`%24(XAIncludeProprietaryBits)` is True; including proprietary Xamarin.Android files from `$(_SourceDir)`"
     />
   </Target>
-  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)">
+  <Target Name="_CleanProprietary" BeforeTargets="Clean">
     <ItemGroup>
       <_FilesToDelete Include="@(Content->'$(OutputPath)\%(Link)')" />
     </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+            "Microsoft.Build.NoTargets": "2.0.1"
+    }
+}

--- a/src/aapt2/aapt2.csproj
+++ b/src/aapt2/aapt2.csproj
@@ -1,14 +1,13 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>0c31de30-f9df-4312-bffe-dcad558ccf08</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" />
+  
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <Import Project="aapt2.targets" />
 </Project>

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -2,13 +2,6 @@
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
     <Aapt2Version>4.0.0-6051327</Aapt2Version>
-    <BuildDependsOn>
-      ResolveReferences;
-      _DownloadAapt2;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      _CleanAapt2;
-    </CleanDependsOn>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
@@ -28,12 +21,9 @@
     </_Aapt2Download>
   </ItemGroup>
 
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
-  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
-
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
 
-  <Target Name="_DownloadAapt2">
+  <Target Name="_DownloadAapt2" BeforeTargets="Build">
     <ItemGroup>
       <_DownloadUrl Include="%(_Aapt2Download.Identity)">
         <Platform>%(_Aapt2Download.Platform)</Platform>
@@ -53,7 +43,7 @@
     />
   </Target>
 
-  <Target Name="_CleanAapt2">
+  <Target Name="_CleanAapt2" BeforeTargets="Clean">
     <Delete Files="@(_Aapt2Download->'$(_Destination)\%(HostOS)')" />
   </Target>
 

--- a/src/apksigner/apksigner.csproj
+++ b/src/apksigner/apksigner.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/bundletool/bundletool.csproj
+++ b/src/bundletool/bundletool.csproj
@@ -1,14 +1,13 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>a0aef446-3368-4591-9de6-bc3b2b33337d</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" />
+  
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <Import Project="bundletool.targets" />
 </Project>

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -1,21 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _DownloadBundleTool;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      _CleanBundleTool;
-    </CleanDependsOn>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
-  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
-
-  <Target Name="_DownloadBundleTool">
+  <Target Name="_DownloadBundleTool" BeforeTargets="Build">
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
         DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
@@ -27,7 +17,7 @@
     />
   </Target>
 
-  <Target Name="_CleanBundleTool">
+  <Target Name="_CleanBundleTool" BeforeTargets="Clean">
     <Delete Files="$(_Destination)bundletool.jar" />
   </Target>
 

--- a/src/java-runtime/java-runtime.csproj
+++ b/src/java-runtime/java-runtime.csproj
@@ -1,26 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1D4FC8F1-0DA4-4F38-BE68-11AEBA9A0EA4}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+  
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\Jar.targets" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
+  <PropertyGroup>
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
-  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  
   <ItemGroup>
     <AllRuntimeSource Include="java/mono/**/*.java" />
     <AllRuntimeSource Include="..\..\src-ThirdParty\bazel\java\mono\**\*.java" />
   </ItemGroup>
+  
   <Import Project="java-runtime.targets" />
 </Project>

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-<PropertyGroup>
-  <BuildDependsOn>
-    ResolveReferences;
-    _BuildJavaRuntimeJar;
-  </BuildDependsOn>
-  <CleanDependsOn>
-    _CleanJavaRuntimeJar;
-  </CleanDependsOn>
-</PropertyGroup>
-
 <ItemGroup>
   <_RuntimeOutput Include="$(OutputPath)java_runtime.jar">
     <OutputJar>$(OutputPath)java_runtime.jar</OutputJar>
@@ -28,10 +18,8 @@
   </_RuntimeOutput>
 </ItemGroup>
 
-<Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
-<Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
-
 <Target Name="_BuildJavaRuntimeJar"
+      BeforeTargets="Build"
       Inputs="@(AllRuntimeSource)"
       Outputs="%(_RuntimeOutput.OutputJar)"
 >
@@ -71,7 +59,7 @@
     Inputs="@(_RuntimeOutput->'%(Identity)')"
     Outputs="@(_RuntimeOutput->'%(OutputDex)')">
   <Exec
-      Command="&quot;$(JavaPath)&quot; -classpath &quot;$(OutputPath)\r8.jar&quot; com.android.tools.r8.D8 --release --no-desugaring --output &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
+      Command="&quot;$(JavaPath)&quot; -classpath &quot;$(OutputPath)r8.jar&quot; com.android.tools.r8.D8 --release --no-desugaring --output &quot;%(_RuntimeOutput.IntermediateRuntimeOutputPath)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
       EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
   />
   <Move
@@ -80,7 +68,7 @@
   />
 </Target>
 
-<Target Name="_CleanJavaRuntimeJar">
+<Target Name="_CleanJavaRuntimeJar" BeforeTargets="Clean">
   <Delete Files="%(_RuntimeOutput.OutputJar)" />
 </Target>
 

--- a/src/manifestmerger/manifestmerger.csproj
+++ b/src/manifestmerger/manifestmerger.csproj
@@ -1,19 +1,16 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>af8ac493-40ac-4195-82f6-b08ee4b4e49e</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" />
+  
   <Import Project="..\..\Configuration.props" />
+  
   <ItemGroup>
-    <ProjectReference Include="..\r8\r8.csproj">
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
+    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  
   <Import Project="manifestmerger.targets" />
 </Project>

--- a/src/manifestmerger/manifestmerger.targets
+++ b/src/manifestmerger/manifestmerger.targets
@@ -1,19 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _BuildManifestMerger;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      _CleanManifestMerger;
-    </CleanDependsOn>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\manifestmerger.jar</_Destination>
   </PropertyGroup>
 
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
-  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
-
   <Target Name="_BuildManifestMerger"
+      BeforeTargets="Build"
       Inputs="$(MSBuildThisFile);build.gradle"
       Outputs="$(_Destination)">
     <Exec
@@ -33,7 +24,7 @@
     <Touch Files="$(_Destination)" />
   </Target>
 
-  <Target Name="_CleanManifestMerger">
+  <Target Name="_CleanManifestMerger" BeforeTargets="Clean">
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"

--- a/src/monodroid/monodroid.csproj
+++ b/src/monodroid/monodroid.csproj
@@ -1,25 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{53EE4C57-1C03-405A-8243-8DA539546C88}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+  
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\lib\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\lib\</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+
   <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _BuildRuntimes;
-    </BuildDependsOn>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\lib\</OutputPath>
   </PropertyGroup>
+
   <Import Project="monodroid.targets" />
+  
   <ItemGroup>
     <!--
       `jnimarshalmethod-gen.exe` needs to be built first because our
@@ -30,10 +25,6 @@
       We don't want our updated version to be replaced by the
       `jnimarshalmethod-gen.exe` build.
       -->
-    <ProjectReference Include="..\..\external\Java.Interop\tools\jnimarshalmethod-gen\Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj">
-      <Project>{D1295A8F-4F42-461D-A046-564476C10002}</Project>
-      <Name>jnimarshalmethod-gen</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\Java.Interop\tools\jnimarshalmethod-gen\Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -13,7 +13,7 @@
     <_EmbeddedBlobSource Include="machine.config.xml" />
     <_EmbeddedBlobDestination Include="jni\machine.config.include" />
   </ItemGroup>
-  <Target Name="_BuildRuntimes"
+  <Target Name="_BuildRuntimes" BeforeTargets="Build"
       DependsOnTargets="_GenerateIncludeFiles;_ConfigureRuntimes;_BuildAndroidRuntimes;_BuildHostRuntimes">
   </Target>
   <Target Name="_GenerateIncludeFiles"

--- a/src/proguard/proguard.csproj
+++ b/src/proguard/proguard.csproj
@@ -1,22 +1,15 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+    
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\proguard\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\proguard\</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+ 
   <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _BuildProGuard
-    </BuildDependsOn>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\proguard\</OutputPath>
   </PropertyGroup>
+  
   <Import Project="proguard.targets" />
 </Project>

--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -9,6 +9,7 @@
     <_Outputs Include="$(_OutputJar);$(_OutputBat);$(_OutputSh);$(_OutputLicense)" />
   </ItemGroup>
   <Target Name="_BuildProGuard"
+      BeforeTargets="Build"
       Inputs="$(MSBuildThisFile)"
       Outputs="@(_Outputs)">
     <Exec
@@ -35,7 +36,7 @@
     />
     <Touch Files="@(_Outputs)" />
   </Target>
-  <Target Name="Clean">
+  <Target Name="_CleanProGuard" BeforeTargets="Clean">
     <Delete Files="@(_Outputs)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"

--- a/src/r8/r8.csproj
+++ b/src/r8/r8.csproj
@@ -1,15 +1,13 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
+ 
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <ProjectGuid>1bafa0cc-0377-46ce-ab7b-7bb2e7b62f63</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" />
-  <Import Project="r8.props" />
+  
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <Import Project="r8.targets" />
 </Project>
-

--- a/src/r8/r8.props
+++ b/src/r8/r8.props
@@ -1,3 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-</Project>
-

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -1,20 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _BuildR8;
-    </BuildDependsOn>
-    <CleanDependsOn>
-      _CleanR8;
-    </CleanDependsOn>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\r8.jar</_Destination>
   </PropertyGroup>
 
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
-  <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
-
   <Target Name="_BuildR8"
+      BeforeTargets="Build"
       Inputs="$(MSBuildThisFile);build.gradle"
       Outputs="$(_Destination)">
     <Exec
@@ -29,7 +20,7 @@
     <Touch Files="$(_Destination)" />
   </Target>
 
-  <Target Name="_CleanR8">
+  <Target Name="_CleanR8" BeforeTargets="Clean">
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"

--- a/src/sqlite-xamarin/sqlite-xamarin.csproj
+++ b/src/sqlite-xamarin/sqlite-xamarin.csproj
@@ -1,23 +1,18 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+  
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <OutputPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <OutputPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+
   <PropertyGroup>
-    <BuildDependsOn>
-      _BuildSqlite;
-    </BuildDependsOn>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\lib</OutputPath>
   </PropertyGroup>
+  
   <Import Project="sqlite-xamarin.targets" />
+  
   <ItemGroup>
     <Content Include="Mono.Data.Sqlite.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -9,7 +9,7 @@
     <_BclFrameworkDir>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</_BclFrameworkDir>
   </PropertyGroup>
 
-  <Target Name="_BuildSqlite" DependsOnTargets="_ConfigureSqlite;_BuildAndroidSqlite" />
+  <Target Name="_BuildSqlite" BeforeTargets="Build" DependsOnTargets="_ConfigureSqlite;_BuildAndroidSqlite" />
 
   <Target Name="_PrepareConfigureSqlite">
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-$(Configuration)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5064

Xamarin.Android has many "projects" that are `.csproj`, but do not actually compile a managed assembly.  Instead, the `Build` and `Clean` targets are overridden to perform other tasks, like compile Java.  When using a `Directory.Build.props` file to add a NuGet to all projects, these projects failed to build due to a NuGet error.

Nowadays there is a better solution for these types of projects that produces more correct projects with fewer side-effects: https://github.com/microsoft/MSBuildSdks/tree/master/src/NoTargets.

This commit converts these projects to SDK-style projects based on `Microsoft.Build.NoTargets`.

Additionally, we add the `Microsoft.Build.NoTargets` version to a `global.json` so the version is consistent among all the projects.

This PR supersedes some of the changes in:
- https://github.com/xamarin/xamarin-android/pull/4950
- https://github.com/xamarin/xamarin-android/pull/4973