### PR TITLE
[Xamarin.Android.Build.Tests] Import regression tests from job 2

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1108,9 +1108,9 @@ stages:
   condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['RunAllTests'], true))
   jobs:
 
-  # Check - "Xamarin.Android (Regression Tests Mac-1)"
-  - job: integrated_regression_mac_1
-    displayName: Mac-1
+  # Check - "Xamarin.Android (Regression Tests Mac)"
+  - job: integrated_regression_mac
+    displayName: Mac
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
@@ -1121,28 +1121,10 @@ stages:
       clean: all
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 1
 
-  # Check - "Xamarin.Android (Regression Tests Mac-2)"
-  - job: integrated_regression_mac_2
-    displayName: Mac-2
-    pool:
-      name: VSEng-Xamarin-Mac-Devices
-      demands:
-      - android
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - template: yaml-templates/run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 2
-
-  # Check - "Xamarin.Android (Regression Tests Windows-1)"
-  - job: integrated_regression_Win_1
-    displayName: Windows-1
+  # Check - "Xamarin.Android (Regression Tests Windows)"
+  - job: integrated_regression_win
+    displayName: Windows
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:
@@ -1157,30 +1139,6 @@ stages:
     - template: remove-visualstudio.yml@yaml
 
     - template: yaml-templates\run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 1
-
-    - template: remove-visualstudio.yml@yaml
-
-  # Check - "Xamarin.Android (Regression Tests Windows-2)"
-  - job: integrated_regression_Win_2
-    displayName: Windows-2
-    pool:
-      name: VSEng-Xamarin-Win-XMA
-      demands:
-      - android
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    variables:
-      XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
-    steps:
-    - template: remove-visualstudio.yml@yaml
-
-    - template: yaml-templates\run-integrated-regression-tests.yaml
-      parameters:
-        node_id: 2
 
     - template: remove-visualstudio.yml@yaml
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -109,27 +109,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Proguard Tests
-      nunitConsoleExtraArgs: --where "cat == Proguard"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Multidex Tests
-      nunitConsoleExtraArgs: --where "cat == Multidex"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: ExplicitCrunch Tests
-      nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: TargetFrameworkVersion Tests
       nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
 
@@ -168,11 +147,11 @@ steps:
       testRunTitle: AndroidApiInfo Tests
       nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Test Environment Cleanup
-      nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Test Environment Cleanup
+    nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
 
 - template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -109,13 +109,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Property Cache Tests
-      nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Code Analysis Tests
       nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,5 +1,4 @@
 parameters:
-  node_id: 0
 
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
@@ -67,64 +66,41 @@ steps:
     }
   displayName: Test Environment Setup
 
-- ${{ if eq(parameters.node_id, 1) }}:
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Mono.Android-Tests Debug on Device
-      nunitConsoleExtraArgs: --where "cat == RuntimeTests"
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Mono.Android-Tests Debug on Device
+    nunitConsoleExtraArgs: --where "cat == RuntimeTests"
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Hello Tests on Device
-      nunitConsoleExtraArgs: --where "cat == Hello"
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Hello Tests on Device
+    nunitConsoleExtraArgs: --where "cat == Hello"
+    condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Smoke Tests on Device
-      nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Smoke Tests on Device
+    nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Incremental Build Tests
-      nunitConsoleExtraArgs: --where "cat == BuildPerformance"
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Incremental Build Tests
+    nunitConsoleExtraArgs: --where "cat == BuildPerformance"
 
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: AOT Tests
-      nunitConsoleExtraArgs: --where "cat == AotSupport"
-
-- ${{ if eq(parameters.node_id, 2) }}:
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Code Analysis Tests
-      nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Networking Options Tests
-      nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: AndroidApiInfo Tests
-      nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: AOT Tests
+    nunitConsoleExtraArgs: --where "cat == AotSupport"
 
 - template: run-nunit-tests.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -116,13 +116,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: Resource Cache Tests
-      nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Property Cache Tests
       nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,5 +1,3 @@
-parameters:
-
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -109,13 +109,6 @@ steps:
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-      testRunTitle: TargetFrameworkVersion Tests
-      nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
-
-  - template: run-nunit-tests.yaml
-    parameters:
-      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Property Cache Tests
       nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1362,6 +1362,9 @@ namespace UnnamedProject {
 			using (var b = CreateApkBuilder ("temp/CustomApplicationClassAndMultiDex")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
+				var customAppContent = File.ReadAllText (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "com", "foxsports", "test", "CustomApp.java"));
+				Assert.IsTrue (customAppContent.Contains ("extends android.support.multidex.MultiDexApplication"),
+					"Custom App class should have inherited from android.support.multidex.MultiDexApplication.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -645,41 +645,6 @@ namespace UnamedProject
 		}
 
 		[Test]
-		public void BuildPropsBreaksConvertResourcesCases ([Values (true, false)] bool useAapt2)
-		{
-			var proj = new XamarinAndroidApplicationProject () {
-				AndroidResources = {
-					new AndroidItem.AndroidResource (() => "Resources\\drawable\\IMALLCAPS.png") {
-						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
-					},
-					new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
-						TextContent = () => {
-							return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ImageView xmlns:android=\"http://schemas.android.com/apk/res/android\" android:src=\"@drawable/IMALLCAPS\" />";
-						}
-					}
-				}
-			};
-			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
-				var assemblyPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
-				var apkPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "UnnamedProject.UnnamedProject-Signed.apk");
-				var firstAssemblyWrite = new FileInfo (assemblyPath).LastWriteTime;
-				var firstApkWrite = new FileInfo (apkPath).LastWriteTime;
-
-				// Invalidate build.props with newer timestamp, by updating a @(_PropertyCacheItems) property
-				proj.SetProperty ("AndroidLinkMode", "SdkOnly");
-				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded.");
-				var secondAssemblyWrite = new FileInfo (assemblyPath).LastWriteTime;
-				var secondApkWrite = new FileInfo (apkPath).LastWriteTime;
-				Assert.IsTrue (secondAssemblyWrite > firstAssemblyWrite,
-					$"Assembly write time was not updated on partially incremental build. Before: {firstAssemblyWrite}. After: {secondAssemblyWrite}.");
-				Assert.IsTrue (secondApkWrite > firstApkWrite,
-					$"Apk write time was not updated on partially incremental build. Before: {firstApkWrite}. After: {secondApkWrite}.");
-			}
-		}
-
-		[Test]
 		public void AndroidResourceNotExist ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -54,8 +54,6 @@ namespace Xamarin.Android.Build.Tests
 				TargetFrameworkVersion = tfv,
 			};
 			using (var b = CreateApkBuilder ()) {
-				var tfvs = b.GetAllSupportedTargetFrameworkVersions ();
-				Console.WriteLine ("TFVS count: " + tfvs.Length);
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
@@ -1726,12 +1724,10 @@ namespace App1
 					TextContent = () => "Test Content 1"
 				});
 				Assert.IsTrue (b.Build (proj), "Build should have built successfully");
-				Assert.IsTrue (
-					b.LastBuildOutput.Contains ("TestContent.txt:  warning XA0101: @(Content) build action is not supported"),
-					"Build Output did not contain the correct error message");
-				Assert.IsTrue (
-					b.LastBuildOutput.Contains ("TestContent1.txt:  warning XA0101: @(Content) build action is not supported"),
-					"Build Output did not contain the correct error message");
+				StringAssertEx.Contains ("TestContent.txt : warning XA0101: @(Content) build action is not supported", b.LastBuildOutput,
+					"Build Output did not contain 'TestContent.txt : warning XA0101'.");
+				StringAssertEx.Contains ("TestContent1.txt : warning XA0101: @(Content) build action is not supported", b.LastBuildOutput,
+					"Build Output did not contain 'TestContent1.txt : warning XA0101'.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1273,12 +1273,12 @@ namespace Lib2
 			var proj = new XamarinFormsAndroidApplicationProject ();
 			proj.SetAndroidSupportedAbis ("armeabi-v7a");
 			using (var b = CreateApkBuilder ()) {
-				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
+				b.Build (proj);
 
 				var parameters = Builder.UseDotNet ?
 					new [] { $"{KnownProperties.RuntimeIdentifier}=android.21-x86" } :
 					new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
-				Assert.IsTrue (b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true), "Second build should have succeeded.");
+				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1281,5 +1281,41 @@ namespace Lib2
 				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
 			}
 		}
+
+		[Test]
+		public void BuildPropsBreaksConvertResourcesCasesOnSecondBuild ([Values (true, false)] bool useAapt2)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				AndroidResources = {
+					new AndroidItem.AndroidResource (() => "Resources\\drawable\\IMALLCAPS.png") {
+						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
+					},
+					new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+						TextContent = () => {
+							return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ImageView xmlns:android=\"http://schemas.android.com/apk/res/android\" android:src=\"@drawable/IMALLCAPS\" />";
+						}
+					}
+				}
+			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				var assemblyPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
+				var apkPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "UnnamedProject.UnnamedProject-Signed.apk");
+				var firstAssemblyWrite = new FileInfo (assemblyPath).LastWriteTime;
+				var firstApkWrite = new FileInfo (apkPath).LastWriteTime;
+
+				// Invalidate build.props with newer timestamp, by updating a @(_PropertyCacheItems) property
+				proj.SetProperty ("AndroidLinkMode", "SdkOnly");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded.");
+				var secondAssemblyWrite = new FileInfo (assemblyPath).LastWriteTime;
+				var secondApkWrite = new FileInfo (apkPath).LastWriteTime;
+				Assert.IsTrue (secondAssemblyWrite > firstAssemblyWrite,
+					$"Assembly write time was not updated on partially incremental build. Before: {firstAssemblyWrite}. After: {secondAssemblyWrite}.");
+				Assert.IsTrue (secondApkWrite > firstApkWrite,
+					$"Apk write time was not updated on partially incremental build. Before: {firstApkWrite}. After: {secondApkWrite}.");
+			}
+		}
+
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1273,12 +1273,12 @@ namespace Lib2
 			var proj = new XamarinFormsAndroidApplicationProject ();
 			proj.SetAndroidSupportedAbis ("armeabi-v7a");
 			using (var b = CreateApkBuilder ()) {
-				b.Build (proj);
+				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
 
 				var parameters = Builder.UseDotNet ?
 					new [] { $"{KnownProperties.RuntimeIdentifier}=android.21-x86" } :
 					new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
-				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
+				Assert.IsTrue (b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true), "Second build should have succeeded.");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -149,32 +149,39 @@ namespace Xamarin.ProjectTools
 
 		public string FirstTargetFrameworkVersion ()
 		{
-			GetTargetFrameworkVersionRange (out string _, out string firstFrameworkVersion, out string _, out string _);
+			GetTargetFrameworkVersionRange (out string _, out string firstFrameworkVersion, out string _, out string _, out string[] _);
 			return firstFrameworkVersion;
 		}
 
 		public string FirstTargetFrameworkVersion (out string apiLevel)
 		{
-			GetTargetFrameworkVersionRange (out apiLevel, out string firstFrameworkVersion, out string _, out string _);
+			GetTargetFrameworkVersionRange (out apiLevel, out string firstFrameworkVersion, out string _, out string _, out string [] _);
 			return firstFrameworkVersion;
 		}
 
 		public string LatestTargetFrameworkVersion () {
-			GetTargetFrameworkVersionRange (out string _, out string _, out string _, out string lastFrameworkVersion);
+			GetTargetFrameworkVersionRange (out string _, out string _, out string _, out string lastFrameworkVersion, out string [] _);
 			return lastFrameworkVersion;
 		}
 
 		public string LatestTargetFrameworkVersion (out string apiLevel) {
-			GetTargetFrameworkVersionRange (out string _, out string _, out apiLevel, out string lastFrameworkVersion);
+			GetTargetFrameworkVersionRange (out string _, out string _, out apiLevel, out string lastFrameworkVersion, out string [] _);
 			return lastFrameworkVersion;
 		}
 
-		public void GetTargetFrameworkVersionRange (out string firstApiLevel, out string firstFrameworkVersion, out string lastApiLevel, out string lastFrameworkVersion)
+		public string[] GetAllSupportedTargetFrameworkVersions ()
+		{
+			GetTargetFrameworkVersionRange (out string _, out string _, out string _, out string _, out string [] allFrameworkVersions);
+			return allFrameworkVersions;
+		}
+
+		public void GetTargetFrameworkVersionRange (out string firstApiLevel, out string firstFrameworkVersion, out string lastApiLevel, out string lastFrameworkVersion, out string[] allFrameworkVersions)
 		{
 			firstApiLevel = firstFrameworkVersion = lastApiLevel = lastFrameworkVersion = null;
 
 			Version firstVersion    = null;
 			Version lastVersion     = null;
+			List<string> allTFVs    = new List<string> ();
 
 			foreach (var dir in Directory.EnumerateDirectories (FrameworkLibDirectory, "v*", SearchOption.TopDirectoryOnly)) {
 				// No binding assemblies in `v1.0`; don't process.
@@ -197,7 +204,9 @@ namespace Xamarin.ProjectTools
 					lastFrameworkVersion    = frameworkVersion;
 					lastApiLevel            = apiLevel;
 				}
+				allTFVs.Add (frameworkVersion);
 			}
+			allFrameworkVersions = allTFVs.ToArray ();
 		}
 
 		static string GetApiLevelFromInfoPath (string androidApiInfo)


### PR DESCRIPTION
Context: https://github.com/xamarin/QualityAssurance/pull/3644

CI and Xamarin.Android.Build.Tests have been updated to reflect the
second round of regression test auditing.  All QA regression tests have
been merged into two total jobs, one per operating system type.

The following regression test categories have been removed, see
https://github.com/xamarin/QualityAssurance/pull/3644 for more info:

 * Proguard - Deprecated tool.
 * Multidex - Deprecated tool.
 * ExplicitCrunch - Obsolete build option.
 * TargetFrameworkTests - Missing coverage partially migrated to BuildBasicApplication and LibraryReferenceWithHigherTFVShouldDisplayWarning.
 * ResourceCacheTests - Category was previously removed.
 * PropertyCacheTests - Missing coverage partially migrated to BuildPropsBreaksConvertResourcesCases.
 * CodeAnalysisTests - Deprecated feature.
 * HttpClientAndTlsProviderPackageTests - Category was previously removed.
 * AndroidApiInfoTests - Mostly duplicated in https://github.com/xamarin/xamarin-android/blob/c31ad9f1e7549c632150e58fc99fe7a2c190c79f/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs#L3250

A minor fix has also been applied to Xamarin.Android.Build.Tests to
bring in a missing [Test] attribute and fix some asserts that were
caught while importing and looking for duplicate tests.
