### PR TITLE
[ci] Copy and publish OSS installer artifacts

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -23,6 +23,7 @@ variables:
   XA.Build.LinuxOSSPool: Xamarin-Android-Ubuntu-Public
   XA.Build.Configuration: Release
   NuGetArtifactName: nupkgs
+  InstallerArtifactName: Installers
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.201
@@ -117,6 +118,19 @@ stages:
         make package-oss CONFIGURATION=$(XA.Build.Configuration) V=1
       workingDirectory: $(Build.SourcesDirectory)
       displayName: package oss
+
+    - script: >
+        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: copy installers
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload installers
+      inputs:
+        artifactName: $(InstallerArtifactName)
+        targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
 
     - script: >
         echo "all-tests CONFIGURATION=$(XA.Build.Configuration) V=1" &&

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -123,7 +123,7 @@ stages:
         mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
         cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
         cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      workingDirectory: $(Build.SourcesDirectory)
       displayName: copy installers
 
     - task: PublishPipelineArtifact@1

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -129,7 +129,7 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: upload installers
       inputs:
-        artifactName: $(InstallerArtifactName)
+        artifactName: $(InstallerArtifactName) - macOS and Windows
         targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
 
     - script: >
@@ -154,7 +154,7 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: upload nupkgs
       inputs:
-        artifactName: $(NuGetArtifactName)
+        artifactName: $(NuGetArtifactName) - macOS
         targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - script: >
@@ -228,13 +228,13 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: publish linux artifacts
       inputs:
-        artifactName: Linux Packages
+        artifactName: $(InstallerArtifactName) - Linux
         targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts
 
     - task: PublishPipelineArtifact@1
       displayName: upload nupkgs
       inputs:
-        artifactName: Linux $(NuGetArtifactName)
+        artifactName: $(NuGetArtifactName) - Linux
         targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - template: yaml-templates/upload-results.yaml


### PR DESCRIPTION
Our OSS builds have been producing .pkg and .vsix installer files,
however we seem to have neglected an attempt to upload these artifacts.
The OSS YAML pipeline has been updated to upload these artifacts for
external consumption as needed.