### PR TITLE
[build] consolidate global.json for Microsoft.Build.NoTargets

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -7,7 +7,7 @@ targeting pack containing reference assemblies and other compile time assets req
 by projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -7,7 +7,7 @@ runtime packs that contain the assets required for a self-contained publish of
 projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -6,7 +6,7 @@ This project file is used to create the Microsoft.Android.Sdk NuGet, which will 
 the new entry point for short-form style Android projets in .NET 5.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
+++ b/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
@@ -6,7 +6,7 @@ This project file is used to create the Xamarin.Android.Sdk.Lite NuGet, which is
 temporary MSBuild project SDK that redirects to a Xamarin.Android installation on disk.
 ***********************************************************************************************
 -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/build-tools/create-packs/global.json
+++ b/build-tools/create-packs/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-      "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
-    }
-}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "msbuild-sdks": {
-            "Microsoft.Build.NoTargets": "2.0.1"
+        "Microsoft.Build.NoTargets": "2.0.1",
+        "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
     }
 }


### PR DESCRIPTION
Let's remove `build-tools/create-packs/global.json` and have a single
`global.json` file in the root. This allows us to remove the version
number for `Sdk="Microsoft.Build.NoTargets"` in several files.

We weren't able to do this in 079197ac because of the extra
`global.json` file that took precendence over the one in the root.