### PR TITLE
[build] dotnet test should set NUnit.NumberOfTestWorkers

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -64,6 +64,7 @@ variables:
   IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
   DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != LibraryProjectZip & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
+  NUnit.NumberOfTestWorkers: 4
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
@@ -375,7 +376,7 @@ stages:
         testRunTitle: Smoke MSBuild Tests - Windows Build Tree
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\net472\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-SmokeMSBuildTests-WinBuildTree-$(XA.Build.Configuration).xml
-        nunitConsoleExtraArgs: --where "cat == SmokeTests" --workers=4
+        nunitConsoleExtraArgs: --where "cat == SmokeTests" --workers=$(NUnit.NumberOfTestWorkers)
 
     - template: yaml-templates\upload-results.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -46,7 +46,7 @@ jobs:
         useDotNet: $(UseDotNet)
         testRunTitle: Xamarin.Android.Build.Tests - Windows-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\${{ parameters.target_framework }}\Xamarin.Android.Build.Tests.dll
-        nunitConsoleExtraArgs: --workers=4 --where "cat == Node-${{ parameters.node_id }} ${{ parameters.nunit_categories }}"
+        nunitConsoleExtraArgs: --where "cat == Node-${{ parameters.node_id }} ${{ parameters.nunit_categories }}"
         dotNetTestExtraArgs: --filter "TestCategory = Node-${{ parameters.node_id }} ${{ parameters.nunit_categories }}"
         testResultsFile: TestResult-MSBuildTests-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 
@@ -64,7 +64,7 @@ jobs:
           useDotNet: $(UseDotNet)
           testRunTitle: Xamarin.Android.Build.Tests - Windows - No Node
           testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\${{ parameters.target_framework }}\Xamarin.Android.Build.Tests.dll
-          nunitConsoleExtraArgs: --workers=4 --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
+          nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3"
           dotNetTestExtraArgs: --filter "TestCategory != Node-1 & TestCategory != Node-2 & TestCategory != Node-3"
           testResultsFile: TestResult-MSBuildTests-Windows-NoNode-$(XA.Build.Configuration).xml
 

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -6,19 +6,20 @@ parameters:
   nunitConsoleExtraArgs: ''
   dotNetTestExtraArgs: ''
   useDotNet: false
+  workers: $(NUnit.NumberOfTestWorkers)
   condition: succeeded()
 
 steps:
 - powershell: |
     if ("${{ parameters.useDotNet }}" -eq $true) {
         Write-Host '##vso[task.setvariable variable=TestResultsFormat]VSTest'
-        dotnet test ${{ parameters.testAssembly }} --results-directory . --logger "trx;LogFileName=${{ parameters.testResultsFile }}" ${{ parameters.dotNetTestExtraArgs }}
+        dotnet test ${{ parameters.testAssembly }} --results-directory . --logger "trx;LogFileName=${{ parameters.testResultsFile }}" ${{ parameters.dotNetTestExtraArgs }} -- NUnit.NumberOfTestWorkers=${{ parameters.workers }}
     } elseif ([Environment]::OSVersion.Platform -eq "Unix") {
         Write-Host '##vso[task.setvariable variable=TestResultsFormat]NUnit'
-        mono ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} ${{ parameters.nunitConsoleExtraArgs }}
+        mono ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
     } else {
         Write-Host '##vso[task.setvariable variable=TestResultsFormat]NUnit'
-        ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }}  ${{ parameters.nunitConsoleExtraArgs }}
+        ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
     }
     if ($LASTEXITCODE -ne 0) {
         Write-Host "##vso[task.logissue type=error]Test suite had $LASTEXITCODE failure(s)."


### PR DESCRIPTION
Context: https://stackoverflow.com/a/57999644

Our nunit3-console commands pass:

    --workers=4

This helped to reduce test parallelism, which could slow the CI
machines to a crawl.

We aren't passing the same switch to instances where we run `dotnet
test`. We can do this by adding `-- NUnit.NumberOfTestWorkers=4` at
the end of the `dotnet test` command.

You can see this applied from the `dotnet test` log:

    > dotnet test .\bin\TestDebug\netcoreapp3.1\Xamarin.Android.Build.Tests.dll --logger trx --filter "Name~BuildBasicApplication" --results-directory . --diag log.txt -- NUnit.NumberOfTestWorkers=4

From `log.txt`:

    TpTrace Information: 0 : 13252, 1, 2020/09/03, 11:10:20.363, 3521331719316, vstest.console.dll, TestRunRequest.ExecuteAsync: Starting run with settings:TestRunCriteria:
    KeepAlive=False,FrequencyOfRunStatsChangeEvent=10,RunStatsChangeEventTimeout=00:00:01.5000000,TestCaseFilter=Name~BuildBasicApplication,TestExecutorLauncher=
    Settingsxml=<RunSettings>
      ...
      <NUnit>
        <NumberOfTestWorkers>4</NumberOfTestWorkers>
      </NUnit>
      ...
    </RunSettings>

We also should start doing this on macOS, as we are commonly hitting:

> We stopped hearing from agent Azure Pipelines 12. Verify the agent
> machine is running and has a healthy network connection. Anything
> that terminates an agent process, starves it for CPU, or blocks its
> network access can cause this error. For more information, see:
> https://go.microsoft.com/fwlink/?linkid=846610

We might certainly be "starving it for CPU"!

I think we should try limiting the NUnit workers to 4 on both Windows
& macOS, to see if things improve.

I setup a new `$(NUnit.NumberOfTestWorkers)` variable to be used throughout
our build, so the value can be changed in one place.