### PR TITLE
Bump to xamarin/Java.Interop/master@da74abd2

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -209,6 +209,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LineEditor.dll"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\LineEditor.pdb"   Condition=" '$(PackageId)' != 'Microsoft.Android.Sdk' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1230070

Changes: https://github.com/xamarin/Java.Interop/compare/b991bb869c022616f53e4c3a324a01d77e6e4a2b...da74abd24d95ce6c3511467e3cd481680d888230

  * xamarin/Java.Interop@da74abd2: Bump to mono/LineEditor/v5.4.1@3fa0c2eb (#740)
  * xamarin/Java.Interop@5fe912ad: Bump to xamarin/xamarin-android-tools/main@26d65d9 (#741)
  * xamarin/Java.Interop@9c73dbff: [generator] Output correct formatting for binding warnings (#737)

Update `create-installers.targets` so that `LineEditor.pdb` is
included in the macOS `.pkg` and Windows `.vsix` installers.