### PR TITLE
Bump to .NET 5.0.100-rc.2.20480.7

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
@@ -66,13 +66,13 @@ Specifies the supported Android platform versions for this SDK.
 				foreach (AndroidVersion version in versions.InstalledBindingVersions
 						.Where (v => v.ApiLevel >= MinimumApiLevel)
 						.OrderBy (v => v.ApiLevel)) {
-					writer.WriteStartElement ("AndroidSdkSupportedTargetPlatform");
+					writer.WriteStartElement ("AndroidSdkSupportedTargetPlatformVersion");
 					writer.WriteAttributeString ("Include", version.ApiLevel.ToString ());
-					writer.WriteEndElement (); // </AndroidSdkSupportedTargetPlatform>
+					writer.WriteEndElement (); // </AndroidSdkSupportedTargetPlatformVersion>
 				}
-				writer.WriteStartElement ("SdkSupportedTargetPlatform");
+				writer.WriteStartElement ("SdkSupportedTargetPlatformVersion");
 				writer.WriteAttributeString ("Condition", " '$(TargetPlatformIdentifier)' == 'Android' ");
-				writer.WriteAttributeString ("Include", "@(AndroidSdkSupportedTargetPlatform)");
+				writer.WriteAttributeString ("Include", "@(AndroidSdkSupportedTargetPlatformVersion)");
 
 				writer.WriteEndDocument (); // </Project>
 			}

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -52,7 +52,7 @@ variables:
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
-  DotNetCorePreviewVersion: 5.0.100-rc.2.20459.1
+  DotNetCorePreviewVersion: 5.0.100-rc.2.20480.7
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/commit/37d5ade0f863258a78313b8421eae0eb02d25c69

Using the latest .NET 5 rc 2 build fails with:

    Microsoft.NET.TargetFrameworkInference.targets(213,5): error NETSDK1140: 30 is not a valid TargetPlatformVersion for android. Valid versions include:
    Microsoft.NET.TargetFrameworkInference.targets(213,5): error NETSDK1140: None

`@(SdkSupportedTargetPlatform)` was renamed to
`@(SdkSupportedTargetPlatformVersion)`. We should fix this and bump to
a later build of .NET 5.0 rc2 to account for this change.

We should also rename `@(AndroidSdkSupportedTargetPlatform)` to
`@(AndroidSdkSupportedTargetPlatformVersion)` to match
`@(WindowsSdkSupportedTargetPlatformVersion)`.

/cc @rolfbjarne I don't know if you have run into this for iOS yet.