### PR TITLE
[tests] cleanup Verbosity in MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -103,11 +103,9 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			using (var l = CreateDllBuilder (Path.Combine (path, lib.ProjectName), false, false)) {
 				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
-					l.Verbosity = LoggerVerbosity.Diagnostic;
 					l.Target = "Build";
 					Assert.IsTrue(l.Clean(lib), "Lib1 should have cleaned successfully");
 					Assert.IsTrue (l.Build (lib), "Lib1 should have built successfully");
-					b.Verbosity = LoggerVerbosity.Diagnostic;
 					b.ThrowOnBuildFailure = false;
 					b.Target = "Compile";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=true" }),
@@ -288,7 +286,6 @@ namespace Xamarin.Android.Build.Tests
 				proj.PackageReferences.Add (KnownPackages.GooglePlayServicesMaps_42_1021_1);
 				proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
 				using (var b = CreateApkBuilder (Path.Combine (projectPath, "Application1"), false, false)) {
-					b.Verbosity = LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 					var path = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/bin/packaged_resources");
 					var data = ZipHelper.ReadFileFromZip (path, "res/drawable/image1.9.png");
@@ -670,7 +667,6 @@ namespace UnnamedProject
 </LinearLayout>";
 			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForMissingResource");
 			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssertEx.Contains ("APT2260: ", b.LastBuildOutput);
@@ -687,9 +683,7 @@ namespace UnnamedProject
 <resources>
 </resources>"
 			});
-			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForInvalidDirectoryName");
-			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssertEx.Contains ("APT2144: ", b.LastBuildOutput);
@@ -711,9 +705,7 @@ namespace UnnamedProject
 	<string name=""hello"">Hello World, Click Me!</string>
 </resources>",
 			});
-			var projectPath = string.Format ($"temp/{TestName}");
-			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssertEx.Contains ("Invalid file name:", b.LastBuildOutput);
@@ -737,9 +729,7 @@ namespace UnnamedProject
 	<string name=""hellome"">Hello World, Click Me!</string>
 </resources>",
 			});
-			var projectPath = string.Format ($"temp/{TestName}");
-			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.DoesNotContain ("Invalid file name:", b.LastBuildOutput);
@@ -759,9 +749,7 @@ namespace UnnamedProject
 	<string name=""some_string_value"">Hello Me From the App</string>
 	<string name=""some_string_value"">Hello Me From the App 2</string>
 </resources>";
-			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForDuplicateResourceinApp");
-			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssertEx.Contains ("APT2057: ", b.LastBuildOutput);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -116,7 +116,6 @@ namespace Xamarin.Android.Build.Tests
 				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
 					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 				b.ThrowOnBuildFailure = false;
-				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)
 					return;
@@ -215,7 +214,6 @@ namespace Xamarin.Android.Build.Tests
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, testPath);
 			var sb = new SolutionBuilder ("BuildAMassiveApp.sln") {
 				SolutionPath = Path.Combine (Root, testPath),
-				Verbosity = LoggerVerbosity.Diagnostic,
 			};
 			var app1 = new XamarinAndroidApplicationProject () {
 				TargetFrameworkVersion = sb.LatestTargetFrameworkVersion (),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -239,7 +239,6 @@ namespace Com.Ipaulpro.Afilechooser {
 				};
 				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\AdalBinding\\UnnamedProject.csproj"));
 				using (var b = CreateApkBuilder ("temp/MergeAndroidManifest/App")) {
-					b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 					var manifest = File.ReadAllText (Path.Combine (Root, b.ProjectDirectory, "obj", "Release", "android", "AndroidManifest.xml"));
 					Assert.IsTrue (manifest.Contains ("com.microsoft.aad.adal.AuthenticationActivity"), "manifest merge failure");
@@ -283,7 +282,6 @@ namespace Com.Ipaulpro.Afilechooser {
 				var proj = new XamarinAndroidApplicationProject ();
 				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", $"..\\MultiDexBinding\\{binding.ProjectName}.csproj"));
 				using (var b = CreateApkBuilder ("temp/BindingCustomJavaApplicationClass/App")) {
-					b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				}
 			}
@@ -327,7 +325,6 @@ namespace Com.Ipaulpro.Afilechooser {
 			});
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var bindingBuilder = CreateDllBuilder (Path.Combine (path, "Binding"))) {
-				bindingBuilder.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
 				var proj = new XamarinAndroidApplicationProject ();
 				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\Binding\\UnnamedProject.csproj"));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1291,8 +1291,7 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 		public void BuildBasicApplicationCheckMdbRepeatBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckMdbRepeatBuild", false)) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (
 					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.mdb")) ||
@@ -1392,8 +1391,7 @@ namespace App1
 		public void BuildBasicApplicationCheckMdbAndPortablePdb ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckMdbAndPortablePdb")) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
 					WebContentFileNameFromAzure = "PdbTestLibrary.dll"
 				};
@@ -1490,8 +1488,7 @@ namespace App1
 		public void BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun", false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "Build should not have failed");
 				Assert.IsFalse (
@@ -1549,8 +1546,7 @@ namespace App1
 			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
 				MetadataValues = "Link=Resources\\layout-xhdpi\\Test.axml"
 			});
-			using (var b = CreateApkBuilder ("temp/DuplicateValuesInResourceCaseMap")) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
@@ -1749,30 +1745,24 @@ namespace App1
 		[TestCaseSource (nameof (BuildApplicationWithJavaSourceChecks))]
 		public void BuildApplicationWithJavaSource (bool isRelease, bool expectedResult)
 		{
-			var path = String.Format ("temp/BuildApplicationWithJavaSource_{0}_{1}",
-				isRelease, expectedResult);
-			try {
-				var proj = new XamarinAndroidApplicationProject () {
-					IsRelease = isRelease,
-					OtherBuildItems = {
-						new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
-							TextContent = () => "public class TestMe { }",
-							Encoding = Encoding.ASCII
-						},
-					}
-				};
-				proj.SetProperty ("TargetFrameworkVersion", "v5.0");
-				using (var b = CreateApkBuilder (path)) {
-					b.Verbosity = LoggerVerbosity.Diagnostic;
-					b.ThrowOnBuildFailure = false;
-					Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}", expectedResult ? "succeeded" : "failed");
-					if (expectedResult)
-						StringAssertEx.DoesNotContain ("XA9002", b.LastBuildOutput, "XA9002 should not have been raised");
-					else
-						StringAssertEx.Contains ("XA9002", b.LastBuildOutput, "XA9002 should have been raised");
-					Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
+						TextContent = () => "public class TestMe { }",
+						Encoding = Encoding.ASCII
+					},
 				}
-			} finally {
+			};
+			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}", expectedResult ? "succeeded" : "failed");
+				if (expectedResult)
+					StringAssertEx.DoesNotContain ("XA9002", b.LastBuildOutput, "XA9002 should not have been raised");
+				else
+					StringAssertEx.Contains ("XA9002", b.LastBuildOutput, "XA9002 should have been raised");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
 
@@ -1834,10 +1824,9 @@ namespace App1
 			proj.SetProperty (proj.ActiveConfigurationProperties, "MonoSymbolArchive", monoSymbolArchive);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", debugType);
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
+			using (var b = CreateApkBuilder ()) {
 				if (aotAssemblies && !b.CrossCompilerAvailable (string.Join (";", abis)))
 					Assert.Ignore ("Cross compiler was not available");
-				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
@@ -2671,8 +2660,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				AndroidUseSharedRuntime = false,
 			};
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", "portable");
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckPdb", false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
 					WebContentFileNameFromAzure = "PdbTestLibrary.dll"
 				};
@@ -2737,20 +2725,19 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		[Test]
 		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
 		{
-			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedParser.ToString ());
-			using (var builder = CreateApkBuilder (path, false ,false)) {
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "UpdateAndroidResources";
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been run.");
-				var librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
+				var intermediate = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath);
+				var librarycache = Path.Combine (intermediate, "designtime", "libraryprojectimports.cache");
 				Assert.IsTrue (File.Exists (librarycache), $"'{librarycache}' should exist.");
-				librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "libraryprojectimports.cache");
+				librarycache = Path.Combine (intermediate, "libraryprojectimports.cache");
 				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
@@ -2758,7 +2745,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (builder.Clean (proj), "Clean Should have succeeded");
 				builder.Target = "_CleanDesignTimeIntermediateDir";
 				Assert.IsTrue (builder.Build (proj), "_CleanDesignTimeIntermediateDir should have succeeded");
-				librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
+				librarycache = Path.Combine (intermediate, "designtime", "libraryprojectimports.cache");
 				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
 			}
 		}
@@ -2780,7 +2767,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			using (var libb = CreateDllBuilder (Path.Combine (path, libproj.ProjectName), false, false)) {
 				Assert.IsTrue (libb.Build (libproj), "Build should have succeeded.");
 				using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
-					builder.Verbosity = LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 					Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
 						"The __library_projects__ directory should exist.");
@@ -2990,7 +2976,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "v8.1")))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				builder.ThrowOnBuildFailure = false;
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "AndroidPrepareForBuild";
 				Assert.IsFalse (builder.Build (proj, parameters: new string [] {
 					$"AndroidSdkBuildToolsVersion=24.0.1",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -696,7 +696,6 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName)
 		{
 			return new LocalBuilder {
-				Verbosity = LoggerVerbosity.Diagnostic,
 				BuildLogFile = $"{baseLogFileName}.log"
 			};
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
@@ -284,7 +284,6 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName, string projectDir)
 		{
 			return new LocalBuilder (projectDir) {
-				Verbosity = LoggerVerbosity.Diagnostic,
 				BuildLogFile = $"{baseLogFileName}.log"
 			};
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -159,7 +159,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, "AndroidPackageFormat", packageFormat);
 			proj.SetAndroidSupportedAbis (supportedAbis);
 			using (var b = CreateApkBuilder ()) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "first build failed");
 				var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -19,8 +19,7 @@ namespace Xamarin.Android.Build.Tests
 		public void BasicApplicationRepetitiveBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/BasicApplicationRepetitiveBuild", cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "first build failed");
 				var firstBuildTime = b.LastBuildTime;
@@ -231,7 +230,6 @@ namespace Lib
 			var testPath = Path.Combine ("temp", "AllProjectsHaveSameOutputDirectory");
 			var sb = new SolutionBuilder("AllProjectsHaveSameOutputDirectory.sln") {
 				SolutionPath = Path.Combine (Root, testPath),
-				Verbosity = LoggerVerbosity.Diagnostic,
 			};
 
 			var app1 = new XamarinAndroidApplicationProject () {
@@ -369,7 +367,6 @@ namespace Lib2
 					};
 					app.SetAndroidSupportedAbis ("armeabi-v7a");
 					using (var builder = CreateApkBuilder (Path.Combine (path, "App"))) {
-						builder.Verbosity = LoggerVerbosity.Diagnostic;
 						Assert.IsTrue (builder.Build (app), "app 1st. build failed");
 
 						var libfoo = ZipHelper.ReadFileFromZip (Path.Combine (Root, builder.ProjectDirectory, app.OutputPath, app.PackageName + "-Signed.apk"),
@@ -1028,7 +1025,6 @@ namespace Lib2
 				b.CleanupAfterSuccessfulBuild = false;
 				b.CleanupOnDispose = false;
 				b.ThrowOnBuildFailure = false;
-				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.AreEqual (expectedResult, b.Build (proj, doNotCleanupOnUpdate: true), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)
 					return;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
@@ -313,7 +313,6 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName)
 		{
 			return new LocalBuilder {
-				Verbosity = LoggerVerbosity.Diagnostic,
 				BuildLogFile = $"{baseLogFileName}.log"
 			};
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -39,7 +39,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, "AndroidPackageFormat", packageFormat);
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ()) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "first build failed");
 				var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
@@ -162,8 +161,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.SetAndroidSupportedAbis ("x86");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : "so");
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
@@ -283,8 +281,7 @@ namespace Xamarin.Android.Build.Tests
 				TextContent = () => "namespace Foo { class Bar : Java.Lang.Object { } }"
 			});
 			proj.SetProperty (proj.DebugProperties, "AndroidPackageNamingPolicy", "Lowercase");
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var text = b.Output.GetIntermediaryAsText (b.Output.IntermediateOutputPath, Path.Combine ("android", "src", "foo", "Bar.java"));
 				Assert.IsTrue (text.Contains ("package foo;"), "expected package not found in the source.");
@@ -335,9 +332,8 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			proj.SetProperty (proj.DebugProperties, "AndroidPackageNamingPolicy", "Lowercase");
 			foreach (var package in packages)
 				proj.PackageReferences.Add (package);
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 				var obj = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Android.Build.Tests
 			return new ProjectBuilder (directory) {
 				CleanupAfterSuccessfulBuild = cleanupAfterSuccessfulBuild,
 				CleanupOnDispose = cleanupOnDispose,
-				Verbosity = LoggerVerbosity.Diagnostic,
 				Root = XABuildPaths.TestOutputDirectory,
 			};
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -33,7 +33,7 @@ namespace Xamarin.ProjectTools
 		/// Passes /m:N to MSBuild, defaults to null to omit the /m parameter completely.
 		/// </summary>
 		public int? MaxCpuCount { get; set; }
-		public LoggerVerbosity Verbosity { get; set; }
+		public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Diagnostic;
 		public IEnumerable<string> LastBuildOutput {
 			get {
 				if (!string.IsNullOrEmpty (buildLogFullPath) && File.Exists (buildLogFullPath)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -13,7 +13,6 @@ namespace Xamarin.ProjectTools
 		public ProjectBuilder (string projectDirectory)
 		{
 			ProjectDirectory = projectDirectory;
-			Verbosity = LoggerVerbosity.Normal;
 			Target = "Build";
 			ThrowOnBuildFailure = true;
 			BuildLogFile = "build.log";

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -62,8 +62,7 @@ namespace Xamarin.Android.Build.Tests
 			if (isRelease) {
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
 				Assert.IsTrue (builder.Install (proj));
 				Assert.IsTrue (builder.Output.AreTargetsAllBuilt ("_Upload"), "_Upload should have built completely.");
@@ -93,8 +92,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
 				Assert.IsTrue (builder.Install (proj));
 				Assert.AreEqual ($"package:{proj.PackageName}", RunAdbCommand ($"shell pm list packages {proj.PackageName}").Trim (),
@@ -153,8 +151,7 @@ namespace Xamarin.Android.Build.Tests
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
 				Assert.IsTrue (builder.Install (proj));
 				Assert.AreEqual ($"package:{proj.PackageName}", RunAdbCommand ($"shell pm list packages {proj.PackageName}").Trim (),
@@ -202,8 +199,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
 			var abis = new [] { "armeabi-v7a", "x86" };
 			proj.SetAndroidSupportedAbis (abis);
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false, false)) {
-				builder.Verbosity = LoggerVerbosity.Diagnostic;
+			using (var builder = CreateApkBuilder ()) {
 				if (RunAdbCommand ("shell pm list packages Mono.Android.DebugRuntime").Trim ().Length != 0)
 					RunAdbCommand ("uninstall Mono.Android.DebugRuntime");
 				Assert.IsTrue (builder.Install (proj));
@@ -417,7 +413,6 @@ namespace Xamarin.Android.Build.Tests
 				Encoding = Encoding.ASCII,
 			});
 			using (var b = CreateApkBuilder (path, false, false)) {
-				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj, environmentVariables: envVar), "Build should have succeeded.");
 				if (packageFormat == "apk") {


### PR DESCRIPTION
Context: https://build.azdo.io/4092693

The `SolutionBuildSeveralProjects` test has been failing with a really
short build log:

    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(1333,2): error MSB3374: The last access/last write time on file "C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib9\bin\Debug\Lib9.dll.mdb" cannot be set. The process cannot access the file 'C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib9\bin\Debug\Lib9.dll.mdb' because it is being used by another process. [C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\App1\App1.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\SolutionBuildSeveralProjects.sln /t:Build /noconsolelogger "/flp1:LogFile=C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\build.log;Encoding=UTF-8;Verbosity=quiet" /restore /maxCpuCount:4 /nodeReuse:false @"C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\project.rsp"
    Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.

    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe /noconsolelogger /bl:C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\msbuild.binlog /flp1:LogFile=C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\build.log;Encoding=UTF-8;Verbosity=quiet /maxCpuCount:4 /nodeReuse:false /p:BuildingInsideVisualStudio=False /p:AndroidSdkDirectory=C:\Users\AzDevOps\android-toolchain\sdk /p:AndroidNdkDirectory=C:\Users\AzDevOps\android-toolchain\ndk /p:JavaSdkDirectory=C:\Users\AzDevOps\android-toolchain\jdk-11 /restore /t:Build C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\SolutionBuildSeveralProjects.sln

This is happening because `SolutionBuilder` doesn't use
`LoggerVerbosity.Diagnostic` by default.

Since I'm not sure we would *ever* want the verbosity to *not* be
diagnostic, I changed the default value for `Builder.Verbosity` to be
diagnostic.

I removed any code that was setting `Verbosity` and cleaned up
`CreateApkBuilder()` usage like this along the way:

```diff
-using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+using (var b = CreateApkBuilder ()) {
```

There is one place in `PerformanceTest` where we use
`LoggerVerbosity.Quiet`. This is still a valid use of the property.

I will fix the actual problem with `SolutionBuildSeveralProjects` in
another PR.