### PR TITLE
[build] Add VSMac workaround for %(Link) metadata

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -18,6 +18,7 @@
     <BuildDependsOn>
       _CopyNDKTools;
       _GenerateXACommonProps;
+      _AssignRelativeParentLinkMetadata;
       $(BuildDependsOn);
       _CopyExtractedMultiDexJar;
       _BuildMonoScripts;
@@ -31,25 +32,29 @@
   <ItemGroup>
     <None Include="MSBuild\Novell\Novell.MonoDroid.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>..\..\Novell\Novell.MonoDroid.Common.targets</Link>
+      <!-- Work around Visual Studio for Mac `Invalid value for Link property`
+           project load error by using custom `%(_RelativeParentLink)` metadata
+           that gets copied into `%(Link)` at build time by
+           `_AssignRelativeParentLinkMetadata`. -->
+      <_RelativeParentLink>..\..\Novell\Novell.MonoDroid.Common.targets</_RelativeParentLink>
     </None>
     <None Include="MSBuild\Novell\Novell.MonoDroid.CSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>..\..\Novell\Novell.MonoDroid.CSharp.targets</Link>
+      <_RelativeParentLink>..\..\Novell\Novell.MonoDroid.CSharp.targets</_RelativeParentLink>
     </None>
     <None Include="MSBuild\Novell\MonoDroid.FSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>..\..\Novell\MonoDroid.FSharp.targets</Link>
+      <_RelativeParentLink>..\..\Novell\MonoDroid.FSharp.targets</_RelativeParentLink>
     </None>
     <None
         Include="MSBuild\Xamarin\Xamarin.Android.Sdk.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>..\Xamarin.Android.Sdk.props</Link>
+      <_RelativeParentLink>..\Xamarin.Android.Sdk.props</_RelativeParentLink>
     </None>
     <None
         Include="MSBuild\Xamarin\Xamarin.Android.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>..\Xamarin.Android.Sdk.targets</Link>
+      <_RelativeParentLink>..\Xamarin.Android.Sdk.targets</_RelativeParentLink>
     </None>
     <None
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Bindings.Before.targets">
@@ -297,6 +302,13 @@
         Overwrite="false"/>
     <ItemGroup>
       <FileWrites Include="$(_GeneratedProfileClass)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_AssignRelativeParentLinkMetadata">
+    <ItemGroup>
+      <None Condition=" '%(None._RelativeParentLink)' != '' ">
+        <Link>%(None._RelativeParentLink)</Link>
+      </None>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/content/problem/1073405/index.html
Context: https://github.com/mono/monodevelop/blob/fb12ccb7f4245eca20803661deaa37ead0ec35af/main/src/core/MonoDevelop.Core/MonoDevelop.Projects/ProjectFile.cs#L336-L337

In Visual Studio for Mac, `Xamarin.Android.Build.Tasks.csproj` was not
loading due to:

	Error while trying to load the project '/Users/macuser/Projects/xamarin-android/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj': Invalid value for Link property

The problem was that the `%(Link)` metadata for some of the files in the
project started with `..\`, which Visual Studio for Mac currently
rejects.  For comparison, Visual Studio on Windows accepts `%(Link)`
metadata starting with `..\` but hides the files from the Solution
Explorer.

To work around the error that happens in Visual Studio for Mac, add a
`MSBuild\..\` directory before the first `..\` in the affected `%(Link)`
metadata paths.  At the moment, this has a side effect of introducing a
confusing recursive `Xamarin.Android.Build.Tasks` item directory under
the `MSBuild` directory in the Solution pad, so also explicitly mark the
items as `%(Visible)`=`false` to prevent that.  On Windows, the
`%(Visible)`=`false` metadata means that the items stay hidden like they
were before.