### PR TITLE
[.vscode] Update tasks to use Configuration.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,5 +5,6 @@
       "ms-vscode.mono-debug",
       "wghats.vscode-nxunit-test-adapter",
       "visualstudioexptteam.vscodeintellicode",
+      "streetsidesoftware.code-spell-checker",
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,8 @@
             "name": "Launch",
             "type": "mono",
             "request": "launch",
-            "program": "${workspaceRoot}packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe ${workspaceRoot}bin/TestDebug/net472/Xamarin.Android.Build.Tests.dll",
-            "cwd": "${workspaceRoot}bin/TestDebug/"
+            "program": "${workspaceRoot}packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe ${workspaceRoot}bin/Test${input:configuration}/net472/Xamarin.Android.Build.Tests.dll",
+            "cwd": "${workspaceRoot}bin/Test${input:configuration}/"
         },
         {
             "name": "Attach",
@@ -23,10 +23,19 @@
           "type": "mono",
           "request": "launch",
           "preLaunchTask": "build-emulator-checkboottimes",
-          "program": "${workspaceRoot}/bin/BuildDebug/check-boot-times.exe",
+          "program": "${workspaceRoot}/bin/Build${input:configuration}/check-boot-times.exe",
           "args": [ ],
           "cwd": "${workspaceRoot}",
           "stopAtEntry": false
         }
+    ],
+    "inputs": [
+      {
+        "id": "configuration",
+        "type": "pickString",
+        "default": "Debug",
+        "description": "The Build Configuration",
+        "options": [ "Debug", "Release"]
+      }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build Xamarin.Android Build Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Build",
+            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Build /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -18,7 +18,7 @@
         {
             "label": "Clean Xamarin.Android Build Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Clean",
+            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Clean /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -30,7 +30,7 @@
         {
             "label": "Build Xamarin.Android Build Test Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build",
+            "command": "msbuild src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -42,7 +42,7 @@
         {
             "label": "Build Xamarin.Android Build Device Tests",
             "type": "shell",
-            "command": "msbuild tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj /restore /t:Build",
+            "command": "msbuild tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj /restore /t:Build /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -54,7 +54,7 @@
         {
             "label": "Build Xamarin.Android Build Commercial Tests",
             "type": "shell",
-            "command": "msbuild external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build",
+            "command": "msbuild external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -66,7 +66,7 @@
         {
             "label": "Run Xamarin.Android Build Tasks Unit Tests",
             "type": "shell",
-            "command": "msbuild Xamarin.Android.sln /t:RunNunitTests",
+            "command": "msbuild Xamarin.Android.sln /t:RunNunitTests /p:Configuration=${input:configuration}",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -78,7 +78,7 @@
         {
           "label": "build-emulator-checkboottimes",
           "type": "shell",
-          "command": "msbuild build-tools/check-boot-times/check-boot-times.csproj",
+          "command": "msbuild build-tools/check-boot-times/check-boot-times.csproj /p:Configuration=${input:configuration}",
           "group": {
               "kind": "build",
               "isDefault": true
@@ -87,5 +87,14 @@
               "$msCompile"
           ]
       },
+    ],
+    "inputs": [
+      {
+        "id": "configuration",
+        "type": "pickString",
+        "default": "Debug",
+        "description": "The Build Configuration",
+        "options": [ "Debug", "Release"]
+      }
     ]
 }


### PR DESCRIPTION
When building in vscode it was hardcoded to build in
`Debug`. This is a problem is you have to build in
`Release` since you can't use the ide.

This commit adds the ability to choose the configuration
when you launch the task. It will default to `Debug`.