### PR TITLE
[One .NET] improve default item groups

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
@@ -7,20 +7,20 @@
   <!-- Default Resource file inclusion -->
   <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
   <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.xml" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.axml" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.png" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.jpg" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.gif" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\**\*.ttf" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\**\*.otf" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\**\*.ttc" />
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\**\*" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.axml" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.png" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.jpg" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.gif" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttf" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
   </ItemGroup>
 
   <!-- Default Asset file inclusion -->
   <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" />
+    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
   </ItemGroup>
 
   <!-- Default References -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -15,6 +15,11 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2"), Category ("DotNetIgnore")] // These don't need to run under `--params dotnet=true`
 	public class XASdkTests : BaseTest
 	{
+		/// <summary>
+		/// The full path to the project directory
+		/// </summary>
+		public string FullProjectDirectory { get; set; }
+
 		[Test]
 		[Category ("SmokeTests")]
 		public void DotNetBuildLibrary ([Values (false, true)] bool isRelease)
@@ -189,6 +194,42 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void DefaultItems ()
+		{
+			void CreateEmptyFile (params string [] paths)
+			{
+				var path = Path.Combine (FullProjectDirectory, Path.Combine (paths));
+				Directory.CreateDirectory (Path.GetDirectoryName (path));
+				File.WriteAllText (path, contents: "");
+			}
+
+			var proj = new XASdkProject ();
+			var dotnet = CreateDotNetBuilder (proj);
+
+			// Build error -> no nested sub-directories in Resources
+			CreateEmptyFile ("Resources", "drawable", "foo", "bar.png");
+			CreateEmptyFile ("Resources", "raw", "foo", "bar.png");
+
+			// Build error -> no files/directories that start with .
+			CreateEmptyFile ("Resources", "raw", ".DS_Store");
+			CreateEmptyFile ("Assets", ".DS_Store");
+			CreateEmptyFile ("Assets", ".svn", "foo.txt");
+
+			// Files that should work
+			CreateEmptyFile ("Resources", "raw", "foo.txt");
+			CreateEmptyFile ("Assets", "foo", "bar.txt");
+
+			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
+
+			var apk = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+			FileAssert.Exists (apk);
+			using (var zip = ZipHelper.OpenZip (apk)) {
+				Assert.IsTrue (zip.ContainsEntry ("res/raw/foo.txt"), "res/raw/foo.txt should exist!");
+				Assert.IsTrue (zip.ContainsEntry ("assets/foo/bar.txt"), "assets/foo/bar.txt should exist!");
+			}
+		}
+
+		[Test]
 		public void BuildWithLiteSdk ()
 		{
 			var proj = new XASdkProject () {
@@ -203,12 +244,12 @@ namespace Xamarin.Android.Build.Tests
 		DotNetCLI CreateDotNetBuilder (XASdkProject project)
 		{
 			var relativeProjDir = Path.Combine ("temp", TestName);
-			var fullProjDir = Path.Combine (Root, relativeProjDir);
-			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] =
+				FullProjectDirectory = Path.Combine (Root, relativeProjDir);
 			var files = project.Save ();
 			project.Populate (relativeProjDir, files);
 			project.CopyNuGetConfig (relativeProjDir);
-			return new DotNetCLI (project, Path.Combine (fullProjDir, project.ProjectFilePath));
+			return new DotNetCLI (project, Path.Combine (FullProjectDirectory, project.ProjectFilePath));
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5071

In writing the fix for #5071, I noticed that our default wildcards for
.NET 6 projects bring in `.DS_Store` files for `@(AndroidAsset)` files
or `Resources\raw` files. I also noticed we bring in sub-directories
for `Resources`, but these are also invalid.

I fixed up all the wildcards, adding appropriate `Include` and
`Exclude`. At first I thought we should use `$(DefaultItemExcludes)`
and `$(DefaultExcludesInProjectFolder)`:

https://github.com/dotnet/sdk/blob/c7ac111a2438fc488229eed6f48a9d5298904bd2/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets#L22-L42

But they won't work due to the way `Exclude` works.

If you have:

    <AndroidAsset Include="Assets\**\*" Exclude="**\.*\**" />

The `Exclude` pattern does not work. You need to have the same
starting path, such as:

    <AndroidAsset Include="Assets\**\*" Exclude="Assets\**\.*\**" />

I added a test for these scenarios, where the build would fail if the
improper files were included.