### PR TITLE
[Xamarin.Android.Build.Tasks] fix -m:4 collision in _ConvertPdbFiles

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1337,7 +1337,7 @@ because xbuild doesn't support framework reference assemblies.
 		Outputs="@(_ConvertedMdbFiles)"
 		DependsOnTargets="_CollectPdbFiles">
 	<ConvertDebuggingFiles Files="@(_ResolvedPdbFiles)" />
-	<Touch Files="@(_ConvertedMdbFiles)" />
+	<Touch Files="@(_ConvertedMdbFiles)" ContinueOnError="true" />
 	<ItemGroup>
 		<FileWrites Include="@(_ConvertedMdbFiles)" />
 	</ItemGroup>


### PR DESCRIPTION
Context: https://build.azdo.io/4092693

The `SolutionBuildSeveralProjects` is failing on CI occasionally with:

    Xamarin.Android.Common.targets(1333,2): error MSB3374: The last access/last write time on file "C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib9\bin\Debug\Lib9.dll.mdb" cannot be set. The process cannot access the file 'C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib9\bin\Debug\Lib9.dll.mdb' because it is being used by another process.

Or another example hit 2 errors:

    Xamarin.Android.Common.targets(1333,2): error MSB3375: The file "C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib4\bin\Debug\Lib4.dll.mdb" does not exist.
    Xamarin.Android.Common.targets(1333,2): error MSB3374: The last access/last write time on file "C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib5\bin\Debug\Lib5.dll.mdb" cannot be set. The process cannot access the file 'C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib5\bin\Debug\Lib5.dll.mdb' because it is being used by another process.

I can't reproduce this locally, even with `[Repeat(10)]` added to the
test...

However, this is displaying a real problem. This test builds a
solution file with multiple Xamarin.Android application projects
referencing the same 10 class library projects. The solution is built
with `-m:4`, so that projects are built in parallel.

We are only hitting the problem, because apparently we are using
`DebugType=Full` by default for class libraries in our MSBuild tests.

I eventually want to deprecate `DebugType=Full` or `DebugType=PdbOnly`
*anyway*, so let's try adding a `ContinueOnError="true"` to the
`<Touch/>` call for now.