### PR TITLE
[One .NET] temporary Windows & macOS installers for .NET 6

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -72,6 +72,7 @@
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">5.0.100</DotNetPreviewVersionBand>
     <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-rtm.20509.5</DotNetPreviewVersionFull>
+    <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.10.2</AndroidCmakeVersion>
     <AndroidCmakeVersionPath Condition=" '$(AndroidCmakeVersionPath)' == '' ">$(AndroidCmakeVersion).4988404</AndroidCmakeVersionPath>
     <AndroidSdkCmakeDirectory>$(AndroidSdkDirectory)\cmake\$(AndroidCmakeVersionPath)</AndroidSdkCmakeDirectory>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ConvertToRichText.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/ConvertToRichText.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	/// <summary>
+	/// Used for converting plain text license files to .rtf format.
+	/// Assumes the file is line wrapped with Environment.NewLine:
+	/// * Double new lines are preserved.
+	/// * Single new lines are replaced with spaces.
+	///
+	/// For a Unicode escape the control word \u is used, followed by
+	/// a 16-bit signed decimal integer giving the Unicode UTF-16 code
+	/// unit number. More information under 'Character encoding' here:
+	/// https://en.wikipedia.org/wiki/Rich_Text_Format
+	/// </summary>
+	public class ConvertToRichText : Task
+	{
+		[Required]
+		public string SourceFile { get; set; }
+
+		[Required]
+		public string DestinationFile { get; set; }
+
+		public override bool Execute ()
+		{
+			var text = File.ReadAllText (SourceFile);
+
+			text = text
+				.Replace (@"\", @"\\")
+				.Replace ("{", @"\{")
+				.Replace ("}", @"\}")
+				// Only want to keep "double" new lines
+				.Replace (Environment.NewLine + Environment.NewLine, $@"\par{Environment.NewLine} \par{Environment.NewLine} ")
+				.Replace (Environment.NewLine, " ");
+
+			Directory.CreateDirectory (Path.GetDirectoryName (DestinationFile));
+			using (var writer = File.CreateText (DestinationFile)) {
+				writer.Write (@"{\rtf1\ansi\ansicpg1250\deff0{\fonttbl\f0\fcharset0 Courier New;}\f0\pard ");
+				foreach (char letter in text) {
+					if (letter <= 0x7f) {
+						writer.Write (letter);
+					} else {
+						writer.Write ("\\u");
+						writer.Write (Convert.ToUInt32 (letter));
+						writer.Write ("?");
+					}
+				}
+				writer.Write (" } ");
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
@@ -1,0 +1,188 @@
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	/// <summary>
+	/// Generates a .wix file for the contents of ~/android-toolchain/dotnet/packs
+	/// The .wix file can be used to generate the .msi installer for Windows.
+	/// </summary>
+	public class GenerateWixFile : Task
+	{
+		[Required]
+		public string Template { get; set; }
+
+		[Required]
+		public string DestinationFile { get; set; }
+
+		[Required]
+		public string DotNetPath { get; set; }
+
+		[Required]
+		public string DotNetVersion { get; set; }
+
+		[Required]
+		public string MSIVersion { get; set; }
+
+		public override bool Execute ()
+		{
+			var settings = new XmlWriterSettings {
+				OmitXmlDeclaration = true,
+				Indent = true,
+			};
+
+			var directories = new StringBuilder ();
+			var components = new StringBuilder ();
+			using (var packWriter = XmlWriter.Create (directories, settings))
+			using (var componentWriter = XmlWriter.Create (components, settings)) {
+
+				// Components
+				componentWriter.WriteStartElement ("ComponentGroup");
+				componentWriter.WriteAttributeString ("Id", "ProductComponents");
+				componentWriter.WriteStartElement ("ComponentRef");
+				componentWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
+				componentWriter.WriteEndElement (); // </ComponentRef>
+
+				// dotnet
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "dotnet");
+				packWriter.WriteAttributeString ("Name", "dotnet");
+
+				// sdk
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "sdk");
+				packWriter.WriteAttributeString ("Name", "sdk");
+
+				// DOTNETVERSION
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "DOTNETVERSION");
+				packWriter.WriteAttributeString ("Name", DotNetVersion);
+				packWriter.WriteAttributeString ("FileSource", Path.Combine (DotNetPath, "sdk", DotNetVersion));
+
+				// EnableWorkloadResolver
+				packWriter.WriteStartElement ("Component");
+				packWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
+				packWriter.WriteStartElement ("File");
+				packWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
+				packWriter.WriteAttributeString ("Name", "EnableWorkloadResolver.sentinel");
+				packWriter.WriteAttributeString ("KeyPath", "yes");
+				packWriter.WriteEndElement (); // </File>
+				packWriter.WriteEndElement (); // </Component>
+				packWriter.WriteEndElement (); // </Directory> DOTNETVERSION
+				packWriter.WriteEndElement (); // </Directory> sdk
+
+				// sdk-manifests
+				var sdk_manifests_root = Path.Combine (DotNetPath, "sdk-manifests");
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "sdk_manifests");
+				packWriter.WriteAttributeString ("Name", "sdk-manifests");
+
+				// 5.0.100
+				var sdk_manifests = Directory.EnumerateDirectories (sdk_manifests_root).FirstOrDefault ();
+				if (string.IsNullOrEmpty (sdk_manifests)) {
+					Log.LogError ($"Cannot find child directory of: {sdk_manifests_root}");
+					return false;
+				}
+				var version_band = Path.GetFileName (sdk_manifests);
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "DOTNETVERSIONBAND");
+				packWriter.WriteAttributeString ("Name", version_band);
+				packWriter.WriteAttributeString ("FileSource", sdk_manifests);
+				var workload = Path.Combine (sdk_manifests, "Microsoft.NET.Workload.Android");
+				if (Directory.Exists (workload)) {
+					RecurseDirectory (sdk_manifests, packWriter, componentWriter, workload);
+				} else {
+					Log.LogError ($"Cannot find directory: {workload}");
+					return false;
+				}
+				packWriter.WriteEndElement (); // </Directory> version_band
+				packWriter.WriteEndElement (); // </Directory> sdk-manifests
+
+				// packs
+				var packs_dir = Path.Combine (DotNetPath, "packs");
+				packWriter.WriteStartElement ("Directory");
+				packWriter.WriteAttributeString ("Id", "packs");
+				packWriter.WriteAttributeString ("Name", "packs");
+				foreach (var directory in Directory.EnumerateDirectories (packs_dir, "Microsoft.Android.*")) {
+					RecurseDirectory (packs_dir, packWriter, componentWriter, directory);
+				}
+
+				packWriter.WriteEndDocument (); // </Directory>
+				componentWriter.WriteEndDocument (); // </ComponentGroup>
+			}
+
+			var template = File.ReadAllText (Template);
+			var contents = template
+				.Replace ("@MSIVERSION@", MSIVersion)
+				.Replace ("@DIRECTORIES@", directories.ToString ())
+				.Replace ("@COMPONENTS@", components.ToString ());
+
+			Log.LogMessage (MessageImportance.Low, "Writing XML to {0}: {1}", DestinationFile, contents);
+			File.WriteAllText (DestinationFile, contents);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		static void RecurseDirectory (string top_dir, XmlWriter packWriter, XmlWriter componentWriter, string directory)
+		{
+			var directoryId = GetId (top_dir, directory);
+			packWriter.WriteStartElement ("Directory");
+			packWriter.WriteAttributeString ("Id", directoryId);
+			packWriter.WriteAttributeString ("Name", Path.GetFileName (directory));
+			packWriter.WriteAttributeString ("FileSource", directory);
+			foreach (var child in Directory.EnumerateDirectories (directory)) {
+				var directoryName = Path.GetFileName (child);
+				if (directoryName.StartsWith (".") || directoryName.StartsWith ("_"))
+					continue;
+				RecurseDirectory (top_dir, packWriter, componentWriter, child);
+			}
+			foreach (var file in Directory.EnumerateFiles (directory)) {
+				var fileName = Path.GetFileName (file);
+				if (fileName.StartsWith (".") || fileName.StartsWith ("_"))
+					continue;
+				var componentId = GetId (top_dir, file);
+				packWriter.WriteStartElement ("Component");
+				packWriter.WriteAttributeString ("Id", componentId);
+				packWriter.WriteStartElement ("File");
+				packWriter.WriteAttributeString ("Id", componentId);
+				packWriter.WriteAttributeString ("Name", Path.GetFileName (file));
+				packWriter.WriteAttributeString ("KeyPath", "yes");
+				packWriter.WriteEndElement (); // </File>
+				packWriter.WriteEndElement (); // </Component>
+				componentWriter.WriteStartElement ("ComponentRef");
+				componentWriter.WriteAttributeString ("Id", componentId);
+				componentWriter.WriteEndElement (); // </ComponentRef>
+			}
+			packWriter.WriteEndElement (); // </Directory>
+		}
+
+		static string GetId (string top_dir, string path)
+		{
+			if (string.IsNullOrEmpty (path))
+				return path;
+			if (path.Length > top_dir.Length + 1) {
+				path = path.Substring (top_dir.Length + 1);
+			}
+			return GetHashString (path);
+		}
+
+		static byte [] GetHash (string inputString)
+		{
+			using (var algorithm = SHA256.Create ())
+				return algorithm.ComputeHash (Encoding.UTF8.GetBytes (inputString));
+		}
+
+		static string GetHashString (string inputString)
+		{
+			var sb = new StringBuilder ("S", 65);
+			foreach (byte b in GetHash (inputString))
+				sb.Append (b.ToString ("X2"));
+			return sb.ToString ();
+		}
+	}
+}

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -103,8 +103,8 @@ stages:
       displayName: make jenkins
 
     - script: >
-        echo "make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)" &&
-        make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+        echo "make create-pkg create-vsix V=1 CONFIGURATION=$(XA.Build.Configuration)" &&
+        make create-pkg create-vsix V=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: create installers
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -203,6 +203,13 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
 
+    - task: MSBuild@1
+      displayName: pack all nupkgs
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+
     # Create installers
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
@@ -226,13 +233,6 @@ stages:
       inputs:
         artifactName: $(InstallerArtifactName)
         targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-
-    - task: MSBuild@1
-      displayName: pack all nupkgs
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
 
     - task: NuGetCommand@2
       displayName: push nupkgs
@@ -1115,6 +1115,60 @@ stages:
 
     - template: yaml-templates/fail-on-issue.yaml
 
+- stage: dotnet_installers
+  displayName: .NET 6 Preview Installers
+  dependsOn: mac_build
+  jobs:
+  # Check - "Xamarin.Android (.NET 6 Preview Installers Create .msi and Upload)"
+  - job: dotnet_preview_installers
+    displayName: Create .msi and Upload
+    pool: $(HostedWinVS2019)
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      submodules: recursive
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(NuGetArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\nupkgs
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(InstallerArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)\installer-artifacts
+        patterns: Microsoft.*.pkg
+
+    - task: MSBuild@1
+      displayName: msbuild Xamarin.Android.BootstrapTasks
+      inputs:
+        solution: Xamarin.Android.BootstrapTasks.sln
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-bootstraptasks.binlog
+
+    - task: MSBuild@1
+      displayName: msbuild /t:CreateWorkloadInstallers
+      inputs:
+        solution: Xamarin.Android.sln
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:CreateWorkloadInstallers /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-workload.binlog
+
+    - script: copy /Y $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\*.msi $(System.DefaultWorkingDirectory)\installer-artifacts
+      displayName: copy .msi
+
+    - template: upload-to-storage\win\v1.yml@yaml
+      parameters:
+        ArtifactsDirectory: $(System.DefaultWorkingDirectory)\installer-artifacts
+        Azure.ContainerName: $(Azure.Container.Name)
+        Azure.BlobPrefix: $(Build.DefinitionName)/public/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        GitHub.Context: .NET 6 Preview Installers
+
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
+        artifactName: Build Results - .NET 6 Preview Installers
+
 - stage: finalize_installers
   displayName: Finalize Installers
   dependsOn: mac_build
@@ -1148,6 +1202,9 @@ stages:
       inputs:
         artifactName: $(InstallerArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/storage-artifacts
+        patterns: |
+          xamarin.android*.pkg
+          Xamarin.Android*.vsix
 
     - powershell: |
         $pkg = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/storage-artifacts/*" -Include *.pkg -File

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -6,6 +6,15 @@ steps:
   inputs:
     artifactName: $(InstallerArtifactName)
     downloadPath: $(System.DefaultWorkingDirectory)
+    patterns: xamarin.android*.pkg
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- task: DownloadPipelineArtifact@2
+  inputs:
+    artifactName: $(InstallerArtifactName)
+    downloadPath: $(System.DefaultWorkingDirectory)
+    patterns: Xamarin.Android*.vsix
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - powershell: |
     $itemPattern = "*.vsix"

--- a/build-tools/create-dotnet-msi/Microsoft.NET.Workload.Android.wix.in
+++ b/build-tools/create-dotnet-msi/Microsoft.NET.Workload.Android.wix.in
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <Product Name="Microsoft.NET.Workload.Android"
+      Id="*"
+      Language="1033"
+      Version="@MSIVERSION@"
+      Manufacturer="Microsoft"
+      UpgradeCode="86a83cc9-6b75-489f-be10-27988df907c6">
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x64" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+    <UIRef Id="WixUI_Minimal" />
+    <Feature Id="ProductFeature" Title="Microsoft.NET.Workload.Android">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+    <WixVariable Id="WixUILicenseRtf" Value="LICENSE.rtf" />
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFiles64Folder">
+        @DIRECTORIES@
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    @COMPONENTS@
+  </Fragment>
+
+</Wix>

--- a/build-tools/create-dotnet-msi/Microsoft.NET.Workload.Android.wix.in
+++ b/build-tools/create-dotnet-msi/Microsoft.NET.Workload.Android.wix.in
@@ -8,7 +8,11 @@
       Manufacturer="Microsoft"
       UpgradeCode="86a83cc9-6b75-489f-be10-27988df907c6">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Platform="x64" />
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <!--
+      Use AllowSameVersionUpgrades for upgrades of an .msi where only the 4th component of the version changed
+      see: https://wixtoolset.org/documentation/manual/v3/xsd/wix/majorupgrade.html
+    -->
+    <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
     <UIRef Id="WixUI_Minimal" />
     <Feature Id="ProductFeature" Title="Microsoft.NET.Workload.Android">

--- a/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
+++ b/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
@@ -90,8 +90,13 @@
       DependsOnTargets="_CompileWixObj"
       Inputs="$(_WixObj)"
       Outputs="$(_WixMsi)">
-    <!--NOTE: ignore ICE03 warning for zh-Hant: error LGHT0204: ICE03: Invalid Language Id -->
-    <Exec Command="&quot;$(WixToolPath)light.exe&quot; -ext WixUIExtension -cultures:en-US -sice:ICE03 Microsoft.NET.Workload.Android.wixobj" WorkingDirectory="$(IntermediateOutputPath)" />
+    <ItemGroup>
+      <!-- ignore ICE03 warning for zh-Hant: error LGHT0204: ICE03: Invalid Language Id -->
+      <_IgnoredWarnings Include="-sice:ICE03" />
+      <!-- ignore ICE61 warning for AllowSameVersionUpgrades usage -->
+      <_IgnoredWarnings Include="-sice:ICE61" />
+    </ItemGroup>
+    <Exec Command="&quot;$(WixToolPath)light.exe&quot; -ext WixUIExtension -cultures:en-US @(_IgnoredWarnings, ' ') Microsoft.NET.Workload.Android.wixobj" WorkingDirectory="$(IntermediateOutputPath)" />
     <ItemGroup>
       <FileWrites Include="$(_WixMsi)" />
       <None Include="$(_WixMsi)" CopyToOutputDirectory="PreserveNewest" Link="Microsoft.NET.Workload.Android.$(AndroidMSIVersion).msi" />

--- a/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
+++ b/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
@@ -1,0 +1,101 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
+    <_WixTemplate>Microsoft.NET.Workload.Android.wix.in</_WixTemplate>
+  </PropertyGroup>
+
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\scripts\XAVersionInfo.targets" />
+
+  <ItemGroup>
+    <None Remove="**" />
+    <None Include="$(_WixTemplate)" />
+  </ItemGroup>
+
+  <UsingTask AssemblyFile="$(PrepTasksAssembly)"      TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.ConvertToRichText" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateWixFile" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
+
+  <Target Name="_DownloadWix">
+    <DownloadUri
+        SourceUris="https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip"
+        DestinationFiles="$(AndroidToolchainCacheDirectory)\wix311-binaries.zip"
+    />
+  </Target>
+
+  <Target Name="_UnzipWix"
+      Inputs="$(AndroidToolchainCacheDirectory)\wix311-binaries.zip"
+      Outputs="$(WixToolPath)candle.exe;$(WixToolPath)light.exe">
+    <UnzipDirectoryChildren
+        NoSubdirectory="True"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\wix311-binaries.zip"
+        DestinationFolder="$(WixToolPath)"
+    />
+  </Target>
+
+  <Target Name="_Properties">
+    <PropertyGroup>
+      <License Condition=" '$(License)' == '' ">$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\LICENSE</License>
+      <_LicenseDestination>$(IntermediateOutputPath)LICENSE.rtf</_LicenseDestination>
+      <_WixFile>$(IntermediateOutputPath)Microsoft.NET.Workload.Android.wix</_WixFile>
+      <_WixObj>$(IntermediateOutputPath)Microsoft.NET.Workload.Android.wixobj</_WixObj>
+      <_WixMsi>$(IntermediateOutputPath)Microsoft.NET.Workload.Android.msi</_WixMsi>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_ConvertLicense"
+      Inputs="$(MSBuildThisFile);$(BootstrapTasksAssembly);$(License)"
+      Outputs="$(_LicenseDestination)">
+    <ConvertToRichText
+        SourceFile="$(License)"
+        DestinationFile="$(_LicenseDestination)"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_LicenseDestination)" />
+      <None       Include="$(_LicenseDestination)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateWix"
+      DependsOnTargets="GetXAVersionInfo"
+      Inputs="$(MSBuildThisFile);$(BootstrapTasksAssembly);@(None)"
+      Outputs="$(_WixFile)">
+    <GenerateWixFile
+        Template="$(_WixTemplate)"
+        DestinationFile="$(_WixFile)"
+        DotNetPath="$(DotNetPreviewPath)"
+        DotNetVersion="$(DotNetPreviewVersionFull)"
+        MSIVersion="$(AndroidMSIVersion)"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_WixFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CompileWixObj"
+      DependsOnTargets="_DownloadWix;_UnzipWix;_Properties;_ConvertLicense;_GenerateWix"
+      Inputs="$(_WixFile)"
+      Outputs="$(_WixObj)">
+    <Exec Command="&quot;$(WixToolPath)candle.exe&quot; -arch x64 Microsoft.NET.Workload.Android.wix" WorkingDirectory="$(IntermediateOutputPath)" />
+    <ItemGroup>
+      <FileWrites Include="$(_WixObj)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_PackageMsi"
+      BeforeTargets="AssignTargetPaths"
+      DependsOnTargets="_CompileWixObj"
+      Inputs="$(_WixObj)"
+      Outputs="$(_WixMsi)">
+    <!--NOTE: ignore ICE03 warning for zh-Hant: error LGHT0204: ICE03: Invalid Language Id -->
+    <Exec Command="&quot;$(WixToolPath)light.exe&quot; -ext WixUIExtension -cultures:en-US -sice:ICE03 Microsoft.NET.Workload.Android.wixobj" WorkingDirectory="$(IntermediateOutputPath)" />
+    <ItemGroup>
+      <FileWrites Include="$(_WixMsi)" />
+      <None Include="$(_WixMsi)" CopyToOutputDirectory="PreserveNewest" Link="Microsoft.NET.Workload.Android.$(AndroidMSIVersion).msi" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -1,0 +1,82 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\scripts\XAVersionInfo.targets" />
+
+  <PropertyGroup>
+    <PkgInstallDir>/</PkgInstallDir>
+    <PayloadDir>$(OutputPath)\pkg\archive</PayloadDir>
+    <PkgOutputPath>$(OutputPath)\pkg\packages</PkgOutputPath>
+    <PkgResourcesPath>$(OutputPath)\pkg\resources</PkgResourcesPath>
+    <PkgDistributionDestination>$(OutputPath)\pkg\distribution.xml</PkgDistributionDestination>
+    <LicenseDestination>$(PkgResourcesPath)\en.lproj</LicenseDestination>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**" />
+    <None Include="distribution.xml.in" />
+  </ItemGroup>
+
+  <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+
+  <Target Name="_FinalizePayload"
+      DependsOnTargets="GetXAVersionInfo">
+    <PropertyGroup>
+      <License Condition=" '$(License)' == '' ">$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\LICENSE</License>
+      <DotNetPayloadDir>$(PayloadDir)\usr\local\share\dotnet\</DotNetPayloadDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(DotNetPreviewVersionFull)\EnableWorkloadResolver.sentinel" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk\**\*" />
+    </ItemGroup>
+    <MakeDir Directories="$(PkgOutputPath);$(PayloadDir);$(PkgResourcesPath);$(LicenseDestination)"/>
+    <ReplaceFileContents
+        SourceFile="distribution.xml.in"
+        DestinationFile="$(PkgDistributionDestination)"
+        Replacements="@PACKAGE_TITLE@=Microsoft.NET.Workload.Android $(AndroidPackVersionLong)"
+    />
+    <Copy
+        SourceFiles="@(_FilesToCopy)"
+        DestinationFiles="@(_FilesToCopy->'$([System.String]::Copy('%(Identity)').Replace($(DotNetPreviewPath),$(DotNetPayloadDir)))')"
+    />
+    <Copy
+        SourceFiles="$(License)"
+        DestinationFiles="$(LicenseDestination)\License"
+    />
+  </Target>
+  <Target Name="_CreatePkg"
+      BeforeTargets="AssignTargetPaths"
+      DependsOnTargets="_FinalizePayload">
+    <PropertyGroup>
+      <PkgProductOutputPath>$(IntermediateOutputPath)Microsoft.NET.Workload.Android.pkg</PkgProductOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <PkgBuildArgs Include="--root &quot;$(PayloadDir)&quot;" />
+      <PkgBuildArgs Include="--identifier com.microsoft.net.workload.android.pkg" />
+      <PkgBuildArgs Include="--version $(AndroidPackVersionLong)"/>
+      <PkgBuildArgs Include="--install-location &quot;$(PkgInstallDir)&quot; "/>
+      <PkgBuildArgs Include="&quot;$(PkgOutputPath)/microsoft.net.workload.android.pkg&quot; "/>
+    </ItemGroup>
+    <Exec Command="pkgbuild @(PkgBuildArgs, ' ')" />
+    <ItemGroup>
+      <ProductBuildArgs Include="--resources &quot;$(PkgResourcesPath)&quot;" />
+      <ProductBuildArgs Include="--distribution &quot;$(PkgDistributionDestination)&quot;" />
+      <ProductBuildArgs Include="--package-path &quot;$(PkgOutputPath)&quot;" />
+      <ProductBuildArgs Include="&quot;$(PkgProductOutputPath)&quot;" />
+    </ItemGroup>
+    <Exec Command="productbuild @(ProductBuildArgs, ' ')" />
+    <RemoveDir Directories="$(OutputPath)\pkg"/>
+    <ItemGroup>
+      <FileWrites Include="$(PkgProductOutputPath)" />
+      <None Include="$(PkgProductOutputPath)" CopyToOutputDirectory="PreserveNewest" Link="Microsoft.NET.Workload.Android-$(AndroidPackVersionLong).pkg" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/build-tools/create-dotnet-pkg/distribution.xml.in
+++ b/build-tools/create-dotnet-pkg/distribution.xml.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+  <license file="License" mime-type="application/rtf" />
+  <title>@PACKAGE_TITLE@</title>
+  <pkg-ref id="microsoft.net.workload.android">
+    <bundle-version/>
+  </pkg-ref>
+  <choices-outline>
+    <line choice="default">
+      <line choice="microsoft.net.workload.android"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="microsoft.net.workload.android" visible="false">
+    <pkg-ref id="microsoft.net.workload.android"/>
+  </choice>
+  <pkg-ref id="microsoft.net.workload.android">#microsoft.net.workload.android.pkg</pkg-ref>
+</installer-gui-script>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -25,6 +25,23 @@
     <FrameworkListFileClass Include="@(_AndroidAppPackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />
   </ItemGroup>
 
+  <!-- LICENSE setup -->
+  <PropertyGroup>
+    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)LICENSE</NuGetLicense>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+  <Target Name="_GetLicense">
+    <!-- NuGet doesn't have a way to change the filename of License.txt, so copy it -->
+    <Copy
+        SourceFiles="$(NuGetLicense)"
+        DestinationFiles="$(IntermediateOutputPath)$(PackageLicenseFile)"
+        SkipUnchangedFiles="true"
+    />
+    <ItemGroup>
+      <_PackageFiles Include="$(IntermediateOutputPath)$(PackageLicenseFile)" PackagePath="\" />
+    </ItemGroup>
+  </Target>
+
  <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
   <Target Name="_GenerateFrameworkListFile" >
     <!-- Hardcode framework attributes -->
@@ -105,6 +122,7 @@
     />
     <!-- Some files had timestamps in the future -->
     <Touch Files="@(_FilesToTouch)" />
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName ($(_WorkloadResolverFlagFile)))" />
     <Touch
         Files="$(_WorkloadResolverFlagFile)"
         AlwaysCreate="true"

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -21,8 +21,6 @@ by projects that use the Microsoft.Android framework in .NET 5.
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)\LICENSE</NuGetLicense>
-    <PackageLicenseFile>$([System.IO.Path]::GetFileName($(NuGetLicense)))</PackageLicenseFile>
     <BeforePack>
       _GetTargetingPackItems;
       _GetDefaultPackageVersion;
@@ -31,13 +29,13 @@ by projects that use the Microsoft.Android framework in .NET 5.
     </BeforePack>
   </PropertyGroup>
 
-  <Target Name="_GetTargetingPackItems" >
+  <Target Name="_GetTargetingPackItems"
+      DependsOnTargets="_GetLicense">
     <PropertyGroup>
       <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <_PackageFiles Include="$(NuGetLicense)" PackagePath="\" />
       <_PackageFiles Include="@(_AndroidAppRefAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -24,8 +24,6 @@ projects that use the Microsoft.Android framework in .NET 5.
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)\LICENSE</NuGetLicense>
-    <PackageLicenseFile>$([System.IO.Path]::GetFileName($(NuGetLicense)))</PackageLicenseFile>
     <BeforePack>
       _GetRuntimePackItems;
       _GetDefaultPackageVersion;
@@ -34,7 +32,8 @@ projects that use the Microsoft.Android framework in .NET 5.
     </BeforePack>
   </PropertyGroup>
 
-  <Target Name="_GetRuntimePackItems" >
+  <Target Name="_GetRuntimePackItems"
+      DependsOnTargets="_GetLicense">
     <PropertyGroup>
       <FrameworkListFile>$(IntermediateOutputPath)$(AndroidRID)\RuntimeList.xml</FrameworkListFile>
     </PropertyGroup>
@@ -48,7 +47,6 @@ projects that use the Microsoft.Android framework in .NET 5.
     </ItemGroup>
 
     <ItemGroup>
-      <_PackageFiles Include="$(NuGetLicense)" PackagePath="\" />
       <_PackageFiles Include="@(_AndroidAppPackAssemblies)" PackagePath="$(_AndroidRuntimePackAssemblyPath)" TargetPath="$(_AndroidRuntimePackAssemblyPath)" />
       <_PackageFiles Include="@(_AndroidRuntimePackAssets)" PackagePath="$(_AndroidRuntimePackNativePath)" TargetPath="$(_AndroidRuntimePackNativePath)" IsNative="true" />
     </ItemGroup>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -26,8 +26,6 @@ sdk pack imported by Microsoft.NET.Workload.Android.
   <Import Project="..\..\build-tools\installers\create-installers.targets" />
 
   <PropertyGroup>
-    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)\LICENSE</NuGetLicense>
-    <PackageLicenseFile>$([System.IO.Path]::GetFileName($(NuGetLicense)))</PackageLicenseFile>
     <BeforePack>
       _GenerateXASdkContent;
       $(BeforePack);
@@ -35,7 +33,7 @@ sdk pack imported by Microsoft.NET.Workload.Android.
   </PropertyGroup>
 
   <Target Name="_GenerateXASdkContent"
-      DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions" >
+      DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions;_GetLicense">
     <PropertyGroup>
       <ToolsSourceDir>$(XamarinAndroidSourcePath)bin\Build$(Configuration)\packs\tools\</ToolsSourceDir>
       <NetCoreAppToolsSourceDir>$(XamarinAndroidSourcePath)bin\$(Configuration)-netcoreapp3.1\</NetCoreAppToolsSourceDir>
@@ -71,7 +69,6 @@ sdk pack imported by Microsoft.NET.Workload.Android.
         Condition="$([MSBuild]::IsOSPlatform('osx')) or $([MSBuild]::IsOSPlatform('linux'))"
     />
     <ItemGroup>
-      <_PackageFiles Include="$(NuGetLicense)" PackagePath="\" />
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.dll" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.runtimeconfig.json" PackagePath="tools" />

--- a/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
@@ -20,8 +20,6 @@ workload manifest pack containing information about the various Microsoft.Androi
   <Import Project="..\..\build-tools\installers\create-installers.targets" />
 
   <PropertyGroup>
-    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)\LICENSE</NuGetLicense>
-    <PackageLicenseFile>$([System.IO.Path]::GetFileName($(NuGetLicense)))</PackageLicenseFile>
     <BeforePack>
       _GenerateXAWorkloadContent;
       $(BeforePack);
@@ -30,7 +28,7 @@ workload manifest pack containing information about the various Microsoft.Androi
 
   <!-- FIXME: Temporarily Generate WorkloadManifest.targets and WorkloadManifest.json files inline while content is trivial. -->
   <Target Name="_GenerateXAWorkloadContent"
-      DependsOnTargets="_GetDefaultPackageVersion" >
+      DependsOnTargets="_GetDefaultPackageVersion;_GetLicense">
     <PropertyGroup>
       <WorkloadManifestTargetsPath>$(OutputPath)\workload-manifest\WorkloadManifest.targets</WorkloadManifestTargetsPath>
       <WorkloadManifestJsonPath>$(OutputPath)\workload-manifest\WorkloadManifest.json</WorkloadManifestJsonPath>
@@ -80,7 +78,6 @@ workload manifest pack containing information about the various Microsoft.Androi
         Overwrite="true" />
 
     <ItemGroup>
-      <_PackageFiles Include="$(NuGetLicense)" PackagePath="\" />
       <_PackageFiles Include="$(WorkloadManifestTargetsPath)" PackagePath="\" />
       <_PackageFiles Include="$(WorkloadManifestJsonPath)" PackagePath="\" />
     </ItemGroup>

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -1,17 +1,36 @@
 <Project>
+  <PropertyGroup>
+    <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
+  </PropertyGroup>
   <Target Name="PackDotNet">
-    <PropertyGroup>
-      <_TopDir>$(MSBuildThisFileDirectory)..\..\</_TopDir>
-    </PropertyGroup>
-    <MSBuild Projects="$(_TopDir)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
-    <MSBuild Projects="$(_TopDir)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
-    <MSBuild Projects="$(_TopDir)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
-    <MSBuild Projects="$(_TopDir)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
+    <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
+    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->
     <ItemGroup>
-      <_OldPackages Include="$(_TopDir)packages\microsoft.android.*\**\*.nupkg" />
+      <_OldPackages Include="$(_Root)packages\microsoft.android.*\**\*.nupkg" />
       <_DirectoriesToRemove Include="%(_OldPackages.RootDir)%(_OldPackages.Directory)" />
     </ItemGroup>
     <RemoveDir Directories="@(_DirectoriesToRemove)" />
+  </Target>
+  <Target Name="CreateWorkloadInstallers">
+    <MSBuild
+        Targets="ExtractWorkloadPacks"
+        Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj"
+        Properties="Configuration=$(Configuration)"
+    />
+    <MSBuild
+        Condition=" $([MSBuild]::IsOSPlatform('windows')) "
+        Targets="Restore;Build"
+        Projects="$(_Root)build-tools\create-dotnet-msi\create-dotnet-msi.csproj"
+        Properties="Configuration=$(Configuration)"
+    />
+    <MSBuild
+        Condition=" $([MSBuild]::IsOSPlatform('osx')) "
+        Targets="Restore;Build"
+        Projects="$(_Root)build-tools\create-dotnet-pkg\create-dotnet-pkg.csproj"
+        Properties="Configuration=$(Configuration)"
+    />
   </Target>
 </Project>

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -1,4 +1,4 @@
-create-installers: create-pkg create-vsix
+create-installers: create-pkg create-vsix create-workload-installers
 
 create-pkg:
 	MONO_IOMAP=all MONO_OPTIONS="$(MONO_OPTIONS)" $(call MSBUILD_BINLOG,create-pkg) /p:Configuration=$(CONFIGURATION) /t:CreatePkg \
@@ -8,6 +8,11 @@ create-pkg:
 		$(if $(PKG_LICENSE_EN),/p:PkgLicenseSrcEn="$(PKG_LICENSE_EN)") \
 		$(if $(PKG_OUTPUT_PATH),/p:PkgProductOutputPath="$(PKG_OUTPUT_PATH)") \
 		$(if $(USE_COMMERCIAL_INSTALLER_NAME),/p:UseCommercialInstallerName="$(USE_COMMERCIAL_INSTALLER_NAME)") \
+		$(if $(_MSBUILD_ARGS),"$(_MSBUILD_ARGS)")
+
+create-workload-installers:
+	MONO_IOMAP=all MONO_OPTIONS="$(MONO_OPTIONS)" $(call MSBUILD_BINLOG,create-workload-installers) /p:Configuration=$(CONFIGURATION) /t:CreateWorkloadInstallers \
+		Xamarin.Android.sln \
 		$(if $(_MSBUILD_ARGS),"$(_MSBUILD_ARGS)")
 
 create-vsix:

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -88,6 +88,7 @@
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
       <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
+      <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>
     </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
For .NET 6 Preview 1, we will need to provide our own installers for
the Android workload. This will also unblock the Xamarin.Forms / MAUI
team as they build on top of the iOS and Android workloads for .NET 6.

We will eventually do some kind of "insertion" process to provide our
`.nupkg` files to the dotnet/installer repo, so these installers will
go away completely at some point.

For now, this creates two new installers:

* Microsoft.Android.Workload.msi - installs to `C:\Program Files\dotnet\`
* Microsoft.Android.Workload.pkg - installs to `/usr/local/share/dotnet/`

Both installers have the following file structure underneath the root
directory:

* sdk\5.0.100-rtm.20509.5\EnableWorkloadResolver.sentinel
* sdk-manifests\5.0.100\Microsoft.Android.Workload\**
* packs\Microsoft.Android.Ref\**
* packs\Microsoft.Android.Sdk\**

The installers will have a hard dependency on .NET
5.0.100-rtm.20509.5, so we will need to have clear instructions for
installing the correct version of .NET for the Android workload.

The Windows installer is made using WIX, to mirror what
dotnet/installer is using:

* https://wixtoolset.org/
* https://github.com/dotnet/installer/blob/861a1dd12cb80bd834d0e51442d46ee7d1a4023f/src/redist/targets/GenerateMSIs.targets

The `.msi` will need to be built on Windows and the `.pkg` will need
to be built on macOS. `create-dotnet-msi.csproj` will download the WIX
toolset to `~\android-toolchain\wix` and call `candle.exe` and
`light.exe` appropriately. `create-dotnet-pkg.csproj` is based on
`create-pkg.csproj`, and no additional tooling is needed.

Changes to CI:

* The `create-installers` make target now creates the .NET 6 `.pkg`
  installer. The `mac_build` stage creates one additional installer.
* Any subsequent stages that download the `installers` artifact, now
  use a wildcard for the installer they need. This will improve some
  of the test stages that were downloading both the `.vsix` and `.pkg`
  installers before.
* A `.NET 6 Preview Installers` Github status will appear that
  contains public download links for the new installers.
* A `Build Results - .NET 6 Preview Installers` artifact will contain
  additional build logs.