### PR TITLE
Bump to xamarin/monodroid/master@0eef8891

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@04b0423ea298eda7263ba23e64df63c940ebddad
+xamarin/monodroid:master@0eef889156e92ff0d47e62477f10798b6d5b5c29
 mono/mono:2020-02@ca11fb0fd819a1e32565b0d626506f66fb9fd272


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/04b0423e...0eef8891

Includes three fixes for the new Fast Deployment system:

* Improved no device error messages for FastDeploy
* Terminate running app on FastDeploy
* workaround <FastDeploy/> hang in .NET 5