### PR TITLE
[illink] Preserve API needed for registration

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveRegistrations.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveRegistrations.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+
+using Java.Interop.Tools.Cecil;
+
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+using MonoDroid.Tuner;
+
+namespace Microsoft.Android.Sdk.ILLink
+{
+	class PreserveRegistrations : BaseSubStep
+	{
+		delegate void AddPreservedMethodDelegate (AnnotationStore store, MethodDefinition key, MethodDefinition method);
+
+		static readonly AddPreservedMethodDelegate addPreservedMethod;
+
+		readonly TypeDefinitionCache cache;
+
+		public PreserveRegistrations (TypeDefinitionCache cache) => this.cache = cache;
+
+		static PreserveRegistrations ()
+		{
+			// temporarily use reflection to get void AnnotationStore::AddPreservedMethod (MethodDefinition key, MethodDefinition method)
+			// this can be removed once we have newer Microsoft.NET.ILLink containing https://github.com/mono/linker/commit/e6dadc995a834603e1178f9a1918f0ae38056b29
+			var method = typeof (AnnotationStore).GetMethod ("AddPreservedMethod", new Type [] { typeof (MethodDefinition), typeof (MethodDefinition) });
+			addPreservedMethod = (AddPreservedMethodDelegate)(method != null ? Delegate.CreateDelegate (typeof (AddPreservedMethodDelegate), null, method, false) : null);
+		}
+
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			return addPreservedMethod != null && (assembly.Name.Name == "Mono.Android" || assembly.MainModule.HasTypeReference ("Android.Runtime.RegisterAttribute"));
+		}
+
+		public override SubStepTargets Targets { get { return SubStepTargets.Method;  } }
+
+		bool PreserveJniMarshalMethods ()
+		{
+			if (Context.TryGetCustomData ("XAPreserveJniMarshalMethods", out var boolValue))
+				return bool.Parse (boolValue);
+
+			return false;
+		}
+
+		protected int PreserveNamedMethod (TypeDefinition type, string method_name, MethodDefinition key)
+		{
+			if (!type.HasMethods)
+				return 0;
+
+			int count = 0;
+			foreach (MethodDefinition method in type.Methods) {
+				if (method.Name != method_name)
+					continue;
+
+				AddPreservedMethod (key, method);
+				count++;
+			}
+
+			return count;
+		}
+
+		void PreserveRegisteredMethod (TypeDefinition type, string member, MethodDefinition key)
+		{
+			var type_ptr = type;
+			var pos = member.IndexOf (':');
+
+			if (pos > 0) {
+				var type_name = member.Substring (pos + 1);
+				member = member.Substring (0, pos);
+				type_ptr = type_ptr.Module.Types.FirstOrDefault (t => t.FullName == type_name);
+			}
+
+			if (type_ptr == null)
+				return;
+
+			while (PreserveNamedMethod (type, member, key) == 0 && type.BaseType != null)
+				type = type.BaseType.Resolve ();
+		}
+
+		public override void ProcessMethod (MethodDefinition method)
+		{
+			bool preserveJniMarshalMethodOnly = false;
+			if (!method.TryGetRegisterMember (out var member, out var nativeMethod, out var signature)) {
+				if (PreserveJniMarshalMethods () &&
+				    method.DeclaringType.GetMarshalMethodsType () != null &&
+				    method.TryGetBaseOrInterfaceRegisterMember (cache, out member, out nativeMethod, out signature)) {
+					preserveJniMarshalMethodOnly = true;
+				} else {
+					return;
+				}
+			}
+
+			if (PreserveJniMarshalMethods () && method.TryGetMarshalMethod (nativeMethod, signature, out var marshalMethod)) {
+				AddPreservedMethod (method, marshalMethod);
+				// TODO: collect marshalTypes and process after MarkStep
+				// marshalTypes.Add (marshalMethod.DeclaringType);
+			}
+
+			if (preserveJniMarshalMethodOnly)
+				return;
+
+			PreserveRegisteredMethod (method.DeclaringType, member, method);
+		}
+
+		void AddPreservedMethod (MethodDefinition key, MethodDefinition method)
+		{
+			addPreservedMethod.Invoke (Context.Annotations, key, method);
+		}
+	}
+}

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -34,14 +34,15 @@ namespace Microsoft.Android.Sdk.ILLink
 			var subSteps1 = new SubStepDispatcher ();
 			subSteps1.Add (new ApplyPreserveAttribute ());
 
+			var cache = new TypeDefinitionCache ();
 			var subSteps2 = new SubStepDispatcher ();
 			subSteps2.Add (new PreserveExportedTypes ());
 			subSteps2.Add (new MarkJavaObjects ());
 			subSteps2.Add (new PreserveJavaExceptions ());
 			subSteps2.Add (new PreserveJavaTypeRegistrations ());
 			subSteps2.Add (new PreserveApplications ());
+			subSteps2.Add (new PreserveRegistrations (cache));
 
-			var cache = new TypeDefinitionCache ();
 			InsertAfter (new FixAbstractMethodsStep (cache), "RemoveUnreachableBlocksStep");
 			InsertAfter (subSteps2, "RemoveUnreachableBlocksStep");
 			InsertAfter (subSteps1, "RemoveUnreachableBlocksStep");


### PR DESCRIPTION
Fix: https://github.com/xamarin/xamarin-android/issues/5156

Create new substep to preserve parts needed for JNI types registration
in `Android.Runtime.AndroidTypeManager.RegisterNativeMembers`. These
are preserved by `MonodroidMarkStep` in the XA linker. We cannot derive
from ILLink's MarkStep in NET5 as the API is not and will not be public.
Thus we need to preserve the API in the new separate substep
`PreserveRegistrations`.

Note: temporarily we need to use reflection to be able to call
`void AnnotationStore::AddPreservedMethod (MethodDefinition key, MethodDefinition method)`
method. This can be removed once we have Microsoft.NET.ILLink containing
https://github.com/mono/linker/commit/e6dadc995a834603e1178f9a1918f0ae38056b29

Example of additions in `Android.App.Activity` type
in `Mono.Andoid.dll` assembly in simple XA app:

    adiff old\obj\Release\net5.0-android\android.21-arm64\linked\Mono.Android.dll new\obj\Release\net5.0-android\android.21-arm64\linked\Mono.Android.dll
    Compare old\obj\Release\net5.0-android\android.21-arm64\linked\Mono.Android.dll with new\obj\Release\net5.0-android\android.21-arm64\linked\Mono.Android.dll
    ...
      Type Android.App.Activity
        +             Field static System.Delegate cb_findViewById_I
        +             Field static System.Delegate cb_onCreate_Landroid_os_Bundle_
        +             Field static System.Delegate cb_setContentView_I
        +             Method static System.Delegate GetFindViewById_IHandler ()
        +             Method static IntPtr n_FindViewById_I (IntPtr, IntPtr, int)
        +             Method static System.Delegate GetOnCreate_Landroid_os_Bundle_Handler ()
        +             Method static void n_OnCreate_Landroid_os_Bundle_ (IntPtr, IntPtr, IntPtr)
        +             Method static System.Delegate GetSetContentView_IHandler ()
        +             Method static void n_SetContentView_I (IntPtr, IntPtr, int)
      Type Android.Content.Context
    ...