### PR TITLE
Bump to r8 2.1.67

### DIFF
--- a/Documentation/release-notes/r8-2.1.67.md
+++ b/Documentation/release-notes/r8-2.1.67.md
@@ -1,0 +1,4 @@
+### D8/R8 version update to 2.1.67
+
+The version of the [D8 dexer and R8 shrinker](https://r8.googlesource.com/r8)
+included in Xamarin.Android has been updated from 1.6.82 to 2.1.67.

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -9,17 +9,13 @@ java {
     targetCompatibility = ext.javaTargetVer
 }
 
-// See: https://r8.googlesource.com/r8/+/refs/tags/1.6.82/build.gradle#55
 repositories {
-    maven {
-       url 'http://storage.googleapis.com/r8-deps/maven_mirror/'
-    }
     google()
     mavenCentral()
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '1.6.82'
+    compile group: 'com.android.tools', name: 'r8', version: '2.1.67'
 }
 
 jar {


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools/r8/2.1.67
Context: https://r8.googlesource.com/r8/+/cc1556056e7317b5b4350c6d92800895e9115550

Google appears to have made several releases to r8 in the past few months; we should update.