### PR TITLE
[build] Bump XliffTasks version

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20206.1" PrivateAssets="all" />
+    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" PrivateAssets="all" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump XliffTasks to the latest version referenced by
dotnet/arcade/master@1b5940fd.

This will help prevent version conflicts for the NuGet package in case
any of xamarin-android's submodules update their XliffTasks references
to this newer version.

Changes: https://github.com/dotnet/xliff-tasks/compare/fdf42c08a386935000f64b1e0fd7d73fa9c961d5...975065e08307a459dc2649b1c852f5c4cafd2f91