### PR TITLE
[CredScan] fix credential scanner failures

### DIFF
--- a/build-tools/automation/CredScanSuppressions.json
+++ b/build-tools/automation/CredScanSuppressions.json
@@ -26,6 +26,10 @@
             "_justification": "Android API documentation, does not contain a password."
         },
         {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Crypto\\ISecretKey.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
             "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Crypto\\KeyAgreementSpi.xml",
             "_justification": "Android API documentation, does not contain a password."
         },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -62,7 +62,7 @@ namespace Xamarin.ProjectTools
       ],
       ""api_key"": [
         {
-          ""current_key"": ""AIzaSyCfJp9rrUEaA07vdoGvGQgJqm0Fa9cJGiw""
+          ""current_key"": ""NOT_A_REAL_KEY""
         }
       ],
       ""services"": {


### PR DESCRIPTION
Context: https://build.azdo.io/4095069

I started seeing two CredScan failures on PRs today. The first:

    external\android-api-docs\docs\Mono.Android\en\Javax.Crypto\ISecretKey.xml(2,): error : SecretinFile : {{Searcher}}CSCAN-GENERAL0060
    {{Code}}See ISecretKey.xml line 2 for the code resulting in match
    {{Info}}Found General Password.
    {{Suggest}}Validate file contains secrets, remove, roll credential, and use approved store. For additional information on secret remediation see https://aka.ms/credscan

We had similar suppressions for other files, so I added an exception
for this one in `CredScanSuppressions.json`.

The second:

    src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Android\XamarinFormsMapsApplicationProject.cs(65,): error : SecretinFile : {{Searcher}}CSCAN-GOOG0010
    {{Code}}See XamarinFormsMapsApplicationProject.cs line 65 for the code resulting in match
    {{Info}}Found Google API key.
    {{Suggest}}Validate file contains secrets, remove, roll credential, and use approved store. For additional information on secret remediation see https://aka.ms/credscan

The key in `XamarinFormsMapsApplicationProject`, I think we can just
put a string that is not a valid key. The MSBuild tests won't actually
check that Google Maps works, just that it builds.

The original key was added in 323f9866 coming from a sample in
xamarin/GooglePlayServicesComponents, but I don't think it is valid
anymore anyway:

https://github.com/xamarin/GooglePlayServicesComponents/blob/fc057c754e04d3e719d8c111d03d60eb2467b9ce/source/com.google.android.gms/play-services-basement/buildtasks.tests/google-services.json