### PR TITLE
[Xamarin.Android.Build.Tasks] remove ${library.imports:} syntax for $(AndroidResgenExtraArgs)

### DIFF
--- a/Documentation/release-notes/androidresgenextraargs.md
+++ b/Documentation/release-notes/androidresgenextraargs.md
@@ -1,0 +1,20 @@
+#### Application and library build and deployment
+
+A text templating feature for aapt/aapt2 has been removed that
+provided a workaround for the Amazon Fire Phone:
+
+```xml
+<AndroidResgenExtraArgs>-I ${library.imports:eac-api.jar} -I ${library.imports:euclid-api.jar}</AndroidResgenExtraArgs>
+```
+
+The `${library.imports:...}` syntax should no longer be needed by
+modern Android libraries. [`.aar`][aar] files are the recommended way
+for Java/Kotlin libraries to distribute Android resources to be
+consumed by Xamarin.Android application projects.
+
+Note that the `$(AndroidResgenExtraArgs)` and
+`$(AndroidAapt2LinkExtraArgs)` MSBuild properties will continue to
+pass additional arguments to `aapt` and `aapt2 link` with the
+`${library.imports:...}` syntax removed.
+
+[aar]: https://developer.android.com/studio/projects/android-library#aar-contents

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -341,35 +341,13 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (ResourceSymbolsTextFileDirectory))
 				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFileDirectory);
 
-			var extraArgsExpanded = ExpandString (ExtraArgs);
-			if (extraArgsExpanded != ExtraArgs)
-				LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
-
-			if (!string.IsNullOrWhiteSpace (extraArgsExpanded))
-				cmd.AppendSwitch (extraArgsExpanded);
+			if (!string.IsNullOrWhiteSpace (ExtraArgs))
+				cmd.AppendSwitch (ExtraArgs);
 
 			if (!AndroidUseLatestPlatformSdk)
 				cmd.AppendSwitchIfNotNull ("--max-res-version ", ApiLevel);
 
 			return cmd.ToString ();
-		}
-
-		string ExpandString (string s)
-		{
-			if (s == null)
-				return null;
-			int start = 0;
-			int st = s.IndexOf ("${library.imports:", start, StringComparison.Ordinal);
-			if (st >= 0) {
-				int ed = s.IndexOf ('}', st);
-				if (ed < 0)
-					return s.Substring (0, st + 1) + ExpandString (s.Substring (st + 1));
-				int ast = st + "${library.imports:".Length;
-				string aname = s.Substring (ast, ed - ast);
-				return s.Substring (0, st) + Path.Combine (OutputImportDirectory, assemblyMap.GetLibraryImportDirectoryNameForAssembly (aname), ImportsDirectory) + Path.DirectorySeparatorChar + ExpandString (s.Substring (ed + 1));
-			}
-			else
-				return s;
 		}
 
 		protected string GenerateFullPathToTool ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -254,12 +254,8 @@ namespace Xamarin.Android.Tasks {
 			if (ProtobufFormat)
 				cmd.Add ("--proto-format");
 
-			var extraArgsExpanded = ExpandString (ExtraArgs);
-			if (extraArgsExpanded != ExtraArgs)
-				LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
-
-			if (!string.IsNullOrWhiteSpace (extraArgsExpanded)) {
-				foreach (Match match in exraArgSplitRegEx.Matches (extraArgsExpanded)) {
+			if (!string.IsNullOrWhiteSpace (ExtraArgs)) {
+				foreach (Match match in exraArgSplitRegEx.Matches (ExtraArgs)) {
 					string value = match.Value.Trim (' ', '"', '\'');
 					if (!string.IsNullOrEmpty (value))
 						cmd.Add (value);
@@ -300,24 +296,6 @@ namespace Xamarin.Android.Tasks {
 			cmd.Add (GetFullPath (currentResourceOutputFile));
 
 			return cmd.ToArray ();
-		}
-
-		string ExpandString (string s)
-		{
-			if (s == null)
-				return null;
-			int start = 0;
-			int st = s.IndexOf ("${library.imports:", start, StringComparison.Ordinal);
-			if (st >= 0) {
-				int ed = s.IndexOf ('}', st);
-				if (ed < 0)
-					return s.Substring (0, st + 1) + ExpandString (s.Substring (st + 1));
-				int ast = st + "${library.imports:".Length;
-				string aname = s.Substring (ast, ed - ast);
-				return s.Substring (0, st) + Path.Combine (OutputImportDirectory, assemblyMap.GetLibraryImportDirectoryNameForAssembly (aname), ImportsDirectory) + Path.DirectorySeparatorChar + ExpandString (s.Substring (ed + 1));
-			}
-			else
-				return s;
 		}
 
 		bool ExecuteForAbi (string [] cmd, string currentResourceOutputFile)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5131
Context: https://github.com/xamarin/monodroid/commit/90c791f89ea065680fafd3ab8301142fb4a9ff18

In #5131, I need to modify `obj\$(Configuration)\lp\map.cache` so the
full file name is listed for each row. I was hitting a collision for
similarly named files such as `Foo.dll` and `Foo.aar`. This led me to
fix all callers of `AssemblyIdentifyMap`, such as
`Aapt.ExpandString()` and `Aapt2Link.ExpandString()`.

Reading `ExpandString()`, it supports some very weird syntax, which
would be something like:

    <AndroidResgenExtraArgs>-I ${library.imports:foo.jar}</AndroidResgenExtraArgs>

Looking at xamarin/monodroid/master@90c791f8, this was a feature added
for the Amazon Fire Phone in ~Oct 2014. Amazon placed
`AndroidResource` files inside a `.jar` file, because the `.aar` file
format did not exist yet.

So the workaround was to use:

    <AndroidResgenExtraArgs>-I obj/$(Configuration)/__library_projects__/Amazon.Euclid/library_project_imports/eac-api.jar -I obj/$(Configuration)/__library_projects__/Amazon.Euclid/library_project_imports/euclid-api.jar</AndroidResgenExtraArgs>

Which could be simplified to:

    <AndroidResgenExtraArgs>-I ${library.imports:eac-api.jar} -I ${library.imports:euclid-api.jar}</AndroidResgenExtraArgs>

The feature for `${library.imports:...}` is undocumented, the Amazon
Fire Phone no longer exists, and we have `.aar` files now.

I could not find any usage on Github either:

https://github.com/search?q=AndroidResgenExtraArgs+%24%7Blibrary.imports%3A&type=code

Let's remove `ExpandString()` instead of fixing up the
`AssemblyIdentifyMap` calls in #5131.