### PR TITLE
[tests] Add test for apk size comparison

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -56,6 +56,21 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void BuildReleaseArm64 ([Values (false, true)] bool forms)
+		{
+			var proj = forms ?
+				new XamarinFormsAndroidApplicationProject () :
+				new XamarinAndroidApplicationProject ();
+			proj.IsRelease = true;
+			proj.SetAndroidSupportedAbis ("arm64-v8a");
+
+			// use BuildHelper.CreateApkBuilder so that the test directory is not removed in tearup
+			using (var b = BuildHelper.CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
 		static readonly object [] BuildHasNoWarningsSource = new object [] {
 			new object [] {
 				/* isRelease */     false,


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5214

Build simple XA and XA/Forms apps in tests with current and NET5/6 XA.
Do not remove the temporary projects, so that it is possible to compare
the apks after tests run.

The apps are built with single arm64 ABI, in Release configuration.

The test can be run like this.

current XA:

    msbuild Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"

NET5/6:

    dotnet test -v diag --filter BuildTest.BuildReleaseArm64 .\bin\TestDebug\netcoreapp3.1\Xamarin.Android.Build.Tests.dll
