### PR TITLE
[tests] add delay for LibraryProjectTargetsDoNotBreak

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -498,6 +498,7 @@ namespace Lib2
 					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
 				}
 
+				WaitFor (1000);
 				proj.Touch ("foo\\armeabi-v7a\\libtest.so");
 				proj.Touch ("Assets\\foo.txt");
 


### PR DESCRIPTION
Context: https://build.azdo.io/4092693

The `LibraryProjectTargetsDoNotBreak` test is occasionally failing on
macOS with:

    _CreateAar should not be skipped on second build!
    Expected: False
    But was:  True

I can't reproduce this locally, even with `[Repeat (10)]`.

I think what is happening is the `Touch()` calls only have a 1 second
resolution as mentioned by the comments in `XamarinProject`:

    // LastWriteTime is inaccurate without milliseconds, but neither mono FileSystemInfo nor UnixFileSystemInfo (in Mono.Posix)
    // handles this precisely. And that causes comparison problem.
    // To avoid this issue, we compare time after removing milliseconds field here.

Adding a `System.Threading.Thread.Sleep(1000)` to see if this helps.

I don't think we can do something like `DateTime.UtcNow.AddSeconds(1)`,
as this may interfere with the third build in this test.