### PR TITLE
[tests] Fix logcat output saving

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Android.Build.Tests
 				string deviceLog = Path.Combine (outputDir, "logcat-failed.log");
 				string remote = "/data/local/tmp/screenshot.png";
 				RunAdbCommand ($"shell screencap {remote}");
-				RunAdbCommand ($"logcat -d > \"{deviceLog}\"");
+				var output = RunAdbCommand ($"logcat -d");
+				File.WriteAllText (deviceLog, output);
 				RunAdbCommand ($"pull {remote} \"{local}\"");
 				RunAdbCommand ($"shell rm {remote}");
 				if (File.Exists (local)) {


### PR DESCRIPTION
The `RunAdbCommand` is not running a shell, so we cannot use output
redirection like:

    RunAdbCommand ($"logcat -d > \"{deviceLog}\"");

So instead just write the output to the file ourselves.

Before the output of the command was:

    Invalid filter expression 'C:\...\bin\TestDebug\temp\DotNetInstallAndRunTrueFalse\logcat-failed.log'
    Usage: logcat [options] [filterspecs]
    options include:
      -s              Set default filter to silent. Equivalent to filterspec '*:S'
      -f <file>, --file=<file>               Log to file. Default is stdout
      -r <kbytes>, --rotate-kbytes=<kbytes>
                      Rotate log every kbytes. Requires -f option
    ...

So we didn't get the logcat output we wanted.