### PR TITLE
Utilize GitHub token in compliance with GitHub service account restrictions

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -29,6 +29,8 @@ variables:
   DotNetCoreVersion: 3.1.201
   # Version number from: https://github.com/dotnet/installer#installers-and-binaries
   DotNetCorePreviewVersion: 5.0.100-rc.2.20459.1
+  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
+
 
 stages:
 - stage: mac_stage
@@ -74,7 +76,7 @@ stages:
     - task: provisionator@2
       displayName: Install Xcode
       inputs:
-        github_token: $(github-pat)
+        github_token: $(GitHub.Token)
         provisioning_script: $(Build.SourcesDirectory)/build-tools/provisioning/xcode.csx
         provisioning_extra_args: '-v -v -v -v'
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -66,6 +66,7 @@ variables:
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
   DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != LibraryProjectZip & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject'
   NUnit.NumberOfTestWorkers: 4
+  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
@@ -156,7 +157,7 @@ stages:
     - task: provisionator@2
       displayName: Install Xcode
       inputs:
-        github_token: $(github-pat)
+        github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
         provisioning_extra_args: '-v -v -v -v'
 


### PR DESCRIPTION
Related to VS #[1225839](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1225839)

As part of the GitHub Single Sign-On (SSO) effort, GitHub service accounts (i.e., any GitHub account not linked with an individual Microsoft account) will be denied GitHub org (Microsoft, Xamarin) access rights. The Xamarin.Android pipelines currently make use of a GitHub token tied to the Xamarin org (e.g., a Microsoft org).  That token is passed to Provisionator.  This change involves replacing that token with a GitHub token tied to a GitHub service account that does not have access to any Microsoft GitHub org (Microsoft or Xamarin).