### PR TITLE
[One .NET] cleanup build output

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -12,6 +12,12 @@ _ResolveAssemblies MSBuild target.
 
   <UsingTask TaskName="Xamarin.Android.Tasks.ProcessAssemblies" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
+  <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' == 'true' ">
+    <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
+    <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>
+    <PublishDir>$(OutputPath)</PublishDir>
+  </PropertyGroup>
+
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
       DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish"
       Returns="@(ResolvedFileToPublish)">
@@ -34,6 +40,7 @@ _ResolveAssemblies MSBuild target.
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true;
         _OuterIntermediateAssembly=@(IntermediateAssembly);
+        _OuterOutputPath=$(OutputPath);
         _ProguardProjectConfiguration=$(_ProguardProjectConfiguration);
       </_AdditionalProperties>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props
@@ -13,6 +13,7 @@
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
+    <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <!-- jar2xml is not supported -->
     <AndroidClassParser>class-parse</AndroidClassParser>
     <!-- mono-symbolicate is not supported -->
@@ -42,6 +43,7 @@
     <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
+    <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' ">false</ProduceReferenceAssembly>
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
     <PublishTrimmed Condition=" '$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full' ">true</PublishTrimmed>
     <!-- Prefer $(RuntimeIdentifiers) plural -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -131,7 +131,18 @@ namespace Xamarin.Android.Build.Tests
 			if (!runtimeIdentifiers.Contains (";")) {
 				outputPath = Path.Combine (outputPath, runtimeIdentifiers);
 			}
-			var assemblyPath = Path.Combine (outputPath, "UnnamedProject.dll");
+
+			var files = Directory.EnumerateFileSystemEntries (outputPath)
+				.Select (Path.GetFileName)
+				.OrderBy (f => f);
+			CollectionAssert.AreEqual (new [] {
+				$"{proj.ProjectName}.dll",
+				$"{proj.ProjectName}.pdb",
+				$"{proj.PackageName}.apk",
+				$"{proj.PackageName}-Signed.apk",
+			}, files);
+
+			var assemblyPath = Path.Combine (outputPath, $"{proj.ProjectName}.dll");
 			FileAssert.Exists (assemblyPath);
 			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
 				var typeName = "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -92,9 +92,6 @@ namespace Xamarin.ProjectTools
 
 					if (Builder.UseDotNet) {
 						this.AddDotNetCompatPackages ();
-
-						// NOTE: workaround for https://github.com/dotnet/sdk/issues/12954
-						SetProperty ("ProduceReferenceAssembly", "false");
 					}
 				}
 			}


### PR DESCRIPTION
I noticed build output for `HelloAndroid.csproj` emits a collection of
junk files & directories that we do not need:

    > ls -r -n .\HelloAndroid\bin\Debug\net5.0-android\
    android.21-arm64
    android.21-x86
    ref
    com.microsoft.net5.helloandroid-Signed.apk
    com.microsoft.net5.helloandroid.apk
    HelloAndroid.deps.json
    HelloAndroid.dll
    HelloAndroid.pdb
    android.21-arm64\publish
    android.21-arm64\ref
    android.21-x86\publish
    android.21-x86\ref
    ref\HelloAndroid.dll

First issue to fix, is we shouldn't set `$(ProduceReferenceAssembly)`
for application projects. Applications shouldn't reference other
applications, so there isn't a need for `$(ProduceReferenceAssembly)`
to be `true` by default.

Xamarin.Android class libraries can have continue to set
`ProduceReferenceAssembly=true` by default as provided by the
dotnet/sdk:

https://github.com/dotnet/sdk/blob/dec3c441c2882dc7880e20e42835ce420b8d13f8/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L236-L238

This gets us down to:

    > ls -r -n .\HelloAndroid\bin\Debug\net5.0-android\
    android.21-arm64
    android.21-x86
    com.microsoft.net5.helloandroid-Signed.apk
    com.microsoft.net5.helloandroid.apk
    HelloAndroid.deps.json
    HelloAndroid.dll
    HelloAndroid.pdb
    android.21-arm64\publish
    android.21-x86\publish

Next, I found that the `PrepareForPublish` MSBuild target creates
directories with no obvious way to prevent it:

https://github.com/dotnet/sdk/blob/44f381b62d466565639d51847c9127afbe7062a9/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L102-L107

The solution here is to set `$(PublishDir)` to `$(OutputPath)` if we
are running a regular build. `dotnet publish` can continue to use a
custom `$(PublishDir)` if desired.

This gets us to:

    > ls -r -n .\HelloAndroid\bin\Debug\net5.0-android\
    android.21-arm64
    android.21-x86
    com.microsoft.net5.helloandroid-Signed.apk
    com.microsoft.net5.helloandroid.apk
    HelloAndroid.deps.json
    HelloAndroid.dll
    HelloAndroid.pdb

This project has `RuntimeIdentifiers=android.21-arm64;android.21-x86`
and so an inner build per RID is creating directories.

We can pass through `$(_OuterOutputPath)` and set `$(OutputPath)` and
`$(OutDir)` on the inner build running the
`_ComputeFilesToPublishForRuntimeIdentifiers` target.

Almost there! What is `HelloAndroid.deps.json`?

    > ls -r -n .\HelloAndroid\bin\Debug\net5.0-android\
    com.microsoft.net5.helloandroid-Signed.apk
    com.microsoft.net5.helloandroid.apk
    HelloAndroid.deps.json
    HelloAndroid.dll
    HelloAndroid.pdb

`HelloAndroid.deps.json` would only be needed if you wanted to
`dotnet  run HelloAndroid.dll`. This wouldn't make any sense to do this,
because you wouldn't be able to run an Android application on the host
machine.

Finally, if we set `GenerateDependencyFile=false` by default we can
get rid of `HelloAndroid.deps.json`!

    > ls -r -n .\HelloAndroid\bin\Debug\net5.0-android\
    com.microsoft.net5.helloandroid-Signed.apk
    com.microsoft.net5.helloandroid.apk
    HelloAndroid.dll
    HelloAndroid.pdb