### PR TITLE
[tests] Use same XF version to compare apk sizes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -65,6 +65,14 @@ namespace Xamarin.Android.Build.Tests
 			proj.IsRelease = true;
 			proj.SetAndroidSupportedAbis ("arm64-v8a");
 
+			if (forms) {
+				proj.PackageReferences.Clear ();
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
+
+				if (Builder.UseDotNet)
+					proj.AddDotNetCompatPackages ();
+			}
+
 			// use BuildHelper.CreateApkBuilder so that the test directory is not removed in tearup
 			using (var b = BuildHelper.CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");


### PR DESCRIPTION
[XamarinFormsAndroidApplicationProject](https://github.com/xamarin/xamarin-android/blob/91498d558e9443f5d4f854b58d64149d9c7c898e/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs#L43-L48)
uses different XF versions for current and dotnet build.

As we want to have the apks as close as possible to compare the apk
sizes, let use the same version for this test.