### PR TITLE
[xaprepare] Remove mingw installation formula

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Prepare
 
 			new HomebrewProgram ("make"),
 
-			new HomebrewProgram ("mingw-w64", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/196509755a5afc1115bf39e02314b99d7ed22eb0/Formula/mingw-w64.rb")) {
+			new HomebrewProgram ("mingw-w64") {
 				MinimumVersion = "7.0.0_2",
 				MaximumVersion = "7.0.0_3",
 				Pin = true,


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4145754&view=results

All of our macOS test jobs are currently blocked during environment
provisioning due to the following error:

```
stderr | Error: Calling Installation of mingw-w64 from a GitHub commit URL is disabled! Use 'brew extract mingw-w64' to stable tap on GitHub instead.

Failed to install some required programs.
System.InvalidOperationException: Failed to install some required programs.
  at Xamarin.Android.Prepare.OS.EnsureDependencies () [0x0050e] in <6cf28c0130c14a06a5b36a148f5fad5c>:0 
  at Xamarin.Android.Prepare.OS.Init () [0x0008b] in <6cf28c0130c14a06a5b36a148f5fad5c>:0 
  at Xamarin.Android.Prepare.Context.Init (System.String scenarioName) [0x001dc] in <6cf28c0130c14a06a5b36a148f5fad5c>:0 
  at Xamarin.Android.Prepare.App.Run (System.String[] args) [0x0075b] in <6cf28c0130c14a06a5b36a148f5fad5c>:0 
```

@grendello will be looking at a more sustainable fix, but this should
hopefully unblock PR builds for the time being.