### PR TITLE
[One .NET] use .aar instead of EmbeddedResource

### DIFF
--- a/Documentation/guides/OneDotNetEmbeddedResources.md
+++ b/Documentation/guides/OneDotNetEmbeddedResources.md
@@ -1,4 +1,4 @@
-# [proposal] Embedded Resources and `.nupkg` Files
+# One .NET: Embedded Resources and `.nupkg` Files
 
 Traditionally, a Xamarin.Android class library can contain many types
 of Android-specific files:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -62,7 +62,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != LibraryProjectZip & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
   NUnit.NumberOfTestWorkers: 4
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -38,14 +38,14 @@ It is shared between "legacy" binding projects and .NET 5 projects.
 
   <Target Name="ExportJarToXml"
       DependsOnTargets="$(ExportJarToXmlDependsOnTargets)"
-      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' ">
+      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' ">
     <PropertyGroup>
       <AllowUnsafeBlocks Condition=" '$(AllowUnsafeBlocks)' != 'true' ">true</AllowUnsafeBlocks>
     </PropertyGroup>
   </Target>
 
   <Target Name="GenerateBindings"
-      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' "
+      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' "
       DependsOnTargets="ExportJarToXml;_ResolveMonoAndroidSdks"
       Inputs="$(ApiOutputFile);@(TransformFile);@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildAllProjects)"
       Outputs="$(_GeneratorStampFile)">
@@ -54,7 +54,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />
 
     <ItemGroup>
-      <AnnotationsZip Include="$(IntermediateOutputPath)library_project_annotations\*.zip" />
+      <AnnotationsZip Include="$(IntermediateOutputPath)library_project_annotations\**\*.zip" />
     </ItemGroup>
 
     <!-- Create the .cs binding source files -->
@@ -89,27 +89,11 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     </ItemGroup>
   </Target>
 
-  <Target Name="AddEmbeddedJarsAsResources" DependsOnTargets="GenerateBindings">
-    <ItemGroup>
-      <EmbeddedResource Include="@(EmbeddedJar)">
-        <LogicalName>%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AddEmbeddedReferenceJarsAsResources" DependsOnTargets="GenerateBindings">
-    <ItemGroup>
-      <EmbeddedResource Include="@(EmbeddedReferenceJar)">
-        <LogicalName>__reference__%(Filename)%(Extension)</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="ResolveLibraryProjects" DependsOnTargets="_CreateBindingResourceArchive" />
+  <Target Name="ResolveLibraryProjects" DependsOnTargets="$(_ResolveLibraryProjectsDependsOn)" />
 
   <Target Name="AddLibraryJarsToBind" DependsOnTargets="ResolveLibraryProjects">
     <ItemGroup>
-      <InputJar Include="$(IntermediateOutputPath)library_project_jars\*.jar" />
+      <InputJar Include="$(IntermediateOutputPath)library_project_jars\**\*.jar" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -1,0 +1,121 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.AndroidLibraries.targets
+
+This file contains the .NET 5-specific targets related to
+@(AndroidLibrary) items and .aar files generation for class library
+projects.
+
+***********************************************************************************************
+-->
+<Project>
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateAar"          AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ExtractJarsFromAar" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
+  <ItemGroup>
+    <AvailableItemName Include="AndroidLibrary" />
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <AndroidLibrary>
+      <Bind>false</Bind>
+      <Pack>true</Pack>
+    </AndroidLibrary>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <_AarCacheFile>$(IntermediateOutputPath)$(TargetName).aar.cache</_AarCacheFile>
+    <_AarOutputPath>$(OutputPath)$(TargetName).aar</_AarOutputPath>
+  </PropertyGroup>
+
+  <Target Name="_CategorizeAndroidLibraries">
+    <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
+      <AndroidAarLibrary    Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' " />
+      <AndroidJavaLibrary   Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' " />
+      <AndroidNativeLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.so' " />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidApplication)' != 'true' ">
+      <AndroidAarLibrary     Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' != 'true' " />
+      <LibraryProjectZip     Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
+      <AndroidJavaLibrary    Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
+      <EmbeddedJar           Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
+      <EmbeddedNativeLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.so' " />
+      <None Include="@(LibraryProjectZip)" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ResolveAars" Condition=" '$(AndroidApplication)' == 'true' ">
+    <ItemGroup>
+      <_AarSearchDirectory   Include="@(_ReferencePath->'%(RootDir)%(Directory)')" />
+      <_AarSearchDirectory   Include="@(_ReferenceDependencyPaths->'%(RootDir)%(Directory)')" />
+      <_AarDistinctDirectory Include="@(_AarSearchDirectory->Distinct())" />
+      <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" />
+    </ItemGroup>
+    <ItemGroup Condition=" '@(_AarFromLibraries->Count())' != '0' ">
+      <AndroidAarLibrary Include="@(_AarFromLibraries)" Exclude="@(AndroidAarLibrary)" />
+      <!--
+        NOTE: %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
+        Update in a second step, in case there is was an existing @(AndroidAarLibrary) with the same path.
+      -->
+      <AndroidAarLibrary Update="@(_AarFromLibraries)" AndroidSkipResourceProcessing="false" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateAarCache"
+      Condition=" '$(AndroidApplication)' != 'true' ">
+    <ItemGroup>
+      <_CreateAarInputs Include="@(AndroidAsset)" />
+      <_CreateAarInputs Include="@(_AndroidResourceDest)" />
+      <_CreateAarInputs Include="@(AndroidEnvironment)" />
+      <_CreateAarInputs Include="@(EmbeddedJar)" />
+      <_CreateAarInputs Include="@(EmbeddedNativeLibrary)" />
+    </ItemGroup>
+    <Hash
+        ItemsToHash="@(_CreateAarInputs)"
+        IgnoreCase="false">
+      <Output TaskParameter="HashResult" PropertyName="_AarDependencyHash" />
+    </Hash>
+    <WriteLinesToFile
+        Condition=" '$(_AarDependencyHash)' != '' "
+        Lines="$(_AarDependencyHash)"
+        File="$(_AarCacheFile)"
+        Overwrite="True"
+        WriteOnlyWhenDifferent="True"
+    />
+    <ItemGroup Condition=" '$(_AarDependencyHash)' != '' ">
+      <_CreateAarInputs Include="$(_AarCacheFile)" />
+      <FileWrites       Include="$(_AarCacheFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateAar"
+      Condition=" '$(AndroidApplication)' != 'true' "
+      DependsOnTargets="_CreateAarCache"
+      Inputs="@(_CreateAarInputs)"
+      Outputs="$(_AarOutputPath)">
+    <CreateAar
+        AssetDirectory="$(MonoAndroidAssetsPrefix)"
+        AndroidAssets="@(AndroidAsset)"
+        AndroidResources="@(_AndroidResourceDest)"
+        AndroidEnvironment="@(AndroidEnvironment)"
+        JarFiles="@(AndroidJavaLibrary);@(EmbeddedJar)"
+        NativeLibraries="@(EmbeddedNativeLibrary)"
+        OutputFile="$(_AarOutputPath)"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AarOutputPath)" />
+      <None       Include="$(_AarOutputPath)" Pack="true" PackagePath="lib\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ExtractAar"
+      Inputs="@(LibraryProjectZip)"
+      Outputs="$(_AndroidStampDirectory)_ExtractAar.stamp">
+    <ExtractJarsFromAar
+        OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
+        OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
+        Libraries="@(LibraryProjectZip)"
+    />
+    <Touch Files="$(_AndroidStampDirectory)_ExtractAar.stamp" AlwaysCreate="true" />
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -16,6 +16,11 @@ _ResolveAssemblies MSBuild target.
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>
     <PublishDir>$(OutputPath)</PublishDir>
+    <BuildDependsOn>_RemoveLegacyDesigner;$(BuildDependsOn)</BuildDependsOn>
+    <!-- We don't want IncrementalClean to run here, or files get deleted -->
+    <CoreBuildDependsOn>
+      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', ''))))
+    </CoreBuildDependsOn>
   </PropertyGroup>
 
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -16,11 +16,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _ValidateLinkMode;
       _CheckNonIdealConfigurations;
       _SetupDesignTimeBuildForBuild;
+      _CategorizeAndroidLibraries;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;
       _CheckProjectItems;
       _CheckForContent;
       _ValidateAndroidPackageProperties;
+      AddLibraryJarsToBind;
       $(BuildDependsOn);
       _CompileDex;
       $(_AfterCompileDex);
@@ -69,14 +71,14 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
     <BuildDependsOn>
       _ValidateLinkMode;
       _SetupDesignTimeBuildForBuild;
+      _CategorizeAndroidLibraries;
       _CreatePropertiesCache;
       _CleanIntermediateIfNeeded;
       _AddAndroidDefines;
-      _CreateNativeLibraryArchive;
-      _AddAndroidEnvironmentToCompile;
       _CheckForContent;
       _RemoveLegacyDesigner;
       _ValidateAndroidPackageProperties;
+      AddLibraryJarsToBind;
       $(BuildDependsOn);
     </BuildDependsOn>
     <_BeforeIncrementalClean>
@@ -90,15 +92,22 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _SeparateAppExtensionReferences;
       $(ResolveReferencesDependsOn);
       _AddAndroidCustomMetaData;
+      _ResolveAars;
     </CoreResolveReferencesDependsOn>
     <ResolveReferencesDependsOn>
       $(CoreResolveReferencesDependsOn);
       UpdateAndroidInterfaceProxies;
       UpdateAndroidResources;
       AddBindingsToCompile;
-      AddEmbeddedJarsAsResources;
-      AddEmbeddedReferenceJarsAsResources;
     </ResolveReferencesDependsOn>
+    <_UpdateAndroidResourcesDependsOn>
+      $(CoreResolveReferencesDependsOn);
+      _CreatePropertiesCache;
+      _CheckForDeletedResourceFile;
+      _ComputeAndroidResourcePaths;
+      _UpdateAndroidResgen;
+      _CreateAar;
+    </_UpdateAndroidResourcesDependsOn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -136,6 +145,7 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _ResolveMonoAndroidSdks;
       _ExtractLibraryProjectImports;
       _GetLibraryImports;
+      _ExtractAar;
       _ExportJarToXml;
     </ExportJarToXmlDependsOnTargets>
     <GetAndroidDependenciesDependsOn>
@@ -145,6 +155,9 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _ResolveAndroidTooling;
       $(GetAndroidDependenciesDependsOn);
     </GetAndroidDependenciesDependsOn>
+    <_ResolveLibraryProjectsDependsOn>
+      _ExtractAar;
+    </_ResolveLibraryProjectsDependsOn>
   </PropertyGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -14,11 +14,12 @@
     <TargetPlatformSupported Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">true</TargetPlatformSupported>
   </PropertyGroup>
   <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
-  <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" />
+  <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' " />
 
   <Import Project="..\tools\Xamarin.Android.Common.targets" />
   <Import Project="..\tools\Xamarin.Android.Bindings.Core.targets" />
   <Import Project="..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
+  <Import Project="Microsoft.Android.Sdk.AndroidLibraries.targets" />
   <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
   <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
   <Import Project="Microsoft.Android.Sdk.DefaultItems.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CreateAar : AndroidTask
+	{
+		public override string TaskPrefix => "CAAR";
+
+		public ITaskItem [] AndroidAssets { get; set; }
+
+		public ITaskItem [] AndroidResources { get; set; }
+
+		public ITaskItem [] AndroidEnvironment { get; set; }
+
+		public ITaskItem [] JarFiles { get; set; }
+
+		public ITaskItem [] NativeLibraries { get; set; }
+
+		[Required]
+		public string AssetDirectory { get; set; }
+
+		[Required]
+		public string OutputFile { get; set; }
+
+		public override bool RunTask ()
+		{
+			Directory.CreateDirectory (Path.GetDirectoryName (OutputFile));
+
+			using (var stream = File.Create (OutputFile))
+			using (var aar = ZipArchive.Open (stream)) {
+				var existingEntries = new HashSet<string> (StringComparer.Ordinal);
+				foreach (var entry in aar) {
+					Log.LogDebugMessage ("Existing entry: " + entry.FullName);
+					existingEntries.Add (entry.FullName);
+				}
+				if (AndroidAssets != null) {
+					foreach (var asset in AndroidAssets) {
+						// See: https://github.com/xamarin/xamarin-android/commit/665cb59205f8ac565b6acbda740624844bc1cbd9
+						if (Directory.Exists (asset.ItemSpec)) {
+							Log.LogDebugMessage ($"Skipping item, is a directory: {asset.ItemSpec}");
+							continue;
+						}
+						var relative = MonoAndroidHelper.GetRelativePathForAndroidAsset (AssetDirectory, asset);
+						var archivePath = "assets/" + relative.Replace ('\\', '/');
+						aar.AddStream (File.OpenRead (asset.ItemSpec), archivePath);
+						existingEntries.Remove (archivePath);
+					}
+				}
+				if (AndroidResources != null) {
+					foreach (var resource in AndroidResources) {
+						// See: https://github.com/xamarin/xamarin-android/commit/665cb59205f8ac565b6acbda740624844bc1cbd9
+						if (Directory.Exists (resource.ItemSpec)) {
+							Log.LogDebugMessage ($"Skipping item, is a directory: {resource.ItemSpec}");
+							continue;
+						}
+						var directory = Path.GetDirectoryName (resource.ItemSpec);
+						var archivePath = "res/" + Path.GetFileName (directory) + "/" + Path.GetFileName (resource.ItemSpec);
+						aar.AddStream (File.OpenRead (resource.ItemSpec), archivePath);
+						existingEntries.Remove (archivePath);
+					}
+				}
+				if (AndroidEnvironment != null) {
+					foreach (var env in AndroidEnvironment) {
+						var archivePath = $".netenv/{GetHashedFileName (env)}.env";
+						aar.AddStream (File.OpenRead (env.ItemSpec), archivePath);
+						existingEntries.Remove (archivePath);
+					}
+				}
+				if (JarFiles != null) {
+					foreach (var jar in JarFiles) {
+						var archivePath = $"libs/{GetHashedFileName (jar)}.jar";
+						aar.AddStream (File.OpenRead (jar.ItemSpec), archivePath);
+						existingEntries.Remove (archivePath);
+					}
+				}
+				if (NativeLibraries != null) {
+					foreach (var lib in NativeLibraries) {
+						var abi = MonoAndroidHelper.GetNativeLibraryAbi (lib);
+						if (string.IsNullOrWhiteSpace (abi)) {
+							Log.LogCodedError ("XA4301", lib.ItemSpec, 0, Properties.Resources.XA4301_ABI, lib.ItemSpec);
+							continue;
+						}
+						var archivePath = "jni/" + abi + "/" + Path.GetFileName (lib.ItemSpec);
+						aar.AddStream (File.OpenRead (lib.ItemSpec), archivePath);
+						existingEntries.Remove (archivePath);
+					}
+				}
+				foreach (var entry in existingEntries) {
+					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");
+					aar.DeleteEntry (entry);
+				}
+			}
+
+			// Delete the archive on failure
+			if (Log.HasLoggedErrors && File.Exists (OutputFile)) {
+				File.Delete (OutputFile);
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		/// <summary>
+		/// Hash the path to an ITaskItem to get a unique file name.
+		/// Replaces \ with /, so we get the same hash on all platforms.
+		/// </summary>
+		static string GetHashedFileName (ITaskItem item) =>
+			Files.HashString (item.ItemSpec.Replace ('\\', '/'));
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -58,16 +58,12 @@ namespace Xamarin.Android.Tasks
 				MonoAndroidHelper.CopyIfChanged (compiledArchive, Path.Combine (outDirInfo.FullName, "compiled.flata"));
 			}
 
-			var dir_sep = new char [] {Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar};
 			if (AndroidAssets != null) {
 				var dstsub = Path.Combine (outDirInfo.FullName, "assets");
 				if (!Directory.Exists (dstsub))
 					Directory.CreateDirectory (dstsub);
 				foreach (var item in AndroidAssets) {
-					var path = item.GetMetadata ("Link");
-					path = !string.IsNullOrWhiteSpace (path) ? path : item.ItemSpec;
-					var head = string.Join ("\\", path.Split (dir_sep).TakeWhile (s => !s.Equals (MonoAndroidAssetsPrefix, StringComparison.OrdinalIgnoreCase)));
-					path = head.Length == path.Length ? path : path.Substring ((head.Length == 0 ? 0 : head.Length + 1) + MonoAndroidAssetsPrefix.Length).TrimStart (dir_sep);
+					var path = MonoAndroidHelper.GetRelativePathForAndroidAsset (MonoAndroidAssetsPrefix, item);
 					MonoAndroidHelper.CopyIfChanged (item.ItemSpec, Path.Combine (dstsub, path));
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ExtractJarsFromAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ExtractJarsFromAar.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Extracts .jar files from @(AndroidLibrary) .aar files or @(LibraryProjectZip) for bindings
+	/// </summary>
+	public class ExtractJarsFromAar : AndroidTask
+	{
+		public override string TaskPrefix => "ELPJ";
+
+		[Required]
+		public string OutputJarsDirectory { get; set; }
+
+		[Required]
+		public string OutputAnnotationsDirectory { get; set; }
+
+		public string [] Libraries { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (Libraries == null || Libraries.Length == 0)
+				return true;
+
+			var memoryStream = MemoryStreamPool.Shared.Rent ();
+			try {
+				var jars = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+				var annotations = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+				foreach (var library in Libraries) {
+					bool isAar = library.EndsWith (".aar", StringComparison.OrdinalIgnoreCase);
+					var jarOutputDirectory = Path.Combine (OutputJarsDirectory, Path.GetFileName (library));
+					var annotationOutputDirectory = Path.Combine (OutputAnnotationsDirectory, Path.GetFileName (library));
+					using (var zip = MonoAndroidHelper.ReadZipFile (library)) {
+						foreach (var entry in zip) {
+							if (entry.IsDirectory)
+								continue;
+							var entryFullName = entry.FullName;
+							var fileName = Path.GetFileName (entryFullName);
+							if (string.Equals (fileName, "annotations.zip", StringComparison.OrdinalIgnoreCase)) {
+								var path = Path.GetFullPath (Path.Combine (annotationOutputDirectory, entryFullName));
+								Extract (entry, memoryStream, path);
+								annotations.Add (path);
+							} else if (!entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
+								continue;
+							} else if (isAar && Files.ShouldSkipEntryInAar (entryFullName)) {
+								continue;
+							} else {
+								var path = Path.GetFullPath (Path.Combine (jarOutputDirectory, entryFullName));
+								Extract (entry, memoryStream, path);
+								jars.Add (path);
+							}
+						}
+					}
+				}
+				DeleteUnknownFiles (OutputJarsDirectory, jars);
+				DeleteUnknownFiles (OutputAnnotationsDirectory, annotations);
+			} finally {
+				MemoryStreamPool.Shared.Return (memoryStream);
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		static void Extract (ZipEntry entry, MemoryStream stream, string destination)
+		{
+			stream.SetLength (0); //Reuse the stream
+			entry.Extract (stream);
+			MonoAndroidHelper.CopyIfStreamChanged (stream, destination);
+		}
+
+		void DeleteUnknownFiles (string directory, HashSet<string> knownFiles)
+		{
+			if (!Directory.Exists (directory))
+				return;
+			foreach (var file in Directory.GetFiles (directory, "*", SearchOption.AllDirectories)) {
+				var path = Path.GetFullPath (file);
+				if (!knownFiles.Contains (path)) {
+					Log.LogDebugMessage ($"Deleting unknown file: {path}");
+					File.Delete (path);
+				}
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil;
+using Mono.Cecil;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -27,11 +27,13 @@ namespace Xamarin.Android.Build.Tests
 			var targets = new List<string> {
 				"_ExportJarToXml",
 				"GenerateBindings",
-				"_CreateBindingResourceArchive",
 				"_ResolveLibraryProjectImports",
 				"CoreCompile",
 			};
-			if (!Builder.UseDotNet) {
+			if (Builder.UseDotNet) {
+				targets.Add ("_CreateAar");
+			} else {
+				targets.Add ("_CreateBindingResourceArchive");
 				//TODO: .NET 5+ cannot support javadoc yet, due to missing mdoc
 				targets.Add ("_ExtractJavaDocJars");
 				targets.Add ("BuildDocumentation");
@@ -98,8 +100,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
-		[Category ("LibraryProjectZip")]
-		public void BuildAarBindigLibraryStandalone (string classParser)
+		public void BuildAarBindingLibraryStandalone (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
 				UseLatestPlatformSdk = true,
@@ -109,15 +110,16 @@ namespace Xamarin.Android.Build.Tests
 				WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 			});
 			proj.AndroidClassParser = classParser;
-			var b = CreateDllBuilder (Path.Combine ("temp", TestName));
-			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-			b.Dispose ();
-
+			using (var b = CreateDllBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				if (Builder.UseDotNet) {
+					FileAssert.Exists (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "material-menu-1.1.0.aar"));
+				}
+			}
 		}
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
-		[Category ("LibraryProjectZip")]
 		public void BuildAarBindigLibraryWithNuGetPackageOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -144,7 +146,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
 		[NonParallelizable]
-		[Category ("SmokeTests"), Category ("LibraryProjectZip")]
+		[Category ("SmokeTests")]
 		public void BuildLibraryZipBindigLibraryWithAarOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -218,10 +220,11 @@ namespace Com.Ipaulpro.Afilechooser {
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void MergeAndroidManifest ()
 		{
-			var binding = new XamarinAndroidBindingProject () {
+			var path = Path.Combine ("temp", TestName);
+			var binding = new XamarinAndroidBindingProject {
+				ProjectName = "AdalBinding",
 				IsRelease = true,
 			};
 			binding.AndroidClassParser = "class-parse";
@@ -232,23 +235,22 @@ namespace Com.Ipaulpro.Afilechooser {
 <metadata>
 	<remove-node path=""/api/package/class[@visibility='']"" />
 </metadata>";
-			using (var bindingBuilder = CreateDllBuilder ("temp/MergeAndroidManifest/AdalBinding")) {
+			using (var bindingBuilder = CreateDllBuilder (Path.Combine (path, binding.ProjectName))) {
 				bindingBuilder.Build (binding);
-				var proj = new XamarinAndroidApplicationProject () {
+				var proj = new XamarinAndroidApplicationProject {
+					ProjectName = "App",
 					IsRelease = true,
 				};
-				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\AdalBinding\\UnnamedProject.csproj"));
-				using (var b = CreateApkBuilder ("temp/MergeAndroidManifest/App")) {
+				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", $"..\\{binding.ProjectName}\\{binding.ProjectName}.csproj"));
+				using (var b = CreateApkBuilder (Path.Combine (path, "App"))) {
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 					var manifest = File.ReadAllText (Path.Combine (Root, b.ProjectDirectory, "obj", "Release", "android", "AndroidManifest.xml"));
 					Assert.IsTrue (manifest.Contains ("com.microsoft.aad.adal.AuthenticationActivity"), "manifest merge failure");
-					Directory.Delete (Path.Combine (Root, "temp", "MergeAndroidManifest"), recursive: true);
 				}
 			}
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void AnnotationSupport ()
 		{
 			// https://trello.com/c/a36dDVS6/37-support-for-annotations-zip
@@ -259,11 +261,12 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\mylibrary.aar") {
 				WebContentFileNameFromAzure = "mylibrary-debug.aar"
 			});
-			var bindingBuilder = CreateDllBuilder ("temp/AnnotationSupport");
-			Assert.IsTrue (bindingBuilder.Build (binding), "binding build failed");
-			var src = File.ReadAllText (Path.Combine (Root, bindingBuilder.ProjectDirectory, "obj", "Release", "generated", "src", "Com.Example.Atsushi.Mylibrary.AnnotSample.cs"));
-			Assert.IsTrue (src.Contains ("IntDef"), "missing IntDef");
-			bindingBuilder.Dispose ();
+			using (var bindingBuilder = CreateDllBuilder ()) {
+				Assert.IsTrue (bindingBuilder.Build (binding), "binding build failed");
+				var cs_file = Path.Combine (Root, bindingBuilder.ProjectDirectory, "obj", "Release", "generated", "src", "Com.Example.Atsushi.Mylibrary.AnnotSample.cs");
+				FileAssert.Exists (cs_file);
+				StringAssert.Contains ("IntDef", File.ReadAllText (cs_file));
+			}
 		}
 
 		[Test]
@@ -288,32 +291,34 @@ namespace Com.Ipaulpro.Afilechooser {
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void BindngFilterUnsupportedNativeAbiLibraries ()
 		{
 			var binding = new XamarinAndroidBindingProject () {
+				ProjectName = "Binding",
 				IsRelease = true,
 			};
 			binding.AndroidClassParser = "class-parse";
 			binding.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\mylibrary.aar") {
 				WebContentFileNameFromAzure = "card.io-5.3.0.aar"
 			});
-			using (var bindingBuilder = CreateDllBuilder (Path.Combine ("temp", "BindngFilterUnsupportedNativeAbiLibraries", "Binding"))) {
+			var path = Path.Combine ("temp", TestName);
+			using (var bindingBuilder = CreateDllBuilder (Path.Combine (path, binding.ProjectName))) {
 				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
-				var proj = new XamarinAndroidApplicationProject ();
-				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\Binding\\UnnamedProject.csproj"));
-				using (var b = CreateApkBuilder (Path.Combine ("temp", "BindngFilterUnsupportedNativeAbiLibraries", "App"))) {
+				var proj = new XamarinAndroidApplicationProject {
+					ProjectName = "App"
+				};
+				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", $"..\\{binding.ProjectName}\\{binding.ProjectName}.csproj"));
+				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName))) {
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				}
 			}
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void BindingCheckHiddenFiles ()
 		{
-			var binding = new XamarinAndroidBindingProject () {
-				UseLatestPlatformSdk = true,
+			var binding = new XamarinAndroidBindingProject {
+				ProjectName = "Binding",
 				IsRelease = true,
 			};
 			binding.AndroidClassParser = "class-parse";
@@ -323,34 +328,35 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.Jars.Add (new AndroidItem.EmbeddedJar ("Jars\\svg-android.jar") {
 				WebContentFileNameFromAzure = "javaBindingIssue.jar"
 			});
-			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
-			using (var bindingBuilder = CreateDllBuilder (Path.Combine (path, "Binding"))) {
+			var path = Path.Combine ("temp", TestName);
+			using (var bindingBuilder = CreateDllBuilder (Path.Combine (path, binding.ProjectName))) {
 				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
-				var proj = new XamarinAndroidApplicationProject ();
-				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\Binding\\UnnamedProject.csproj"));
+				var proj = new XamarinAndroidApplicationProject {
+					ProjectName = "App",
+				};
+				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", $"..\\{binding.ProjectName}\\{binding.ProjectName}.csproj"));
 				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" xmlns:tools=""http://schemas.android.com/tools"" android:versionCode=""1"" android:versionName=""1.0"" package=""{proj.PackageName}"">
 	<uses-sdk />
 	<application android:label=""{proj.ProjectName}"" tools:replace=""android:label"">
 	</application>
 </manifest>";
-				using (var b = CreateApkBuilder (Path.Combine (path, "App"))) {
+				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName))) {
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 					var assemblyMap = b.Output.GetIntermediaryPath (Path.Combine ("lp", "map.cache"));
-					Assert.IsTrue (File.Exists (assemblyMap), $"{assemblyMap} should exist.");
-					var assemblyIdentityMap = new List<string> ();
-					foreach (var s in File.ReadLines (assemblyMap)) {
-						assemblyIdentityMap.Add (s);
-					}
-					var assemblyIdentity = assemblyIdentityMap.IndexOf ("UnnamedProject").ToString ();
-					var dsStorePath = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "lp", assemblyIdentity, "jl");
-					Assert.IsTrue (Directory.Exists (dsStorePath), "{0} should exist.", dsStorePath);
-					Assert.IsFalse (File.Exists (Path.Combine (dsStorePath, ".DS_Store")), "{0} should NOT exist.",
-						Path.Combine (dsStorePath, ".DS_Store"));
-					var _macOSStorePath = Path.Combine (dsStorePath, "_MACOSX");
-					Assert.IsFalse (Directory.Exists (_macOSStorePath), "{0} should NOT exist.", _macOSStorePath);
-					var svgJar = Path.Combine (dsStorePath, "svg-android.jar");
-					Assert.IsTrue (File.Exists (svgJar), $"{svgJar} should exist.");
+					FileAssert.Exists (assemblyMap);
+					var libraryProjects = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "lp");
+					var assemblyIdentityMap = b.Output.GetAssemblyMapCache ();
+					var assemblyIdentityName = Builder.UseDotNet ? "mylibrary.aar" : $"{binding.ProjectName}.dll";
+					var assemblyIdentity = assemblyIdentityMap.IndexOf (assemblyIdentityName).ToString ();
+					var dsStorePath = Path.Combine (libraryProjects, assemblyIdentity, "jl");
+					DirectoryAssert.Exists (dsStorePath);
+					FileAssert.DoesNotExist (Path.Combine (dsStorePath, ".DS_Store"));
+					DirectoryAssert.DoesNotExist (Path.Combine (dsStorePath, "_MACOSX"));
+					var svgJar = Builder.UseDotNet ?
+						Path.Combine (libraryProjects, assemblyIdentityMap.IndexOf ($"{binding.ProjectName}.aar").ToString (), "jl", "libs", "FD575F2BC294C4A9.jar") : 
+						Path.Combine (dsStorePath, "svg-android.jar");
+					FileAssert.Exists (svgJar);
 				}
 			}
 		}
@@ -406,7 +412,6 @@ namespace Foo {
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void RemoveEventHandlerResolution ()
 		{
 			var binding = new XamarinAndroidBindingProject () {
@@ -481,7 +486,6 @@ namespace Foo {
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
-		[Category ("LibraryProjectZip")]
 		public void DesignTimeBuild (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject {
@@ -490,9 +494,8 @@ namespace Foo {
 			proj.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\material-menu-1.1.0.aar") {
 				WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 			});
-			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
-				b.Target = "Compile";
-				Assert.IsTrue (b.Build (proj, parameters: new [] { "DesignTimeBuild=True" }), "design-time build should have succeeded.");
+			using (var b = CreateDllBuilder ()) {
+				Assert.IsTrue (b.DesignTimeBuild (proj), "design-time build should have succeeded.");
 
 				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
 				var api_xml = Path.Combine (intermediate, "api.xml");
@@ -569,7 +572,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
+		[Category ("DotNetIgnore")] //TODO: @(LibraryProjectProperties) not supported yet in .NET 5+
 		public void BugzillaBug11964 ()
 		{
 			var proj = new XamarinAndroidBindingProject ();
@@ -589,7 +592,6 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void LibraryProjectZipWithLint ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2005,26 +2005,30 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		[Category ("SmokeTests")]
 		public void BuildWithExternalJavaLibrary ()
 		{
-			var path = Path.Combine ("temp", "BuildWithExternalJavaLibrary");
-			var binding = new XamarinAndroidBindingProject () {
+			var path = Path.Combine ("temp", TestName);
+			var binding = new XamarinAndroidBindingProject {
 				ProjectName = "BuildWithExternalJavaLibraryBinding",
 				AndroidClassParser = "class-parse",
 			};
 			using (var bbuilder = CreateDllBuilder (Path.Combine (path, "BuildWithExternalJavaLibraryBinding"))) {
-				string multidex_path = TestEnvironment.IsRunningOnCI ? TestEnvironment.MonoAndroidToolsDirectory : @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild\Xamarin\Android";
-				string multidex_jar = $@"{multidex_path}\android-support-multidex.jar";
+				string multidex_path = TestEnvironment.IsRunningOnCI ?
+					TestEnvironment.MonoAndroidToolsDirectory :
+					Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
+				string multidex_jar = Path.Combine (multidex_path, "android-support-multidex.jar");
 				binding.Jars.Add (new AndroidItem.InputJar (() => multidex_jar));
 
-				Assert.IsTrue (bbuilder.Build (binding));
-				var proj = new XamarinAndroidApplicationProject () {
+				Assert.IsTrue (bbuilder.Build (binding), "Binding build should succeed.");
+				var proj = new XamarinAndroidApplicationProject {
 					References = { new BuildItem ("ProjectReference", "..\\BuildWithExternalJavaLibraryBinding\\BuildWithExternalJavaLibraryBinding.csproj"), },
 					OtherBuildItems = { new BuildItem ("AndroidExternalJavaLibrary", multidex_jar) },
-					Sources = { new BuildItem ("Compile", "Foo.cs") {
+					Sources = {
+						new BuildItem ("Compile", "Foo.cs") {
 							TextContent = () => "public class Foo { public void X () { new Android.Support.Multidex.MultiDexApplication (); } }"
-						} },
+						}
+					},
 				};
 				using (var builder = CreateApkBuilder (Path.Combine (path, "BuildWithExternalJavaLibrary"))) {
-					Assert.IsTrue (builder.Build (proj));
+					Assert.IsTrue (builder.Build (proj), "App build should succeed");
 				}
 			}
 		}
@@ -2178,16 +2182,11 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			proj.AndroidUseAapt2 = useAapt2;
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
-				var assemblyMap = builder.Output.GetIntermediaryPath (Path.Combine ("lp", "map.cache"));
 				var cache = builder.Output.GetIntermediaryPath ("libraryprojectimports.cache");
-				Assert.IsTrue (File.Exists (assemblyMap), $"{assemblyMap} should exist.");
 				Assert.IsTrue (File.Exists (cache), $"{cache} should exist.");
-				var assemblyIdentityMap = new List<string> ();
-				foreach (var s in File.ReadLines (assemblyMap)) {
-					assemblyIdentityMap.Add (s);
-				}
+				var assemblyIdentityMap = builder.Output.GetAssemblyMapCache ();
 				var libraryProjects = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "lp");
-				FileAssert.Exists (Path.Combine (libraryProjects, assemblyIdentityMap.IndexOf ("android-crop-1.0.1").ToString (), "jl", "classes.jar"),
+				FileAssert.Exists (Path.Combine (libraryProjects, assemblyIdentityMap.IndexOf ("android-crop-1.0.1.aar").ToString (), "jl", "classes.jar"),
 					"classes.jar was not extracted from the aar.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
@@ -2748,6 +2747,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[Category ("DotNetIgnore")] // n/a in .NET 5+, test validates __AndroidLibraryProjects__.zip generation
 		public void CheckLibraryImportsUpgrade ()
 		{
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
@@ -2811,6 +2811,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[Category ("DotNetIgnore")] // n/a in .NET 5+, test validates __AndroidLibraryProjects__.zip generation
 		public void AndroidLibraryProjectsZipWithOddPaths ()
 		{
 			var proj = new XamarinAndroidLibraryProject ();
@@ -2825,7 +2826,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\foo.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?><resources><string name=""foo"">bar</string></resources>",
 			});
-			using (var b = CreateDllBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			using (var b = CreateDllBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				var zipFile = Path.Combine (Root, b.ProjectDirectory, b.Output.IntermediateOutputPath, "foo", "__AndroidLibraryProjects__.zip");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿using System;
+﻿﻿using System;
 using System.Linq;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -588,7 +588,6 @@ namespace Bug12935
 		}
 
 		[Test]
-		[Category ("LibraryProjectZip")]
 		public void MergeLibraryManifest ()
 		{
 			byte [] classesJar;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -963,7 +963,8 @@ public class Test
 				}
 				using (var b = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 					Assert.IsTrue (b.Build (app), "Build of jar should have succeeded.");
-					string expected = "Failed to add jar entry AndroidManifest.xml from test.jar: the same file already exists in the apk";
+					var jar = Builder.UseDotNet ? "2965D0C9A2D5DB1E.jar" : "test.jar";
+					string expected = $"Failed to add jar entry AndroidManifest.xml from {jar}: the same file already exists in the apk";
 					Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"AndroidManifest.xml for test.jar should have been ignored.");
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
@@ -1,10 +1,15 @@
+using System.Diagnostics;
+using System.IO;
 using NUnit.Framework;
+using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
+using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
 	public static class AssertionExtensions
 	{
+		[DebuggerHidden]
 		public static void AssertTargetIsSkipped (this BuildOutput output, string target, int? occurrence = null)
 		{
 			if (occurrence != null)
@@ -13,6 +18,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (output.IsTargetSkipped (target), $"The target {target} should have been skipped.");
 		}
 
+		[DebuggerHidden]
 		public static void AssertTargetIsNotSkipped (this BuildOutput output, string target, int? occurrence = null)
 		{
 			if (occurrence != null)
@@ -21,12 +27,49 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsFalse (output.IsTargetSkipped (target), $"The target {target} should have *not* been skipped.");
 		}
 
+		[DebuggerHidden]
 		public static void AssertTargetIsPartiallyBuilt (this BuildOutput output, string target, int? occurrence = null)
 		{
 			if (occurrence != null)
 				Assert.IsTrue (output.IsTargetPartiallyBuilt (target), $"The target {target} should have been partially built. ({occurrence})");
 			else
 				Assert.IsTrue (output.IsTargetPartiallyBuilt (target), $"The target {target} should have been partially built.");
+		}
+
+		[DebuggerHidden]
+		public static void AssertContainsEntry (this ZipArchive zip, string zipPath, string archivePath)
+		{
+			Assert.IsTrue (zip.ContainsEntry (archivePath), $"{zipPath} should contain {archivePath}");
+		}
+
+		[DebuggerHidden]
+		public static void AssertDoesNotContainEntry (this ZipArchive zip, string zipPath, string archivePath)
+		{
+			Assert.IsFalse (zip.ContainsEntry (archivePath), $"{zipPath} should *not* contain {archivePath}");
+		}
+
+		[DebuggerHidden]
+		public static void AssertContainsEntry (this ZipArchive zip, string zipPath, string archivePath, bool shouldContainEntry)
+		{
+			if (shouldContainEntry) {
+				zip.AssertContainsEntry (zipPath, archivePath);
+			} else {
+				zip.AssertDoesNotContainEntry (zipPath, archivePath);
+			}
+		}
+
+		[DebuggerHidden]
+		public static void AssertEntryContents (this ZipArchive zip, string zipPath, string archivePath, string contents)
+		{
+			var entry = zip.ReadEntry (archivePath);
+			Assert.IsNotNull (entry, $"{zipPath} should contain {archivePath}");
+			using (var stream = new MemoryStream ())
+			using (var reader = new StreamReader (stream)) {
+				entry.Extract (stream);
+				stream.Position = 0;
+				var actual = reader.ReadToEnd ();
+				Assert.AreEqual (contents, actual, $"{archivePath} should contain {contents}");
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -20,26 +20,226 @@ namespace Xamarin.Android.Build.Tests
 		/// </summary>
 		public string FullProjectDirectory { get; set; }
 
+		static readonly object [] DotNetBuildLibrarySource = new object [] {
+			new object [] {
+				/* isRelease */    false,
+				/* duplicateAar */ false,
+			},
+			new object [] {
+				/* isRelease */    false,
+				/* duplicateAar */ true,
+			},
+			new object [] {
+				/* isRelease */    true,
+				/* duplicateAar */ false,
+			},
+		};
+
 		[Test]
 		[Category ("SmokeTests")]
-		public void DotNetBuildLibrary ([Values (false, true)] bool isRelease)
+		[TestCaseSource (nameof (DotNetBuildLibrarySource))]
+		public void DotNetBuildLibrary (bool isRelease, bool duplicateAar)
 		{
-			var proj = new XASdkProject (outputType: "Library") {
-				IsRelease = isRelease
-			};
-			var dotnet = CreateDotNetBuilder (proj);
-			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
+			var path = Path.Combine ("temp", TestName);
+			var env_var = "MY_ENVIRONMENT_VAR";
+			var env_val = "MY_VALUE";
 
-			var assemblyPath = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
+			// Setup dependencies App A -> Lib B -> Lib C
+
+			var libC = new XASdkProject (outputType: "Library") {
+				ProjectName = "LibraryC",
+				IsRelease = isRelease,
+				Sources = {
+					new BuildItem.Source ("Bar.cs") {
+						TextContent = () => "public class Bar { }",
+					}
+				}
+			};
+			libC.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\bar\\bar.txt") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			var activity = libC.Sources.FirstOrDefault (s => s.Include () == "MainActivity.cs");
+			if (activity != null)
+				libC.Sources.Remove (activity);
+			var libCBuilder = CreateDotNetBuilder (libC, Path.Combine (path, libC.ProjectName));
+			Assert.IsTrue (libCBuilder.Build (), $"{libC.ProjectName} should succeed");
+
+			var libB = new XASdkProject (outputType: "Library") {
+				ProjectName = "LibraryB",
+				IsRelease = isRelease,
+				Sources = {
+					new BuildItem.Source ("Foo.cs") {
+						TextContent = () => "public class Foo : Bar { }",
+					}
+				}
+			};
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\foo\\foo.txt") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidResource ("Resources\\raw\\bar.txt") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidEnvironment ("env.txt") {
+				TextContent = () => $"{env_var}={env_val}",
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidEnvironment ("sub\\directory\\env.txt") {
+				TextContent = () => $"{env_var}={env_val}",
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("sub\\directory\\foo.jar") {
+				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64),
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("sub\\directory\\arm64-v8a\\libfoo.so") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("libfoo.so") {
+				MetadataValues = "Link=x86\\libfoo.so",
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			libB.AddReference (libC);
+
+			activity = libB.Sources.FirstOrDefault (s => s.Include () == "MainActivity.cs");
+			if (activity != null)
+				libB.Sources.Remove (activity);
+			var libBBuilder = CreateDotNetBuilder (libB, Path.Combine (path, libB.ProjectName));
+			Assert.IsTrue (libBBuilder.Build (), $"{libB.ProjectName} should succeed");
+
+			// Check .aar file for class library
+			var aarPath = Path.Combine (FullProjectDirectory, libB.OutputPath, $"{libB.ProjectName}.aar");
+			FileAssert.Exists (aarPath);
+			using (var aar = ZipHelper.OpenZip (aarPath)) {
+				aar.AssertContainsEntry (aarPath, "assets/foo/foo.txt");
+				aar.AssertContainsEntry (aarPath, "res/raw/bar.txt");
+				aar.AssertContainsEntry (aarPath, ".netenv/190E30B3D205731E.env");
+				aar.AssertContainsEntry (aarPath, ".netenv/2CBDAB7FEEA94B19.env");
+				aar.AssertContainsEntry (aarPath, "libs/A1AFA985571E728E.jar");
+				aar.AssertContainsEntry (aarPath, "jni/arm64-v8a/libfoo.so");
+				aar.AssertContainsEntry (aarPath, "jni/x86/libfoo.so");
+			}
+
+			// Check EmbeddedResource files do not exist
+			var assemblyPath = Path.Combine (FullProjectDirectory, libB.OutputPath, $"{libB.ProjectName}.dll");
 			FileAssert.Exists (assemblyPath);
 			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
-				var resourceName = "__AndroidLibraryProjects__.zip";
-				var resource = assembly.MainModule.Resources.OfType<EmbeddedResource> ().FirstOrDefault (r => r.Name == resourceName);
-				Assert.IsNotNull (resource, $"{assemblyPath} should contain a {resourceName} EmbeddedResource");
-				using (var zip = ZipArchive.Open (resource.GetResourceStream ())) {
-					var entry = "library_project_imports/res/values/strings.xml";
-					Assert.IsTrue (zip.ContainsEntry (entry), $"{resourceName} should contain {entry}");
+				Assert.AreEqual (0, assembly.MainModule.Resources.Count);
+			}
+
+			var appA = new XASdkProject {
+				ProjectName = "AppA",
+				IsRelease = isRelease,
+				Sources = {
+					new BuildItem.Source ("Bar.cs") {
+						TextContent = () => "public class Bar : Foo { }",
+					}
 				}
+			};
+			appA.AddReference (libB);
+			if (duplicateAar) {
+				// Test a duplicate @(AndroidLibrary) item with the same path of LibraryB.aar
+				appA.OtherBuildItems.Add (new AndroidItem.AndroidLibrary (aarPath));
+			}
+			var appBuilder = CreateDotNetBuilder (appA, Path.Combine (path, appA.ProjectName));
+			Assert.IsTrue (appBuilder.Build (), $"{appA.ProjectName} should succeed");
+
+			// Check .apk for assets, res, and native libraries
+			var apkPath = Path.Combine (FullProjectDirectory, appA.OutputPath, $"{appA.PackageName}.apk");
+			FileAssert.Exists (apkPath);
+			using (var apk = ZipHelper.OpenZip (apkPath)) {
+				apk.AssertContainsEntry (apkPath, "assets/foo/foo.txt");
+				apk.AssertContainsEntry (apkPath, "assets/bar/bar.txt");
+				apk.AssertContainsEntry (apkPath, "res/raw/bar.txt");
+				apk.AssertContainsEntry (apkPath, "lib/arm64-v8a/libfoo.so");
+				apk.AssertContainsEntry (apkPath, "lib/x86/libfoo.so");
+			}
+
+			// Check classes.dex contains foo.jar
+			var intermediate = Path.Combine (FullProjectDirectory, appA.IntermediateOutputPath);
+			var dexFile = Path.Combine (intermediate, "android", "bin", "classes.dex");
+			FileAssert.Exists (dexFile);
+			string className = "Lcom/xamarin/android/test/msbuildtest/JavaSourceJarTest;";
+			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
+
+			// Check environment variable
+			var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediate, "x86", required: true);
+			var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);
+			Assert.IsTrue (environmentVariables.TryGetValue (env_var, out string actual), $"Environment should contain {env_var}");
+			Assert.AreEqual (env_val, actual, $"{env_var} should be {env_val}");
+		}
+
+		[Test]
+		public void DotNetPack ()
+		{
+			var proj = new XASdkProject (outputType: "Library") {
+				IsRelease = true,
+				Sources = {
+					new BuildItem.Source ("Foo.cs") {
+						TextContent = () => "public class Foo { }",
+					}
+				}
+			};
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidResource ("Resources\\raw\\bar.txt") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("sub\\directory\\foo.jar") {
+				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64),
+			});
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("sub\\directory\\arm64-v8a\\libfoo.so") {
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("libfoo.so") {
+				MetadataValues = "Link=x86\\libfoo.so",
+				BinaryContent = () => Array.Empty<byte> (),
+			});
+
+			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Pack (), "`dotnet pack` should succeed");
+
+			var nupkgPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "..", $"{proj.ProjectName}.1.0.0.nupkg");
+			FileAssert.Exists (nupkgPath);
+			using (var nupkg = ZipHelper.OpenZip (nupkgPath)) {
+				// TODO: should eventually be $"lib/net5.0-android/{proj.ProjectName}.dll"
+				// See: https://github.com/dotnet/sdk/issues/14042
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net5.0/{proj.ProjectName}.dll");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net5.0-android/{proj.ProjectName}.aar");
+			}
+		}
+
+		[Test]
+		public void DotNetLibraryAarChanges ()
+		{
+			var proj = new XASdkProject (outputType: "Library");
+			proj.Sources.Add (new AndroidItem.AndroidResource ("Resources\\raw\\foo.txt") {
+				TextContent = () => "foo",
+			});
+			proj.Sources.Add (new AndroidItem.AndroidResource ("Resources\\raw\\bar.txt") {
+				TextContent = () => "bar",
+			});
+
+			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Build (), "first build should succeed");
+			var aarPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.aar");
+			FileAssert.Exists (aarPath);
+			using (var aar = ZipHelper.OpenZip (aarPath)) {
+				aar.AssertEntryContents (aarPath, "res/raw/foo.txt", contents: "foo");
+				aar.AssertEntryContents (aarPath, "res/raw/bar.txt", contents: "bar");
+			}
+
+			// Change res/raw/bar.txt contents
+			var bar_txt = Path.Combine (FullProjectDirectory, "Resources", "raw", "bar.txt");
+			File.WriteAllText (bar_txt, contents: "baz");
+			Assert.IsTrue (dotnet.Build (), "second build should succeed");
+			FileAssert.Exists (aarPath);
+			using (var aar = ZipHelper.OpenZip (aarPath)) {
+				aar.AssertEntryContents (aarPath, "res/raw/foo.txt", contents: "foo");
+				aar.AssertEntryContents (aarPath, "res/raw/bar.txt", contents: "baz");
+			}
+
+			// Delete res/raw/bar.txt
+			File.Delete (bar_txt);
+			Assert.IsTrue (dotnet.Build (), "third build should succeed");
+			FileAssert.Exists (aarPath);
+			using (var aar = ZipHelper.OpenZip (aarPath)) {
+				aar.AssertEntryContents (aarPath, "res/raw/foo.txt", contents: "foo");
+				aar.AssertDoesNotContainEntry (aarPath, "res/raw/bar.txt");
 			}
 		}
 
@@ -48,7 +248,8 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuildBinding ()
 		{
 			var proj = new XASdkProject (outputType: "Library");
-			proj.OtherBuildItems.Add (new AndroidItem.EmbeddedJar ("javaclasses.jar") {
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("javaclasses.jar") {
+				MetadataValues = "Bind=true",
 				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64)
 			});
 			// TODO: bring back when Xamarin.Android.Bindings.Documentation.targets is working
@@ -58,7 +259,7 @@ namespace Xamarin.Android.Build.Tests
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 
-			var assemblyPath = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
+			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
 			FileAssert.Exists (assemblyPath);
 			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
 				var typeName = "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest";
@@ -127,7 +328,7 @@ namespace Xamarin.Android.Build.Tests
 			if (!isRelease)
 				Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
 
-			var outputPath = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath);
+			var outputPath = Path.Combine (FullProjectDirectory, proj.OutputPath);
 			if (!runtimeIdentifiers.Contains (";")) {
 				outputPath = Path.Combine (outputPath, runtimeIdentifiers);
 			}
@@ -150,22 +351,18 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsNotNull (type, $"{assemblyPath} should contain {typeName}");
 			}
 
-			var apk = Path.Combine (outputPath, "UnnamedProject.UnnamedProject.apk");
-			FileAssert.Exists (apk);
-
-			bool expectEmbededAssembies = !(CommercialBuildAvailable && !isRelease);
-
-			using (var zip = ZipHelper.OpenZip (apk)) {
+			bool expectEmbeddedAssembies = !(CommercialBuildAvailable && !isRelease);
+			var apkPath = Path.Combine (outputPath, "UnnamedProject.UnnamedProject.apk");
+			FileAssert.Exists (apkPath);
+			using (var apk = ZipHelper.OpenZip (apkPath)) {
 				var rids = runtimeIdentifiers.Split (';');
 				foreach (var abi in rids.Select (MonoAndroidHelper.RuntimeIdentifierToAbi)) {
-					Assert.IsTrue (zip.ContainsEntry ($"lib/{abi}/libmonodroid.so"), "libmonodroid.so should exist.");
-					Assert.IsTrue (zip.ContainsEntry ($"lib/{abi}/libmonosgen-2.0.so"), "libmonosgen-2.0.so should exist.");
+					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonodroid.so");
+					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonosgen-2.0.so");
 					if (rids.Length > 1) {
-						var entry = $"assemblies/{abi}/System.Private.CoreLib.dll";
-						Assert.AreEqual (expectEmbededAssembies, zip.ContainsEntry (entry), $"{entry} should {(expectEmbededAssembies ? "" : "not")} exist.");
+						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll", expectEmbeddedAssembies);
 					} else {
-						var entry = "assemblies/System.Private.CoreLib.dll";
-						Assert.AreEqual (expectEmbededAssembies, zip.ContainsEntry (entry), $"{entry} should {(expectEmbededAssembies ? "" : "not")} exist.");
+						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll", expectEmbeddedAssembies);
 					}
 				}
 			}
@@ -192,7 +389,7 @@ namespace Xamarin.Android.Build.Tests
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Publish (), "first `dotnet publish` should succeed");
 
-			var publishDirectory = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, runtimeIdentifier, "publish");
+			var publishDirectory = Path.Combine (FullProjectDirectory, proj.OutputPath, runtimeIdentifier, "publish");
 			var apk = Path.Combine (publishDirectory, $"{proj.PackageName}.apk");
 			var apkSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apk);
@@ -235,11 +432,11 @@ namespace Xamarin.Android.Build.Tests
 
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 
-			var apk = Path.Combine (Root, dotnet.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
-			FileAssert.Exists (apk);
-			using (var zip = ZipHelper.OpenZip (apk)) {
-				Assert.IsTrue (zip.ContainsEntry ("res/raw/foo.txt"), "res/raw/foo.txt should exist!");
-				Assert.IsTrue (zip.ContainsEntry ("assets/foo/bar.txt"), "assets/foo/bar.txt should exist!");
+			var apkPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+			FileAssert.Exists (apkPath);
+			using (var apk = ZipHelper.OpenZip (apkPath)) {
+				apk.AssertContainsEntry (apkPath, "res/raw/foo.txt");
+				apk.AssertContainsEntry (apkPath, "assets/foo/bar.txt");
 			}
 		}
 
@@ -255,14 +452,16 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		DotNetCLI CreateDotNetBuilder (XASdkProject project)
+		DotNetCLI CreateDotNetBuilder (XASdkProject project, string relativeProjectDir = null)
 		{
-			var relativeProjDir = Path.Combine ("temp", TestName);
+			if (string.IsNullOrEmpty (relativeProjectDir)) {
+				relativeProjectDir = Path.Combine ("temp", TestName);
+			}
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] =
-				FullProjectDirectory = Path.Combine (Root, relativeProjDir);
+				FullProjectDirectory = Path.Combine (Root, relativeProjectDir);
 			var files = project.Save ();
-			project.Populate (relativeProjDir, files);
-			project.CopyNuGetConfig (relativeProjDir);
+			project.Populate (relativeProjectDir, files);
+			project.CopyNuGetConfig (relativeProjectDir);
 			return new DotNetCLI (project, Path.Combine (FullProjectDirectory, project.ProjectFilePath));
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidBuildActions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidBuildActions.cs
@@ -16,6 +16,10 @@ namespace Xamarin.ProjectTools
 		public const string AndroidInterfaceDescription = "AndroidInterfaceDescription";
 		public const string AndroidJavaSource = "AndroidJavaSource";
 		public const string AndroidJavaLibrary = "AndroidJavaLibrary";
+		/// <summary>
+		/// Only supported in .NET 5+
+		/// </summary>
+		public const string AndroidLibrary = "AndroidLibrary";
 		public const string AndroidLintConfig = "AndroidLintConfig";
 		public const string AndroidNativeLibrary = "AndroidNativeLibrary";
 		public const string ProguardConfiguration = "ProguardConfiguration";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
@@ -37,6 +37,20 @@ namespace Xamarin.ProjectTools
 			{
 			}
 		}
+		/// <summary>
+		/// Only supported in .NET 5+
+		/// </summary>
+		public class AndroidLibrary : BuildItem
+		{
+			public AndroidLibrary (string include)
+				: this (() => include)
+			{
+			}
+			public AndroidLibrary (Func<string> include)
+				: base (AndroidBuildActions.AndroidLibrary, include)
+			{
+			}
+		}
 		public class AndroidLintConfig : BuildItem 
 		{
 			public AndroidLintConfig (string include)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -45,6 +46,11 @@ namespace Xamarin.ProjectTools
 			return File.ReadAllText (GetIntermediaryPath (file));
 		}
 
+		public List<string> GetAssemblyMapCache ()
+		{
+			var path = GetIntermediaryPath (Path.Combine ("lp", "map.cache"));
+			return File.ReadLines (path).ToList ();
+		}
 
 		public bool IsTargetSkipped (string target)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -79,6 +79,12 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
+		public bool Pack (string target = null, string [] parameters = null)
+		{
+			var arguments = GetDefaultCommandLineArgs ("pack", target, parameters);
+			return Execute (arguments.ToArray ());
+		}
+
 		public bool Publish (string target = null, string [] parameters = null)
 		{
 			var arguments = GetDefaultCommandLineArgs ("publish", target, parameters);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/IShortFormProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/IShortFormProject.cs
@@ -12,6 +12,7 @@ namespace Xamarin.ProjectTools
 		bool EnableDefaultItems { get; }
 		string Sdk { get; set; }
 		IList<PropertyGroup> PropertyGroups { get; }
+		IList<BuildItem> References { get; }
 		IList<Package> PackageReferences { get; }
 		IList<BuildItem> OtherBuildItems { get; }
 		IList<IList<BuildItem>> ItemGroupList { get; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/XmlUtils.cs
@@ -30,7 +30,14 @@ namespace Xamarin.ProjectTools
 				sb.AppendLine ("\t</ItemGroup>");
 			}
 			if (project.EnableDefaultItems) {
-				// If $(EnableDefaultItems), then only OtherBuildItems are added
+				// If $(EnableDefaultItems), then only OtherBuildItems and References are added
+				if (project.References.Count > 0) {
+					sb.AppendLine ("\t<ItemGroup>");
+					foreach (var reference in project.References) {
+						AppendBuildItem (sb, reference);
+					}
+					sb.AppendLine ("\t</ItemGroup>");
+				}
 				if (project.OtherBuildItems.Count > 0) {
 					sb.AppendLine ("\t<ItemGroup>");
 					foreach (var bi in project.OtherBuildItems) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyIdentityMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyIdentityMap.cs
@@ -20,6 +20,11 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
+		/// <summary>
+		/// Returns the index of the file in $(_AndroidLibrayProjectAssemblyMapFile): map.cache
+		/// Adds the file to the cache if it doesn't exist.
+		/// </summary>
+		/// <param name="assemblyIdentity">The file name including extension.</param>
 		public string GetLibraryImportDirectoryNameForAssembly (string assemblyIdentity)
 		{
 			if (map.Contains (assemblyIdentity)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -329,6 +329,7 @@ namespace Xamarin.Android.Tools
 						continue;
 					if (entry.FullName.Contains ("/__MACOSX/") ||
 							entry.FullName.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
+							string.Equals (entry.FullName, ".DS_Store", StringComparison.OrdinalIgnoreCase) ||
 							entry.FullName.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))
 						continue;
 					if (skipCallback != null && skipCallback (entry.FullName))

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -657,6 +657,20 @@ namespace Xamarin.Android.Tasks
 			return string.Empty;
 		}
 
+		static readonly char [] DirectorySeparators = new [] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+		/// <summary>
+		/// Returns the relative path that should be used for an @(AndroidAsset) item
+		/// </summary>
+		public static string GetRelativePathForAndroidAsset (string assetsDirectory, ITaskItem androidAsset)
+		{
+			var path = androidAsset.GetMetadata ("Link");
+			path = !string.IsNullOrWhiteSpace (path) ? path : androidAsset.ItemSpec;
+			var head = string.Join ("\\", path.Split (DirectorySeparators).TakeWhile (s => !s.Equals (assetsDirectory, StringComparison.OrdinalIgnoreCase)));
+			path = head.Length == path.Length ? path : path.Substring ((head.Length == 0 ? 0 : head.Length + 1) + assetsDirectory.Length).TrimStart (DirectorySeparators);
+			return path;
+		}
+
 		/// <summary>
 		/// Converts .NET 5 RIDs to Android ABIs or an empty string if no match.
 		/// 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -31,6 +31,10 @@
 			<SubType>Designer</SubType>
 			<Generator>MSBuild:UpdateGeneratedFiles</Generator>
 		</AndroidResource>
+		<!-- NOTE: .aar items should skip %(AndroidSkipResourceProcessing) by default -->
+		<AndroidAarLibrary>
+			<AndroidSkipResourceProcessing>true</AndroidSkipResourceProcessing>
+		</AndroidAarLibrary>
 	</ItemDefinitionGroup>
         <ItemGroup>
           <AndroidMinimumSupportedApiLevel Include="armeabi-v7a">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -973,9 +973,10 @@ because xbuild doesn't support framework reference assemblies.
 
 <!-- Resource Build -->
 
-<Target Name="_UpdateAndroidResources" Condition=" '$(ManagedDesignTimeBuild)' == 'False' "
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CreatePropertiesCache;_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_CreateManagedLibraryResourceArchive">
-</Target>
+<Target Name="_UpdateAndroidResources"
+    Condition=" '$(ManagedDesignTimeBuild)' == 'False' "
+    DependsOnTargets="$(_UpdateAndroidResourcesDependsOn)"
+/>
 
 <Target Name="UpdateAndroidResources"
     Condition=" '$(DesignTimeBuild)' != 'True' Or '$(DeferredBuildSupported)' != 'True' Or '$(DeferredBuild)' == 'True' "
@@ -1036,14 +1037,6 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
   <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == '' ">
     <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
-  </ItemGroup>
-</Target>
-
-<Target Name="_AddAndroidEnvironmentToCompile">
-  <ItemGroup>
-    <EmbeddedResource Include="@(AndroidEnvironment)">
-      <LogicalName>__AndroidEnvironment__%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -2,9 +2,11 @@
 ***********************************************************************************************
 Xamarin.Android.EmbeddedResource.targets
 
-This file contains MSBuild targets related to the creation or extraction
-of `__AndroidLibraryProjects__.zip` or `__AndroidNativeLibraries__.zip`.
-These are packaged as `EmbeddedResource` files in Xamarin.Android assemblies.
+This file contains MSBuild targets related to the creation or
+extraction of `__AndroidLibraryProjects__.zip` or
+`__AndroidNativeLibraries__.zip`. These are packaged as
+`EmbeddedResource` files in Xamarin.Android assemblies. The actual
+creation of these files has moved to Xamarin.Android.Legacy.targets.
 
 This file is used by all project types, including binding projects.
 
@@ -13,9 +15,6 @@ This file is used by all project types, including binding projects.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="Xamarin.Android.Tasks.CreateLibraryResourceArchive"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GetImportedLibraries"                AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache"      AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -91,66 +90,6 @@ This file is used by all project types, including binding projects.
       <Output TaskParameter="NativeLibraries"   ItemName="AndroidNativeLibrary" />
       <Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
     </ReadImportedLibrariesCache>
-  </Target>
-    
-  <Target Name="_CreateNativeLibraryArchive"
-      Condition=" '$(AndroidApplication)' != 'true' And '@(EmbeddedNativeLibrary->Count())' != '0' "
-      Inputs="@(EmbeddedNativeLibrary)"
-      Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-    <CreateNativeLibraryArchive
-        OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
-        EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)"
-    />
-    <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
-    <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
-      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
-        <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_CreateManagedLibraryResourceArchive"
-      Condition=" '$(AndroidApplication)' != 'true' And '$(_AndroidIsBindingProject)' != 'true' "
-      Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
-      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-    <CreateManagedLibraryResourceArchive
-        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-        ResourceDirectory="$(MonoAndroidResDirIntermediate)"
-        AndroidAssets="@(AndroidAsset)"
-        MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
-        AndroidJavaSources="@(AndroidJavaSource)"
-        AndroidJavaLibraries="@(AndroidJavaLibrary)"
-        AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
-        FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
-        RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
-    />
-    <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
-    <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
-      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_CreateBindingResourceArchive"
-      Condition=" '$(_AndroidIsBindingProject)' == 'true' "
-      Inputs="@(LibraryProjectProperties);@(LibraryProjectZip)"
-      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-    <CreateLibraryResourceArchive
-        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
-        OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
-        OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
-        LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
-        LibraryProjectZipFiles="@(LibraryProjectZip)"
-    />
-    <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
-      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
-      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
-        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -143,6 +143,14 @@ projects. .NET 5 projects will not import this file.
       _IncludeNativeSystemLibraries;
       _CheckGoogleSdkRequirements;
     </_PrepareBuildApkDependsOnTargets>
+    <_UpdateAndroidResourcesDependsOn>
+      $(CoreResolveReferencesDependsOn);
+      _CreatePropertiesCache;
+      _CheckForDeletedResourceFile;
+      _ComputeAndroidResourcePaths;
+      _UpdateAndroidResgen;
+      _CreateManagedLibraryResourceArchive;
+    </_UpdateAndroidResourcesDependsOn>
     <GetAndroidDependenciesDependsOn>
       _BeforeGetAndroidDependencies;
       _SetLatestTargetFrameworkVersion;
@@ -190,13 +198,20 @@ projects. .NET 5 projects will not import this file.
       _ExportJarToXml;
     </ExportJarToXmlDependsOnTargets>
 
+    <_ResolveLibraryProjectsDependsOn>
+      _CreateBindingResourceArchive;
+    </_ResolveLibraryProjectsDependsOn>
+
   </PropertyGroup>
 
-  <UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.ConvertDebuggingFiles"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion"   AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies"               AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ConvertDebuggingFiles"               AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateLibraryResourceArchive"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ValidateJavaVersion"          AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.Legacy.ResolveAndroidTooling"        AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies"                      AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
   <Target Name="_CheckTargetFramework">
     <Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/>
@@ -382,6 +397,90 @@ projects. .NET 5 projects will not import this file.
     <Touch Files="$(OutDir)$(TargetFileName).mdb" />
     <ItemGroup>
       <FileWrites Include="$(OutDir)$(TargetFileName).mdb" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AddAndroidEnvironmentToCompile">
+    <ItemGroup>
+      <EmbeddedResource Include="@(AndroidEnvironment)">
+        <LogicalName>__AndroidEnvironment__%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddEmbeddedJarsAsResources" DependsOnTargets="GenerateBindings">
+    <ItemGroup>
+      <EmbeddedResource Include="@(EmbeddedJar)">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddEmbeddedReferenceJarsAsResources" DependsOnTargets="GenerateBindings">
+    <ItemGroup>
+      <EmbeddedResource Include="@(EmbeddedReferenceJar)">
+        <LogicalName>__reference__%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateNativeLibraryArchive"
+      Condition=" '$(AndroidApplication)' != 'true' And '@(EmbeddedNativeLibrary->Count())' != '0' "
+      Inputs="@(EmbeddedNativeLibrary)"
+      Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
+    <CreateNativeLibraryArchive
+        OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
+        EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)"
+    />
+    <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
+        <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateManagedLibraryResourceArchive"
+      Condition=" '$(AndroidApplication)' != 'true' And '$(_AndroidIsBindingProject)' != 'true' "
+      Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
+      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+    <CreateManagedLibraryResourceArchive
+        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+        ResourceDirectory="$(MonoAndroidResDirIntermediate)"
+        AndroidAssets="@(AndroidAsset)"
+        MonoAndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
+        AndroidJavaSources="@(AndroidJavaSource)"
+        AndroidJavaLibraries="@(AndroidJavaLibrary)"
+        AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
+        FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
+        RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
+    />
+    <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CreateBindingResourceArchive"
+      Condition=" '$(_AndroidIsBindingProject)' == 'true' "
+      Inputs="@(LibraryProjectProperties);@(LibraryProjectZip)"
+      Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+    <CreateLibraryResourceArchive
+        OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
+        OutputJarsDirectory="$(IntermediateOutputPath)library_project_jars"
+        OutputAnnotationsDirectory="$(IntermediateOutputPath)library_project_annotations"
+        LibraryProjectPropertiesFiles="@(LibraryProjectProperties)"
+        LibraryProjectZipFiles="@(LibraryProjectZip)"
+    />
+    <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
+      <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
+      </EmbeddedResource>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2441
Implements: Documentation/proposals/OneDotNetEmbeddedResources.md

Creation of `EmbeddedResource` files:

* `__AndroidEnvironment__*`
* `__AndroidLibraryProjects__.zip`
* `__AndroidNativeLibraries__.zip`
* `*.jar`

...has moved to `Xamarin.Android.Legacy.targets`.

A new `_CreateAar` MSBuild target and `<CreateAar/>` MSBuild task now
creates `.aar` files in `$(OutputPath)` for class libraries.

The `_ResolveAars` MSBuild target will locate `.aar` files next to
.NET assemblies and use them if found.

The MSBuild targets/tasks for consuming `EmbeddedResource` files in
assemblies remains in place for backwards compatibility. The only
change was to support the new `.netenv` directory inside `.aar` files.

The `_CategorizeAndroidLibraries` MSBuild target handles setting up
the new, simplified `@(AndroidLibrary)` item group.

I added several tests for these scenarios.

Other changes:

* A new `<ExtractJarsFromAar/>` MSBuild task is needed for
  `@(LibraryProjectZip)` items for Java bindings. This task extracts
  `.jar` files to `$(IntermediateOutputPath)library_project_jars` and
  `annotations.zip` items to `$(IntermediateOutputPath)library_project_annotations`.
* The `@(LibraryProjectZip)` item group now works in .NET 5+. We no
  longer need the `LibraryProjectZip` test category, as these tests
  pass. Several of these tests needed to set `ProjectName` as they had
  two projects named `UnnamedProject.csproj`.
* `<ResolveLibraryProjectImports/>` needs to store the full file *and*
  the extension in `obj\$(Configuration)\lp\map.cache` now as you
  would commonly have both a `Foo.dll` and `Foo.aar`. I had to adjust
  `AssemblyIdentityMap` to account for this.
* `.aar` files can no longer assume `%(AndroidSkipResourceProcessing)`
  is `false` by default. `.aar` files coming from Xamarin.Android
  class libraries could have custom views that need to be fixed up at
  build time in the main Xamarin.Android application project.
* When the nested, inner build for the
  `_ComputeFilesToPublishForRuntimeIdentifiers` MSBuild target runs, I
  further trimmed down which targets run. `IncrementalClean` was
  running multiple times and deleting files!
* Fixed where `Files.ExtractAll` was extracting a `.DS_Store` file in
  the root of `.aar` files.