### PR TITLE
[Xamarin.Android.Build.Tasks] Dont copy assets for Library Projects.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -247,6 +247,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       SupportedAbis="@(_BuildTargetAbis)"
       CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
       AssetsDirectory="$(MonoAndroidAssetsDirIntermediate)"
+      AdditionalAndroidAssetPaths="@(LibraryAssetDirectories)"
       AndroidSdkPlatform="$(_AndroidApiLevel)"
       JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
       ManifestFiles="$(IntermediateOutputPath)android\AndroidManifest.xml"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1644,7 +1644,13 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="ExtraPackages" PropertyName="AaptExtraPackages" />
   </GetExtraPackages>
   
+
+  <!--
+  For aapt copy the assets into one folder.
+  For aapt2 we will consule the library assets in place.
+  -->
   <CollectLibraryAssets
+      Condition=" '$(_AndroidUseAapt2)' != 'True' "
       AdditionalAssetDirectories="@(LibraryAssetDirectories)"
       AssetDirectory="$(MonoAndroidAssetsDirIntermediate)" />
 </Target>

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -6,6 +6,7 @@ Build_From_Clean_DontIncludeRestore,13000
 Build_No_Changes,2250
 Build_CSharp_Change,3350
 Build_AndroidResource_Change,3250
+Build_AndroidAsset_Change,10000
 Build_AndroidManifest_Change,3500
 Build_Designer_Change,2650
 Build_JLO_Change,10000


### PR DESCRIPTION
We currently copy all the assets for all Library Projects
into one main directory. This can slow down build times
if the assets are large. So what we should do is use those
assets in place.

This will also allow us to consume .nuget assets in place as
well sometime in the future.