### PR TITLE
[ci] Improve test dependency installation times

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1080,6 +1080,9 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -410,6 +410,9 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
     - task: CmdLine@2
       displayName: install apkdiff dotnet tool
       inputs:
@@ -680,6 +683,9 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
@@ -841,6 +847,9 @@ stages:
       clean: all
     steps:
     - template: yaml-templates/setup-test-environment.yaml
+
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
 
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -51,13 +51,13 @@ steps:
 - script: >
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
-    mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+    mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidTestDependencies --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: >
     ${{ parameters.xaSourcePath }}\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI &&
-    ${{ parameters.xaSourcePath }}\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+    ${{ parameters.xaSourcePath }}\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidTestDependencies --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 

--- a/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
+++ b/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Android.Prepare
 		public bool IsMultiVersion        { get; }
 		public bool NoSubdirectory        { get; }
 		public string? PkgRevision        { get; }
+		public AndroidToolchainComponentType DependencyType { get; }
 
-		public AndroidToolchainComponent (string name, string destDir, Uri? relativeUrl = null, bool isMultiVersion = false, bool noSubdirectory = false, string? pkgRevision = null)
+		public AndroidToolchainComponent (string name, string destDir, Uri? relativeUrl = null, bool isMultiVersion = false, bool noSubdirectory = false, string? pkgRevision = null,
+			AndroidToolchainComponentType dependencyType = AndroidToolchainComponentType.CoreDependency)
 		{
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
@@ -25,6 +27,7 @@ namespace Xamarin.Android.Prepare
 			IsMultiVersion = isMultiVersion;
 			NoSubdirectory = noSubdirectory;
 			PkgRevision = pkgRevision;
+			DependencyType = dependencyType;
 		}
 	}
 
@@ -34,4 +37,14 @@ namespace Xamarin.Android.Prepare
 			: base (name, Path.Combine ("platforms", $"android-{apiLevel}"), pkgRevision: pkgRevision)
 		{}
 	}
+
+	[Flags]
+	enum AndroidToolchainComponentType
+	{
+		CoreDependency          = 0,
+		BuildDependency         = 1 << 0,
+		EmulatorDependency      = 1 << 1,
+		All                     = CoreDependency | BuildDependency | EmulatorDependency,
+	}
+
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -19,9 +19,11 @@ namespace Xamarin.Android.Prepare
 		const string JetBrainsOpenJDK11Release = "944.14";
 		static readonly string JetBrainsOpenJDK11DownloadVersion = JetBrainsOpenJDK11Version.Replace ('.', '_');
 
-		const string JetBrainsOpenJDK8Version = "8.202";
+		const string JetBrainsOpenJDK8VersionMinor = "8";
+		const string JetBrainsOpenJDK8VersionRevision = "202";
+		const string JetBrainsOpenJDK8VersionFull = "1." + JetBrainsOpenJDK8VersionMinor + ".0." + JetBrainsOpenJDK8VersionRevision;
 		const string JetBrainsOpenJDK8Release = "1483.37";
-		static readonly string JetBrainsOpenJDK8DownloadVersion = JetBrainsOpenJDK8Version.Replace ('.', 'u');
+		static readonly string JetBrainsOpenJDK8DownloadVersion = $"{JetBrainsOpenJDK8VersionMinor}u{JetBrainsOpenJDK8VersionRevision}";
 
 		const string CorrettoDistVersion = "8.242.08.1";
 		const string CorrettoUrlPathVersion = CorrettoDistVersion;
@@ -59,7 +61,7 @@ namespace Xamarin.Android.Prepare
 			public static readonly Version JetBrainsOpenJDK11Version = new Version (Configurables.JetBrainsOpenJDK11Version);
 			public static readonly Version JetBrainsOpenJDK11Release = new Version (Configurables.JetBrainsOpenJDK11Release);
 
-			public static readonly Version JetBrainsOpenJDK8Version = new Version (Configurables.JetBrainsOpenJDK8Version);
+			public static readonly Version JetBrainsOpenJDK8Version = new Version (Configurables.JetBrainsOpenJDK8VersionFull);
 			public static readonly Version JetBrainsOpenJDK8Release = new Version (Configurables.JetBrainsOpenJDK8Release);
 
 			// Mono runtimes

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",                            destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7", dependencyType: AndroidToolchainComponentType.EmulatorDependency),
-				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision, dependencyType: AndroidToolchainComponentType.BuildDependency),
+				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
 				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"commandlinetools-{cltOsTag}-{CommandLineToolsVersion}",
 					destDir: Path.Combine ("cmdline-tools", CommandLineToolsFolder), isMultiVersion: true),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -62,17 +62,16 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-29_r01",   apiLevel: "29", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
 
-				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1"),
-				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0"),
-				new AndroidToolchainComponent ($"x86-29_r07-{osTag}",                               destDir: Path.Combine ("system-images", "android-29", "default", "x86"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7"),
-				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",                            destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7"),
-				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
+				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
+				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0", dependencyType: AndroidToolchainComponentType.BuildDependency),
+				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",                            destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7", dependencyType: AndroidToolchainComponentType.EmulatorDependency),
+				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision, dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"commandlinetools-{cltOsTag}-{CommandLineToolsVersion}",
 					destDir: Path.Combine ("cmdline-tools", CommandLineToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"{XAPlatformToolsPackagePrefix}platform-tools_r{XAPlatformToolsVersion}-{osTag}", destDir: "platform-tools", pkgRevision: XAPlatformToolsVersion),
 				new AndroidToolchainComponent ($"sdk-tools-{osTag}-4333796",                        destDir: "tools", pkgRevision: "26.1.1"),
-				new AndroidToolchainComponent ($"emulator-{osTag}-{EmulatorVersion}",               destDir: "emulator", pkgRevision: EmulatorPkgRevision),
+				new AndroidToolchainComponent ($"emulator-{osTag}-{EmulatorVersion}",               destDir: "emulator", pkgRevision: EmulatorPkgRevision, dependencyType: AndroidToolchainComponentType.EmulatorDependency),
 				new AndroidToolchainComponent ($"cmake-{AndroidCmakeVersion}-{osTag}-x86_64",       destDir: Path.Combine ("cmake", AndroidCmakeVersionPath), isMultiVersion: true, noSubdirectory: true, pkgRevision: "3.10.2"),
 			};
 		}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Xamarin.Android.Prepare
+{
+	[Scenario (isDefault: false)]
+	partial class Scenario_AndroidTestDependencies : ScenarioNoStandardEndSteps
+	{
+		public Scenario_AndroidTestDependencies () 
+			: base ("AndroidTestDependencies", "Install Android SDK and OpenJDK test dependencies.")
+		{}
+
+		protected override void AddSteps (Context context)
+		{
+			Steps.Add (new Step_InstallJetBrainsOpenJDK8 ());
+			Steps.Add (new Step_InstallJetBrainsOpenJDK11 ());
+			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));
+
+			// disable installation of missing programs...
+			context.SetCondition (KnownConditions.AllowProgramInstallation, false);
+
+			// ...but do not signal an error when any are missing
+			context.SetCondition (KnownConditions.IgnoreMissingPrograms, true);
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_EmulatorTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_EmulatorTestDependencies.cs
@@ -1,19 +1,17 @@
-﻿using System;
+using System;
 
 namespace Xamarin.Android.Prepare
 {
 	[Scenario (isDefault: false)]
-	partial class Scenario_AndroidToolchain : ScenarioNoStandardEndSteps
+	partial class Scenario_EmulatorTestDependencies : ScenarioNoStandardEndSteps
 	{
-		public Scenario_AndroidToolchain () 
-			: base ("AndroidToolchain", "Install Android SDK, NDK and OpenJDK.")
+		public Scenario_EmulatorTestDependencies () 
+			: base ("EmulatorTestDependencies", "Install Android SDK emulator dependencies.")
 		{}
 
 		protected override void AddSteps (Context context)
 		{
-			Steps.Add (new Step_InstallJetBrainsOpenJDK8 ());
-			Steps.Add (new Step_InstallJetBrainsOpenJDK11 ());
-			Steps.Add (new Step_Android_SDK_NDK ());
+			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.EmulatorDependency));
 
 			// disable installation of missing programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.cs
@@ -174,6 +174,7 @@ namespace Xamarin.Android.Prepare
 				}
 
 				cv = line.Substring (line.IndexOf ('=') + 1).Trim ('"');
+				cv = cv.Replace ("_", ".");
 				break;
 			}
 

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -131,7 +131,8 @@
     <Compile Include="OperatingSystems\OS.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenarios\Scenario_DetermineApplicableTests.cs" />
-    <Compile Include="Scenarios\Scenario_AndroidToolchain.cs" />
+    <Compile Include="Scenarios\Scenario_EmulatorTestDependencies.cs" />
+    <Compile Include="Scenarios\Scenario_AndroidTestDependencies.cs" />
     <Compile Include="Scenarios\Scenario_PrepareExternal.cs" />
     <Compile Include="Scenarios\Scenario_PrepareExternalGitDependencies.cs" />
     <Compile Include="Scenarios\Scenario_PrepareImageDependencies.cs" />


### PR DESCRIPTION
The `AndroidToolchain` scenario previously used for installing Android
test dependencies has been replaced by two new scenarios responsible
for less work overall.  The `AndroidTestDependencies` scenario is
responsible for installing both JDKs, as well as the core Android SDK
components required for all test jobs.  The `EmulatorTestDependencies`
scenario is responsible for installing the Android SDK `emulator` tool,
as well as the `x86_64` system image that is used for emulator tests.

The majority of test jobs now skip the download of roughly 2 GB of
components.  The unused `x86` emulator system image has been removed,
and the `x86_64` system image, emulator, docs, and m2repository
components should not be needed for tests that don't require a device.
Jobs requiring emulator components skip roughly 1.2 GB of unnecessary
components (`x86` image, docs, m2repository).

A minor bug in JDK 1.8 version detection has also been fixed, which
prevents JDK 1.8 from being re-installed every time.