### PR TITLE
[build] check if $DotNetRoot exists before deletion

### DIFF
--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -11,7 +11,7 @@ steps:
       $ErrorActionPreference = 'Stop'
       $ProgressPreference = 'SilentlyContinue'
       $DotNetRoot = "$env:ProgramFiles\dotnet\"
-      if ("${{ parameters.remove_dotnet }}" -eq $true) {
+      if ("${{ parameters.remove_dotnet }}" -eq $true -And (Test-Path $DotNetRoot)) {
         Remove-Item -Recurse $DotNetRoot -Verbose
       }
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1


### PR DESCRIPTION
Context: https://build.azdo.io/4072655
Context: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/remove-item

I saw the build error:

    Remove-Item : Cannot find path 'C:\Program Files\dotnet\' because it does not exist.

I probably caused this by canceling a build. Whoops. I think we need a
`Test-Path` check to only delete if the file exists:

    if ("${{ parameters.remove_dotnet }}" -eq $true -And (Test-Path $DotNetRoot)) {
        Remove-Item -Recurse $DotNetRoot -Verbose
    }

`Remove-Item` does not appear to have an option to prevent failure if
the path does not exist.

The macOS side seems like it would already work if the directory did
not exist:

    rm -rfv $DOTNET_ROOT