### PR TITLE
[One .NET ] consolidate linker MSBuild properties

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -135,6 +135,38 @@ Default Android related file globbing behavior is defined in `Microsoft.Android.
 This behavior can be disabled for Android items by setting `$(EnableDefaultAndroidItems)` to `false`, or
 all default item inclusion behavior can be disabled by setting `$(EnableDefaultItems)` to `false`.
 
+## Linker (ILLink)
+
+.NET 5 and higher has new [settings for the linker][linker]:
+
+* `<PublishTrimmed>true</PublishTrimmed>`
+* `<TrimMode>copyused</TrimMode>` - Enable assembly-level trimming.
+* `<TrimMode>link</TrimMode>` - Enable member-level trimming.
+
+In Android application projects by default, `Debug` builds will not
+use the linker and `Release` builds will set `PublishTrimmed=true` and
+`TrimMode=link`. `TrimMode=copyused` is the default the dotnet/sdk,
+but it doesn't not seem to be appropriate for mobile applications.
+Developers can still opt into `TrimMode=copyused` if needed.
+
+If the legacy `AndroidLinkMode` setting is used, both `SdkOnly` and
+`Full` will default to equivalent linker settings:
+
+* `<PublishTrimmed>true</PublishTrimmed>`
+* `<TrimMode>link</TrimMode>`
+
+With `AndroidLinkMode=SdkOnly` only BCL and SDK assemblies marked with
+`%(Trimmable)` will be linked at the member level.
+`AndroidLinkMode=Full` will set `%(TrimMode)=link` on all .NET
+assemblies similar to the example in the [trimming
+documentation][linker-full].
+
+It is recommended to migrate to the new linker settings, as
+`AndroidLinkMode` will eventually be deprecated.
+
+[linker]: https://docs.microsoft.com/dotnet/core/deploying/trimming-options
+[linker-full]: https://docs.microsoft.com/dotnet/core/deploying/trimming-options#trimmed-assemblies
+
 ## dotnet cli
 
 There are currently a few "verbs" we are aiming to get working in

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
@@ -30,7 +30,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' ">false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
-    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">SdkOnly</AndroidLinkMode>
     <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
   </PropertyGroup>
 
@@ -43,7 +42,10 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
-    <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
+    <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and ('$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full') ">true</PublishTrimmed>
+    <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>
+    <TrimMode Condition=" '$(PublishTrimmed)' == 'true' and '$(TrimMode)' == '' ">link</TrimMode>
+    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -13,6 +13,16 @@ This file contains the .NET 5-specific targets to customize ILLink
       Condition=" '$(PublishTrimmed)' == 'true' "
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths">
+    <ItemGroup>
+      <!-- Mark all assemblies to be linked for AndroidLinkMode=Full -->
+      <ResolvedFileToPublish
+          Update="@(ResolvedFileToPublish)"
+          Condition=" '$(AndroidLinkMode)' == 'Full' and '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.AssetType)' != 'native' "
+          TrimMode="link"
+      />
+      <!-- Mark our entry assembly as a root assembly. -->
+      <TrimmerRootAssembly Include="$(AssemblyName)" />
+    </ItemGroup>
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->
       <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose --deterministic --custom-data XATargetFrameworkDirectories="$(_XATargetFrameworkDirectories)"</_ExtraTrimmerArgs>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -45,7 +45,10 @@ namespace Xamarin.Android.Build.Tests
 			using (var appb = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
 				Assert.IsTrue (libb.Build (lib), "Library build should have succeeded.");
 				Assert.IsTrue (appb.Build (app), "App should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (appb.LastBuildOutput, $"Save assembly: {linkSkip}"), $"{linkSkip} should be saved, and not linked!");
+				if (!Builder.UseDotNet) {
+					//TODO: $(AndroidLinkSkip) is not yet implemented
+					Assert.IsTrue (StringAssertEx.ContainsText (appb.LastBuildOutput, $"Save assembly: {linkSkip}"), $"{linkSkip} should be saved, and not linked!");
+				}
 
 				string intermediateOutputDir = Path.Combine (Root, appb.ProjectDirectory, app.IntermediateOutputPath);
 				List<string> envFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediateOutputDir, supportedAbis, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -68,16 +68,20 @@ namespace Xamarin.Android.Build.Tests
 				new [] {
 					"Java.Interop.dll",
 					"Mono.Android.dll",
+					"System.Collections.NonGeneric.dll",
 					"System.ComponentModel.Primitives.dll",
 					"System.Console.dll",
 					"System.Linq.Expressions.dll",
 					"System.ObjectModel.dll",
+					"System.Private.Uri.dll",
 					"System.Private.Xml.dll",
+					"System.Private.Xml.Linq.dll",
 					"System.Runtime.CompilerServices.Unsafe.dll",
 					"System.Runtime.Serialization.Formatters.dll",
 					"System.Runtime.Serialization.Primitives.dll",
 					"System.Security.Cryptography.Algorithms.dll",
 					"System.Security.Cryptography.Primitives.dll",
+					"System.Text.RegularExpressions.dll",
 					"System.Private.CoreLib.dll",
 					"System.Collections.Concurrent.dll",
 					"System.Collections.dll",
@@ -111,7 +115,7 @@ namespace Xamarin.Android.Build.Tests
 						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var existingFiles = zip.Where (a => a.FullName.StartsWith ("assemblies/", StringComparison.InvariantCultureIgnoreCase));
-					var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assmelbies/" + Path.GetFileName (x)));
+					var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assemblies/" + Path.GetFileName (x)));
 					Assert.IsTrue (missingFiles.Any (),
 					string.Format ("The following Expected files are missing. {0}",
 						string.Join (Environment.NewLine, missingFiles)));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -193,6 +193,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("DotNetIgnore")] //TODO: @(LinkDescription) is not implemented yet
 		public void LinkDescription ()
 		{
 			string assembly_name = Builder.UseDotNet ? "System.Console" : "mscorlib";


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/deploying/trimming-options

This sets up sensible defaults for the linker while supporting the
legacy `$(AndroidLinkMode)` MSBuild property.

For `Release` builds by default:

* `PublishTrimmed=true`
* `TrimMode=link`

I documented these settings in `OneDotNet.md`.

This may cause some tests to fail because we are using `TrimMode=Link`, we'll see what happens.

/cc @rolfbjarne