### PR TITLE
Bump to xamarin/monodroid/master@a9ae74d4

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@92b9cce8dacad8b7ce48ddbcf9e5247598cd2ccd
+xamarin/monodroid:master@a9ae74d474583211c153b2b868417383afd4cb3a
 mono/mono:2020-02@83105ba22461455f4343d6bb14976eba8b0b3f39

--- a/Documentation/release-notes/5112.md
+++ b/Documentation/release-notes/5112.md
@@ -1,0 +1,4 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 4996](https://github.com/xamarin/xamarin-android/issues/4996):
+   application deploy on Android 11 emulator fails with Mono.AndroidTools.AdbException: secure_mkdirs failed: Permission denied


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4996

Changes: https://github.com/xamarin/monodroid/compare/92b9cce8dacad8b7ce48ddbcf9e5247598cd2ccd...a9ae74d474583211c153b2b868417383afd4cb3a

  * xamarin/monodroid@a9ae74d47: Bump to xamarin/android-sdk-installer/master@1928338b (#1113)
  * xamarin/monodroid@4afc0d960: [RuntimeService] Update Shared runtime to use `getExternalFilesDir` (#1111)