### PR TITLE
Remove [Preserve] attributes where not needed

### DIFF
--- a/src/Mono.Android/Android.Runtime/CharSequence.cs
+++ b/src/Mono.Android/Android.Runtime/CharSequence.cs
@@ -33,19 +33,16 @@ namespace Android.Runtime {
 			return ret;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (string? value)
 		{
 			return JNIEnv.NewString (value);
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (Java.Lang.ICharSequence? value)
 		{
 			return value == null ? IntPtr.Zero : JNIEnv.ToLocalJniHandle (value);
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IEnumerable<char>? value)
 		{
 			if (value == null) {

--- a/src/Mono.Android/Android.Runtime/InputStreamAdapter.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamAdapter.cs
@@ -41,7 +41,6 @@ namespace Android.Runtime {
 			return res;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (Stream? value)
 		{
 			if (value == null)

--- a/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
@@ -153,7 +153,6 @@ namespace Android.Runtime
 			}
 		}
 		
-		[Preserve (Conditional=true)]
 		public static Stream? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)

--- a/src/Mono.Android/Android.Runtime/JavaArray.cs
+++ b/src/Mono.Android/Android.Runtime/JavaArray.cs
@@ -86,7 +86,6 @@ namespace Android.Runtime {
 			throw new InvalidOperationException ();
 		}
 
-		[Preserve (Conditional=true)]
 		public static JavaArray<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -100,7 +99,6 @@ namespace Android.Runtime {
 			return new JavaArray<T>(handle, transfer);
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IList<T>? value)
 		{
 			if (value == null)

--- a/src/Mono.Android/Android.Runtime/JavaCollection.cs
+++ b/src/Mono.Android/Android.Runtime/JavaCollection.cs
@@ -174,7 +174,6 @@ namespace Android.Runtime {
 			return System.Linq.Extensions.ToEnumerator_Dispose (Iterator ());
 		}
 
-		[Preserve (Conditional=true)]
 		public static ICollection? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -189,7 +188,6 @@ namespace Android.Runtime {
 			return (ICollection) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (ICollection? items)
 		{
 			if (items == null)
@@ -394,7 +392,6 @@ namespace Android.Runtime {
 			return System.Linq.Extensions.ToEnumerator_Dispose<T> (Iterator());
 		}
 		
-		[Preserve (Conditional=true)]
 		public static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -409,7 +406,6 @@ namespace Android.Runtime {
 			return (ICollection<T>) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (ICollection<T>? items)
 		{
 			if (items == null)

--- a/src/Mono.Android/Android.Runtime/JavaDictionary.cs
+++ b/src/Mono.Android/Android.Runtime/JavaDictionary.cs
@@ -356,7 +356,6 @@ namespace Android.Runtime {
 			JNIEnv.DeleteLocalRef (r);
 		}
 		
-		[Preserve (Conditional=true)]
 		public static IDictionary? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -371,7 +370,6 @@ namespace Android.Runtime {
 			return (IDictionary) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IDictionary? dictionary)
 		{
 			if (dictionary == null)
@@ -638,7 +636,6 @@ namespace Android.Runtime {
 			return ContainsKey (key);
 		}
 		
-		[Preserve (Conditional=true)]
 		public static IDictionary<K, V>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -653,7 +650,6 @@ namespace Android.Runtime {
 			return (IDictionary<K, V>) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IDictionary<K, V>? dictionary)
 		{
 			if (dictionary == null)

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -475,7 +475,6 @@ namespace Android.Runtime {
 					JniHandleOwnership.TransferLocalRef);
 		}
 		
-		[Preserve (Conditional=true)]
 		public static IList? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -490,7 +489,6 @@ namespace Android.Runtime {
 			return (IList) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IList? items)
 		{
 			if (items == null)
@@ -940,7 +938,6 @@ namespace Android.Runtime {
 			return true;
 		}
 		
-		[Preserve (Conditional=true)]
 		public static IList<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -955,7 +952,6 @@ namespace Android.Runtime {
 			return (IList<T>) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (IList<T>? items)
 		{
 			if (items == null)

--- a/src/Mono.Android/Android.Runtime/JavaSet.cs
+++ b/src/Mono.Android/Android.Runtime/JavaSet.cs
@@ -238,7 +238,6 @@ namespace Android.Runtime {
 			});
 		}
 
-		[Preserve (Conditional=true)]
 		public static ICollection? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -253,7 +252,6 @@ namespace Android.Runtime {
 			return (ICollection) inst;
 		}
 		
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (ICollection? items)
 		{
 			if (items == null)
@@ -426,7 +424,6 @@ namespace Android.Runtime {
 			});
 		}
 
-		[Preserve (Conditional=true)]
 		public static ICollection<T>? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			if (handle == IntPtr.Zero)
@@ -441,7 +438,6 @@ namespace Android.Runtime {
 			return (ICollection<T>) inst;
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (ICollection<T>? items)
 		{
 			if (items == null)

--- a/src/Mono.Android/Android.Runtime/OutputStreamAdapter.cs
+++ b/src/Mono.Android/Android.Runtime/OutputStreamAdapter.cs
@@ -44,7 +44,6 @@ namespace Android.Runtime
 			BaseStream.WriteByte ((byte)oneByte);
 		}
 
-		[Preserve (Conditional=true)]
 		public static IntPtr ToLocalJniHandle (Stream? value)
 		{
 			if (value == null)

--- a/src/Mono.Android/Android.Runtime/OutputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/OutputStreamInvoker.cs
@@ -124,7 +124,6 @@ namespace Android.Runtime
 			set { throw new NotSupportedException (); }
 		}
 		
-		[Preserve (Conditional=true)]
 		public static Stream? FromJniHandle (IntPtr handle, JniHandleOwnership transfer)
 		{
 			return FromNative (handle, transfer);

--- a/tests/api-compatibility/api-compat-exclude-attributes.txt
+++ b/tests/api-compatibility/api-compat-exclude-attributes.txt
@@ -1,5 +1,7 @@
 // These attributes should be excluded from api-compat check reference assemblies.
 
+T:Android.Runtime.PreserveAttribute
+
 T:Java.Interop.JavaTypeParametersAttribute
 
 T:System.Diagnostics.DebuggerStepThroughAttribute


### PR DESCRIPTION
As part of https://github.com/xamarin/xamarin-android/issues/5197 I am
reviewing usage of `PreserveAttribute`.

The ones removed here are not needed as their declaring types are
already preserved by `Mono.Android.xml` preserve list.

Also remove `Android.Runtime.PreserveAttribute` from API compatibility
checks as these are removed by the linker anyway.