### PR TITLE
[CI] Skip required program installation for most test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -402,6 +402,9 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+      displayName: install required brew tools and prepare java.interop
+
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
       displayName: install emulator
 

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -46,13 +46,11 @@ steps:
 
 - script: >
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
-    mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidTestDependencies --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: >
-    ${{ parameters.xaSourcePath }}\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI &&
     ${{ parameters.xaSourcePath }}\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidTestDependencies --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -6,11 +6,12 @@ namespace Xamarin.Android.Prepare
 	partial class Scenario_AndroidTestDependencies : ScenarioNoStandardEndSteps
 	{
 		public Scenario_AndroidTestDependencies () 
-			: base ("AndroidTestDependencies", "Install Android SDK and OpenJDK test dependencies.")
+			: base ("AndroidTestDependencies", "Install Android SDK, OpenJDK and .NET preview test dependencies.")
 		{}
 
 		protected override void AddSteps (Context context)
 		{
+			Steps.Add (new Step_InstallDotNetPreview ());
 			Steps.Add (new Step_InstallJetBrainsOpenJDK8 ());
 			Steps.Add (new Step_InstallJetBrainsOpenJDK11 ());
 			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));


### PR DESCRIPTION
The setup-test-environment.yaml template has been updated to reduce the
amount of dependency installation that happens by default for all test
jobs.  The majority of these jobs do not need all dependencies defined
by xaprepare, and we can save time provisioning by skipping these steps.