### PR TITLE
[One .NET] fix <Import/> ordering

### DIFF
--- a/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
+++ b/build-tools/create-packs/Xamarin.Android.Sdk.Lite.proj
@@ -20,6 +20,7 @@ temporary MSBuild project SDK that redirects to a Xamarin.Android installation o
 
   <ItemGroup>
     <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.DefaultItems.targets" PackagePath="targets\Microsoft.Android.Sdk.DefaultItems.targets" />
+    <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.DefaultProperties.props" PackagePath="targets\Microsoft.Android.Sdk.DefaultProperties.props" />
     <!-- The Lite SDK replaces the full Sdk.props/Sdk.targets -->
     <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Xamarin.Android.Sdk.Lite.props" PackagePath="targets\Microsoft.Android.Sdk.props" />
     <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\Xamarin.Android.Sdk.Lite.targets" PackagePath="targets\Microsoft.Android.Sdk.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultItems.targets
@@ -33,4 +33,14 @@
     />
   </ItemGroup>
 
+  <!-- Automatically supply project capabilities for IDE use -->
+  <ItemGroup>
+    <ProjectCapability Include="Mobile" />
+    <ProjectCapability Include="Android" />
+    <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
+    
+    <!-- Conflicts with our targets generator in VS+CPS: See https://work.azdo.io/1112733 -->
+    <ProjectCapability Remove="LaunchProfiles" />
+  </ItemGroup>
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
@@ -1,0 +1,53 @@
+<Project>
+
+  <!-- User-facing configuration-agnostic defaults -->
+  <PropertyGroup>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
+    <LatestSupportedJavaVersion Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.99</LatestSupportedJavaVersion>
+    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
+    <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
+    <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
+    <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
+    <AndroidResgenFile Condition=" '$(AndroidResgenFile)' == '' ">$(MonoAndroidResourcePrefix)\$(_AndroidResourceDesigner)</AndroidResgenFile>
+    <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
+    <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
+    <!-- jar2xml is not supported -->
+    <AndroidClassParser>class-parse</AndroidClassParser>
+    <!-- mono-symbolicate is not supported -->
+    <MonoSymbolArchive>false</MonoSymbolArchive>
+    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+
+  <!--  User-facing configuration-specific defaults -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <!--FIXME: Disable the shared runtime and fast deployment default -->
+    <AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' ">false</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
+    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' ">false</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
+    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">SdkOnly</AndroidLinkMode>
+    <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
+  </PropertyGroup>
+
+  <!-- Application project settings -->
+  <PropertyGroup>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
+    <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
+    <!-- We don't ever need a `static void Main` method, so switch to Library here-->
+    <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
+    <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
+    <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
+    <!-- Prefer $(RuntimeIdentifiers) plural -->
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
+    <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
+    <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">Properties\AndroidManifest.xml</AndroidManifest>
+  </PropertyGroup>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.props
@@ -4,43 +4,9 @@
 
   <PropertyGroup>
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
-    <LatestSupportedJavaVersion  Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.99</LatestSupportedJavaVersion>
-    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
-    <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <!-- Enable nuget package conflict resolution -->
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     <_AndroidResourceDesigner>Resource.designer.cs</_AndroidResourceDesigner>
-  </PropertyGroup>
-
-  <!-- User-facing configuration-agnostic defaults -->
-  <PropertyGroup>
-    <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
-    <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
-    <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
-    <AndroidResgenFile Condition=" '$(AndroidResgenFile)' == '' ">$(MonoAndroidResourcePrefix)\$(_AndroidResourceDesigner)</AndroidResgenFile>
-    <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
-    <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
-    <!-- jar2xml is not supported -->
-    <AndroidClassParser>class-parse</AndroidClassParser>
-    <!-- mono-symbolicate is not supported -->
-    <MonoSymbolArchive>false</MonoSymbolArchive>
-    <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
-  </PropertyGroup>
-
-  <!--  User-facing configuration-specific defaults -->
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <!--FIXME: Disable the shared runtime and fast deployment default -->
-    <AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' ">false</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
-    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' ">false</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
-    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">SdkOnly</AndroidLinkMode>
-    <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
   </PropertyGroup>
 
   <Import Project="Microsoft.Android.Sdk.BundledVersions.props" Condition=" Exists('Microsoft.Android.Sdk.BundledVersions.props') " />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -2,53 +2,29 @@
 
   <PropertyGroup>
     <MicrosoftAndroidSdkTargetsImported>true</MicrosoftAndroidSdkTargetsImported>
-    <_XamarinAndroidBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
+    <_XamarinAndroidBuildTasksAssembly>..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AndroidApplication Condition=" '$(AndroidApplication)' == '' And '$(OutputType)' == 'Exe' ">true</AndroidApplication>
-    <AndroidApplication Condition=" '$(AndroidApplication)' == '' ">false</AndroidApplication>
-    <SelfContained Condition=" '$(SelfContained)' == '' And '$(AndroidApplication)' == 'true' ">true</SelfContained>
-    <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
-    <!-- Prefer $(RuntimeIdentifiers) plural -->
-    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' And '$(AndroidApplication)' == 'true' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
-    <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
-    <AndroidManifest Condition=" '$(AndroidManifest)' == '' And '$(AndroidApplication)' == 'true' ">Properties\AndroidManifest.xml</AndroidManifest>
-    <!-- We don't ever need a `static void Main` method, so switch to Library here-->
-    <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
-  </PropertyGroup>
-
+  <!-- Default property settings, imported before Microsoft.NET.Sdk -->
+  <Import Project="Microsoft.Android.Sdk.DefaultProperties.props" />
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <PropertyGroup>
     <TargetPlatformSupported Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">true</TargetPlatformSupported>
   </PropertyGroup>
 
-  <!-- Default item includes (globs and implicit references) -->
-  <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
-  <Import Project="Microsoft.Android.Sdk.SupportedPlatforms.props" />
   <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BuildOrder.targets" />
+  <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" />
 
-  <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.Core.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.AssemblyResolution.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.ILLink.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.NuGet.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Publish.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.Tooling.targets" />
-
-  <!-- Automatically supply project capabilities for IDE use -->
-  <ItemGroup>
-    <ProjectCapability Include="Mobile" />
-    <ProjectCapability Include="Android" />
-    <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
-    
-    <!-- Conflicts with our targets generator in VS+CPS: See https://work.azdo.io/1112733 -->
-    <ProjectCapability Remove="LaunchProfiles" />
-  </ItemGroup>
-
-  <!-- NOTE: We have to replace the Run target after Microsoft.NET.Sdk.targets are imported -->
+  <Import Project="..\tools\Xamarin.Android.Common.targets" />
+  <Import Project="..\tools\Xamarin.Android.Bindings.Core.targets" />
+  <Import Project="..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
   <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
+  <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
+  <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />
+  <Import Project="Microsoft.Android.Sdk.ILLink.targets" />
+  <Import Project="Microsoft.Android.Sdk.NuGet.targets" />
+  <Import Project="Microsoft.Android.Sdk.Publish.targets" />
+  <Import Project="Microsoft.Android.Sdk.SupportedPlatforms.props" />
+  <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Xamarin.Android.Sdk.Lite.props
@@ -6,6 +6,7 @@
 
   <!-- This is the renamed-on-pack Xamarin.Android.Sdk.props from the full SDK -->
   <Import Project="Microsoft.Android.Sdk.Default.props" />
+  <Import Project="Microsoft.Android.Sdk.DefaultProperties.props" />
 
   <PropertyGroup>
     <!-- Ensure $(UsingAndroidNETSdk) is not set to retain legacy behavior -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -94,7 +94,7 @@ $@"{{
 			Sources.Add (new BuildItem.Source ($"Resources\\Resource.designer{Language.DefaultExtension}") { TextContent = () => string.Empty });
 		}
 
-		protected override bool SetExtraNuGetConfigSources => true;
+		protected override bool UseDotNet => true;
 
 		public string OutputPath => Path.Combine ("bin", Configuration, TargetFramework.ToLowerInvariant ());
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -78,8 +78,8 @@ namespace Xamarin.ProjectTools
 			Packages = new List<Package> ();
 			Imports = new List<Import> ();
 
-			//NOTE: for SDK-style projects, we need $(Configuration) set before Microsoft.NET.Sdk.targets
-			if (Builder.UseDotNet) {
+			if (UseDotNet) {
+				//NOTE: for SDK-style projects, we need $(Configuration) set before Microsoft.NET.Sdk.targets
 				Imports.Add (new Import ("Directory.Build.props") {
 					TextContent = () =>
 $@"<Project>
@@ -88,16 +88,14 @@ $@"<Project>
 	</PropertyGroup>
 </Project>"
 				});
-			} else {
-				SetProperty (KnownProperties.Configuration, () => Configuration);
-			}
 
-			// Feeds only needed for .NET 5+
-			if (SetExtraNuGetConfigSources) {
+				// Feeds only needed for .NET 5+
 				ExtraNuGetConfigSources = new List<string> {
 					Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
 					"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
 				};
+			} else {
+				SetProperty (KnownProperties.Configuration, () => Configuration);
 			}
 		}
 
@@ -112,7 +110,7 @@ $@"<Project>
 			References.Add (new BuildItem.ProjectReference (include, other.ProjectName, other.ProjectGuid));
 		}
 
-		protected virtual bool SetExtraNuGetConfigSources => Builder.UseDotNet;
+		protected virtual bool UseDotNet => Builder.UseDotNet;
 
 		public string GetProperty (string name)
 		{


### PR DESCRIPTION
We were setting several MSBuild property defaults in
`Microsoft.Android.Sdk.props`. The problem with this, is that it
doesn't enable the properties to be overridden in a .csproj file at
all.

The import ordering should be:

1. `Microsoft.Android.Sdk.props` - only contains properties that
   cannot be overridden, or properties that the `.csproj` might need
   to rely on.
2. The `.csproj` file
3. `Microsoft.Android.Sdk.targets`
  a. `Microsoft.Android.Sdk.DefaultProperties.props`
  b. `Microsoft.NET.Sdk/Sdk.targets`
4. Any other `.targets` files where we have functionality split up.

I took the opportunity to reorganize/cleanup a few other things:

* `@(ProjectCapability)` should go in
  `Microsoft.Android.Sdk.DefaultItems.targets`.
* Lots of usage of `$(MSBuildThisFileDirectory)` that wasn't needed.
* Sorted `<Import/>` alphabetically on the ones that ordering doesn't
  matter.

After these changes, I found that `XASdkProject` wasn't properly
building for `Release` configurations. We needed the same workaround
to set `$(Configuration)` in `Directory.Build.props`. To do this I
renamed `SetExtraNuGetConfigSources` to `UseDotNet`.