### PR TITLE
[Xamarin.Android.Build.Tasks] remove acw-map.txt usage in <ConvertResourcesCases/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
@@ -37,7 +37,6 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
       Condition="'$(_AndroidUseAapt2)' != 'True'"
       ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
-      AcwMapFile="$(_AcwMapFile)"
       CustomViewMapFile="$(_CustomViewMapFile)"
       AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
   />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -99,7 +99,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <!-- Change cases so we support mixed case resource names -->
   <ConvertResourcesCases
       ContinueOnError="$(DesignTimeBuild)"
-      AcwMapFile="$(_AcwMapFile)"
       AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
       CustomViewMapFile="$(_CustomViewMapFile)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceDirectories)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Build.Tests {
 <LinearLayout>
 </LinearLayout>
 ");
-			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, new Dictionary<string, string> (), null);
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, null);
 			var mainText = File.ReadAllText (main);
 			Assert.True (mainText.Contains ("@layout/headerlayout"), "'@layout/headerLayout' was not converted to '@layout/headerlayout'");
 			Directory.Delete (path, recursive: true);
@@ -98,7 +98,7 @@ namespace Xamarin.Android.Build.Tests {
 		app:showAsAction = ""never"" />
 
 </menu>");
-			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), actions, new Dictionary<string, string> (), null);
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), actions, null);
 			var actionsText = File.ReadAllText (actions);
 			Assert.True (actionsText.Contains ("@layout/servinglayout"), "'@layout/ServingLayout' was not converted to '@layout/servinglayout'");
 			Directory.Delete (path, recursive: true);
@@ -134,8 +134,8 @@ namespace Xamarin.Android.Build.Tests {
 	</declare-styleable>
 </resources>
 ");
-			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), attrs, new Dictionary<string, string> (), null);
-			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, new Dictionary<string, string> (), null);
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), attrs, null);
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, null);
 			var mainText = File.ReadAllText (main);
 			Assert.True (mainText.Contains ("FixedWidth"), "'FixedWidth' was converted to 'fixedwidth'");
 			Directory.Delete (path, recursive: true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
@@ -75,21 +75,20 @@ namespace Xamarin.Android.Build.Tests
 			task.ResourceDirectories = new ITaskItem [] {
 				new TaskItem (resPath),
 			};
-			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
 			task.CustomViewMapFile = Path.Combine (path, "classmap.txt");
-			File.WriteAllLines (task.AcwMapFile, new string [] {
-				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
-				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
-			});
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
 			var custom = new ConvertCustomView () {
 				BuildEngine = engine,
 				CustomViewMapFile = task.CustomViewMapFile,
-				AcwMapFile = task.AcwMapFile,
+				AcwMapFile = Path.Combine (path, "acwmap.txt"),
 				ResourceDirectories = new ITaskItem [] {
 					new TaskItem (resPath),
 				},
 			};
+			File.WriteAllLines (custom.AcwMapFile, new string [] {
+				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+			});
 			Assert.IsTrue (custom.Execute (), "Task should have executed successfully");
 			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
 			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
@@ -124,12 +123,7 @@ namespace Xamarin.Android.Build.Tests
 			task.ResourceDirectories = new ITaskItem [] {
 				new TaskItem (resPath),
 			};
-			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
 			task.CustomViewMapFile = Path.Combine (path, "classmap.txt");
-			File.WriteAllLines (task.AcwMapFile, new string [] {
-				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
-				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
-			});
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
 			if (IsWindows) {
 				// Causes an NRE
@@ -138,11 +132,15 @@ namespace Xamarin.Android.Build.Tests
 			var custom = new ConvertCustomView () {
 				BuildEngine = engine,
 				CustomViewMapFile = task.CustomViewMapFile,
-				AcwMapFile = task.AcwMapFile,
+				AcwMapFile = Path.Combine (path, "acwmap.txt"),
 				ResourceDirectories = new ITaskItem [] {
 					new TaskItem (resPath),
 				},
 			};
+			File.WriteAllLines (custom.AcwMapFile, new string [] {
+				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+			});
 			Assert.IsFalse (custom.Execute (), "Task should have executed successfully");
 			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
 			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -12,11 +12,11 @@ using Xamarin.Android.Tasks;
 namespace Monodroid {
 	static class AndroidResource {
 		
-		public static bool UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null, Action<string, string> registerCustomView = null)
+		public static bool UpdateXmlResource (string res, string filename, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null, Action<string, string> registerCustomView = null)
 		{
 			try {
 				XDocument doc = XDocument.Load (filename, LoadOptions.SetLineInfo);
-				UpdateXmlResource (res, doc.Root, acwMap, additionalDirectories, (e) => {
+				UpdateXmlResource (res, doc.Root, additionalDirectories, (e) => {
 					registerCustomView?.Invoke (e, filename);
 				});
 				using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ())
@@ -44,15 +44,10 @@ namespace Monodroid {
 
 		public static void UpdateXmlResource (XElement e)
 		{
-			UpdateXmlResource (e, new Dictionary<string,string> ());
+			UpdateXmlResource (null, e);
 		}
 
-		public static void UpdateXmlResource (XElement e, Dictionary<string, string> acwMap)
-		{
-			UpdateXmlResource (null, e, acwMap);
-		}
-
-		static void UpdateXmlResource (string resourcesBasePath, XElement e, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<string> registerCustomView = null)
+		static void UpdateXmlResource (string resourcesBasePath, XElement e, IEnumerable<string> additionalDirectories = null, Action<string> registerCustomView = null)
 		{
 			foreach (var elem in GetElements (e).Prepend (e)) {
 				registerCustomView?.Invoke (elem.Name.ToString ());
@@ -68,12 +63,12 @@ namespace Monodroid {
 				if (a.IsNamespaceDeclaration)
 					continue;
 
-				TryFixFragment (a, acwMap, registerCustomView);
+				TryFixFragment (a, registerCustomView);
 				
-				if (TryFixResAuto (a, acwMap))
+				if (TryFixResAuto (a))
 					continue;
 
-				TryFixCustomClassAttribute (a, acwMap, registerCustomView);
+				TryFixCustomClassAttribute (a, registerCustomView);
 
 				if (a.Name.Namespace != android &&
 						!(a.Name.LocalName == "layout" && a.Name.Namespace == XNamespace.None &&
@@ -172,7 +167,7 @@ namespace Monodroid {
 			}
 		}
 
-		private static void TryFixFragment (XAttribute attr, Dictionary<string, string> acwMap, Action<string> registerCustomView = null)
+		private static void TryFixFragment (XAttribute attr, Action<string> registerCustomView = null)
 		{
 			// Looks for any: 
 			//   <fragment class="My.DotNet.Class" 
@@ -194,7 +189,7 @@ namespace Monodroid {
 			}
 		}
 
-		private static bool TryFixResAuto (XAttribute attr, Dictionary<string, string> acwMap)
+		private static bool TryFixResAuto (XAttribute attr)
 		{
 			if (attr.Name.Namespace != res_auto)
 				return false;
@@ -207,7 +202,7 @@ namespace Monodroid {
 			return false;
 		}
 
-		private static void TryFixCustomClassAttribute (XAttribute attr, Dictionary<string, string> acwMap, Action<string> registerCustomView = null)
+		private static void TryFixCustomClassAttribute (XAttribute attr, Action<string> registerCustomView = null)
 		{
 			/* Some attributes reference a Java class name.
 			 * try to convert those like for TryFixCustomView


### PR DESCRIPTION
The `<ConvertResourcesCases/>` loads the `acw-map.txt` file and passes
the dictionary throughout several methods in `AndroidResource`.
However, this dictionary is completely unused throughout?

Since 1886e6f1, the logic using `acw-map.txt` was moved to the
`<ConvertCustomView/>` MSBuild task. We no longer need to use this
file in the `<ConvertResourcesCases/>` task.

At the time `<ConvertResourcesCases/>` runs (before `Build`),
`acw-map.txt` does not even exist. It is created by the
`<GenerateJavaStubs/>` MSBuild task, that runs after `Build`.

I was working on a performance improvement, where I was attempting to
use `acw-map.txt` -- unfortunately an empty dictionary.

To eliminate confusion and clean things up, I removed all usage of
`acw-map.txt` in the `<ConvertResourcesCases/>` MSBuild task and
`AndroidResource` class. I was not able to see a performance
improvement with this change, as it is likely too small to notice.