### PR TITLE
Bump to xamarin/Java.Interop/d16-8@79d95334

### DIFF
--- a/Documentation/release-notes/5139.md
+++ b/Documentation/release-notes/5139.md
@@ -1,0 +1,13 @@
+### Binding Issues
+
+* [GitHub Issue 682](https://github.com/xamarin/java.interop/issues/682):
+  Prevent BG8604 warning by hiding `public` nested types of *non*-`public`
+  Kotlin "outer" types.
+
+* [GitHub Issue 717](https://github.com/xamarin/java.interop/issues/717):
+  Allow `android.app.IntentService` to be resolved from `Mono.Android.dll`.
+
+* [GitHub Issue 719](https://github.com/xamarin/java.interop/issues/719):
+  Prevent a `JNI DETECTED ERROR IN APPLICATION` runtime error which can
+  occur when a `Java.Lang.Object` subclass is GC'd before it can be
+  passed into Java code.

--- a/Documentation/release-notes/5139.md
+++ b/Documentation/release-notes/5139.md
@@ -1,13 +1,40 @@
-### Binding Issues
+### Deprecations, removals, and default configuration changes
 
-* [GitHub Issue 682](https://github.com/xamarin/java.interop/issues/682):
-  Prevent BG8604 warning by hiding `public` nested types of *non*-`public`
-  Kotlin "outer" types.
+#### Corrected garbage collection behavior for Android bindings and bindings projects
 
-* [GitHub Issue 717](https://github.com/xamarin/java.interop/issues/717):
-  Allow `android.app.IntentService` to be resolved from `Mono.Android.dll`.
+In previous Xamarin.Android versions, errors similar to _JNI DETECTED ERROR IN
+APPLICATION: use of deleted global reference_ and _JNI ERROR (app bug): attempt
+to use stale Global 0x2a2a (should be 0x2a26)_ could cause apps to abort under
+certain specific timing conditions where a managed garbage collection started
+just after a `Java.Lang.Object` subclass method call.
 
-* [GitHub Issue 719](https://github.com/xamarin/java.interop/issues/719):
-  Prevent a `JNI DETECTED ERROR IN APPLICATION` runtime error which can
-  occur when a `Java.Lang.Object` subclass is GC'd before it can be
-  passed into Java code.
+The Xamarin.Android bindings project build process now includes a fix for this
+issue.
+
+The set of Android API bindings that are included directly as part of the
+Xamarin.Android SDK have been updated accordingly to include the fix.
+
+> [!NOTE]
+> This fix will not solve the problem for other bindings libraries until the
+> libraries are rebuilt using this new Xamarin.Android version.  Bindings
+> library authors are therefore encouraged to build and publish new versions of
+> their libraries using this new Xamarin.Android version at their earliest
+> convenience.
+
+### Issues fixed
+
+#### Bindings projects
+
+- [Java.Interop GitHub 682](https://github.com/xamarin/java.interop/issues/682):
+  Ignorable _warning BG8604: top ancestor ... not found for nested type ..._
+  appeared for `public` types nested under non-`public` types in Kotlin
+  libraries.  Those nested types are now skipped as expected.
+
+- [Java.Interop GitHub 717](https://github.com/xamarin/java.interop/issues/717):
+  _Error while processing type ... Type 'android.app.IntentService' was not
+  found._ prevented building bindings for libraries with classes that inherited
+  from `android.app.IntentService`.
+
+- [Java.Interop GitHub 719](https://github.com/xamarin/java.interop/issues/719):
+  Bindings did not yet use `GC.KeepAlive()` calls to ensure that method
+  arguments would never be garbage collected before they were passed to Java.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/682
Fixes: https://github.com/xamarin/java.interop/issues/717

Context: https://github.com/xamarin/java.interop/issues/719

Changes: https://github.com/xamarin/java.interop/compare/a807961666bc48b81d46aa16bc02baf9bf05bd45...79d95334219690fc51c30baeccaf702542afeba1

  * xamarin/java.interop@79d95334: [generator] Use GC.KeepAlive for reference type method parameters. (#722)
  * xamarin/java.interop@1a19ec04: [Xamarin.Android.Tools.Bytecode] Hide Kotlin nested types inside (#723)
  * xamarin/java.interop@24a9abdb: [Xamarin.Android.Tools.ApiXmlAdjuster] Find app.android.IntentService (#718)