### PR TITLE
[tests] Fix process output collection

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Android.Build.Tests
 				});
 				proc.ErrorDataReceived += new DataReceivedEventHandler ((sender, e) => {
 					if (!string.IsNullOrEmpty (e.Data))
-						errorOutput.Append (Environment.NewLine + e.Data);
+						errorOutput.AppendLine (e.Data);
 				});
 
 				proc.Start ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -234,7 +234,7 @@ namespace Xamarin.Android.Build.Tests
 				proc.StartInfo = info;
 				proc.OutputDataReceived += new DataReceivedEventHandler ((sender, e) => {
 					if (!string.IsNullOrEmpty (e.Data))
-						standardOutput.Append (Environment.NewLine + e.Data);
+						standardOutput.AppendLine (e.Data);
 				});
 				proc.ErrorDataReceived += new DataReceivedEventHandler ((sender, e) => {
 					if (!string.IsNullOrEmpty (e.Data))
@@ -560,4 +560,3 @@ namespace Xamarin.Android.Build.Tests
 		}
 	}
 }
-

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -229,14 +229,31 @@ namespace Xamarin.Android.Build.Tests
 				CreateNoWindow = true,
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
-			using (var proc = Process.Start (info)) {
+			using (var proc = new Process ()) {
+				StringBuilder standardOutput = new StringBuilder (), errorOutput = new StringBuilder ();
+				proc.StartInfo = info;
+				proc.OutputDataReceived += new DataReceivedEventHandler ((sender, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						standardOutput.Append (Environment.NewLine + e.Data);
+				});
+				proc.ErrorDataReceived += new DataReceivedEventHandler ((sender, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						errorOutput.Append (Environment.NewLine + e.Data);
+				});
+
+				proc.Start ();
+				proc.BeginOutputReadLine ();
+				proc.BeginErrorReadLine ();
+
 				if (!proc.WaitForExit ((int)TimeSpan.FromSeconds (30).TotalMilliseconds)) {
 					proc.Kill ();
 					TestContext.Out.WriteLine ($"{nameof (RunProcess)} timed out: {exe} {args}");
 					return null; //Don't try to read stdout/stderr
 				}
-				var result = proc.StandardOutput.ReadToEnd ().Trim () + proc.StandardError.ReadToEnd ().Trim ();
-				return result;
+
+				proc.WaitForExit ();
+
+				return standardOutput.ToString ().Trim () + errorOutput.ToString ().Trim ();
 			}
 		}
 


### PR DESCRIPTION
The `BaseTest.RunProcess` is redirecting the standard and error output,
so that it can be captured. It didn't work, because it was not using the
output related events and so if there was enough output, we got dead
lock and timeout as a result.

Context: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standarderror

Example behaviour before the fix - notice the timeout:

    RunProcess: C:\Users\rodo\android-toolchain\sdk\platform-tools\adb.exe  logcat -d > "C:\Users\rodo\git\xa-master\bin\TestDebug\temp\otNetInstallAndRunTrueFalse\logcat-failed.log"
    RunProcess timed out: C:\Users\rodo\android-toolchain\sdk\platform-tools\adb.exe  logcat -d > "C:\Users\rodo\git\xa-master\bin\TestDbug\temp\DotNetInstallAndRunTrueFalse\logcat-failed.log"