### PR TITLE
[One .NET] <CreateAar/> should generate resource case map

### DIFF
--- a/Documentation/guides/OneDotNetEmbeddedResources.md
+++ b/Documentation/guides/OneDotNetEmbeddedResources.md
@@ -75,15 +75,27 @@ files. A Xamarin.Android library, `Foo.csproj`, could also generate an
         libs/*.jar
         jni/[arch]/*.so
 
-`@(AndroidEnvironment)` files are specific to Xamarin.Android, so we
-can make one addition to the file format:
+Additionally, there is a need for Xamarin.Android-specific files
+within the [`.aar`][aar]. These are placed in a `.net` directory:
 
     Foo.aar
-        .netenv/MyEnvironment.txt
+        .net/__res_name_case_map.txt
+        .net/env/MyEnvironment.txt
 
-The name `.netenv` would be unlikely to collide with anything Google
-creates in the `.aar` file format in the future. It should also be
-completely ignored by Android tooling.
+The `__res_name_case_map.txt` file includes the original casing of
+`@(AndroidResource)` files. This is used during `Resource.designer.cs`
+generation to ensure that the casing matches the original file for a
+layout such as `Resource.Layout.Foo`. It is the same file format
+included in `__AndroidLibraryProjects__.zip` in "legacy" Xamarin.Android.
+
+`@(AndroidEnvironment)` files will be placed in `.net/env` so they can
+be added to the `@(AndroidEnvironment)` item group for application
+projects that consuming the class library.
+
+The name `.net` would be unlikely to collide with anything Google
+creates in the `.aar` file format in the future. These folders should
+also be completely ignored by Android tooling. The `.net` folder could
+also be used for other Xamarin.Android specific files down the road.
 
 So the output of `Foo.csproj` would look like:
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -85,12 +85,17 @@ namespace Xamarin.Android.Tasks
 			}
 			if (AdditionalResourceDirectories != null) {
 				foreach (var additionalDir in AdditionalResourceDirectories) {
-					var file = Path.Combine (ProjectDir, Path.GetDirectoryName (additionalDir.ItemSpec), "__res_name_case_map.txt");
-					if (File.Exists (file)) {
-						foreach (var line in File.ReadAllLines (file).Where (l => !string.IsNullOrEmpty (l))) {
-							string [] tok = line.Split (';');
-							AddRename (tok [1].Replace ('/', Path.DirectorySeparatorChar), tok [0].Replace ('/', Path.DirectorySeparatorChar));
-						}
+					var dir = Path.Combine (ProjectDir, Path.GetDirectoryName (additionalDir.ItemSpec));
+					var file = Path.Combine (dir, "__res_name_case_map.txt");
+					if (!File.Exists (file)) {
+						// .NET 6 .aar files place the file in a sub-directory
+						file = Path.Combine (dir, ".net", "__res_name_case_map.txt");
+						if (!File.Exists (file))
+							continue;
+					}
+					foreach (var line in File.ReadAllLines (file).Where (l => !string.IsNullOrEmpty (l))) {
+						string [] tok = line.Split (';');
+						AddRename (tok [1].Replace ('/', Path.DirectorySeparatorChar), tok [0].Replace ('/', Path.DirectorySeparatorChar));
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -383,8 +383,8 @@ namespace Xamarin.Android.Tasks
 							}
 							if (entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
 								AddJar (jars, importsDir, entryFullName, aarFullPath);
-							} else if (entryFullName.StartsWith (".netenv/", StringComparison.OrdinalIgnoreCase) ||
-									entryFullName.StartsWith (".netenv\\", StringComparison.OrdinalIgnoreCase)) {
+							} else if (entryFullName.StartsWith (".net/env/", StringComparison.OrdinalIgnoreCase) ||
+									entryFullName.StartsWith (".net\\env\\", StringComparison.OrdinalIgnoreCase)) {
 								var fullPath = Path.GetFullPath (Path.Combine (importsDir, entryFullName));
 								resolvedEnvironments.Add (new TaskItem (fullPath, new Dictionary<string, string> {
 									{ OriginalFile, aarFile.ItemSpec }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -76,6 +76,9 @@ namespace Xamarin.Android.Build.Tests
 			libB.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\foo\\foo.txt") {
 				BinaryContent = () => Array.Empty<byte> (),
 			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidResource ("Resources\\layout\\MyLayout.axml") {
+				TextContent = () => "<?xml version=\"1.0\" encoding=\"utf-8\" ?><LinearLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" />"
+			});
 			libB.OtherBuildItems.Add (new AndroidItem.AndroidResource ("Resources\\raw\\bar.txt") {
 				BinaryContent = () => Array.Empty<byte> (),
 			});
@@ -108,9 +111,11 @@ namespace Xamarin.Android.Build.Tests
 			FileAssert.Exists (aarPath);
 			using (var aar = ZipHelper.OpenZip (aarPath)) {
 				aar.AssertContainsEntry (aarPath, "assets/foo/foo.txt");
+				aar.AssertContainsEntry (aarPath, "res/layout/mylayout.xml");
 				aar.AssertContainsEntry (aarPath, "res/raw/bar.txt");
-				aar.AssertContainsEntry (aarPath, ".netenv/190E30B3D205731E.env");
-				aar.AssertContainsEntry (aarPath, ".netenv/2CBDAB7FEEA94B19.env");
+				aar.AssertContainsEntry (aarPath, ".net/__res_name_case_map.txt");
+				aar.AssertContainsEntry (aarPath, ".net/env/190E30B3D205731E.env");
+				aar.AssertContainsEntry (aarPath, ".net/env/2CBDAB7FEEA94B19.env");
 				aar.AssertContainsEntry (aarPath, "libs/A1AFA985571E728E.jar");
 				aar.AssertContainsEntry (aarPath, "jni/arm64-v8a/libfoo.so");
 				aar.AssertContainsEntry (aarPath, "jni/x86/libfoo.so");
@@ -146,6 +151,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var apk = ZipHelper.OpenZip (apkPath)) {
 				apk.AssertContainsEntry (apkPath, "assets/foo/foo.txt");
 				apk.AssertContainsEntry (apkPath, "assets/bar/bar.txt");
+				apk.AssertContainsEntry (aarPath, "res/layout/mylayout.xml");
 				apk.AssertContainsEntry (apkPath, "res/raw/bar.txt");
 				apk.AssertContainsEntry (apkPath, "lib/arm64-v8a/libfoo.so");
 				apk.AssertContainsEntry (apkPath, "lib/x86/libfoo.so");
@@ -163,6 +169,12 @@ namespace Xamarin.Android.Build.Tests
 			var environmentVariables = EnvironmentHelper.ReadEnvironmentVariables (environmentFiles);
 			Assert.IsTrue (environmentVariables.TryGetValue (env_var, out string actual), $"Environment should contain {env_var}");
 			Assert.AreEqual (env_val, actual, $"{env_var} should be {env_val}");
+
+			// Check Resource.designer.cs
+			var resource_designer_cs = Path.Combine (intermediate, "Resource.designer.cs");
+			FileAssert.Exists (resource_designer_cs);
+			var resource_designer_text = File.ReadAllText (resource_designer_cs);
+			StringAssert.Contains ("public const int MyLayout", resource_designer_text);
 		}
 
 		[Test]


### PR DESCRIPTION
The following situation was broken in .NET 6 after the new `.aar` file
implementation in fcd7cf8:

* A class library includes `Resources\layout\Foo.axml` with an
  uppercase name.
* An application references the library and uses the
  `Resource.designer.cs` definition of `Resource.Layout.Foo`.
* `Resource.Layout.Foo` will have the incorrect integer value and
  crash at runtime!

Reviewing the `Resource.designer.cs` file of the library:

    // aapt resource value: 0x7F030000
    public static int Foo = 2130903040;

Compared to the app:

    // aapt resource value: 0x7F030000
    public const int Foo = 2130903040;
    // aapt resource value: 0x7F030001
    public const int foo = 2130903041;

The reason this works in "legacy" Xamarin.Android is the
`__res_name_case_map.txt` file that is generated in
`__AndroidLibraryProjects__.zip`:

https://github.com/xamarin/xamarin-android/blob/57c5a5fde5efd23f5958cfd8119b7f9c31d9e39d/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs#L100-L105

If we generate the same `__res_name_case_map.txt` file and place it in
the `.aar` file we generate, this problem is solved.

We decided to place the file in a `.net` directory, as well as moving
the `.netenv` directory for `@(AndroidEnvironment)` files to `.net/env`:

    .net/__res_name_case_map.txt
    .net/env/MyAndroidEnvironment.txt

Going forward, we could potentially put other files in the `.net` folder.

I updated a test for this scenario; it checks we get the proper casing
for a `MyLayout.axml` in `Resource.designer.cs`.