### PR TITLE
[tests] add/remove NUnit RetryAttribute

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -32,7 +32,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Retry (1)]
 		public void ApplicationRunsWithoutDebugger ([Values (false, true)] bool isRelease, [Values (false, true)] bool extractNativeLibs)
 		{
 			AssertHasDevices ();
@@ -156,7 +155,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
-		[Retry (1)]
 		public void CustomApplicationRunsWithDebuggerAndBreaks (bool useSharedRuntime, bool embedAssemblies, string fastDevType, bool activityStarts)
 		{
 			AssertCommercialBuild ();
@@ -308,7 +306,6 @@ namespace ${ROOT_NAMESPACE} {
 
 		[Test]
 		[TestCaseSource (nameof(DebuggerTestCases))]
-		[Retry (1)]
 		public void ApplicationRunsWithDebuggerAndBreaks (bool useSharedRuntime, bool embedAssemblies, string fastDevType, bool allowDeltaInstall)
 		{
 			AssertCommercialBuild ();

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -204,19 +204,16 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 0 })]
-		[Retry (1)]
 		[Category ("TimeZoneInfo")]
 		public void CheckTimeZoneInfoIsCorrectNode1 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
 		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 1 })]
-		[Retry (1)]
 		[Category ("TimeZoneInfo")]
 		public void CheckTimeZoneInfoIsCorrectNode2 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
 		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 2 })]
-		[Retry (1)]
 		[Category ("TimeZoneInfo")]
 		public void CheckTimeZoneInfoIsCorrectNode3 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -57,7 +57,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (MonoAndroidExportTestCases))]
-		[Retry (1)]
 		public void MonoAndroidExportReferencedAppStarts (bool useSharedRuntime, bool embedAssemblies, string fastDevType, bool activityStarts)
 		{
 			AssertCommercialBuild ();

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -94,6 +94,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_From_Clean_DontIncludeRestore ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -106,6 +107,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_No_Changes ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -128,6 +130,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_CSharp_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -144,6 +147,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_AndroidResource_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -159,6 +163,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_Designer_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -179,6 +184,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_JLO_Change ()
 		{
 			var className = "Foo";
@@ -198,6 +204,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_AndroidManifest_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -213,6 +220,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Retry (2)]
 		public void Build_CSProj_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -246,6 +254,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[TestCaseSource (nameof (XAML_Change))]
 		[Category ("UsesDevice")]
+		[Retry (2)]
 		public void Build_XAML_Change (bool produceReferenceAssembly, bool install)
 		{
 			if (install) {
@@ -324,6 +333,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("UsesDevice")]
+		[Retry (2)]
 		public void Install_CSharp_Change ()
 		{
 			AssertCommercialBuild (); // This test will fail without Fast Deployment

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,15 +2,15 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,11000
+Build_From_Clean_DontIncludeRestore,13000
 Build_No_Changes,2250
 Build_CSharp_Change,3350
 Build_AndroidResource_Change,3250
 Build_AndroidManifest_Change,3500
 Build_Designer_Change,2650
 Build_JLO_Change,10000
-Build_CSProj_Change,10750
-Build_XAML_Change,7250
+Build_CSProj_Change,12500
+Build_XAML_Change,7400
 Build_XAML_Change_RefAssembly,4000
 Install_CSharp_Change,4000
 Install_XAML_Change,5000


### PR DESCRIPTION
Context: https://docs.nunit.org/articles/nunit/writing-tests/attributes/retry.html

Frequently, the `PerformanceTest` fails by just missing the time limit
by a couple ms:

    Exceeded expected time of 4000ms, actual 4011.701ms

Downloading the log, there usually isn't performance regression. CI
machines' performance just seems to fluctuate.

I think we should add a `[Retry(2)]` to every `PerformanceTest` and
see if this helps.

In reading about `RetryAttribute`, I found:

> The argument you specify is the total number of attempts and *not*
> the number of retries after an initial failure. So `[Retry(1)]` does
> nothing and should not be used.

We have `[Retry(1)]` throughout our codebase a lot -- which does
nothing. I removed these for now, as I don't think they actually need
to become `[Retry(2)]`.

Another comment on `[Retry]`:

> Only assertion failures can trigger a retry.

If timings are too slow in `PerformanceTest`, there is an
`Assert.Fail()` call. This works fine when debugging the test, you can
see two break points occur, but the test log is cleared for the second
try! So CI doesn't appear to have a way to "know" if a retry happened
or not...

I bumped some of the timings:

    Build_XAML_Change(false, false)
    Exceeded expected time of 7250ms, actual 7359.297ms
    Build_From_Clean_DontIncludeRestore
    Exceeded expected time of 11000ms, actual 11495.799ms
    Build_CSProj_Change
    Exceeded expected time of 10750ms, actual 11093.169ms
    Exceeded expected time of 11150ms, actual 12047.555ms
    Exceeded expected time of 12000ms, actual 12164.529ms