### PR TITLE
[build] clean up past .NET 5 installations

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -52,6 +52,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_dotnet: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -138,6 +138,7 @@ stages:
     - template: yaml-templates/use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_dotnet: true
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:
@@ -283,6 +284,7 @@ stages:
     - template: yaml-templates\use-dot-net.yaml
       parameters:
         version: $(DotNetCorePreviewVersion)
+        remove_dotnet: true
 
     - template: yaml-templates\use-dot-net.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -24,6 +24,7 @@ steps:
 - template: use-dot-net.yaml
   parameters:
     version: $(DotNetCorePreviewVersion)
+    remove_dotnet: true
 
 - template: use-dot-net.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -3,23 +3,29 @@
 
 parameters:
   version: $(DotNetCoreVersion)
+  remove_dotnet: false
 
 steps:
 
   - powershell: |
       $ErrorActionPreference = 'Stop'
       $ProgressPreference = 'SilentlyContinue'
+      $DotNetRoot = "$env:ProgramFiles\dotnet\"
+      if ("${{ parameters.remove_dotnet }}" -eq $true) {
+        Remove-Item -Recurse $DotNetRoot -Verbose
+      }
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
       & dotnet --list-sdks
     displayName: install .NET Core ${{ parameters.version }}
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - bash: >
       DOTNET_ROOT=~/.dotnet/ &&
-      PATH="$DOTNET_ROOT:$PATH" &&
+      (if [[ "${{ parameters.remove_dotnet }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT; fi) &&
       curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
       sh dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&
+      PATH="$DOTNET_ROOT:$PATH" &&
       dotnet --list-sdks &&
       echo "##vso[task.setvariable variable=DOTNET_ROOT]$DOTNET_ROOT" &&
       echo "##vso[task.setvariable variable=PATH]$PATH"


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/tools/dotnet-install-script

The `use-dot-net.yaml` template is leaving behind old installations of
.NET 5:

    $ dotnet --list-sdks
    3.1.201 [/Users/builder/.dotnet/sdk]
    5.0.100-preview.6.20265.2 [/Users/builder/.dotnet/sdk]
    5.0.100-preview.7.20307.3 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20365.11 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20411.10 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20414.5 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.1.20426.3 [/Users/builder/.dotnet/sdk]
    5.0.100-rc.2.20458.11 [/Users/builder/.dotnet/sdk]

We are currently using `dotnet-install.sh` or `dotnet-install.ps1` to
install nightly builds of .NET 5. These scripts basically download a
`.zip` file and extract them.

I added a new `remove_dotnet` parameter to delete the `dotnet`
directory completely. This will ensure we only have the versions of
.NET Core 3.x and .NET 5 specified in our build definition.

Usage would look like:

    - template: yaml-templates/use-dot-net.yaml
      parameters:
        version: $(DotNetCorePreviewVersion)
        remove_dotnet: true
    - template: yaml-templates/use-dot-net.yaml
      parameters:
        version: $(DotNetCoreVersion)

Simply deleting the directories is similar to what this script is
doing here:

https://github.com/dotnet/sdk/blob/feae865a0614026d72ed9a9558d0111e5fcd5765/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh#L35