### PR TITLE
[Microsoft.Android.Ref] use reference assembly for Mono.Android.dll

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,8 +10,11 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
 
-  <!-- Include initial pack content in ref and runtime. We aren't yet generating separate reference and runtime assemblies. -->
   <ItemGroup>
+    <!-- NOTE: we don't have a reference assembly for Java.Interop.dll yet -->
+    <_AndroidAppRefAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\Java.Interop.dll" />
+    <_AndroidAppRefAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\ref\Mono.Android.dll" />
+    <_AndroidAppRefAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\ref\Mono.Android.Export.dll" />
     <_AndroidAppPackAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\Java.Interop.dll" />
     <_AndroidAppPackAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\Mono.Android.dll" />
     <_AndroidAppPackAssemblies Include="$(XamarinAndroidSourcePath)bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\netcoreapp3.1\Mono.Android.Export.dll" />

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -33,7 +33,7 @@ by projects that use the Microsoft.Android framework in .NET 5.
     </PropertyGroup>
 
     <ItemGroup>
-      <_PackageFiles Include="@(_AndroidAppPackAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="@(_AndroidAppRefAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\AndroidApiInfo.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -1,15 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>monoandroid10;netcoreapp3.1</TargetFrameworks>
+    <!-- Only build for netcoreapp3.1 for $(AndroidLatestStableFrameworkVersion) -->
+    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoStdLib>true</NoStdLib>
     <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
@@ -58,12 +59,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj" />
   </ItemGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-
-  <!-- Only build the 'netcoreapp3.1' version of 'Mono.Android.Export.dll' once. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' And '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">
-    <BuildDependsOn></BuildDependsOn>
-  </PropertyGroup>
 
 </Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -21,6 +21,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">


### PR DESCRIPTION
The `Microsoft.Android.Ref.nupkg` file is meant to only contain
reference assemblies, and we are currently shipping the *real* assembly.

The actual runtime assembly is found in the runtime pack for each RID:

* `Microsoft.Android.Runtime.android.21-arm.nupkg`
* `Microsoft.Android.Runtime.android.21-arm64.nupkg`
* `Microsoft.Android.Runtime.android.21-x86.nupkg`
* `Microsoft.Android.Runtime.android.21-x64.nupkg`

To fix this, we need to set `$(ProduceReferenceAssembly)` for each
assembly we distribute in `Microsoft.Android.Ref`.

The MSBuild targets in dotnet/sdk already handle passing the correct
reference assembly to the `<Csc/>` MSBuild task, and passing us the
runtime assembly to place in `.apk` files.

I also cleaned up `Mono.Android.Export.csproj` so we don't need to
clear `$(BuildDependsOn)` after manually importing `Micrsoft.NET.Sdk`.
We could simply change `$(TargetFrameworks)` instead.

Using a reference assembly has the benefit of saving ~3.5 MB of file
size:

    Length Name
    ------ ----
    7167945 Microsoft.Android.Ref.11.0.100-ci.master.120.nupkg
    3641811 Microsoft.Android.Ref.11.0.100-ci.microsoft-android-ref.121.nupkg

And saves ~18.9 MB when extracted:

            Size   Compressed  Name
    ------------ ------------  ------------------------
        32411136      6748183  ref\net5.0\Mono.Android.dll
           78336        30619  ref\net5.0\Mono.Android.Export.dll
        13564928      3244535  ref\net5.0\Mono.Android.dll
           22016         8077  ref\net5.0\Mono.Android.Export.dll

We will need a future change in xamarin/java.interop to make a
reference assembly for `Java.Interop.dll`.