### PR TITLE
[Xamarin.Android.Build.Tasks] remove $(_AndroidResourceNameCaseMap) for performance

### DIFF
--- a/Documentation/release-notes/5188.md
+++ b/Documentation/release-notes/5188.md
@@ -1,0 +1,7 @@
+### Build and deployment performance
+
+  * [GitHub PR 5188](https://github.com/xamarin/xamarin-android/pull/5188):
+    Improve performance by lazily loading an Android resource mapping
+    file that is only used for error messages. This reduced the
+    overall build time by 348ms in a real-world project in an initial
+    clean build or incremental builds with Android resource changes.

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
@@ -36,7 +36,6 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
   <!-- Change cases so we support mixed case resource names -->
   <ConvertResourcesCases
       ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       CustomViewMapFile="$(_CustomViewMapFile)"
       AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
   />
@@ -61,7 +60,6 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
       ToolExe="$(AaptToolExe)"
       ApiLevel="$(_AndroidTargetSdkVersion)"
       AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       SupportedAbis="@(_BuildTargetAbis)"
@@ -90,7 +88,6 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
      ToolExe="$(AaptToolExe)"
      ApiLevel="$(_AndroidTargetSdkVersion)"
      AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-     ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
      AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
      SupportedAbis="@(_BuildTargetAbis)"
      CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -102,7 +102,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
       CustomViewMapFile="$(_CustomViewMapFile)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceDirectories)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
   />
   <Touch Files="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp" AlwaysCreate="True" />
 </Target>
@@ -130,7 +129,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
       ResourcesToCompile="@(_CompileResourcesInputs)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
   />
@@ -161,7 +159,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ContinueOnError="$(DesignTimeBuild)"
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
       DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
       ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
       OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
@@ -223,7 +220,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
       DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
       AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
       ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -114,7 +114,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       CustomViewMapFile="$(_CustomViewMapFile)"
       AcwMapFile="$(_AcwMapFile)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
   />
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -77,8 +77,6 @@ namespace Xamarin.Android.Tasks
 		public string OutputImportDirectory { get; set; }
 		public string AssemblyIdentityMapFile { get; set; }
 
-		public string ResourceNameCaseMap { get; set; }
-
 		// pattern to use for the version code. Used in CreatePackagePerAbi
 		// eg. {abi:00}{dd}{version}
 		// known keyworks
@@ -94,9 +92,11 @@ namespace Xamarin.Android.Tasks
 
 		public string ResourceSymbolsTextFileDirectory { get; set; }
 
-		Dictionary<string,string> resource_name_case_map;
+		Dictionary<string,string> _resource_name_case_map;
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		string resourceDirectory;
+
+		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4);
 
 		bool ManifestIsUpToDate (string manifestFile)
 		{
@@ -218,8 +218,6 @@ namespace Xamarin.Android.Tasks
 			resourceDirectory = ResourceDirectory.TrimEnd ('\\');
 			if (!Path.IsPathRooted (resourceDirectory))
 				resourceDirectory = Path.Combine (WorkingDirectory, resourceDirectory);
-
-			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 
 			assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -22,7 +22,9 @@ namespace Xamarin.Android.Tasks {
 	public abstract class Aapt2 : AndroidAsyncTask {
 
 		private static readonly int DefaultMaxAapt2Daemons = 6;
-		protected Dictionary<string, string> resource_name_case_map;
+		protected Dictionary<string, string> _resource_name_case_map;
+
+		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4);
 
 		protected virtual int ProcessorCount => Environment.ProcessorCount;
 
@@ -33,8 +35,6 @@ namespace Xamarin.Android.Tasks {
 		public ITaskItem [] ResourceDirectories { get; set; }
 
 		public ITaskItem AndroidManifestFile { get; set;}
-
-		public string ResourceNameCaseMap { get; set; }
 
 		public string ResourceSymbolsTextFile { get; set; }
 
@@ -202,11 +202,6 @@ namespace Xamarin.Android.Tasks {
 				LogCodedWarning (GetErrorCode (singleLine), singleLine);
 			}
 			return true;
-		}
-
-		protected void LoadResourceCaseMap ()
-		{
-			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 		}
 
 		static string GetErrorCode (string message)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -41,8 +41,6 @@ namespace Xamarin.Android.Tasks {
 
 		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			LoadResourceCaseMap ();
-
 			await this.WhenAllWithLock (ResourcesToCompile ?? ResourceDirectories, ProcessDirectory);
 
 			ProcessOutput ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -92,8 +92,6 @@ namespace Xamarin.Android.Tasks {
 		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			try {
-				LoadResourceCaseMap ();
-
 				assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 
 				proguardRuleOutputTemp = GetTempFile ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -20,16 +20,16 @@ namespace Xamarin.Android.Tasks {
 		[Required]
 		public string AcwMapFile { get; set; }
 
-		public string ResourceNameCaseMap { get; set; }
-
 		public ITaskItem [] ResourceDirectories { get; set; }
 
 		[Output]
 		public ITaskItem [] Processed { get; set; }
 
+		Dictionary<string, string> _resource_name_case_map;
+		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4);
+
 		public override bool RunTask ()
 		{
-			var resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
 			var customViewMap = MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
 			var processed = new HashSet<string> ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -23,15 +23,13 @@ namespace Xamarin.Android.Tasks
 
 		public string AndroidConversionFlagFile { get; set; }
 
-		public string ResourceNameCaseMap { get; set; }
-
-		Dictionary<string,string> resource_name_case_map;
+		Dictionary<string,string> _resource_name_case_map;
 		Dictionary<string, HashSet<string>> customViewMap;
+
+		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4);
 
 		public override bool RunTask ()
 		{
-			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
-
 			if (CustomViewMapFile != null)
 				customViewMap = Xamarin.Android.Tasks.MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -40,13 +40,15 @@ namespace Xamarin.Android.Tasks
 		const string NoFileWarningOrErrorRegExString = @"(?<type>Warning|Error):(?<text>.+)";
 		Regex codeErrorRegEx = new Regex (CodeErrorRegExString, RegexOptions.Compiled);
 		Regex noFileWarningOrErrorRegEx = new Regex(NoFileWarningOrErrorRegExString, RegexOptions.Compiled);
-		protected Dictionary<string, string> resource_name_case_map;
+		Dictionary<string, string> _resource_name_case_map;
 		bool matched = false;
 		string file;
 		int line;
 		int column;
 		string text;
 		string type;
+
+		Dictionary<string, string> resource_name_case_map => _resource_name_case_map ??= MonoAndroidHelper.LoadResourceCaseMap (BuildEngine4);
 
 		[Required]
 		public string TargetDirectory { get; set; }
@@ -150,8 +152,6 @@ namespace Xamarin.Android.Tasks
 			get { return OS.IsWindows ? "lint.bat" : "lint"; }
 		}
 
-		public string ResourceNameCaseMap { get; set; }
-
 		public Lint ()
 		{
 			ResourceDirectories = new ITaskItem[0];
@@ -214,8 +214,6 @@ namespace Xamarin.Android.Tasks
 			}
 
 			EnvironmentVariables = new [] { "JAVA_HOME=" + JavaSdkPath };
-
-			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 
 			base.RunTask ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -403,11 +403,15 @@ namespace Xamarin.Android.Build.Tests
 </LinearLayout>
 ");
 			var errors = new List<BuildErrorEventArgs> ();
-			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var engine = new MockBuildEngine (TestContext.Out, errors);
 			var directorySeperator = Path.DirectorySeparatorChar;
 			var current = Directory.GetCurrentDirectory ();
 			try {
 				Directory.SetCurrentDirectory (path);
+				MonoAndroidHelper.SaveResourceCaseMap (engine, new Dictionary<string, string> {
+					{ $"layout{directorySeperator}main.axml", $"Layout{directorySeperator}Main.xml" },
+					{ $"values{directorySeperator}strings.xml", $"Values{directorySeperator}Strings.xml" },
+ 				});
 				var task = new Aapt2Compile {
 					BuildEngine = engine,
 					ToolPath = GetPathToAapt2 (),
@@ -419,7 +423,6 @@ namespace Xamarin.Android.Build.Tests
 					},
 					FlatArchivesDirectory = archivePath,
 					FlatFilesDirectory = flatFilePath,
-					ResourceNameCaseMap = $"Layout{directorySeperator}Main.xml|layout{directorySeperator}main.axml;Values{directorySeperator}Strings.xml|values{directorySeperator}strings.xml",
 				};
 				Assert.False (task.Execute (), "task should not have succeeded.");
 			} finally {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -615,15 +615,14 @@ namespace Xamarin.Android.Tasks
 			return Path.Combine (platformPath, "android.jar");
 		}
 
-		public static Dictionary<string, string> LoadResourceCaseMap (string resourceCaseMap)
-		{
-			var result = new Dictionary<string, string> ();
-			if (resourceCaseMap != null) {
-				foreach (var arr in resourceCaseMap.Split (';').Select (l => l.Split ('|')).Where (a => a.Length == 2))
-					result [arr [1]] = arr [0]; // lowercase -> original
-			}
-			return result;
-		}
+		static readonly string ResourceCaseMapKey = $"{nameof (MonoAndroidHelper)}_ResourceCaseMap";
+
+		public static void SaveResourceCaseMap (IBuildEngine4 engine, Dictionary<string, string> map) =>
+			engine.RegisterTaskObject (ResourceCaseMapKey, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+
+		public static Dictionary<string, string> LoadResourceCaseMap (IBuildEngine4 engine) =>
+			engine.GetRegisteredTaskObject (ResourceCaseMapKey, RegisteredTaskObjectLifetime.Build)
+				as Dictionary<string, string> ?? new Dictionary<string, string> (0);
 
 		public static string FixUpAndroidResourcePath (string file, string resourceDirectory, string resourceDirectoryFullPath, Dictionary<string, string> resource_name_case_map)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -787,7 +787,6 @@ because xbuild doesn't support framework reference assemblies.
 		ToolPath="$(LintToolPath)"
 		ToolExe="$(LintToolExe)"
 		JavaSdkPath="$(_JavaSdkDirectory)"
-		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 	/>
 </Target>
 
@@ -991,7 +990,6 @@ because xbuild doesn't support framework reference assemblies.
 			AndroidLibraryFlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
 	>
 		<Output ItemName="_AndroidResourceDest" TaskParameter="IntermediateFiles" />
-		<Output PropertyName="_AndroidResourceNameCaseMap" TaskParameter="ResourceNameCaseMap" />
 		<Output ItemName="_AndroidResolvedResources" TaskParameter="ResolvedResourceFiles" />
 	</AndroidComputeResPaths>
   
@@ -1466,8 +1464,7 @@ because xbuild doesn't support framework reference assemblies.
   <ConvertCustomView
       CustomViewMapFile="$(_CustomViewMapFile)"
       AcwMapFile="$(_AcwMapFile)"
-      ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceHashDirectories)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)">
+      ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceHashDirectories)">
     <Output TaskParameter="Processed" ItemName="_ProcessedCustomViews" />	
   </ConvertCustomView>
   <Touch Files="$(_AndroidStampDirectory)_ConvertCustomView.stamp" AlwaysCreate="True" />


### PR DESCRIPTION
Reviewing a customer's large solution, `$(_AndroidResourceNameCaseMap)`
contains a ~20,000 character string that is logged and parsed multiple
times throughout the build.

Improvements:

* The `<AndroidComputeResPaths/>` MSBuild task can create a
  `Dictionary<string,string>` directly and store it via
  `RegisterTaskObject`. No need to create a giant string at all.
* `<AndroidComputeResPaths/>` shouldn't log all the output values, as
  it adds hundreds of log messages per `LogDebugTaskItems()` call in
  this customer's project. The surrounding log has enough context, so
  these messages are not needed.
* `MonoAndroidHelper.LoadResourceCaseMap` should only be called when
  the value is actually needed. This is normally for error messages.
* `MonoAndroidHelper.LoadResourceCaseMap` can call
  `GetRegisteredTaskObject` and will no longer need to parse or split
  any strings.
* The `$(_AndroidResourceNameCaseMap)` MSBuild property can be
  completely removed. We no longer need to pass it into various
  MSBuild tasks.

## Results ##

Testing this change in the customer's large solution:

    Before:
       17 ms  ConvertCustomView                          1 calls
      103 ms  AndroidComputeResPaths                    10 calls
     7692 ms  Aapt2Link                                 10 calls
    14288 ms  Aapt2Compile                              10 calls
    After:
       16 ms  ConvertCustomView                          1 calls
       99 ms  AndroidComputeResPaths                    10 calls
     7643 ms  Aapt2Link                                 10 calls
    13994 ms  Aapt2Compile                              10 calls

This should save ~348ms in an initial build of this large solution or
incremental builds with `AndroidResource` changes.

The `.binlog` file produced (which is a compressed format) is also
334,415 bytes smaller.