### PR TITLE
[Xamarin.Android.Build.Tasks] do not require JDK 11 for build-tools 30

### DIFF
--- a/Documentation/release-notes/5234.md
+++ b/Documentation/release-notes/5234.md
@@ -1,0 +1,6 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5234](https://github.com/xamarin/xamarin-android/issues/5234):
+  Fixed *error XA0032: Java SDK 11.0 or above is required when using
+  Android SDK Build-Tools 30.x.x.* that could occur when building on a
+  system with the Android SDK `build-tools` 30 or higher installed.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ValidateJavaVersion.cs
@@ -76,8 +76,6 @@ namespace Xamarin.Android.Tasks.Legacy
 			if (!Version.TryParse (buildToolsVersionString, out buildTools)) {
 				return Version.Parse (LatestSupportedJavaVersion);
 			}
-			if (buildTools >= new Version (30, 0, 0))
-				return new Version (11, 0);
 			if (buildTools >= new Version (24, 0, 1))
 				return new Version (1, 8);
 			return Version.Parse (MinimumSupportedJavaVersion);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5234

I was building a project and hit:

```
error XA0032: Java SDK 11.0 or above is required when using Android SDK Build-Tools 30.0.2.
```

This is actually not true anymore since we got c50df1c5 and other
changes in to redistribute `apksigner.jar`. Let's drop this check, and
just require JDK 1.8.

I'm not actually sure how others haven't run into this?