### PR TITLE
[Xamarin.Android.Build.Tasks] Guard against only having 1 processor.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Tasks {
 			// Must register on the UI thread!
 			// We don't want to use up ALL the available cores especially when
 			// running in the IDE. So lets cap it at DefaultMaxAapt2Daemons (6).
-			int maxInstances = Math.Min (ProcessorCount - 1, DefaultMaxAapt2Daemons);
+			int maxInstances = Math.Min (Math.Max (1, ProcessorCount - 1), DefaultMaxAapt2Daemons);
 			if (DaemonMaxInstanceCount == 0)
 				DaemonMaxInstanceCount = maxInstances;
 			else


### PR DESCRIPTION
Fixes https://work.azdo.io/1216790

We had this very weird situation where the `Aapt2Compile` step
would hang indefinately. This did not happen on every machine,
just on a particular customer's setup.

It turns out that `Environment.ProcessorCount` was returning 1.
This would cause the following code to return a value of 0.

	Math.Min(Environment.ProcessorCount -1, DefaultMaxAapt2Daemons);

We did not have any protection in place to guard against getting
a 0 from this code. As a result we tried to spawn 0 instances of
aapt2. This would result in the `Aapt2Compile` task to wait for
jobs that were never going to be completed.