### PR TITLE
[Xamarin.Android.Build.Tasks] audit WorkingDirectory usage in <Aapt2Link/> (#5107)

### DIFF
--- a/Documentation/release-notes/5107.md
+++ b/Documentation/release-notes/5107.md
@@ -1,0 +1,14 @@
+#### Application and library build and deployment
+
+* [Github PR 5107](https://github.com/xamarin/xamarin-android/pull/5107):
+  Starting in Xamarin.Android 11.0, building
+  solutions in parallel with `msbuild YourSolution.sln -m` could
+  fail with errors such as:
+
+    ```
+    obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource mipmap/ic_launcher (aka com.companyname.skiasharpsample:mipmap/ic_launcher) not found.
+    obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource string/app_name (aka com.companyname.skiasharpsample:string/app_name) not found.
+    obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource mipmap/ic_launcher_round (aka com.companyname.skiasharpsample:mipmap/ic_launcher_round) not found.
+    obj\Release\100\android\manifest\AndroidManifest.xml(9,0): error APT2260: resource style/MainTheme.Splash (aka com.companyname.skiasharpsample:style/MainTheme.Splash) not found.
+    Xamarin.Android.Aapt2.targets(226,3): error APT2067: failed processing manifest.
+    ```

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1395,5 +1395,64 @@ namespace UnnamedProject
 				b.Output.AssertTargetIsSkipped ("_CompileResources");
 			}
 		}
+
+		[Test]
+		public void SolutionBuildSeveralProjects ()
+		{
+			const int libraryCount = 10;
+			var path = Path.Combine ("temp", TestName);
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, path);
+			using (var sb = new SolutionBuilder ($"{TestName}.sln") {
+				SolutionPath = Path.Combine (Root, path),
+				MaxCpuCount = 4,
+				BuildingInsideVisualStudio = false, // allow projects dependencies to build
+			}) {
+				var apps = new List<XamarinAndroidApplicationProject> ();
+				var app1 = new XamarinAndroidApplicationProject {
+					ProjectName = "App1"
+				};
+				apps.Add (app1);
+				sb.Projects.Add (app1);
+
+				var app2 = new XamarinAndroidApplicationProject {
+					ProjectName = "App2"
+				};
+				apps.Add (app2);
+				sb.Projects.Add (app2);
+
+				for (var i = 0; i < libraryCount; i++) {
+					var index = i;
+					var lib = new XamarinAndroidLibraryProject {
+						ProjectName = $"Lib{i}",
+						AndroidResources = {
+							new AndroidItem.AndroidResource ($"Resources\\values\\library_name{index}.xml") {
+								TextContent = () =>
+$@"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""library_name{index}"">Lib{index}</string>
+</resources>"
+							}
+						}
+					};
+					foreach (var app in apps) {
+						app.AddReference (lib);
+					}
+					sb.Projects.Add (lib);
+				}
+
+				// Add usage of Lib0.Resource.String.library_name0
+				var builder = new StringBuilder ();
+				for (int i = 0; i < libraryCount; i++) {
+					builder.AppendLine ($"int library_name{i} = Lib{i}.Resource.String.library_name{i};");
+				}
+				foreach (var app in apps) {
+					app.Sources.Add (new BuildItem.Source ("Foo.cs") {
+						TextContent = () => $"class Foo {{ void Bar () {{ {builder} }} }}",
+					});
+				}
+
+				Assert.IsTrue (sb.Build (), "Solution should have built.");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -29,6 +29,10 @@ namespace Xamarin.ProjectTools
 		/// This passes /p:BuildingInsideVisualStudio=True, command-line to MSBuild
 		/// </summary>
 		public bool BuildingInsideVisualStudio { get; set; } = true;
+		/// <summary>
+		/// Passes /m:N to MSBuild, defaults to null to omit the /m parameter completely.
+		/// </summary>
+		public int? MaxCpuCount { get; set; }
 		public LoggerVerbosity Verbosity { get; set; }
 		public IEnumerable<string> LastBuildOutput {
 			get {
@@ -287,6 +291,14 @@ namespace Xamarin.ProjectTools
 					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
 			if (AutomaticNuGetRestore && restore && !UseDotNet) {
 				args.Append (" /restore");
+			}
+			if (MaxCpuCount != null) {
+				if (!string.Equals (Path.GetFileNameWithoutExtension (psi.FileName), "xabuild", StringComparison.OrdinalIgnoreCase)) {
+					args.Append ($" /maxCpuCount:{MaxCpuCount}");
+					args.Append (" /nodeReuse:false"); // Disable the MSBuild daemon
+				} else {
+					Console.WriteLine ($"Ignoring MaxCpuCount={MaxCpuCount}, running with xabuild.");
+				}
 			}
 			args.Append ($" @\"{responseFile}\"");
 			using (var sw = new StreamWriter (responseFile, append: false, encoding: Encoding.UTF8)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -101,6 +101,17 @@ $@"<Project>
 			}
 		}
 
+		/// <summary>
+		/// Adds a reference to another project. The optional include path uses a relative path and ProjectName if omitted.
+		/// </summary>
+		public void AddReference (XamarinProject other, string include = null)
+		{
+			if (string.IsNullOrEmpty (include)) {
+				include = $"..\\{other.ProjectName}\\{other.ProjectName}.csproj";
+			}
+			References.Add (new BuildItem.ProjectReference (include, other.ProjectName, other.ProjectGuid));
+		}
+
 		protected virtual bool SetExtraNuGetConfigSources => Builder.UseDotNet;
 
 		public string GetProperty (string name)


### PR DESCRIPTION
@mattleibow was hitting an error building a `.sln` file using
`msbuild /m` on Windows:

	> msbuild /m …
	obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource mipmap/ic_launcher (aka com.companyname.skiasharpsample:mipmap/ic_launcher) not found.
	obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource string/app_name (aka com.companyname.skiasharpsample:string/app_name) not found.
	obj\Release\100\android\manifest\AndroidManifest.xml(7,0): error APT2260: resource mipmap/ic_launcher_round (aka com.companyname.skiasharpsample:mipmap/ic_launcher_round) not found.
	obj\Release\100\android\manifest\AndroidManifest.xml(9,0): error APT2260: resource style/MainTheme.Splash (aka com.companyname.skiasharpsample:style/MainTheme.Splash) not found.
	Xamarin.Android.Aapt2.targets(226,3): error APT2067: failed processing manifest.

Reviewing the code and the `.binlog`, it seemed like the
`File.Exists()` check within `<Aapt2Link/>` was returning `false`.

This failure only happened on Windows, and it only failed *sometimes*.

This is the classic problem when:

 1. MSBuild is building a solution on multiple nodes.
 2. A background thread uses a relative path.
 3. The value of the current working directory sometimes changes.

I went through and audited all the paths in the `<Aapt2Link/>` MSBuild
task.  I made sure they all explicitly use full paths and log if any
`File.Exist()` or `Directory.Exists()` checks return `false`.

I added a new test for this scenario.  This test won't fully reproduce
the problem when using `xabuild`, as it crashes with:

	MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
	Microsoft.Build.Shared.InternalErrorException: MSB0001: Internal MSBuild Error: Node 6 does not have a provider.
	    at Microsoft.Build.Shared.ErrorUtilities.ThrowInternalError(String message, Object[] args)
	    at Microsoft.Build.BackEnd.NodeManager.SendData(Int32 node, INodePacket packet)
	    at Microsoft.Build.Execution.BuildManager.PerformSchedulingActions(IEnumerable`1 responses)
	    at Microsoft.Build.Execution.BuildManager.PerformSchedulingActions(IEnumerable`1 responses)
	    at Microsoft.Build.Execution.BuildManager.HandleNewRequest(Int32 node, BuildRequestBlocker blocker)
	    at Microsoft.Build.Execution.BuildManager.ProcessPacket(Int32 node, INodePacket packet)
	    at Microsoft.Build.Execution.BuildManager.<>c__DisplayClass70_0.<Microsoft.Build.BackEnd.INodePacketHandler.PacketReceived>b__0()
	    at Microsoft.Build.Execution.BuildManager.ProcessWorkQueue(Action action)
	    --- End of stack trace from previous location where exception was thrown ---
	    at Microsoft.Build.Execution.BuildManager.EndBuild()
	    at Microsoft.Build.CommandLine.MSBuildApp.BuildProject(String projectFile, String[] targets, String toolsVersion, Dictionary`2 globalProperties, Dictionary`2 restoreProperties, ILogger[] loggers, LoggerVerbosity verbosity, DistributedLoggerRecord[] distributedLoggerRecords, Boolean needToValidateProject, String schemaFile, Int32 cpuCount, Boolean enableNodeReuse, TextWriter preprocessWriter, TextWriter targetsWriter, Boolean detailedSummary, ISet`1 warningsAsErrors, ISet`1 warningsAsMessages, Boolean enableRestore, ProfilerLogger profilerLogger, Boolean enableProfiler, Boolean interactive, Boolean isolateProjects, Boolean graphBuild, Boolean lowPriority, String[] inputResultsCaches, String outputResultsCache)

On our CI the test should be valid, however; it uses a system install
of Xamarin.Android.

[0]: https://github.com/xamarin/xamarin-android/blob/3a067cc4b1706c8b6413e96598ae317c8f73c2e5/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs#L223