### PR TITLE
[linker] set %(IsTrimmable) for @(KnownFrameworkReference)

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -113,17 +113,19 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <XamarinAndroidVersion>$(AndroidPackVersionLong)</XamarinAndroidVersion>
   </PropertyGroup>
   <ItemGroup>
-    <KnownFrameworkReference Include="Microsoft.Android"
-                              TargetFramework="$(_AndroidNETAppTargetFramework)"
-                              RuntimeFrameworkName="Microsoft.Android"
-                              DefaultRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
-                              LatestRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
-                              TargetingPackName="Microsoft.Android.Ref"
-                              TargetingPackVersion="$(AndroidPackVersionLong)"
-                              RuntimePackNamePatterns="Microsoft.Android.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
-                              Profile="Android"
-                              />
+    <KnownFrameworkReference
+        Include="Microsoft.Android"
+        TargetFramework="$(_AndroidNETAppTargetFramework)"
+        RuntimeFrameworkName="Microsoft.Android"
+        DefaultRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
+        LatestRuntimeFrameworkVersion="$(AndroidPackVersionLong)"
+        TargetingPackName="Microsoft.Android.Ref"
+        TargetingPackVersion="$(AndroidPackVersionLong)"
+        RuntimePackNamePatterns="Microsoft.Android.Runtime.**RID**"
+        RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
+        Profile="Android"
+        IsTrimmable="true"
+    />
   </ItemGroup>
 </Project>
 ]]>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Microsoft.Android.Sdk.AssemblyResolution.targets
+Microsoft.Android.Sdk.ILLink.targets
 
 This file contains the .NET 5-specific targets to customize ILLink
 
@@ -13,14 +13,6 @@ This file contains the .NET 5-specific targets to customize ILLink
       Condition=" '$(PublishTrimmed)' == 'true' "
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths">
-    <ItemGroup>
-      <ResolvedFileToPublish
-          Update="@(ResolvedFileToPublish)"
-          Condition="'%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'Java.Interop.dll' or '%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'Mono.Android.dll' or '%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'Mono.Android.Export.dll'">
-        <!-- This makes it so that the platform assembly isn't treated as a root assembly -->
-      <IsTrimmable>true</IsTrimmable>
-    </ResolvedFileToPublish>
-    </ItemGroup>
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->
       <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose --deterministic --custom-data XATargetFrameworkDirectories="$(_XATargetFrameworkDirectories)"</_ExtraTrimmerArgs>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -33,7 +33,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.Core.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.AssemblyResolution.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Linker.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.ILLink.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.NuGet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Publish.targets" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Tooling.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -439,15 +439,8 @@ namespace Lib2
 					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
 				}
 
-				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
-				var filesToTouch = new [] {
-					Path.Combine (Root, b.ProjectDirectory, "foo", "armeabi-v7a", "libtest.so"),
-					Path.Combine (Root, b.ProjectDirectory, "Assets", "foo.txt"),
-				};
-				foreach (var file in filesToTouch) {
-					FileAssert.Exists (file);
-					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
-				}
+				proj.Touch ("foo\\armeabi-v7a\\libtest.so");
+				proj.Touch ("Assets\\foo.txt");
 
 				//NOTE: second build, targets will run because inputs changed
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second build should succeed");


### PR DESCRIPTION
Context: https://github.com/dotnet/installer/blob/97f447f228824c0217d2c8b845b003118673ff22/src/redist/targets/GenerateBundledVersions.targets#L208-L218
Context: https://docs.microsoft.com/dotnet/core/deploying/trimming-options

Right now we are modifying the `@(ResolvedFileToPublish)` item group
and setting `%(IsTrimmable)` for `Mono.Android.dll`,
`Mono.Android.Export.dll`, and `Java.Interop.dll`. Instead we can set
this metadata on `@(KnownFrameworkReference)`, which is the way that
`Microsoft.NETCore.App` is setup. This way these assembly references
will be "trimmable" by default.

We should also rename `Microsoft.Android.Sdk.Linker.targets` to
`Microsoft.Android.ILLink.targets` to better match the naming in .NET 5.