### PR TITLE
[One .NET] fix duplicate .pdb files for multiple RIDs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -33,6 +33,10 @@ _ResolveAssemblies MSBuild target.
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
       <IntermediateAssembly Include="$(_OuterIntermediateAssembly)" />
     </ItemGroup>
+    <ItemGroup Condition=" '@(_DebugSymbolsIntermediatePath->Count())' != '0' ">
+      <_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)" />
+      <_DebugSymbolsIntermediatePath Include="$([System.IO.Path]::ChangeExtension ($(_OuterIntermediateAssembly), '.pdb'))" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_ResolveAssemblies">
@@ -67,8 +71,8 @@ _ResolveAssemblies MSBuild target.
         Condition=" '%(Identity)' != '' "
     />
     <ProcessAssemblies
-        InputAssemblies="@(_ResolvedAssemblyFiles)"
-        ResolvedSymbols="@(_ResolvedSymbolFiles)"
+        InputAssemblies="@(_ResolvedAssemblyFiles->Distinct())"
+        ResolvedSymbols="@(_ResolvedSymbolFiles->Distinct())"
         IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
         LinkMode="$(AndroidLinkMode)">
       <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
@@ -121,10 +125,10 @@ _ResolveAssemblies MSBuild target.
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
     <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' And '$(AndroidIncludeDebugSymbols)' == 'true'  ">
-      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
-      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
-      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
-      <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />
+      <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"          Condition=" '%(DestinationSubPath)' != '' " />
+      <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"      Condition=" '%(DestinationSubPath)' != '' " />
+      <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" Condition=" '%(DestinationSubPath)' != '' " />
+      <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"             Condition=" '%(DestinationSubPath)' != '' " />
       <_ShrunkAssemblies            Include="@(_ResolvedAssemblies)" />
       <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
       <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -66,12 +66,7 @@ namespace Xamarin.Android.Tasks
 						assembly.SetMetadata ("FrameworkAssembly", frameworkAssembly.ToString ());
 						assembly.SetMetadata ("HasMonoAndroidReference", MonoAndroidHelper.HasMonoAndroidReference (reader).ToString ());
 					} else {
-						Log.LogDebugMessage ($"Removing duplicate: {assembly.ItemSpec}");
-
-						var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
-						if (symbols.Remove (symbolPath)) {
-							Log.LogDebugMessage ($"Removing duplicate: {symbolPath}");
-						}
+						symbols.Remove (Path.ChangeExtension (assembly.ItemSpec, ".pdb"));
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -359,14 +359,16 @@ namespace Xamarin.Android.Build.Tests
 			var apkPath = Path.Combine (outputPath, "UnnamedProject.UnnamedProject.apk");
 			FileAssert.Exists (apkPath);
 			using (var apk = ZipHelper.OpenZip (apkPath)) {
+				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
+				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !CommercialBuildAvailable && !isRelease);
 				var rids = runtimeIdentifiers.Split (';');
 				foreach (var abi in rids.Select (MonoAndroidHelper.RuntimeIdentifierToAbi)) {
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonodroid.so");
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonosgen-2.0.so");
 					if (rids.Length > 1) {
-						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll", expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll", shouldContainEntry: expectEmbeddedAssembies);
 					} else {
-						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll", expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll", shouldContainEntry: expectEmbeddedAssembies);
 					}
 				}
 			}


### PR DESCRIPTION
Deploying a project that uses two `$(RuntimeIdentifiers)` will fail on
our new fast deploy system with:

    Xamarin.Android.Common.Debugging.targets(589,5): Access to the path 'obj/Debug/net5.0-android/android/assets/' is denied.
        at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
        at Xamarin.Android.Tasks.FastDeploy.DeployFileWithFastDevTool(ITaskItem file, String toolPath, String overridePath, Byte[] buffer, Byte[] compressed, LZ4Level lz4level) in /Users/builder/azdo/_work/18/s/xamarin-android/external/monodroid/tools/msbuild/Tasks/FastDeploy.cs:line 579
        at Xamarin.Android.Tasks.FastDeploy.DeployFastDevFiles(String toolPath, String overridePath) in /Users/builder/azdo/_work/18/s/xamarin-android/external/monodroid/tools/msbuild/Tasks/FastDeploy.cs:line 491
        at Xamarin.Android.Tasks.FastDeploy.RunTaskAsync() in /Users/builder/azdo/_work/18/s/xamarin-android/external/monodroid/tools/msbuild/Tasks/FastDeploy.cs:line 175

Reviewing the log, there are some weird things happening. Some
incorrect `@(_ResolvedSymbols)` items are passed to the
`<FastDeploy/>` MSBuild task:

    _ResolvedSymbols
        obj/Debug/net5.0-android/android/assets/
        obj/Debug/net5.0-android/android/assets/

This is caused by the contents of the `@(ResolvedFileToPublish)` item
group that is populated by the `ComputeFilesToPublish` MSBuild target
in the dotnet/sdk:

    ResolvedFileToPublish
        obj/Debug/net5.0-android/HelloForms.dll
        obj/Debug/net5.0-android/android.21-arm64/HelloForms.pdb
        obj/Debug/net5.0-android/android.21-x86/HelloForms.pdb

The `HelloForms.pdb` files listed here do not actually *exist*, the
path should be: `obj/Debug/net5.0-android/HelloForms.pdb`.
This is caused by the way our "outer" build has no `$(RuntimeIdentifer)`,
while we have an "inner" build that runs per-RID.

The "inner" build needs to fix up the `@(_DebugSymbolsIntermediatePath)`
item group to account for this:

https://github.com/dotnet/sdk/blob/ee455863aa6ddf13108bb54b37a5a47fb12fe39e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L522-L555

We were already fixing up `@(IntermediateAssembly)`.

When `HelloForms.dll` did not map to a single `HelloForms.pdb`, the
`%(DestinationSubPath)` item metadata is not added by the
`<ProcessAssemblies/>` MSBuild task in Xamarin.Android.

And so the following item transform generated an incorrect result:

    <_ResolvedSymbols Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" />

To fix this:

* `@(_ResolvedSymbols)` should check if `%(DestinationSubPath)` is blank.
* Call `->Distinct()` on input to the `<ProcessAssemblies/>` MSBuild task.
* Patch up the `@(_DebugSymbolsIntermediatePath)` item group, so that
  it uses the proper value for `@(IntermediateOutputPath)` of the
  outer build.

See dotnet/msbuild for the definition of `@(_DebugSymbolsIntermediatePath)`: https://github.com/dotnet/msbuild/blob/65d31a0151b072b910d9ea16e152265d467e3239/src/Tasks/Microsoft.Common.CurrentVersion.targets#L374

After these changes, the `@(ResolvedFileToPublish)` item group appears
correct now:

    ResolvedFileToPublish
        obj/Debug/net5.0-android/HelloForms.dll
        obj/Debug/net5.0-android/HelloForms.pdb

`HelloForms.pdb` now makes it to the `.apk` file as well.

Other changes:

* Updated a test to look for `UnnamedProject.pdb` during a multiple
  RID build.
* I removed the `Removing duplicate: ...` log message, as it was
  printing hundreds of log messages that aren't particularly useful.