### PR TITLE
[Xamarin.Android.Build.Tasks] Mention VS settings for XA5300

### DIFF
--- a/Documentation/release-notes/reword-xa5300-1.md
+++ b/Documentation/release-notes/reword-xa5300-1.md
@@ -1,0 +1,5 @@
+#### Application and library build and deployment
+
+- _error XA5300: The Android SDK directory could not be found._ and _error
+  XA5300: The Java SDK directory could not be found._ did not yet mention which
+  Visual Studio settings to check.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1258,7 +1258,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory..
+        ///   Looks up a localized string similar to The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the &apos;AndroidSdkDirectory&apos; MSBuild property to the custom path..
         /// </summary>
         internal static string XA5300_Android_SDK {
             get {
@@ -1267,7 +1267,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory..
+        ///   Looks up a localized string similar to The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the &apos;JavaSdkDirectory&apos; MSBuild property to the custom path..
         /// </summary>
         internal static string XA5300_Java_SDK {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -771,12 +771,12 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</comment>
   </data>
   <data name="XA5300_Android_SDK" xml:space="preserve">
-    <value>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</value>
-    <comment>The following are literal names and should not be translated: /p:AndroidSdkDirectory</comment>
+    <value>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</value>
+    <comment>The following terms should not be translated: AndroidSdkDirectory</comment>
   </data>
   <data name="XA5300_Java_SDK" xml:space="preserve">
-    <value>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</value>
-    <comment>The following are literal names and should not be translated: /p:JavaSdkDirectory</comment>
+    <value>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</value>
+    <comment>The following terms should not be translated: JavaSdkDirectory</comment>
   </data>
   <data name="XA5301" xml:space="preserve">
     <value>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Adresář sady Android SDK se nepovedlo najít. Nastavte ho prosím pomocí /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Adresář sady Android SDK se nepovedlo najít. Nastavte ho prosím pomocí /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Adresář sady Java SDK se nepovedlo najít. Nastavte ho prosím pomocí /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Adresář sady Java SDK se nepovedlo najít. Nastavte ho prosím pomocí /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Das Android SDK-Verzeichnis wurde nicht gefunden. Legen Sie es über "/p:AndroidSdkDirectory" fest.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Das Android SDK-Verzeichnis wurde nicht gefunden. Legen Sie es über "/p:AndroidSdkDirectory" fest.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Das Java SDK-Verzeichnis wurde nicht gefunden. Legen Sie es über "/p:JavaSdkDirectory" fest.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Das Java SDK-Verzeichnis wurde nicht gefunden. Legen Sie es über "/p:JavaSdkDirectory" fest.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">No se encontró el directorio de Android SDK. Debe establecerse a través de /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">No se encontró el directorio de Android SDK. Debe establecerse a través de /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">No se encontró el directorio del SDK de Java. Debe establecerse a través de /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">No se encontró el directorio del SDK de Java. Debe establecerse a través de /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Le répertoire Android SDK est introuvable. Définissez-le avec /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Le répertoire Android SDK est introuvable. Définissez-le avec /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Le répertoire Java SDK est introuvable. Définissez-le avec /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Le répertoire Java SDK est introuvable. Définissez-le avec /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Non è stato possibile trovare la directory di Android SDK. Impostarla tramite /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Non è stato possibile trovare la directory di Android SDK. Impostarla tramite /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Non è stato possibile trovare la directory di Java SDK. Impostarla tramite /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Non è stato possibile trovare la directory di Java SDK. Impostarla tramite /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Android SDK ディレクトリが見つかりませんでした。/p:AndroidSdkDirectory 経由で設定してください。</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Android SDK ディレクトリが見つかりませんでした。/p:AndroidSdkDirectory 経由で設定してください。</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Java SDK ディレクトリが見つかりませんでした。/p:JavaSdkDirectory 経由で設定してください。</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Java SDK ディレクトリが見つかりませんでした。/p:JavaSdkDirectory 経由で設定してください。</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Android SDK 디렉터리를 찾을 수 없습니다. /p:AndroidSdkDirectory를 통해 설정하세요.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Android SDK 디렉터리를 찾을 수 없습니다. /p:AndroidSdkDirectory를 통해 설정하세요.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Java SDK 디렉터리를 찾을 수 없습니다. /p:JavaSdkDirectory를 통해 설정하세요.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Java SDK 디렉터리를 찾을 수 없습니다. /p:JavaSdkDirectory를 통해 설정하세요.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Nie udało się znaleźć katalogu zestawu Android SDK. Określ go za pomocą opcji /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Nie udało się znaleźć katalogu zestawu Android SDK. Określ go za pomocą opcji /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Nie udało się znaleźć katalogu zestawu Java SDK. Określ go za pomocą opcji /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Nie udało się znaleźć katalogu zestawu Java SDK. Określ go za pomocą opcji /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Não foi possível encontrar o diretório do SDK do Android. Defina-o por meio de /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Não foi possível encontrar o diretório do SDK do Android. Defina-o por meio de /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Não foi possível encontrar o diretório do SDK do Java. Defina-o por meio de /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Não foi possível encontrar o diretório do SDK do Java. Defina-o por meio de /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Не удалось найти каталог пакета SDK для Android. Укажите путь к нему с помощью параметра /p:AndroidSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Не удалось найти каталог пакета SDK для Android. Укажите путь к нему с помощью параметра /p:AndroidSdkDirectory.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Не удалось найти каталог пакета SDK для Java. Укажите путь к нему с помощью параметра /p:JavaSdkDirectory.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Не удалось найти каталог пакета SDK для Java. Укажите путь к нему с помощью параметра /p:JavaSdkDirectory.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">Android SDK dizini bulunamadı. Lütfen /p:AndroidSdkDirectory ile ayarlayın.</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Android SDK dizini bulunamadı. Lütfen /p:AndroidSdkDirectory ile ayarlayın.</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">Java SDK dizini bulunamadı. Lütfen /p:JavaSdkDirectory ile ayarlayın.</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">Java SDK dizini bulunamadı. Lütfen /p:JavaSdkDirectory ile ayarlayın.</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">找不到 Android SDK 目录。请通过 /p:AndroidSdkDirectory 进行设置。</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">找不到 Android SDK 目录。请通过 /p:AndroidSdkDirectory 进行设置。</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">找不到 Java SDK 目录。请通过 /p:JavaSdkDirectory 进行设置。</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">找不到 Java SDK 目录。请通过 /p:JavaSdkDirectory 进行设置。</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -795,14 +795,14 @@ In this message, the term "handheld app" means "app for handheld devices."
 {3} - The installer program name</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_SDK">
-        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
-        <target state="translated">找不到 Android SDK 目錄。請透過 /p:AndroidSdkDirectory 進行設定。</target>
-        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+        <source>The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">找不到 Android SDK 目錄。請透過 /p:AndroidSdkDirectory 進行設定。</target>
+        <note>The following terms should not be translated: AndroidSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5300_Java_SDK">
-        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
-        <target state="translated">找不到 Java SDK 目錄。請透過 /p:JavaSdkDirectory 進行設定。</target>
-        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+        <source>The Java SDK directory could not be found. Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured. To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.</source>
+        <target state="needs-review-translation">找不到 Java SDK 目錄。請透過 /p:JavaSdkDirectory 進行設定。</target>
+        <note>The following terms should not be translated: JavaSdkDirectory</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>


### PR DESCRIPTION
Context: https://github.com/xamarin/androidtools/pull/241

Update the XA5300 messages about SDK locations to sync with the new
wording from the corresponding androidtools string resources in
xamarin/androidtools#241 that mention some Visual Studio settings to check to
help resolve the errors.