### PR TITLE
[C++] Add support for native code static checkers and sanitizers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,6 +41,12 @@ tab_width = 8
 indent_size = 8
 max_line_length = 180
 
+# CMake files
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+
 ###############################
 # .NET Coding Conventions     #
 ###############################

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -555,6 +555,50 @@ The most common values for this property are:
 
 Added in Xamarin.Android 6.1.
 
+## AndroidIncludeWrapSh
+
+A boolean value which indicates whether the Android wrapper script
+([`wrap.sh`](https://developer.android.com/ndk/guides/wrap-script))
+should be packaged into the APK. The property defaults to `false`
+since the wrapper script may significantly influence the way the
+application starts up and works and the script should be included only
+when necessary e.g. for debugging or otherwise changing the
+application startup/runtime behavior.
+
+The script is added to the project using the
+[`@(AndroidNativeLibrary)`](~/android/deploy-test/building-apps/build-items.md#androidnativelibrary)
+build action, because it is placed in the same directory where
+architecture-specific native libraries, and must be named `wrap.sh`.
+
+The easiest way to specify path to the `wrap.sh` script is to put it
+in a directory named after the target architecture. This approach will
+work if you have just one `wrap.sh` per architecture:
+
+```xml
+<AndroidNativeLibrary Include="path/to/arm64-v8a/wrap.sh" />
+```
+
+However, if your project needs more than one `wrap.sh` per
+architecture, for different purposes, this approach won't work.
+Instead, in such cases the name can be specified using the `Link`
+metadata of the `AndroidNativeLibrary`:
+
+```xml
+<AndroidNativeLibrary Include="/path/to/my/arm64-wrap.sh">
+  <Link>lib\arm64-v8a\wrap.sh</Link>
+</AndroidNativeLibrary>
+```
+
+If the `Link` metadata is used, the path specified in its value must
+be a valid native architecture-specific library path, relative to the
+APK root directory. The format of the path is `lib\ARCH\wrap.sh` where
+`ARCH` can be one of:
+
++ `arm64-v8a`
++ `armeabi-v7a`
++ `x86_64`
++ `x86`
+
 ## AndroidKeyStore
 
 A boolean value which indicates whether

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -29,6 +29,7 @@
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)**\CMakeFiles\*.log" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)**\.ninja_log" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)**\android-*.config.cache" />
+    <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)\bin\Build$(Configuration)\clang-tidy*.log" />
   </ItemGroup>
   <ItemGroup>
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)TestResult-*.xml" />

--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -50,7 +50,6 @@ macro(xa_common_prepare)
     Wa,-noexecstack
     fPIC
     g
-    fomit-frame-pointer
     O2
     )
 

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -160,8 +160,14 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.pdb" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.debug.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-asan.debug.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-ubsan.debug.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.release.so')"     Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-asan.release.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-ubsan.release.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api.so')"          Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-asan.so')"     Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-ubsan.so')"    Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-btls-shared.so')"         Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-btls-shared.d.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-profiler-aot.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
@@ -174,6 +180,8 @@
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmonosgen-2.0.d.so')"           Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libsqlite3_xamarin.so')"          Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-asan.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-ubsan.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-btls-shared.so')"         Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-profiler-aot.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-profiler-log.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -160,14 +160,14 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.pdb" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.debug.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-asan.debug.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-ubsan.debug.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-checked+asan.debug.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-checked+ubsan.debug.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.release.so')"     Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-asan.release.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-ubsan.release.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-checked+asan.release.so')"  Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android-checked+ubsan.release.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api.so')"          Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-asan.so')"     Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-ubsan.so')"    Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-checked+asan.so')"     Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxa-internal-api-checked+ubsan.so')"    Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-btls-shared.so')"         Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-btls-shared.d.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-profiler-aot.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
@@ -180,8 +180,8 @@
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmonosgen-2.0.d.so')"           Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libsqlite3_xamarin.so')"          Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper.so')" Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-asan.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-ubsan.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-checked+asan.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper-checked+ubsan.so')"       Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-btls-shared.so')"         Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-profiler-aot.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\interpreter-%(Identity)\libmono-profiler-log.so')"        Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />

--- a/build-tools/wrap.sh/asan.sh
+++ b/build-tools/wrap.sh/asan.sh
@@ -1,0 +1,11 @@
+#!/system/bin/sh
+HERE="$(cd "$(dirname "$0")" && pwd)"
+export ASAN_OPTIONS=log_to_syslog=false,allow_user_segv_handler=1
+ASAN_LIB=$(ls $HERE/libclang_rt.asan-*-android.so)
+if [ -f "$HERE/libc++_shared.so" ]; then
+    # Workaround for https://github.com/android-ndk/ndk/issues/988.
+    export LD_PRELOAD="$ASAN_LIB $HERE/libc++_shared.so"
+else
+    export LD_PRELOAD="$ASAN_LIB"
+fi
+"$@"

--- a/build-tools/wrap.sh/asan.sh
+++ b/build-tools/wrap.sh/asan.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 HERE="$(cd "$(dirname "$0")" && pwd)"
-export ASAN_OPTIONS=log_to_syslog=false,allow_user_segv_handler=1
+export ASAN_OPTIONS="log_to_syslog=false,allow_user_segv_handler=1,check_initialization_order=true,print_stats=true,detect_invalid_pointer_pairs=2"
 ASAN_LIB=$(ls $HERE/libclang_rt.asan-*-android.so)
 if [ -f "$HERE/libc++_shared.so" ]; then
     # Workaround for https://github.com/android-ndk/ndk/issues/988.

--- a/build-tools/wrap.sh/ubsan.sh
+++ b/build-tools/wrap.sh/ubsan.sh
@@ -1,0 +1,10 @@
+#!/system/bin/sh
+HERE="$(cd "$(dirname "$0")" && pwd)"
+UBSAN_LIB=$(ls $HERE/libclang_rt.ubsan_standalone-*-android.so)
+if [ -f "$HERE/libc++_shared.so" ]; then
+    # Workaround for https://github.com/android-ndk/ndk/issues/988.
+    export LD_PRELOAD="$UBSAN_LIB $HERE/libc++_shared.so"
+else
+    export LD_PRELOAD="$UBSAN_LIB"
+fi
+"$@"

--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
@@ -20,5 +20,6 @@
         <JarPath Condition=" '$(JarPath)' == '' ">@jar@</JarPath>
         <JavaPath Condition=" '$(JavaPath)' == '' ">@java@</JavaPath>
         <HostHomebrewPrefix Condition=" '$(HostHomebrewPrefix)' == '' ">@HOST_HOMEBREW_PREFIX@</HostHomebrewPrefix>
+        <NdkLlvmTag Condition=" '$(NdkLlvmTag)' == '' ">@NDK_LLVM_TAG@</NdkLlvmTag>
     </PropertyGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -101,6 +101,7 @@ namespace Xamarin.Android.Prepare
 				{ "@javac@",                context.OS.JavaCPath },
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },
+				{ "@NDK_LLVM_TAG@",         $"{context.OS.Type.ToLowerInvariant ()}-x86_64" },
 			};
 
 			return new GeneratedPlaceholdersFile (

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -24,6 +24,11 @@
     <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidDexTool Condition=" '$(AndroidDexTool)' == '' ">d8</AndroidDexTool>
     <_SkipJniAddNativeMethodRegistrationAttributeScan>True</_SkipJniAddNativeMethodRegistrationAttributeScan>
+    <AndroidIncludeWrapSh Condition=" '$(UseASAN)' != '' Or '$(UseUBSAN)' != '' ">true</AndroidIncludeWrapSh>
+    <_AndroidCheckedBuild Condition=" '$(UseASAN)' != '' ">asan</_AndroidCheckedBuild>
+    <_AndroidCheckedBuild Condition=" '$(UseUBSAN)' != '' ">ubsan</_AndroidCheckedBuild>
+    <_ASANScript>..\..\..\build-tools\wrap.sh\asan.sh</_ASANScript>
+    <_UBSANScript>..\..\..\build-tools\wrap.sh\ubsan.sh</_UBSANScript>
   </PropertyGroup>
   <Import Project="Mono.Android-Test.Shared.projitems" Label="Shared" Condition="Exists('Mono.Android-Test.Shared.projitems')" />
   <Import Project="..\..\..\Configuration.props" />
@@ -123,5 +128,32 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Localization\" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\arm64-v8a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\armeabi-v7a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\x86\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\x86_64\wrap.sh</Link>
+    </AndroidNativeLibrary>
+
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\arm64-v8a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\armeabi-v7a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\x86\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\x86_64\wrap.sh</Link>
+    </AndroidNativeLibrary>
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Tasks
 		public bool IncludeWrapSh { get; set; }
 
 		public string CheckedBuild { get; set; }
-		
+
 		[Required]
 		public string ProjectFullPath { get; set; }
 
@@ -579,7 +579,6 @@ namespace Xamarin.Android.Tasks
 				sanitizerName = "asan";
 			} else if (String.Compare ("ubsan", mode, StringComparison.Ordinal) == 0) {
 				sanitizerName = "ubsan_standalone";
-				throw new NotImplementedException ();
 			} else {
 				Log.LogWarning ($"Unknown checked build mode '{CheckedBuild}'");
 				return;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -573,7 +573,7 @@ namespace Xamarin.Android.Tasks
 			if (String.IsNullOrWhiteSpace (CheckedBuild))
 				return;
 
-			string mode = CheckedBuild.Trim ().ToLowerInvariant ();
+			string mode = CheckedBuild;
 			string sanitizerName;
 			if (String.Compare ("asan", mode, StringComparison.Ordinal) == 0) {
 				sanitizerName = "asan";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -85,6 +85,8 @@ namespace Xamarin.Android.Tasks
 		//[Required]
 		public bool EnableCompression { get; set; }
 
+		public bool IncludeWrapSh { get; set; }
+
 		[Required]
 		public string ProjectFullPath { get; set; }
 
@@ -537,6 +539,14 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
+		bool IncludeNativeLibrary (ITaskItem item)
+		{
+			if (IncludeWrapSh)
+				return true;
+
+			return String.Compare (Path.GetFileName (item.ItemSpec), "wrap.sh", StringComparison.Ordinal) != 0;
+		}
+
 		private void AddNativeLibraries (ArchiveFileList files, string [] supportedAbis)
 		{
 			var frameworkLibs = FrameworkNativeLibraries.Select (v => new LibInfo {
@@ -548,6 +558,7 @@ namespace Xamarin.Android.Tasks
 			AddNativeLibraries (files, supportedAbis, frameworkLibs);
 
 			var libs = NativeLibraries.Concat (BundleNativeLibraries ?? Enumerable.Empty<ITaskItem> ())
+				.Where (v => IncludeNativeLibrary (v))
 				.Select (v => new LibInfo {
 						Path = v.ItemSpec,
 						Abi = GetNativeLibraryAbi (v),

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -77,6 +77,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool SkipJniAddNativeMethodRegistrationAttributeScan { get; set; }
 
+		public string CheckedBuild { get; set; }
+
 		[Output]
 		public string [] GeneratedBinaryTypeMaps { get; set; }
 
@@ -265,6 +267,13 @@ namespace Xamarin.Android.Tasks
 			manifest.MultiDex = MultiDex;
 			manifest.NeedsInternet = NeedsInternet;
 			manifest.InstantRunEnabled = InstantRunEnabled;
+
+			if (!String.IsNullOrWhiteSpace (CheckedBuild)) {
+				// We don't validate CheckedBuild value here, this will be done in BuildApk. We just know that if it's
+				// on then we need android:debuggable=true and android:extractNativeLibs=true
+				manifest.ForceDebuggable = true;
+				manifest.ForceExtractNativeLibs = true;
+			}
 
 			var additionalProviders = manifest.Merge (Log, cache, allJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Android.Tasks
 					return libDir;
 				}
 			}
-			
+
 			return null;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -88,6 +88,8 @@ namespace Xamarin.Android.Tasks {
 		public bool MultiDex { get; set; }
 		public bool NeedsInternet { get; set; }
 		public bool InstantRunEnabled { get; set; }
+		public bool ForceExtractNativeLibs { get; set; }
+		public bool ForceDebuggable { get; set; }
 		public string VersionCode {
 			get {
 				XAttribute attr = doc.Root.Attribute (androidNs + "versionCode");
@@ -375,6 +377,7 @@ namespace Xamarin.Android.Tasks {
 
 			var providerNames = AddMonoRuntimeProviders (app);
 
+			bool needDebuggable = false;
 			if (Debug) {
 				app.Add (new XComment ("suppress ExportedReceiver"));
 				app.Add (new XElement ("receiver",
@@ -385,8 +388,13 @@ namespace Xamarin.Android.Tasks {
 							new XElement ("category",
 								new XAttribute (androidNs + "name", "mono.android.intent.category.SEPPUKU." + PackageName)))));
 				if (app.Attribute (androidNs + "debuggable") == null)
-					app.Add (new XAttribute (androidNs + "debuggable", "true"));
+					needDebuggable = true;
 			}
+
+			if (ForceDebuggable || needDebuggable) {
+				app.Add (new XAttribute (androidNs + "debuggable", "true"));
+			}
+
 			if (Debug || NeedsInternet)
 				AddInternetPermissionForDebugger ();
 
@@ -411,7 +419,7 @@ namespace Xamarin.Android.Tasks {
 			AddSupportsGLTextures (app);
 
 			if (targetSdkVersionValue >= 23) {
-				if (app.Attribute (androidNs + "extractNativeLibs") == null)
+				if (ForceExtractNativeLibs || app.Attribute (androidNs + "extractNativeLibs") == null)
 					app.SetAttributeValue (androidNs + "extractNativeLibs", "true");
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -392,7 +392,11 @@ namespace Xamarin.Android.Tasks {
 			}
 
 			if (ForceDebuggable || needDebuggable) {
-				app.Add (new XAttribute (androidNs + "debuggable", "true"));
+				XAttribute debuggable = app.Attribute (androidNs + "debuggable");
+				if (debuggable == null)
+					app.Add (new XAttribute (androidNs + "debuggable", "true"));
+				else
+					debuggable.Value = "true";
 			}
 
 			if (Debug || NeedsInternet)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -255,6 +255,21 @@ namespace Xamarin.Android.Tasks
 			"x86_64",
 		};
 
+		static readonly Dictionary<string, string> ClangAbiMap = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase) {
+			{"arm64-v8a",   "aarch64"},
+			{"armeabi-v7a", "arm"},
+			{"x86",         "i686"},
+			{"x86_64",      "x86_64"}
+		};
+
+		public static string MapAndroidAbiToClang (string androidAbi)
+		{
+			if (ClangAbiMap.TryGetValue (androidAbi, out string clangAbi)) {
+				return clangAbi;
+			}
+			return null;
+		}
+
 		public static string GetNativeLibraryAbi (string lib)
 		{
 			// The topmost directory the .so file is contained within

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -195,7 +195,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidFragmentType Condition=" '$(AndroidFragmentType)' == '' ">Android.App.Fragment</AndroidFragmentType>
 	<AndroidEnableAssemblyCompression Condition=" '$(AndroidEnableAssemblyCompression)' == '' ">True</AndroidEnableAssemblyCompression>
 	<AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>
-	<AndroidCheckedBuild Condition=" '$(AndroidCheckedBuild)' == '' "></AndroidCheckedBuild>
+	<_AndroidCheckedBuild Condition=" '$(_AndroidCheckedBuild)' == '' "></_AndroidCheckedBuild>
 
 	<!-- Currently only C# is supported -->
 	<AndroidGenerateLayoutBindings Condition=" '$(Language)' != 'C#' ">False</AndroidGenerateLayoutBindings>
@@ -1411,7 +1411,7 @@ because xbuild doesn't support framework reference assemblies.
       AcwMapFile="$(_AcwMapFile)"
       SupportedAbis="@(_BuildTargetAbis)"
       SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
-      CheckedBuild="$(AndroidCheckedBuild)">
+      CheckedBuild="$(_AndroidCheckedBuild)">
     <Output TaskParameter="GeneratedBinaryTypeMaps" ItemName="_AndroidTypeMapping" Condition=" '$(_InstantRunEnabled)' == 'True' " />
   </GenerateJavaStubs>
 
@@ -1852,17 +1852,17 @@ because xbuild doesn't support framework reference assemblies.
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libMonoPosixHelper.d.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll')) and '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libMonoPosixHelper.so" />
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.so" Condition=" '$(_AndroidDebugNativeLibraries)' != 'True' " />
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.d.so" Condition=" '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libmono-native.so" />
-    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' == '' "/>
-    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-$(AndroidCheckedBuild).so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libxamarin-debug-app-helper.so" />
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(_AndroidCheckedBuild)' == '' "/>
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-checked+$(_AndroidCheckedBuild).so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(_AndroidCheckedBuild)' != '' " ArchiveFileName="libxamarin-debug-app-helper.so" />
     <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' " Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.so" />
-    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' == '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" />
-    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' != '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-$(AndroidCheckedBuild).so" ArchiveFileName="libxamarin-debug-app-helper.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-$(AndroidCheckedBuild).debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True'  And '$(AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-$(AndroidCheckedBuild).release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api.so" Condition=" '$(AndroidCheckedBuild)' == ''" />
-    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api-$(AndroidCheckedBuild).so" Condition=" '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libxa-internal-api.so" />
+    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(_AndroidCheckedBuild)' == '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" />
+    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(_AndroidCheckedBuild)' != '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-checked+$(_AndroidCheckedBuild).so" ArchiveFileName="libxamarin-debug-app-helper.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(_AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-checked+$(_AndroidCheckedBuild).debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(_AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True'  And '$(_AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-checked+$(_AndroidCheckedBuild).release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' And '$(_AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api.so" Condition=" '$(_AndroidCheckedBuild)' == ''" />
+    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api-checked+$(_AndroidCheckedBuild).so" Condition=" '$(_AndroidCheckedBuild)' != '' " ArchiveFileName="libxa-internal-api.so" />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-btls-shared.so" Condition=" '$(_AndroidDebugNativeLibraries)' != 'True' " />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-btls-shared.d.so" Condition=" '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libmono-btls-shared.so" />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-profiler-aot.so" Condition=" @(_EmbedProfilers->Count()) > 0 and (@(_EmbedProfilers->AnyHaveMetadataValue('Identity', 'aot')) or @(_EmbedProfilers->AnyHaveMetadataValue('Identity', 'all'))) " />
@@ -2083,7 +2083,7 @@ because xbuild doesn't support framework reference assemblies.
     InterpreterEnabled="$(_AndroidUseInterpreter)"
     ProjectFullPath="$(MSBuildProjectFullPath)"
     IncludeWrapSh="$(AndroidIncludeWrapSh)"
-    CheckedBuild="$(AndroidCheckedBuild)">
+    CheckedBuild="$(_AndroidCheckedBuild)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle
@@ -2114,7 +2114,7 @@ because xbuild doesn't support framework reference assemblies.
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
       ProjectFullPath="$(MSBuildProjectFullPath)"
       IncludeWrapSh="$(AndroidIncludeWrapSh)"
-      CheckedBuild="$(AndroidCheckedBuild)">
+      CheckedBuild="$(_AndroidCheckedBuild)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>
   <BuildAppBundle

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1852,12 +1852,17 @@ because xbuild doesn't support framework reference assemblies.
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libMonoPosixHelper.d.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll')) and '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libMonoPosixHelper.so" />
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.so" Condition=" '$(_AndroidDebugNativeLibraries)' != 'True' " />
     <AndroidNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.d.so" Condition=" '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libmono-native.so" />
-    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' "/>
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' == '' "/>
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-$(AndroidCheckedBuild).so" Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libxamarin-debug-app-helper.so" />
     <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' " Include="%(_TargetLibInterpreterDir.Identity)\libmono-native.so" />
-    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' " ArchiveFileName="libmonodroid.so" />
-    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api.so"  />
+    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' == '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper.so" />
+    <_AndroidNativeLibraryForFastDev Condition=" '$(_InstantRunEnabled)' == 'True' And '$(AndroidUseDebugRuntime)' == 'True' And '$(AndroidCheckedBuild)' != '' " Include="%(_TargetLibDir.Identity)\libxamarin-debug-app-helper-$(AndroidCheckedBuild).so" ArchiveFileName="libxamarin-debug-app-helper.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-$(AndroidCheckedBuild).debug.so" Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android.release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True'  And '$(AndroidCheckedBuild)' == '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibDir.Identity)\libmono-android-$(AndroidCheckedBuild).release.so" Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' And '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libmonodroid.so" />
+    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api.so" Condition=" '$(AndroidCheckedBuild)' == ''" />
+    <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libxa-internal-api-$(AndroidCheckedBuild).so" Condition=" '$(AndroidCheckedBuild)' != '' " ArchiveFileName="libxa-internal-api.so" />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-btls-shared.so" Condition=" '$(_AndroidDebugNativeLibraries)' != 'True' " />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-btls-shared.d.so" Condition=" '$(_AndroidDebugNativeLibraries)' == 'True' " ArchiveFileName="libmono-btls-shared.so" />
     <FrameworkNativeLibrary Include="%(_TargetLibInterpreterDir.Identity)\libmono-profiler-aot.so" Condition=" @(_EmbedProfilers->Count()) > 0 and (@(_EmbedProfilers->AnyHaveMetadataValue('Identity', 'aot')) or @(_EmbedProfilers->AnyHaveMetadataValue('Identity', 'all'))) " />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -194,7 +194,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">False</AndroidGenerateLayoutBindings>
 	<AndroidFragmentType Condition=" '$(AndroidFragmentType)' == '' ">Android.App.Fragment</AndroidFragmentType>
 	<AndroidEnableAssemblyCompression Condition=" '$(AndroidEnableAssemblyCompression)' == '' ">True</AndroidEnableAssemblyCompression>
-    <AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>
+	<AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>
+	<AndroidCheckedBuild Condition=" '$(AndroidCheckedBuild)' == '' "></AndroidCheckedBuild>
 
 	<!-- Currently only C# is supported -->
 	<AndroidGenerateLayoutBindings Condition=" '$(Language)' != 'C#' ">False</AndroidGenerateLayoutBindings>
@@ -1409,7 +1410,8 @@ because xbuild doesn't support framework reference assemblies.
       FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
       AcwMapFile="$(_AcwMapFile)"
       SupportedAbis="@(_BuildTargetAbis)"
-      SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)">
+      SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
+      CheckedBuild="$(AndroidCheckedBuild)">
     <Output TaskParameter="GeneratedBinaryTypeMaps" ItemName="_AndroidTypeMapping" Condition=" '$(_InstantRunEnabled)' == 'True' " />
   </GenerateJavaStubs>
 
@@ -2075,7 +2077,8 @@ because xbuild doesn't support framework reference assemblies.
     UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
     InterpreterEnabled="$(_AndroidUseInterpreter)"
     ProjectFullPath="$(MSBuildProjectFullPath)"
-    IncludeWrapSh="$(AndroidIncludeWrapSh)">
+    IncludeWrapSh="$(AndroidIncludeWrapSh)"
+    CheckedBuild="$(AndroidCheckedBuild)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle
@@ -2104,7 +2107,9 @@ because xbuild doesn't support framework reference assemblies.
       LibraryProjectJars="@(ExtractedJarImports)"
       TlsProvider="$(AndroidTlsProvider)"
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-      ProjectFullPath="$(MSBuildProjectFullPath)">
+      ProjectFullPath="$(MSBuildProjectFullPath)"
+      IncludeWrapSh="$(AndroidIncludeWrapSh)"
+      CheckedBuild="$(AndroidCheckedBuild)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>
   <BuildAppBundle

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -194,6 +194,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">False</AndroidGenerateLayoutBindings>
 	<AndroidFragmentType Condition=" '$(AndroidFragmentType)' == '' ">Android.App.Fragment</AndroidFragmentType>
 	<AndroidEnableAssemblyCompression Condition=" '$(AndroidEnableAssemblyCompression)' == '' ">True</AndroidEnableAssemblyCompression>
+    <AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>
 
 	<!-- Currently only C# is supported -->
 	<AndroidGenerateLayoutBindings Condition=" '$(Language)' != 'C#' ">False</AndroidGenerateLayoutBindings>
@@ -2073,7 +2074,8 @@ because xbuild doesn't support framework reference assemblies.
     TlsProvider="$(AndroidTlsProvider)"
     UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
     InterpreterEnabled="$(_AndroidUseInterpreter)"
-    ProjectFullPath="$(MSBuildProjectFullPath)">
+    ProjectFullPath="$(MSBuildProjectFullPath)"
+    IncludeWrapSh="$(AndroidIncludeWrapSh)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -19,8 +19,9 @@ option(STRIP_DEBUG "Strip debugging information when linking" OFF)
 option(ENABLE_TIMING "Build with timing support" OFF)
 option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
 option(ENABLE_CLANG_ASAN "Enable the clang AddressSanitizer support" OFF)
+option(ENABLE_CLANG_UBSAN "Enable the clang UndefinedBehaviorSanitizer support" OFF)
 
-include(CheckIncludeFiles)
+include(CheckIncludeFileCXX)
 include(CheckCXXSymbolExists)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
@@ -118,15 +119,29 @@ set(TEST_COMPILER_ARGS_CPP ${XA_COMPILER_FLAGS}
   )
 
 if(ENABLE_NDK)
-  if (ENABLE_CLANG_ASAN)
+  if (ENABLE_CLANG_ASAN OR ENABLE_CLANG_UBSAN)
 	set(TEST_COMPILER_ARGS_CPP
 	  ${TEST_COMPILER_ARGS_CPP}
 	  fno-omit-frame-pointer
 	  fno-optimize-sibling-calls
 	  )
-	set(CHECKED_COMPILER_FLAGS -fsanitize=address)
-	set(CHECKED_LINKER_FLAGS -fsanitize=address)
+  endif()
+
+  unset(SANITIZER_FLAGS)
+  if (ENABLE_CLANG_ASAN)
+	set(SANITIZER_FLAGS "-fsanitize=address")
 	set(CHECKED_BUILD_INFIX "-asan")
+  elseif(ENABLE_CLANG_UBSAN)
+	set(SANITIZER_FLAGS "-fsanitize=undefined")
+	set(CHECKED_BUILD_INFIX "-ubsan")
+  endif()
+
+  if(SANITIZER_FLAGS)
+	set(CHECKED_COMPILER_FLAGS "${CHECKED_COMPILER_FLAGS} ${SANITIZER_FLAGS}")
+	set(CHECKED_LINKER_FLAGS "${CHECKED_LINKER_FLAGS} ${SANITIZER_FLAGS}")
+
+	string(STRIP "${CHECKED_COMPILER_FLAGS}" CHECKED_COMPILER_FLAGS)
+	string(STRIP "${CHECKED_LINKER_FLAGS}" CHECKED_LINKER_FLAGS)
   endif()
 endif()
 
@@ -286,9 +301,19 @@ include_directories("${MONO_PATH}/mono/eglib")
 include_directories("jni/zip")
 include_directories("${JAVA_INTEROP_SRC_PATH}")
 
-check_include_files("linux/netlink.h" HAVE_LINUX_NETLINK_H)
-check_include_files("linux/rtnetlink.h" HAVE_LINUX_RTNETLINK_H)
-check_include_files("linux/if_arp.h" HAVE_LINUX_IF_ARP_H)
+if(ENABLE_NDK AND (ENABLE_CLANG_UBSAN OR ENABLE_CLANG_ASAN))
+  set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -llog")
+  string(STRIP "${CMAKE_REQUIRED_FLAGS}" CMAKE_REQUIRED_FLAGS)
+endif()
+
+check_include_file_cxx("linux/netlink.h" HAVE_LINUX_NETLINK_H)
+check_include_file_cxx("linux/rtnetlink.h" HAVE_LINUX_RTNETLINK_H)
+check_include_file_cxx("linux/if_arp.h" HAVE_LINUX_IF_ARP_H)
+
+if(ENABLE_NDK AND (ENABLE_CLANG_UBSAN OR ENABLE_CLANG_ASAN))
+  set(CMAKE_REQUIRED_FLAGS "${OLD_CMAKE_REQUIRED_FLAGS}")
+endif()
 
 configure_file(jni/host-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/host-config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/ ${CMAKE_SOURCE_DIR}/include)

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -120,28 +120,28 @@ set(TEST_COMPILER_ARGS_CPP ${XA_COMPILER_FLAGS}
 
 if(ENABLE_NDK)
   if (ENABLE_CLANG_ASAN OR ENABLE_CLANG_UBSAN)
-	set(TEST_COMPILER_ARGS_CPP
-	  ${TEST_COMPILER_ARGS_CPP}
-	  fno-omit-frame-pointer
-	  fno-optimize-sibling-calls
-	  )
+    set(TEST_COMPILER_ARGS_CPP
+      ${TEST_COMPILER_ARGS_CPP}
+      fno-omit-frame-pointer
+      fno-optimize-sibling-calls
+      )
   endif()
 
   unset(SANITIZER_FLAGS)
   if (ENABLE_CLANG_ASAN)
-	set(SANITIZER_FLAGS "-fsanitize=address")
-	set(CHECKED_BUILD_INFIX "-asan")
+    set(SANITIZER_FLAGS "-fsanitize=address")
+    set(CHECKED_BUILD_INFIX "-checked+asan")
   elseif(ENABLE_CLANG_UBSAN)
-	set(SANITIZER_FLAGS "-fsanitize=undefined")
-	set(CHECKED_BUILD_INFIX "-ubsan")
+    set(SANITIZER_FLAGS "-fsanitize=undefined")
+    set(CHECKED_BUILD_INFIX "-checked+ubsan")
   endif()
 
   if(SANITIZER_FLAGS)
-	set(CHECKED_COMPILER_FLAGS "${CHECKED_COMPILER_FLAGS} ${SANITIZER_FLAGS}")
-	set(CHECKED_LINKER_FLAGS "${CHECKED_LINKER_FLAGS} ${SANITIZER_FLAGS}")
+    set(CHECKED_COMPILER_FLAGS "${CHECKED_COMPILER_FLAGS} ${SANITIZER_FLAGS}")
+    set(CHECKED_LINKER_FLAGS "${CHECKED_LINKER_FLAGS} ${SANITIZER_FLAGS}")
 
-	string(STRIP "${CHECKED_COMPILER_FLAGS}" CHECKED_COMPILER_FLAGS)
-	string(STRIP "${CHECKED_LINKER_FLAGS}" CHECKED_LINKER_FLAGS)
+    string(STRIP "${CHECKED_COMPILER_FLAGS}" CHECKED_COMPILER_FLAGS)
+    string(STRIP "${CHECKED_LINKER_FLAGS}" CHECKED_LINKER_FLAGS)
   endif()
 endif()
 
@@ -351,9 +351,9 @@ set(XA_INTERNAL_API_SOURCES
 
 if(ENABLE_NDK)
   set(MONODROID_SOURCES
-	${MONODROID_SOURCES}
-	${LZ4_SOURCES}
-	)
+    ${MONODROID_SOURCES}
+    ${LZ4_SOURCES}
+    )
 endif()
 
 if(UNIX)
@@ -411,12 +411,12 @@ if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
       ${XAMARIN_DEBUG_APP_HELPER}
       PROPERTIES
       OSX_ARCHITECTURES "${XA_OSX_ARCHITECTURES}"
-	  )
+    )
   endif()
   target_compile_options(
-	${XAMARIN_DEBUG_APP_HELPER}
-	PRIVATE ${CHECKED_COMPILER_FLAGS}
-	)
+    ${XAMARIN_DEBUG_APP_HELPER}
+    PRIVATE ${CHECKED_COMPILER_FLAGS}
+  )
 endif()
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} MONO_ANDROID_SUFFIX)
@@ -455,7 +455,7 @@ endif()
 target_compile_options(
   ${MONO_ANDROID_LIB}
   PRIVATE ${CHECKED_COMPILER_FLAGS}
-  )
+)
 
 target_link_libraries(${MONO_ANDROID_LIB} ${LINK_LIBS} xamarin-app)
 

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -18,6 +18,7 @@ option(ENABLE_NDK "Build with Android's NDK" ON)
 option(STRIP_DEBUG "Strip debugging information when linking" OFF)
 option(ENABLE_TIMING "Build with timing support" OFF)
 option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
+option(ENABLE_CLANG_ASAN "Enable the clang AddressSanitizer support" OFF)
 
 include(CheckIncludeFiles)
 include(CheckCXXSymbolExists)
@@ -115,6 +116,19 @@ set(TEST_COMPILER_ARGS_CPP ${XA_COMPILER_FLAGS}
   Wsign-compare
   Wuninitialized
   )
+
+if(ENABLE_NDK)
+  if (ENABLE_CLANG_ASAN)
+	set(TEST_COMPILER_ARGS_CPP
+	  ${TEST_COMPILER_ARGS_CPP}
+	  fno-omit-frame-pointer
+	  fno-optimize-sibling-calls
+	  )
+	set(CHECKED_COMPILER_FLAGS -fsanitize=address)
+	set(CHECKED_LINKER_FLAGS -fsanitize=address)
+	set(CHECKED_BUILD_INFIX "-asan")
+  endif()
+endif()
 
 set(TEST_COMPILER_ARGS_C ${XA_COMPILER_FLAGS})
 
@@ -243,8 +257,11 @@ add_definitions("-D_REENTRANT")
 add_definitions("-DJI_DLL_EXPORT")
 add_definitions("-DMONO_DLL_EXPORT")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_C_FLAGS} ${CHECKED_COMPILER_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_COMPILER_FLAGS} ${EXTRA_CXX_FLAGS} ${CHECKED_COMPILER_FLAGS}")
+
+string(STRIP "${CMAKE_C_FLAGS}" CMAKE_C_FLAGS)
+string(STRIP "${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS)
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   # Convince NDK to really optimize our Debug builds. Without this, NDK's cmake toolchain definition
@@ -322,10 +339,11 @@ if(UNIX)
     )
 endif()
 
-add_library(xa-internal-api SHARED ${XA_INTERNAL_API_SOURCES})
-target_link_libraries(xa-internal-api ${EXTRA_LINKER_FLAGS})
+set(XA_INTERNAL_API xa-internal-api${CHECKED_BUILD_INFIX})
+add_library(${XA_INTERNAL_API} SHARED ${XA_INTERNAL_API_SOURCES})
+target_link_libraries(${XA_INTERNAL_API} ${EXTRA_LINKER_FLAGS})
 set_target_properties(
-  xa-internal-api
+  ${XA_INTERNAL_API}
   PROPERTIES
   COMPILE_FLAGS -fvisibility=default
   LINK_FLAGS -fvisibility=default
@@ -357,22 +375,27 @@ if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
     ${SOURCES_DIR}/new_delete.cc
     ${SOURCES_DIR}/shared-constants.cc
     )
-  add_library(xamarin-debug-app-helper SHARED ${XAMARIN_DEBUG_APP_HELPER_SOURCES})
+  set(XAMARIN_DEBUG_APP_HELPER xamarin-debug-app-helper${CHECKED_BUILD_INFIX})
+  add_library(${XAMARIN_DEBUG_APP_HELPER} SHARED ${XAMARIN_DEBUG_APP_HELPER_SOURCES})
   target_compile_definitions(
-    xamarin-debug-app-helper
+    ${XAMARIN_DEBUG_APP_HELPER}
     PUBLIC -DDEBUG_APP_HELPER
     )
   if(APPLE)
     set_target_properties(
-      xamarin-debug-app-helper
+      ${XAMARIN_DEBUG_APP_HELPER}
       PROPERTIES
       OSX_ARCHITECTURES "${XA_OSX_ARCHITECTURES}"
-    )
+	  )
   endif()
+  target_compile_options(
+	${XAMARIN_DEBUG_APP_HELPER}
+	PRIVATE ${CHECKED_COMPILER_FLAGS}
+	)
 endif()
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} MONO_ANDROID_SUFFIX)
-set(MONO_ANDROID_LIB "mono-android.${MONO_ANDROID_SUFFIX}")
+set(MONO_ANDROID_LIB "mono-android${CHECKED_BUILD_INFIX}.${MONO_ANDROID_SUFFIX}")
 add_library(${MONO_ANDROID_LIB} SHARED ${MONODROID_SOURCES})
 if(APPLE)
   set_target_properties(
@@ -388,10 +411,11 @@ if(APPLE)
 endif()
 
 if(MINGW_ZLIB_LIBRARY_PATH)
-  set(LINK_LIBS "-lmonosgen-2.0.dll ${MINGW_ZLIB_LIBRARY_PATH} ${EXTRA_LINKER_FLAGS}")
+  set(LINK_LIBS "-lmonosgen-2.0.dll ${MINGW_ZLIB_LIBRARY_PATH} ${EXTRA_LINKER_FLAGS} ${CHECKED_LINKER_FLAGS}")
 else()
-  set(LINK_LIBS "-lmonosgen-2.0 -lz ${EXTRA_LINKER_FLAGS}")
+  set(LINK_LIBS "-lmonosgen-2.0 -lz ${EXTRA_LINKER_FLAGS} ${CHECKED_LINKER_FLAGS}")
 endif()
+string(STRIP "${LINK_LIBS}" LINK_LIBS)
 
 if(NOT MINGW AND NOT WIN32)
   set(DEBUG_HELPER_LINK_LIBS "-ldl")
@@ -403,8 +427,13 @@ elseif(NOT ANDROID AND NOT MINGW AND NOT WIN32)
   set(LINK_LIBS "-pthread ${LINK_LIBS} -ldl")
 endif()
 
+target_compile_options(
+  ${MONO_ANDROID_LIB}
+  PRIVATE ${CHECKED_COMPILER_FLAGS}
+  )
+
 target_link_libraries(${MONO_ANDROID_LIB} ${LINK_LIBS} xamarin-app)
 
 if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
-  target_link_libraries(xamarin-debug-app-helper ${DEBUG_HELPER_LINK_LIBS})
+  target_link_libraries(${XAMARIN_DEBUG_APP_HELPER} ${DEBUG_HELPER_LINK_LIBS})
 endif()

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -495,7 +495,7 @@ AndroidSystem::get_max_gref_count_from_system (void)
 	}
 
 	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> override;
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, &override) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, override) > 0) {
 		char *e;
 		max       = strtol (override.get (), &e, 10);
 		switch (*e) {
@@ -515,7 +515,6 @@ AndroidSystem::get_max_gref_count_from_system (void)
 		}
 		log_warn (LOG_GC, "Overriding max JNI Global Reference count to %i", max);
 	}
-
 	return max;
 }
 

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -495,7 +495,7 @@ AndroidSystem::get_max_gref_count_from_system (void)
 	}
 
 	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> override;
-	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, override) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, &override) > 0) {
 		char *e;
 		max       = strtol (override.get (), &e, 10);
 		switch (*e) {
@@ -515,6 +515,7 @@ AndroidSystem::get_max_gref_count_from_system (void)
 		}
 		log_warn (LOG_GC, "Overriding max JNI Global Reference count to %i", max);
 	}
+
 	return max;
 }
 

--- a/src/monodroid/jni/basic-utilities.cc
+++ b/src/monodroid/jni/basic-utilities.cc
@@ -28,9 +28,9 @@ BasicUtilities::path_combine (const char *path1, const char *path2)
 	char *ret = new char [len];
 	*ret = '\0';
 
-	strcat (ret, path1);
-	strcat (ret, MONODROID_PATH_SEPARATOR);
-	strcat (ret, path2);
+	strncat (ret, path1, len - 1);
+	strncat (ret, MONODROID_PATH_SEPARATOR, len - 1);
+	strncat (ret, path2, len - 1);
 
 	return ret;
 }

--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -380,7 +380,6 @@ EmbeddedAssemblies::zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& b
 	static constexpr size_t CD_LOCAL_HEADER_POS_OFFSET   = 42;
 	static constexpr size_t CD_COMMENT_LENGTH_OFFSET     = 32;
 
-	file_name = nullptr;
 	size_t index = buf_offset;
 	zip_ensure_valid_params (buf, buf_len, index, ZIP_CENTRAL_LEN);
 

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -805,7 +805,10 @@ EmbeddedAssemblies::typemap_load_file (BinaryTypeMapHeader &header, const char *
 		cur = &module.java_to_managed[i];
 		cur->from = reinterpret_cast<char*>(java_pos);
 
-		uint32_t idx = *(reinterpret_cast<uint32_t*>(java_pos + header.java_name_width));
+		uint32_t idx;
+		// This might seem slow but it is in fact compiled into a single instruction and is safe when loading the 32-bit
+		// integer from unaligned memory
+		memcpy (&idx, java_pos + header.java_name_width, sizeof (idx));
 		if (idx < INVALID_TYPE_INDEX) {
 			cur->to = reinterpret_cast<char*>(managed_start + (managed_entry_size * idx));
 		} else {
@@ -817,7 +820,7 @@ EmbeddedAssemblies::typemap_load_file (BinaryTypeMapHeader &header, const char *
 		cur = &module.managed_to_java[i];
 		cur->from = reinterpret_cast<char*>(managed_pos);
 
-		idx = *(reinterpret_cast<uint32_t*>(managed_pos + header.managed_name_width));
+		memcpy (&idx, managed_pos + header.managed_name_width, sizeof (idx));
 		cur->to = reinterpret_cast<char*>(java_start + (java_entry_size * idx));
 		managed_pos += managed_entry_size;
 	}

--- a/src/monodroid/jni/globals.hh
+++ b/src/monodroid/jni/globals.hh
@@ -2,11 +2,7 @@
 #ifndef __GLOBALS_H
 #define __GLOBALS_H
 
-#if !defined (DEBUG_APP_HELPER)
 #include "util.hh"
-#else
-#include "basic-utilities.hh"
-#endif
 #include "timing.hh"
 
 #include "debug.hh"
@@ -16,11 +12,7 @@
 #include "cppcompat.hh"
 
 extern xamarin::android::Debug debug;
-#if !defined (DEBUG_APP_HELPER)
 extern xamarin::android::Util utils;
-#else
-extern xamarin::android::BasicUtilities utils;
-#endif
 extern xamarin::android::internal::AndroidSystem androidSystem;
 extern xamarin::android::internal::OSBridge osBridge;
 extern xamarin::android::internal::EmbeddedAssemblies embeddedAssemblies;

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -743,6 +743,9 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	// delete[] x;
 	// log_warn (LOG_DEFAULT, "x == %s", x);
 
+	// TESTING UBSAN: integer overflow
+	//log_warn (LOG_DEFAULT, "Let us have an overflow: %d", INT_MAX + 1);
+
 	bool log_methods = utils.should_log (LOG_TIMING) && !(log_timing_categories & LOG_TIMING_BARE);
 	if (XA_UNLIKELY (log_methods)) {
 		simple_pointer_guard<char[]> jit_log_path = utils.path_combine (androidSystem.get_override_dir (0), "methods.txt");

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -652,6 +652,7 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 		log_error (LOG_DEFAULT, "Failed to parse runtime args: '%s'", runtime_args.get ());
 	} else if (options.debug && cur_time > options.timeout_time) {
 		log_warn (LOG_DEBUGGER, "Not starting the debugger as the timeout value has been reached; current-time: %lli  timeout: %lli", cur_time, options.timeout_time);
+		delete[] options.host;
 	} else if (options.debug && cur_time <= options.timeout_time) {
 		embeddedAssemblies.set_register_debug_symbols (true);
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -643,7 +643,7 @@ void
 MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& runtime_args)
 {
 #if defined (DEBUG) && !defined (WINDOWS)
-	RuntimeOptions options;
+	RuntimeOptions options{};
 	int64_t cur_time;
 
 	cur_time = time (nullptr);
@@ -652,7 +652,6 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 		log_error (LOG_DEFAULT, "Failed to parse runtime args: '%s'", runtime_args.get ());
 	} else if (options.debug && cur_time > options.timeout_time) {
 		log_warn (LOG_DEBUGGER, "Not starting the debugger as the timeout value has been reached; current-time: %lli  timeout: %lli", cur_time, options.timeout_time);
-		delete[] options.host;
 	} else if (options.debug && cur_time <= options.timeout_time) {
 		embeddedAssemblies.set_register_debug_symbols (true);
 
@@ -734,6 +733,8 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	} else {
 		set_debug_options ();
 	}
+
+	delete[] options.host;
 #else
 	set_debug_options ();
 #endif

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -738,6 +738,11 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	set_debug_options ();
 #endif
 
+	// TESTING ASAN: use-after-free
+	// char *x = new char[10]{};
+	// delete[] x;
+	// log_warn (LOG_DEFAULT, "x == %s", x);
+
 	bool log_methods = utils.should_log (LOG_TIMING) && !(log_timing_categories & LOG_TIMING_BARE);
 	if (XA_UNLIKELY (log_methods)) {
 		simple_pointer_guard<char[]> jit_log_path = utils.path_combine (androidSystem.get_override_dir (0), "methods.txt");

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -55,6 +55,16 @@
       </_ConfigureRuntimeCommands>
     </ItemGroup>
 
+    <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Debug" />
+    <ItemGroup>
+      <_ConfigureRuntimeCommands
+          Include="@(AndroidSupportedTargetJitAbi)">
+        <Command>$(CmakePath)</Command>
+        <Arguments>--debug-output $(_CmakeAndroidFlags) -DENABLE_CLANG_UBSAN=ON -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
+        <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Debug</WorkingDirectory>
+      </_ConfigureRuntimeCommands>
+    </ItemGroup>
+
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release" />
     <ItemGroup>
       <_ConfigureRuntimeCommands
@@ -72,6 +82,16 @@
         <Command>$(CmakePath)</Command>
         <Arguments>--debug-output $(_CmakeAndroidFlags) -DENABLE_CLANG_ASAN=ON -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
         <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Release</WorkingDirectory>
+      </_ConfigureRuntimeCommands>
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Release" />
+    <ItemGroup>
+      <_ConfigureRuntimeCommands
+          Include="@(AndroidSupportedTargetJitAbi)">
+        <Command>$(CmakePath)</Command>
+        <Arguments>--debug-output $(_CmakeAndroidFlags) -DENABLE_CLANG_UBSAN=ON -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
+        <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Release</WorkingDirectory>
       </_ConfigureRuntimeCommands>
     </ItemGroup>
 
@@ -107,7 +127,7 @@
 
   <Target Name="_BuildAndroidRuntimes"
       Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
@@ -120,12 +140,22 @@
 
     <Exec
         Command="$(NinjaPath) -v"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Debug"
+    />
+
+    <Exec
+        Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release"
     />
 
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Release"
+    />
+
+    <Exec
+        Command="$(NinjaPath) -v"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Release"
     />
   </Target>
 

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -161,4 +161,36 @@
   <Target Name="CoreCompile"
       DependsOnTargets="Build">
   </Target>
+
+  <Target Name="_GetCompileCommandsDirs"
+          DependsOnTargets="_BuildHostRuntimes;_BuildAndroidRuntimes">
+    <ItemGroup>
+      <_CompileCommandsDir Include="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug">
+        <LogTag>%(AndroidSupportedTargetJitAbi.Identity)-Debug</LogTag>
+      </_CompileCommandsDir>
+      <_CompileCommandsDir Include="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release">
+        <LogTag>%(AndroidSupportedTargetJitAbi.Identity)-Release</LogTag>
+      </_CompileCommandsDir>
+
+      <!-- clang-tidy won't work with mingw builds, we need to disable them -->
+      <_CompileCommandsDir Include="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Debug" Condition=" '%(_HostRuntime.Identity)' != 'host-mxe-Win64' And '%(_HostRuntime.Identity)' != 'host-mxe-Win32' ">
+        <LogTag>%(_HostRuntime.OutputDirectory)-Debug</LogTag>
+      </_CompileCommandsDir>
+      <_CompileCommandsDir Include="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Release" Condition=" '%(_HostRuntime.Identity)' != 'host-mxe-Win64' And '%(_HostRuntime.Identity)' != 'host-mxe-Win32' ">
+        <LogTag>%(_HostRuntime.OutputDirectory)-Release</LogTag>
+      </_CompileCommandsDir>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ClangTidyCheck"
+          DependsOnTargets="_GetCompileCommandsDirs">
+    <PropertyGroup>
+      <ClangTidy>$(AndroidNdkDirectory)\toolchains\llvm\prebuilt\$(NdkLlvmTag)\bin\clang-tidy</ClangTidy>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(ClangTidy) -p $(MSBuildThisFileDirectory)%(_CompileCommandsDir.Identity) *.cc > ..\..\..\bin\Build$(Configuration)\clang-tidy.%(_CompileCommandsDir.LogTag).log"
+      WorkingDirectory="$(MSBuildThisFileDirectory)\jni"
+      ContinueOnError="ErrorAndContinue" />
+  </Target>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -127,7 +127,7 @@
 
   <Target Name="_BuildAndroidRuntimes"
       Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
@@ -249,8 +249,9 @@
     </PropertyGroup>
 
     <Exec
-      Command="$(ClangTidy) -p $(MSBuildThisFileDirectory)%(_CompileCommandsDir.Identity) *.cc > ..\..\..\bin\Build$(Configuration)\clang-tidy.%(_CompileCommandsDir.LogTag).log"
-      WorkingDirectory="$(MSBuildThisFileDirectory)\jni"
-      ContinueOnError="ErrorAndContinue" />
+        ContinueOnError="ErrorAndContinue"
+        Command="$(ClangTidy) -p $(MSBuildThisFileDirectory)%(_CompileCommandsDir.Identity) *.cc > ..\..\..\bin\Build$(Configuration)\clang-tidy.%(_CompileCommandsDir.LogTag).log"
+        WorkingDirectory="$(MSBuildThisFileDirectory)\jni"
+    />
   </Target>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -45,6 +45,16 @@
       </_ConfigureRuntimeCommands>
     </ItemGroup>
 
+    <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Debug" />
+    <ItemGroup>
+      <_ConfigureRuntimeCommands
+          Include="@(AndroidSupportedTargetJitAbi)">
+        <Command>$(CmakePath)</Command>
+        <Arguments>--debug-output $(_CmakeAndroidFlags) -DENABLE_CLANG_ASAN=ON -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
+        <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Debug</WorkingDirectory>
+      </_ConfigureRuntimeCommands>
+    </ItemGroup>
+
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release" />
     <ItemGroup>
       <_ConfigureRuntimeCommands
@@ -52,6 +62,16 @@
         <Command>$(CmakePath)</Command>
         <Arguments>--debug-output $(_CmakeAndroidFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
         <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release</WorkingDirectory>
+      </_ConfigureRuntimeCommands>
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Release" />
+    <ItemGroup>
+      <_ConfigureRuntimeCommands
+          Include="@(AndroidSupportedTargetJitAbi)">
+        <Command>$(CmakePath)</Command>
+        <Arguments>--debug-output $(_CmakeAndroidFlags) -DENABLE_CLANG_ASAN=ON -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)</Arguments>
+        <WorkingDirectory>$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Release</WorkingDirectory>
       </_ConfigureRuntimeCommands>
     </ItemGroup>
 
@@ -87,7 +107,7 @@
 
   <Target Name="_BuildAndroidRuntimes"
       Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-asan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
@@ -95,7 +115,17 @@
 
     <Exec
         Command="$(NinjaPath) -v"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Debug"
+    />
+
+    <Exec
+        Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release"
+    />
+
+    <Exec
+        Command="$(NinjaPath) -v"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-asan-Release"
     />
   </Target>
 

--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -9,6 +9,7 @@ project(libsqlite-xamarin C)
 
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 include("../../build-tools/cmake/xa_macros.cmake")
 
 if(NOT DEFINED SQLITE_LIBRARY_NAME)

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -20,6 +20,11 @@
     <AndroidSupportedAbis Condition=" '$(Enable64BitBuild)' == '' ">armeabi-v7a;x86</AndroidSupportedAbis>
     <AndroidSupportedAbis  Condition=" '$(Enable64BitBuild)' != '' ">arm64-v8a;x86</AndroidSupportedAbis>
     <AndroidEnablePreloadAssemblies Condition=" '$(AndroidEnablePreloadAssemblies)' == '' ">True</AndroidEnablePreloadAssemblies>
+    <AndroidIncludeWrapSh Condition=" '$(UseASAN)' != '' Or '$(UseUBSAN)' != '' ">true</AndroidIncludeWrapSh>
+    <_AndroidCheckedBuild Condition=" '$(UseASAN)' != '' ">asan</_AndroidCheckedBuild>
+    <_AndroidCheckedBuild Condition=" '$(UseUBSAN)' != '' ">ubsan</_AndroidCheckedBuild>
+    <_ASANScript>..\..\..\build-tools\wrap.sh\asan.sh</_ASANScript>
+    <_UBSANScript>..\..\..\build-tools\wrap.sh\ubsan.sh</_UBSANScript>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
@@ -77,6 +82,33 @@
     <AndroidResource Include="Resources\layout\Tabbar.axml" />
     <AndroidResource Include="Resources\layout\Toolbar.axml" />
     <AndroidResource Include="Resources\values\styles.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\arm64-v8a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\armeabi-v7a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\x86\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
+      <Link>lib\x86_64\wrap.sh</Link>
+    </AndroidNativeLibrary>
+
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\arm64-v8a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\armeabi-v7a\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\x86\wrap.sh</Link>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
+      <Link>lib\x86_64\wrap.sh</Link>
+    </AndroidNativeLibrary>
   </ItemGroup>
   <Import Project="Xamarin.Forms.Performance.Integration.Droid.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />


### PR DESCRIPTION
We now support the [`clang-tidy`][0] static analysis of the C++ code
and the [`ASAN`][1] and [`UBSAN`][2] clang sanitizers on the runtime to find issues
that cannot be detected by static analysis. All of the tools are shipped
with the Android NDK which currently ships the clang 9 toolchain.

All of the tools require separate builds of the native code.
`clang-tidy` builds the entire codebase to generate an AST and then
analyze it, reporting possible errors but it does not output any
binaries.

The two runtime sanitizers, however, instrument the generated code in
numerous ways thus making it much (up to 3x) slower to execute.
Therefore, we now build our native code 4 additional times - for each
sanitizer in both `Debug` and `Release` modes. The output binaries have
the `-checked+SANITIZER_NAME` infix added to their name.

The instrumented binaries will not be currently distributed to the end
users since they are intended for internal use.

Also added are two [`wrap.sh`][3] scripts, one for `ASAN` and the other
for `UBSAN` and can be found in the `build-tools/wrap.sh/` directory.

The instrumented binaries can then be placed in the APK instead of the
standard binaries by adding the following to the project file:

```xml
<PropertyGroup>
  <AndroidIncludeWrapSh Condition=" '$(UseASAN)' != '' Or '$(UseUBSAN)' != '' ">true</AndroidIncludeWrapSh>
  <_AndroidCheckedBuild Condition=" '$(UseASAN)' != '' ">asan</_AndroidCheckedBuild>
  <_AndroidCheckedBuild Condition=" '$(UseUBSAN)' != '' ">ubsan</_AndroidCheckedBuild>
  <_ASANScript>../path/to/build-scripts/wrap.sh/asan.sh</_ASANScript>
	<_UBSANScript>../path/to/build-scripts/wrap.sh/ubsan.sh</_UBSANScript>
</PropertyGroup>

<ItemGroup>
  <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
    <Link>lib\arm64-v8a\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
    <Link>lib\armeabi-v7a\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
    <Link>lib\x86\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_ASANScript)" Condition=" '$(UseASAN)' != '' ">
    <Link>lib\x86_64\wrap.sh</Link>
  </AndroidNativeLibrary>

  <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
    <Link>lib\arm64-v8a\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
    <Link>lib\armeabi-v7a\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
    <Link>lib\x86\wrap.sh</Link>
  </AndroidNativeLibrary>
  <AndroidNativeLibrary Include="$(_UBSANScript)" Condition=" '$(UseUBSAN)' != '' ">
    <Link>lib\x86_64\wrap.sh</Link>
  </AndroidNativeLibrary>
</ItemGroup>
```

The `Link` metadata value **must** be valid path to the native library
directory inside the APK since the wrapper scripts are
achitecture-specific and are expected by the Android loader to be found in
architecture-specific library directories.

The checked build is enabled by setting the `$(_AndroidCheckedBuild)`
MSBuild property to either `asan` or `ubsan` value.

[0]: https://releases.llvm.org/9.0.0/tools/clang/tools/extra/docs/clang-tidy/
[1]: https://releases.llvm.org/9.0.0/tools/clang/docs/AddressSanitizer.html
[2]: https://releases.llvm.org/9.0.0/tools/clang/docs/UndefinedBehaviorSanitizer.html
[3]: https://developer.android.com/ndk/guides/wrap-script
