### PR TITLE
[One .NET] place .aar files in NuGet packages properly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -103,7 +103,21 @@ projects.
     />
     <ItemGroup>
       <FileWrites Include="$(_AarOutputPath)" />
-      <None       Include="$(_AarOutputPath)" Pack="true" PackagePath="lib\$(TargetFramework)$(TargetPlatformVersion).0" />
+    </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_IncludeAarInNuGetPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="_IncludeAarInNuGetPackage"
+      Condition=" '$(IncludeBuildOutput)' != 'false' and '$(AndroidApplication)' != 'true' and Exists('$(_AarOutputPath)') ">
+    <GetNuGetShortFolderName
+        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+        TargetPlatformMoniker="$(TargetPlatformMoniker)">
+      <Output TaskParameter="NuGetShortFolderName" PropertyName="_NuGetShortFolderName" />
+    </GetNuGetShortFolderName>
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(_AarOutputPath)" PackagePath="lib\$(_NuGetShortFolderName)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -166,9 +166,10 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void DotNetPack ()
+		public void DotNetPack ([Values ("net5.0-android", "net5.0-android30")] string targetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
+				TargetFramework = targetFramework,
 				IsRelease = true,
 				Sources = {
 					new BuildItem.Source ("Foo.cs") {


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/14042#issuecomment-716868311

We had been using an unfortunate hack to get the proper directory for
placing `.aar` files in NuGet packages:

    <None Include="$(_AarOutputPath)" Pack="true" PackagePath="lib\$(TargetFramework)$(TargetPlatformVersion).0" />

Not only was the `.0` weird, but it would also produce the wrong
result if the `$(TargetFramework)` was `net5.0-android30`:

    lib\net5.0-android3030.0

Using an example from the NuGet team, we can run a run a target by
setting `$(TargetsForTfmSpecificContentInPackage)`:

    <PropertyGroup>
      <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_IncludeAarInNuGetPackage</TargetsForTfmSpecificContentInPackage>
    </PropertyGroup>

Then we can run the `<GetNuGetShortFolderName/>` MSBuild task to get
the NuGet folder name:

    <GetNuGetShortFolderName
        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
        TargetPlatformMoniker="$(TargetPlatformMoniker)">
      <Output TaskParameter="NuGetShortFolderName" PropertyName="_NuGetShortFolderName" />
    </GetNuGetShortFolderName>

Lastly, we add to the `@(TfmSpecificPackageFile)` item group:

    <ItemGroup>
      <TfmSpecificPackageFile Include="$(_AarOutputPath)" PackagePath="lib\$(_NuGetShortFolderName)" />
    </ItemGroup>

Using these changes we can remove the `@(None)` item we were using
originally. I also updated a test to verify that `net5.0-android30`
works.