### PR TITLE
[Xamarin.Android.Build.Tasks] fix DirectoryNotFoundException for builds on network shares

### DIFF
--- a/Documentation/release-notes/5221.md
+++ b/Documentation/release-notes/5221.md
@@ -1,0 +1,5 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5218](https://github.com/xamarin/xamarin-android/issues/5218):
+  Fixed a *System.IO.DirectoryNotFoundException* that could occur when
+  building a project on a Windows network share.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MonoAndroidHelperTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MonoAndroidHelperTests.cs
@@ -204,5 +204,34 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreSame (expected, actual);
 			Assert.AreEqual (0, actual.Length);
 		}
+
+		[Test]
+		public void SetWriteable ()
+		{
+			File.WriteAllText (temp, contents: "foo");
+			File.SetAttributes (temp, FileAttributes.ReadOnly);
+
+			MonoAndroidHelper.SetWriteable (temp);
+
+			var attributes = File.GetAttributes (temp);
+			Assert.AreEqual (FileAttributes.Normal, attributes);
+			File.WriteAllText (temp, contents: "bar");
+		}
+
+		[Test]
+		public void SetDirectoryWriteable ()
+		{
+			Directory.CreateDirectory (temp);
+			try {
+				var directoryInfo = new DirectoryInfo (temp);
+				directoryInfo.Attributes |= FileAttributes.ReadOnly;
+				MonoAndroidHelper.SetDirectoryWriteable (temp);
+
+				directoryInfo = new DirectoryInfo (temp);
+				Assert.AreEqual (FileAttributes.Directory, directoryInfo.Attributes);
+			} finally {
+				Directory.Delete (temp);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -88,10 +88,12 @@ namespace Xamarin.Android.Tools
 					Directory.CreateDirectory (directory);
 
 				if (!Directory.Exists (source)) {
-					MonoAndroidHelper.SetWriteable (destination);
-					File.Delete (destination);
-					File.Copy (source, destination);
-					MonoAndroidHelper.SetWriteable (destination);
+					if (File.Exists (destination)) {
+						MonoAndroidHelper.SetWriteable (destination, checkExists: false);
+						File.Delete (destination);
+					}
+					File.Copy (source, destination, overwrite: true);
+					MonoAndroidHelper.SetWriteable (destination, checkExists: false);
 					File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
 					return true;
 				}
@@ -114,8 +116,10 @@ namespace Xamarin.Android.Tools
 				if (!string.IsNullOrEmpty (directory))
 					Directory.CreateDirectory (directory);
 
-				MonoAndroidHelper.SetWriteable (destination);
-				File.Delete (destination);
+				if (File.Exists (destination)) {
+					MonoAndroidHelper.SetWriteable (destination, checkExists: false);
+					File.Delete (destination);
+				}
 				File.WriteAllBytes (destination, bytes);
 				return true;
 			}
@@ -129,8 +133,10 @@ namespace Xamarin.Android.Tools
 				if (!string.IsNullOrEmpty (directory))
 					Directory.CreateDirectory (directory);
 
-				MonoAndroidHelper.SetWriteable (destination);
-				File.Delete (destination);
+				if (File.Exists (destination)) {
+					MonoAndroidHelper.SetWriteable (destination, checkExists: false);
+					File.Delete (destination);
+				}
 				using (var fileStream = File.Create (destination)) {
 					stream.Position = 0; //HasStreamChanged read to the end
 					stream.CopyTo (fileStream);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -360,14 +360,14 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public static void SetWriteable (string source)
+		public static void SetWriteable (string source, bool checkExists = true)
 		{
-			if (!File.Exists (source))
+			if (checkExists && !File.Exists (source))
 				return;
 
-			var fileInfo = new FileInfo (source);
-			if (fileInfo.IsReadOnly)
-				fileInfo.IsReadOnly = false;
+			var attributes = File.GetAttributes (source);
+			if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+				File.SetAttributes (source, attributes & ~FileAttributes.ReadOnly);
 		}
 
 		public static void SetDirectoryWriteable (string directory)
@@ -376,12 +376,12 @@ namespace Xamarin.Android.Tasks
 				return;
 
 			var dirInfo = new DirectoryInfo (directory);
-			if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+			if ((dirInfo.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
 				dirInfo.Attributes &= ~FileAttributes.ReadOnly;
 
 			foreach (var dir in Directory.EnumerateDirectories (directory, "*", SearchOption.AllDirectories)) {
 				dirInfo = new DirectoryInfo (dir);
-				if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+				if ((dirInfo.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
 					dirInfo.Attributes &= ~FileAttributes.ReadOnly;
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5218

Builds could fail on a Windows network share with:

    System.IO.DirectoryNotFoundException: Could not find a part of the path 'XYZ'
        at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
        at System.IO.File.InternalDelete(String path, Boolean checkHost)
        at System.IO.File.Delete(String path)
        at Xamarin.Android.Tools.Files.CopyIfStreamChanged(Stream stream, String destination)
        at Xamarin.Android.Tools.Files.ExtractAll(ZipArchive zip, String destination, Action`2 progressCallback, Func`2 modifyCallback, Func`2 deleteCallback, Func`2 skipCallback)
        at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments)
        at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask()
        at Xamarin.Android.Tasks.AndroidTask.Execute()

Normally a call to `File.Delete()` completes silently if the file does
not exist:

> If the file to be deleted does not exist, no exception is thrown.

https://docs.microsoft.com/dotnet/api/system.io.file.delete#remarks

However, this does not appear to be the case for a file on a network
share. `DirectoryNotFoundException` is thrown?!?

`Files.CopyIf*Changed` is a hot path, that is called many times
throughout a build. A simple `File.Exists()` check solves the problem,
but we don't want to add additional I/O calls. I made
`MonoAndroidHelper.SetWriteable()` able to optionally skip the
`File.Exists()` check.

When reviewing this code, I fixed some other issues: :eyes:

* `MonoAndroidHelper.SetDirectoryWriteable()` did not have the correct
  enum flags logic to check for `FileAttributes.ReadOnly`.
* `MonoAndroidHelper.SetWriteable()` can avoid using the
  `System.IO.FileInfo` API, as it creates an object on the heap.
  `File.GetAttributes()` and `File.SetAttributes()` are more
  appropriate for this case.