### PR TITLE
[Mono.Android] Remove default method ICursor.SetNotificationUris that causes binding error.

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1626,6 +1626,10 @@
   <attr path="/api/package[@name='android.database']/class[@name='CursorJoiner']/method[@name='iterator' and count(parameter)=0]" name="return-not-null">true</attr>
   <attr api-since="24" path="/api/package[@name='android.icu.text']/class[@name='UnicodeSet']/method[@name='iterator' and count(parameter)=0]" name="return-not-null">true</attr>
 
+  <!-- If you try to implement ICursor in API-30+, we generate an invalid invoker for this method due to the
+       generic parameters.  Since this is a default method we can just remove it until that bug is fixed.
+       https://github.com/xamarin/java.interop/issues/699 -->
+  <remove-node api-since="30" path="/api/package[@name='android.database']/interface[@name='Cursor']/method[@name='setNotificationUris' and count(parameter)=2 and parameter[1][@type='android.content.ContentResolver'] and parameter[2][@type='java.util.List&lt;android.net.Uri&gt;']]" />
   
   <!--
     ***********************************************************************


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5027
Context: https://github.com/xamarin/java.interop/issues/699

There is an issue with implementing `Android.Database.ICursor` in API-30+.  A default method [`setnotificationUris (ContentResolver, List<Uri>)`](https://developer.android.com/reference/android/database/Cursor#setNotificationUris(android.content.ContentResolver,%20java.util.List%3Candroid.net.Uri%3E)) was added in API-29.  If a user tries to bind a Java class that implements `ICursor`, we generate invalid C# code when we generate the interface invoker method:

```
var uris = (global::System.Collections.Generic.IList`1)global::Java.Lang.Object.GetObject<global::System.Collections.Generic.IList`1> (native_uris, JniHandleOwnership.DoNotTransfer);
```

The `generator` fix for this seems tricky, so as a workaround for now we can simply remove this new default method so users can implement the interface.

(Although the method was added in API-29, we don't support DIM in API-29 so it is ignored. Thus this problem isn't showing up until API-30+.)