### PR TITLE
[l10n] Tidy generated resource files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -437,7 +437,9 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is using a deprecated debug information level. Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the &apos;DebugType&apos; MSBuild property to &apos;portable&apos; to use the newer, cross-platform debug information level. If this file comes from a NuGet package, update to a newer version of the NuGet package or notify the library author..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is using a deprecated debug information level.
+        ///Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the &apos;DebugType&apos; MSBuild property to &apos;portable&apos; to use the newer, cross-platform debug information level.
+        ///If this file comes from a NuGet package, update to a newer version of the NuGet package or notify the library author..
         /// </summary>
         internal static string XA0125 {
             get {


### PR DESCRIPTION
Add the automatic changes that Visual Studio makes when saving the
resource files so there won't be any need to worry about them getting
included unintentionally as part of an unrelated future change to the
`.resx` file.