### PR TITLE
[build] define .NET Core version in global.json

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -52,7 +52,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
-        remove_preview_versions: true
+        remove_dotnet: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -52,6 +52,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_preview_versions: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -138,6 +138,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_preview_versions: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:
@@ -283,6 +284,7 @@ stages:
     - template: yaml-templates\use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_preview_versions: true
 
     - template: yaml-templates\use-dot-net.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -138,7 +138,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
-        remove_preview_versions: true
+        remove_dotnet: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:
@@ -284,7 +284,7 @@ stages:
     - template: yaml-templates\use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
-        remove_preview_versions: true
+        remove_dotnet: true
 
     - template: yaml-templates\use-dot-net.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -24,6 +24,7 @@ steps:
 - template: use-dot-net.yaml
   parameters:
     version: $(DotNetCorePreviewVersion)
+    remove_preview_versions: true
 
 - template: use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -24,7 +24,7 @@ steps:
 - template: use-dot-net.yaml
   parameters:
     version: $(DotNetCorePreviewVersion)
-    remove_preview_versions: true
+    remove_dotnet: true
 
 - template: use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -3,7 +3,7 @@
 
 parameters:
   version: $(DotNetCoreVersion)
-  remove_preview_versions: false
+  remove_dotnet: false
 
 steps:
 
@@ -11,8 +11,8 @@ steps:
       $ErrorActionPreference = 'Stop'
       $ProgressPreference = 'SilentlyContinue'
       $DotNetRoot = "$env:ProgramFiles\dotnet"
-      if ("${{ parameters.remove_preview_versions }}" -eq $true) {
-        Remove-Item -Recurse "$DotNetRoot\5.0.*\" -Verbose
+      if ("${{ parameters.remove_dotnet }}" -eq $true) {
+        Remove-Item -Recurse $DotNetRoot -Verbose
       }
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
       & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
@@ -22,7 +22,7 @@ steps:
 
   - bash: >
       DOTNET_ROOT=~/.dotnet &&
-      (if [[ "${{ parameters.remove_preview_versions }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT/5.0.*/; fi) &&
+      (if [[ "${{ parameters.remove_dotnet }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT; fi) &&
       PATH="$DOTNET_ROOT:$PATH" &&
       curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
       sh dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -22,7 +22,7 @@ steps:
 
   - bash: >
       DOTNET_ROOT=~/.dotnet &&
-      if [[ "${{ parameters.remove_preview_versions }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT/5.0.*/; else 1; fi &&
+      (if [[ "${{ parameters.remove_preview_versions }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT/5.0.*/; fi) &&
       PATH="$DOTNET_ROOT:$PATH" &&
       curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
       sh dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -3,20 +3,26 @@
 
 parameters:
   version: $(DotNetCoreVersion)
+  remove_preview_versions: false
 
 steps:
 
   - powershell: |
       $ErrorActionPreference = 'Stop'
       $ProgressPreference = 'SilentlyContinue'
+      $DotNetRoot = "$env:ProgramFiles\dotnet"
+      if ("${{ parameters.remove_preview_versions }}" -eq $true) {
+        Remove-Item -Recurse "$DotNetRoot\5.0.*\" -Verbose
+      }
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
       & dotnet --list-sdks
     displayName: install .NET Core ${{ parameters.version }}
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - bash: >
-      DOTNET_ROOT=~/.dotnet/ &&
+      DOTNET_ROOT=~/.dotnet &&
+      if [[ "${{ parameters.remove_preview_versions }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT/5.0.*/; else 1; fi &&
       PATH="$DOTNET_ROOT:$PATH" &&
       curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
       sh dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -48,6 +48,11 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="DotNetVersion">
+    <!-- For debugging, print the version of dotnet -->
+    <Exec Command="dotnet --version" />
+  </Target>
+
   <Target Name="CreateAllRuntimePacks" >
     <Exec Command="dotnet pack -p:Configuration=$(Configuration) -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack -p:Configuration=$(Configuration) -p:AndroidRID=android.21-arm64 -p:AndroidABI=arm64-v8a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -56,7 +61,7 @@
   </Target>
 
   <Target Name="CreateAllPacks"
-      DependsOnTargets="CreateAllRuntimePacks" >
+      DependsOnTargets="DotNetVersion;CreateAllRuntimePacks" >
     <Exec Command="dotnet pack -p:Configuration=$(Configuration) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
     <Exec Command="dotnet pack -p:Configuration=$(Configuration) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" />
     <Exec Command="dotnet pack -p:Configuration=$(Configuration) &quot;$(MSBuildThisFileDirectory)Xamarin.Android.Sdk.Lite.proj&quot;" />

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -7,7 +7,7 @@ targeting pack containing reference assemblies and other compile time assets req
 by projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -7,7 +7,7 @@ runtime packs that contain the assets required for a self-contained publish of
 projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -6,7 +6,7 @@ This project file is used to create the Microsoft.Android.Sdk NuGet, which will 
 the new entry point for short-form style Android projets in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
+++ b/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
@@ -6,7 +6,7 @@ This project file is used to create the Xamarin.Android.Sdk.Lite NuGet, which is
 temporary MSBuild project SDK that redirects to a Xamarin.Android installation on disk.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/build-tools/create-packs/global.json
+++ b/build-tools/create-packs/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-      "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
-    }
-}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,10 @@
 {
+    "sdk": {
+        "version": "3.1.201",
+        "rollForward": "latestFeature"
+    },
     "msbuild-sdks": {
-            "Microsoft.Build.NoTargets": "2.0.1"
+        "Microsoft.Build.NoTargets": "2.0.1",
+        "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
     }
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -248,7 +248,6 @@ namespace Xamarin.Android.Build.Tests
 				FullProjectDirectory = Path.Combine (Root, relativeProjDir);
 			var files = project.Save ();
 			project.Populate (relativeProjDir, files);
-			project.CopyNuGetConfig (relativeProjDir);
 			return new DotNetCLI (project, Path.Combine (FullProjectDirectory, project.ProjectFilePath));
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -61,8 +61,12 @@ namespace Xamarin.ProjectTools
 		{
 			File.WriteAllText (Path.Combine (directory, "global.json"),
 $@"{{
+    ""sdk"": {{
+        ""version"": ""5.0"",
+        ""rollForward"": ""latestMajor""
+    }},
     ""msbuild-sdks"": {{
-            ""Microsoft.Android.Sdk"": ""{SdkVersion}""
+        ""Microsoft.Android.Sdk"": ""{SdkVersion}""
     }}
 }}");
 		}
@@ -115,6 +119,13 @@ $@"{{
 		/// Defaults to API 19
 		/// </summary>
 		public string MinSdkVersion { get; set; } = "19";
+
+		public override void Populate (string directory, IEnumerable<ProjectResource> projectFiles)
+		{
+			base.Populate (directory, projectFiles);
+
+			SaveGlobalJson (Path.Combine (Root, directory));
+		}
 
 		public virtual string ProcessManifestTemplate ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -54,8 +54,6 @@ namespace Xamarin.ProjectTools
 					}
 					project.Populate (ProjectDirectory, files);
 				}
-
-				project.CopyNuGetConfig (ProjectDirectory);
 			}
 			else
 				project.UpdateProjectFiles (ProjectDirectory, files, doNotCleanupOnUpdate);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -273,7 +273,7 @@ $@"<Project>
 			}
 		}
 
-		public void Populate (string directory, IEnumerable<ProjectResource> projectFiles)
+		public virtual void Populate (string directory, IEnumerable<ProjectResource> projectFiles)
 		{
 			directory = directory.Replace ('\\', '/').Replace ('/', Path.DirectorySeparatorChar);
 
@@ -283,6 +283,7 @@ $@"<Project>
 			Directory.CreateDirectory (Path.Combine (Root, directory));
 
 			UpdateProjectFiles (directory, projectFiles);
+			CopyNuGetConfig (directory);
 		}
 
 		public virtual void UpdateProjectFiles (string directory, IEnumerable<ProjectResource> projectFiles, bool doNotCleanup = false)

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -38,7 +38,6 @@ namespace Xamarin.Android.Build.Tests
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
 			var files = proj.Save ();
 			proj.Populate (relativeProjDir, files);
-			proj.CopyNuGetConfig (relativeProjDir);
 			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
 
 			Assert.IsTrue (dotnet.Run (), "`dotnet run` should succeed");
@@ -67,7 +66,6 @@ namespace Xamarin.Android.Build.Tests
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
 			var files = proj.Save ();
 			proj.Populate (relativeProjDir, files);
-			proj.CopyNuGetConfig (relativeProjDir);
 			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
 			Assert.IsTrue (dotnet.Build ("Install"), "`dotnet build` should succeed");
 


### PR DESCRIPTION
We are hitting an issue where a CI machine has a broken build of .NET
5 rc2 installed:

    Exec
        Assembly = Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
        CommandLineArguments = dotnet pack -p:Configuration=Release -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a "/Users/builder/azdo/_work/4/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj"
        Welcome to .NET 5.0!
        ---------------------
        SDK Version: 5.0.100-rc.2.20458.11
        Telemetry
        ---------
        The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
        Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
        ----------------
        Installed an ASP.NET Core HTTPS development certificate.
        To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
        Learn about HTTPS: https://aka.ms/dotnet-https
        ----------------
        Write your first app: https://aka.ms/dotnet-hello-world
        Find out what's new: https://aka.ms/dotnet-whats-new
        Explore documentation: https://aka.ms/dotnet-docs
        Report issues and find source on GitHub: https://github.com/dotnet/core
        Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
        --------------------------------------------------------------------------------------
        /var/folders/9k/brhlbh9d729gxd3m_9j0t23w0000gn/T/tmpc81db9a1c872436bb5f037f3e6d68f71.exec.cmd: line 2: 24887 Illegal instruction: 4  dotnet pack -p:Configuration=Release -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a "/Users/builder/azdo/_work/4/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj"
        Errors
            /Users/builder/azdo/_work/4/s/xamarin-android/build-tools/create-packs/Directory.Build.targets(52,5): error MSB3073: The command "dotnet pack -p:Configuration=Release -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a "/Users/builder/azdo/_work/4/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj"" exited with code 132.

Earlier in the build, we can see lots of .NET versions installed:

    $ dotnet --list-sdks
    3.1.201 [/Users/builder/.dotnet/sdk]
    5.0.100-preview.6.20265.2 [/Users/builder/.dotnet/sdk]
    5.0.100-preview.7.20307.3 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20365.11 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20411.10 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20414.5 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20426.3 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.2.20458.11 [/Users/builder/.dotnet/sdk]

We should add to our `global.json` file:

    {
        "sdk": {
            "version": "3.1.201",
            "rollForward": "latestFeature"
        }
    }

This will make the `dotnet` command use .NET Core 3.1.x when building
Xamarin.Android itself. This version number matches what we set for
`$(DotNetCoreVersion)` in `azure-pipelines.yaml`, and we can allow it
to roll forward for feature releases like 3.1.402.

We should also print the output of `dotnet --version` when running the
`CreateAllPacks` MSBuild target for troubleshooting purposes.

While we are doing this, let's go ahead and remove
`build-tools/create-packs/global.json` and have a single `global.json`
file in the root. This allows us to remove the version number for
`Sdk="Microsoft.Build.NoTargets"` in several files. We weren't able to
do this in 079197ac because of the extra `global.json` file.