### PR TITLE
Bump to bundletool 1.2.0

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -110,7 +110,7 @@
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">b2be9c80582174e645d3736daa0d44d8610b38a8.</XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>30.0.2</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.14.0</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.2.0</XABundleToolVersion>
     <XAManifestMergerToolVersion Condition="'$(XAManifestMergerToolVersion)' == ''">26.5.0</XAManifestMergerToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != '' ">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' ">$(XamarinAndroidSourcePath)\packages</XAPackagesDir>

--- a/Documentation/release-notes/bundletool-1.2.0.md
+++ b/Documentation/release-notes/bundletool-1.2.0.md
@@ -1,0 +1,8 @@
+### bundletool version update to 1.2.0
+
+The version of the [`bundletool`][bundletool] executable included in
+Xamarin.Android has been updated from 0.14.0 to [1.2.0][bundletool-1.2.0],
+bringing in several improvements and bug fixes.
+
+[bundletool]: https://developer.android.com/studio/command-line/bundletool
+[bundletool-1.2.0]: https://github.com/google/bundletool/releases/tag/1.2.0


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/1.2.0

Changes (from release notes)

0.15.0

* Support output-zip option for bundletool extract-apks command that
  allows to output requested apks into zip archive.
* Forbid application downgrades in bundletool install-multiple-apks.

1.0.0

* Merge unconditional install-time modules into base module by
  default.
* Add --overwrite (overwriteOutput) option to BuildBundleCommand.

1.1.0

* ADB support for install-multi-apks
* Verbose log for build-apks
* Fix Wear APK path resolution

1.2.0

* Support options to generate system APKs with uncompressed native
  libraries and uncompressed dex.