### PR TITLE
[tests] use latest Xamarin.GooglePlayServices in tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -262,7 +262,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[NonParallelizable]
-		[Category ("DotNetIgnore")] // <ProcessGoogleServicesJson/> task is built for net45
 		public void Check9PatchFilesAreProcessed ()
 		{
 			var projectPath = Path.Combine ("temp", "Check9PatchFilesAreProcessed");
@@ -275,7 +274,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 			using (var libb = CreateDllBuilder (Path.Combine (projectPath, "Library1"))) {
 				libb.Build (libproj);
-				var proj = new XamarinAndroidApplicationProject ();
+				var proj = new XamarinFormsMapsApplicationProject ();
 				using (var stream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.Image.9.png")) {
 					var image_data = new byte [stream.Length];
 					stream.Read (image_data, 0, (int)stream.Length);
@@ -283,11 +282,6 @@ namespace Xamarin.Android.Build.Tests
 					proj.AndroidResources.Add (image1);
 				}
 				proj.References.Add (new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj"));
-				proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.GooglePlayServicesMaps_42_1021_1);
-				proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
 				using (var b = CreateApkBuilder (Path.Combine (projectPath, "Application1"), false, false)) {
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 					var path = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/bin/packaged_resources");
@@ -1248,82 +1242,6 @@ namespace UnnamedProject
 				FileAssert.Exists (r_java);
 				var r_java_contents = File.ReadAllLines (r_java);
 				Assert.IsTrue (StringAssertEx.ContainsText (r_java_contents, textView1), $"android/support/compat/R.java should contain `{textView1}`!");
-			}
-		}
-
-		// https://github.com/xamarin/xamarin-android/issues/2205
-		[Test]
-		[NonParallelizable]
-		[Category ("DotNetIgnore")] // <ProcessGoogleServicesJson/> task is built for net45
-		public void Issue2205 ([Values (false, true)] bool useAapt2)
-		{
-			AssertAaptSupported (useAapt2);
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.AndroidUseAapt2 = useAapt2;
-			proj.PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Gcm);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Iid);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
-			proj.OtherBuildItems.Add (new BuildItem ("GoogleServicesJson", "googleservices.json") {
-				Encoding = Encoding.ASCII,
-				TextContent = () => @"{
-    ""project_info"": {
-        ""project_number"": ""12351255213413432"",
-        ""project_id"": ""12341234-app""
-    },
-    ""client"": [
-        {
-            ""client_info"": {
-                ""mobilesdk_app_id"": ""1:111111111:android:asdfasdf"",
-                ""android_client_info"": {
-                    ""package_name"": ""com.app.apppp""
-                }
-            },
-            ""oauth_client"": [
-                {
-                    ""client_id"": ""dddddddddddddddddd.apps.googleusercontent.com"",
-                    ""client_type"": 3
-                }
-            ],
-            ""api_key"": [
-                {
-                    ""current_key"": ""aaaaaaapppp1123423""
-                }
-            ],
-            ""services"": {
-                ""analytics_service"": {
-                    ""status"": 1
-                },
-                ""appinvite_service"": {
-                    ""status"": 1,
-                    ""other_platform_oauth_client"": []
-                },
-                ""ads_service"": {
-                    ""status"": 2
-                }
-            }
-        }
-    ],
-    ""configuration_version"": ""1""
-}"
-			});
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -214,21 +214,11 @@ namespace Xamarin.Android.Build.Tests
 			var sb = new SolutionBuilder ("BuildAMassiveApp.sln") {
 				SolutionPath = Path.Combine (Root, testPath),
 			};
-			var app1 = new XamarinAndroidApplicationProject () {
+			var app1 = new XamarinFormsMapsApplicationProject {
 				TargetFrameworkVersion = sb.LatestTargetFrameworkVersion (),
 				ProjectName = "App1",
 				AotAssemblies = true,
 				IsRelease = true,
-				PackageReferences = {
-					KnownPackages.SupportDesign_27_0_2_1,
-					KnownPackages.SupportCompat_27_0_2_1,
-					KnownPackages.SupportCoreUI_27_0_2_1,
-					KnownPackages.SupportCoreUtils_27_0_2_1,
-					KnownPackages.SupportFragment_27_0_2_1,
-					KnownPackages.SupportMediaCompat_27_0_2_1,
-					KnownPackages.GooglePlayServicesMaps_42_1021_1,
-					KnownPackages.Xamarin_Build_Download_0_4_11,
-				},
 			};
 			//NOTE: BuildingInsideVisualStudio prevents the projects from being built as dependencies
 			sb.BuildingInsideVisualStudio = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -326,14 +326,14 @@ class MemTest {
 		}
 
 		[Test]
-		[Category ("SmokeTests"), Category ("DotNetIgnore")] // <ProcessGoogleServicesJson/> task is built for net45]
+		[Category ("SmokeTests")]
 		[NonParallelizable] // parallel NuGet restore causes failures
 		public void BuildXamarinFormsMapsApplication ([Values (true, false)] bool multidex)
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();
 			if (multidex)
 				proj.SetProperty ("AndroidEnableMultiDex", "True");
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "first should have succeeded.");
 				b.BuildLogFile = "build2.log";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second should have succeeded.");
@@ -342,19 +342,19 @@ class MemTest {
 					"_UpdateAndroidResgen",
 				};
 				foreach (var target in targets) {
-					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped.");
+					b.Output.AssertTargetIsSkipped (target);
 				}
 				proj.Touch ("MainPage.xaml");
 				b.BuildLogFile = "build3.log";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "third should have succeeded.");
 				foreach (var target in targets) {
-					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped.");
+					b.Output.AssertTargetIsSkipped (target);
 				}
-				Assert.IsFalse (b.Output.IsTargetSkipped ("CoreCompile"), $"`CoreCompile` should not be skipped.");
+				b.Output.AssertTargetIsNotSkipped ("CoreCompile");
 				b.BuildLogFile = "build4.log";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "forth should have succeeded.");
 				foreach (var target in targets) {
-					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped.");
+					b.Output.AssertTargetIsSkipped (target);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -155,16 +155,6 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Design.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Design.dll" }
 				}
 		};
-		public static Package GooglePlayServicesMaps_42_1021_1 = new Package {
-			Id = "Xamarin.GooglePlayServices.Maps",
-			Version = "42.1021.1",
-			TargetFramework = "MonoAndroid70",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Maps.dll") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Maps.42.1021.1\\lib\\MonoAndroid70\\Xamarin.GooglePlayServices.Maps.dll"
-				}
-			}
-		};
 		public static Package XamarinFormsPCL_2_3_4_231 = new Package {
 			Id = "Xamarin.Forms",
 			Version = "2.3.4.231",
@@ -536,67 +526,19 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_GooglePlayServices_Base = new Package {
 			Id = "Xamarin.GooglePlayServices.Base",
-	    		Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-	    		References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Base") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Base.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Base.dll"
-				}
-			},
+			Version = "117.1.0",
 		};
-		public static Package Xamarin_GooglePlayServices_Basement = new Package
-		{
+		public static Package Xamarin_GooglePlayServices_Basement = new Package {
 			Id = "Xamarin.GooglePlayServices.Basement",
-			Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Basement") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Basement.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Basement.dll"
-				}
-			},
+			Version = "117.1.0",
 		};
-		public static Package Xamarin_GooglePlayServices_Tasks = new Package
-		{
+		public static Package Xamarin_GooglePlayServices_Tasks = new Package {
 			Id = "Xamarin.GooglePlayServices.Tasks",
-			Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Tasks") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Tasks.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Tasks.dll"
-				}
-			},
-		};
-		public static Package Xamarin_GooglePlayServices_Iid = new Package
-		{
-			Id = "Xamarin.GooglePlayServices.Iid",
-			Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Iid") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Iid.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Iid.dll"
-				}
-			},
-		};
-		public static Package Xamarin_GooglePlayServices_Gcm = new Package
-		{
-			Id = "Xamarin.GooglePlayServices.Gcm",
-			Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Gcm") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Gcm.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Gcm.dll"
-				}
-			},
+			Version = "117.0.0",
 		};
 		public static Package Xamarin_GooglePlayServices_Maps = new Package {
 			Id = "Xamarin.GooglePlayServices.Maps",
-			Version = "60.1142.1",
-			TargetFramework = "MonoAndroid80",
-			References = {
-				new BuildItem.Reference ("Xamarin.GooglePlayServices.Maps") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Maps.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Maps.dll"
-				}
-			},
+			Version = "117.0.0",
 		};
 		public static Package Acr_UserDialogs = new Package {
 			Id = "Acr.UserDialogs",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -17,6 +17,10 @@ namespace Xamarin.ProjectTools
 		{
 			if (Builder.UseDotNet) {
 				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_7_0_1142);
+				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
+				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
+				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Maps);
+				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
 			} else {
 				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_0_0_425677);
 			}


### PR DESCRIPTION
* Bump to Xamarin.GooglePlayServices 117.x.

Running under a `dotnet` context, a MSBuild tests using Google Play
Services would fail because of a `<ProcessGoogleServicesJson/>`
MSBuild task. The assembly was built for .NET framework, and so it
fails when running with `dotnet build`. We can update to
Xamarin.GooglePlayServices 117.x, because it is a netstandard2.0
assembly now.

I did some other general cleanup here:

* Setup `XamarinFormsMapsApplicationProject` so it will bring in the
  newest Xamarin.GooglePlayServices.
* Removed old Xamarin.GooglePlayServices packages from `KnownPackages`.
* Updated tests to use `XamarinFormsMapsApplicationProject` instead of
  the various GooglePlayServices packages directly.
* Removed the relevant `[Category ("DotNetIgnore")]`.

I also completely removed `AndroidUpdateResourcesTest.Issue2205`,
because it seems completely duplicate of
`BuildTest.BuildXamarinFormsMapsApplication` and other tests.
`Issue2205` was only checking that build succeeds for a project with a
`@(GoogleServicesJson)` item, and `XamarinFormsMapsApplicationProject`
has a `@(GoogleServicesJson)` file.