### PR TITLE
[tests] Clear adb log after running the test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -40,6 +40,8 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 
+			ClearAdbLogcat ();
+
 			base.CleanupTest ();
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.CopyNuGetConfig (relativeProjDir);
 			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
 
+			ClearAdbLogcat ();
 			Assert.IsTrue (dotnet.Run (), "`dotnet run` should succeed");
 			bool didLaunch = WaitForActivityToStart (proj.PackageName, "MainActivity",
 				Path.Combine (fullProjDir, "logcat.log"), 30);

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -41,7 +41,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.CopyNuGetConfig (relativeProjDir);
 			var dotnet = new DotNetCLI (proj, Path.Combine (fullProjDir, proj.ProjectFilePath));
 
-			ClearAdbLogcat ();
 			Assert.IsTrue (dotnet.Run (), "`dotnet run` should succeed");
 			bool didLaunch = WaitForActivityToStart (proj.PackageName, "MainActivity",
 				Path.Combine (fullProjDir, "logcat.log"), 30);


### PR DESCRIPTION
To make sure we don't get activity displayed message from previous run.

`WaitForActivityToStart` doesn't know the `PID`, so it can match the
previous run.

I was curious why CI test run doesn't show the crash I see when running
manualy on hardware device. Let see whether it will catch it with this
change.

Update: it works and the tests fails now as it should. Opened issue
https://github.com/xamarin/xamarin-android/issues/5166,
which should be fixed by
https://github.com/xamarin/xamarin-android/pull/5145