### PR TITLE
[Xamarin.Android.Build.Tasks] .gitignore files in __AndroidLibraryProjects__.zip

### DIFF
--- a/Documentation/release-notes/5113.md
+++ b/Documentation/release-notes/5113.md
@@ -1,0 +1,8 @@
+#### Application and library build and deployment
+
+  * [Developer Community 1141659][0]: Starting in Xamarin.Android
+    11.0, the *Updating Resources...* build step could get stuck
+    indefinitely if a NuGet package containing an **AndroidResource**
+    file name starting with `.` was included in a project.
+
+[0]: https://developercommunity.visualstudio.com/content/problem/1141659/android-build-process-never-stops.html

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -44,6 +44,12 @@ namespace Xamarin.Android.Tasks {
 
 		public string ToolExe { get; set; }
 
+		/// <summary>
+		/// Returns true if a filename starts with a . character.
+		/// </summary>
+		public static bool IsInvalidFilename (string path) =>
+			Path.GetFileName (path).StartsWith (".", StringComparison.Ordinal);
+
 		protected string ResourceDirectoryFullPath (string resourceDirectory)
 		{
 			return (Path.IsPathRooted (resourceDirectory) ? resourceDirectory : Path.Combine (WorkingDirectory, resourceDirectory)).TrimEnd ('\\');

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -85,6 +85,10 @@ namespace Xamarin.Android.Tasks {
 				outputArchive = Path.Combine (outputArchive, filename);
 				expectedOutputFile = outputArchive;
 			} else {
+				if (IsInvalidFilename (fileOrDirectory)) {
+					LogDebugMessage ($"Invalid filename, ignoring: {fileOrDirectory}");
+					return;
+				}
 				expectedOutputFile = Path.Combine (outputArchive, flatFile);
 			}
 			RunAapt (GenerateCommandLineCommands (fileOrDirectory, isDirectory, outputArchive), expectedOutputFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -117,8 +117,8 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string baseFileName = LowercaseFilenames ? rel.ToLowerInvariant () : rel;
-				if (Path.GetFileName (baseFileName).StartsWith (".", StringComparison.Ordinal)) {
-					Log.LogDebugMessage ($"Skipping ignored file: {baseFileName}");
+				if (Aapt2.IsInvalidFilename (baseFileName)) {
+					Log.LogDebugMessage ($"Invalid filename, ignoring: {baseFileName}");
 					continue;
 				}
 				if (Path.GetExtension (baseFileName) == ".axml")

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -100,6 +100,10 @@ namespace Xamarin.Android.Tasks {
 					}
 					output.Add (taskItem);
 					foreach (var file in files) {
+						if (Aapt2.IsInvalidFilename (file)) {
+							Log.LogDebugMessage ($"Invalid filename, ignoring: {file}");
+							continue;
+						}
 						var fileTaskItem = new TaskItem (file, new Dictionary<string, string> () {
 							{ "ResourceDirectory", directory.ItemSpec },
 							{ "StampFile", generateArchive ? stampFile : file },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1386,6 +1386,10 @@ namespace UnnamedProject
 				};
 
 			var proj = new XamarinAndroidApplicationProject ();
+			// Package requires packages.config
+			if (!Builder.UseDotNet) {
+				proj.Packages.Add (KnownPackages.Xamarin_PdfView_Android);
+			}
 			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.foo"));
 			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.git"));
 			proj.AndroidResources.Add (CreateItem ("Resources\\raw\\.svn"));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -636,7 +636,19 @@ namespace Xamarin.ProjectTools
 			Version = "6.0.30",
 			TargetFramework = "netstandard2.0",
 		};
-
+		/// <summary>
+		/// A NuGet package that has an EmbeddedResource in PdfViewBinding.dll:
+		/// __AndroidLibraryProjects__.zip\library_project_imports\res\.gitignore
+		/// </summary>
+		public static Package Xamarin_PdfView_Android = new Package {
+			Id = "Xamarin.PdfView.Android",
+			Version = "1.0.4",
+			References = {
+				new BuildItem.Reference ("Xamarin.PdfView.Android") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.PdfView.Android.1.0.4\\lib\\PdfViewBinding.dll"
+				}
+			},
+		};
 		public static Package ZXing_Net_Mobile = new Package {
 			Id = "ZXing.Net.Mobile",
 			Version = "2.4.1",


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/1141659/android-build-process-never-stops.html
Context: https://www.nuget.org/packages/Xamarin.PdfView.Android/

In addition to:

    <AndroidResource Include="Resources\values\.gitignore" />

The Xamarin.PdfView.Android NuGet package causes the `<Aapt2Compile/>`
MSBuild task to hang indefinitely. This is a package last updated
11/26/2015 that has a very weird file layout:

    Xamarin.PdfView.Android.1.0.4.nupkg
        lib\PdfViewBinding.dll
            __AndroidLibraryProjects__.zip
                library_project_imports\res\.gitignore

The `res` directory is otherwise empty!

The `<CollectNonEmptyDirectories/>` MSBuild task returned:

    _LibraryResourceFiles
        obj\Debug\lp\0\jl\res\.gitignore
            FilesCache = obj\Debug\lp\0\jl\res\..\files.cache
            Hash = obj\Debug\lp\0.stamp
            ResourceDirectory = obj\Debug\lp\0\jl\res
            StampFile = obj\Debug\lp\0\jl\res\.gitignore
            _ArchiveDirectory = obj\Debug\lp\0\jl\res\..\flat\
            _FlatFile = res_.gitignore.flat

And so `obj\Debug\lp\0\jl\res\.gitignore` is passed to `aapt2 compile`.

a7f7ae61 successfully solved the issue for `.gitignore` (or any `.`
prefix) files present in a project, but not NuGet packages.

I think we should fix two things here:

1. The `aapt2 compile` command should skip files that start with `.`,
   in case somehow one is passed in. We should do this because it
   causes the `<Aapt2Compile/>` to hang indefinitely.
2. The `<CollectNonEmptyDirectories/>` MSBuild task should also ignore
   files that start with `.`

I updated the `AndroidUpdateResourcesTest.InvalidFilenames` test so it
checks this scenario.