### PR TITLE
[Mono.Android] Remove problematic default interface method Cursor.getNotificationUris.

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1630,7 +1630,8 @@
        generic parameters.  Since this is a default method we can just remove it until that bug is fixed.
        https://github.com/xamarin/java.interop/issues/699 -->
   <remove-node api-since="30" path="/api/package[@name='android.database']/interface[@name='Cursor']/method[@name='setNotificationUris' and count(parameter)=2 and parameter[1][@type='android.content.ContentResolver'] and parameter[2][@type='java.util.List&lt;android.net.Uri&gt;']]" />
-  
+  <remove-node api-since="30" path="/api/package[@name='android.database']/interface[@name='Cursor']/method[@name='getNotificationUris']" />
+
   <!--
     ***********************************************************************
     THE FOLLOWING LINES MUST BE CREATED FOR ANY NEW PLATFORM THAT IS ADDED.


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/699

In https://github.com/xamarin/xamarin-android/pull/5124 we removed `Cursor.setNotificationUris (...)` because it causes binding problems when it is overridden.  `Cursor.getNotificationUris ()` was not removed because it was believed that the issue was confined to parameters, however it affects return values as well.

Remove default interface method `Cursor.getNotificationUris ()` until `generator` can be properly fixed.