### PR TITLE
[build-tools] Bump Test emulator to use API 31

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -184,8 +184,9 @@
     <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">5.0</CommandLineToolsFolder>
     <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">7583922_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
-    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">7033400</EmulatorVersion>
-    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.3.5</EmulatorPkgRevision>
+    <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-1.xml -->
+    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">8129060</EmulatorVersion>
+    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">31.3.1</EmulatorPkgRevision>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
@@ -242,12 +243,12 @@
 
   <!-- Fix for IDEs -->
   <Target Name="CreateManifestResourceNames" />
-   
+
   <!-- Don't analyze code from external repos -->
   <PropertyGroup Condition=" !$(MSBuildProjectDirectory.Contains ('external')) and !$(MSBuildProjectDirectory.Contains ('NUnitLite')) ">
     <XAShouldAnalyzeAssembly>True</XAShouldAnalyzeAssembly>
   </PropertyGroup>
-   
+
   <!-- The net6.0 versions of these analyzers are stricter and require overloads not available in .NET Framework, so start with just .NET Framework -->
   <PropertyGroup Condition=" '$(TargetFramework)' != '' And (!$(TargetFramework.StartsWith('nets')) And !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('monoandroid'))) ">
     <XABuildingForNetCoreApp>True</XABuildingForNetCoreApp>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public                  string          ImageName           {get; set;} = "XamarinAndroidTestRunner64";
 		public                  string          DeviceName          {get; set;} = "pixel_4";
+		public			string		ImageType	    {get; set;} = "default";
 
 		public                  string          DataPartitionSizeMB {get; set;} = "2048";
 		public                  string          RamSizeMB           {get; set;} = "2048";
@@ -32,6 +33,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public override bool Execute ()
 		{
+			if (string.IsNullOrEmpty (ToolExe))
+				ToolExe = "avdmanager";
+
 			var dirs = string.IsNullOrEmpty (ToolPath)
 				? null
 				: new [] { ToolPath };
@@ -43,7 +47,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			ToolExe = filename;
 
 			if (string.IsNullOrEmpty (TargetId) && !string.IsNullOrEmpty (SdkVersion)) {
-				TargetId = "system-images;android-" + SdkVersion + ";default;" + AndroidAbi;
+				TargetId    = $"system-images;android-{SdkVersion};{ImageType};{AndroidAbi}";
 			}
 
 			var env = new List<string> ();

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -19,7 +19,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		const                   int                 StateGetLogcat              = 1;
 		const                   int                 StateClearLogcat            = 2;
 		const                   int                 StatePullFiles              = 3;
-		const                   int                 MaxState                    = StatePullFiles;
+		const                   int                 StateRunAsCatFiles          = 4;
+		const                   int                 MaxState                    = StateRunAsCatFiles;
 
 		public                  string              TestFixture                 { get; set; }
 
@@ -40,6 +41,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string              FailedToRun                 { get; set; }
 
 		public                  string              LogLevel                    { get; set; }
+
+		public                  int                 ApiLevel                    { get; set; }
 
 		int                     currentState = -1;
 		int                     instrumentationExitCode = 99;
@@ -98,10 +101,17 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -c",
 					IgnoreExitCode = true,
 				},
-
 				new CommandInfo {
 					ArgumentsGenerator = () => $"{AdbTarget} {AdbOptions} pull \"{targetTestResultsPath}\" \"{NUnit2TestResultsFile}\"",
-					ShouldRun = () => !String.IsNullOrEmpty (targetTestResultsPath)
+					ShouldRun = () => !String.IsNullOrEmpty (targetTestResultsPath) && ApiLevel != 30,
+					IgnoreExitCode = true,
+				},
+				new CommandInfo {
+					ArgumentsGenerator = () => $"{AdbTarget} {AdbOptions} shell run-as {PackageName} cat \"{targetTestResultsPath}\"",
+					ShouldRun = () => !String.IsNullOrEmpty (targetTestResultsPath) && ApiLevel == 30,
+					StdoutFilePath = NUnit2TestResultsFile,
+					StdoutAppend = false,
+					IgnoreExitCode = true,
 				},
 			};
 		}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          ToolPath        {get; set;}
 		public                  string          ToolExe         {get; set;}
 		public                  string          LogcatFile      {get; set;}
+		public                  bool            ShowWindow      {get; set;} = true;
 
 		public override bool Execute ()
 		{
@@ -69,7 +70,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"{Arguments ?? string.Empty} -verbose -logcat-output \"{LogcatFile}\" -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
+			var showWindow = ShowWindow ? "" : " -no-window";
+			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" {showWindow}{port} -avd {ImageName}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -74,18 +74,31 @@ stages:
         Android21-x86:
           avdApiLevel: 21
           avdAbi: x86
+          avdType: default
         Android23-x86:
           avdApiLevel: 23
           avdAbi: x86
+          avdType: default
         Android24-x86:
           avdApiLevel: 24
           avdAbi: x86
+          avdType: default
         Android26-x86_64:
           avdApiLevel: 26
           avdAbi: x86_64
+          avdType: default
         Android28-x86_64:
           avdApiLevel: 28
           avdAbi: x86_64
+          avdType: default
+        Android30-x86_64:
+          avdApiLevel: 30
+          avdAbi: x86_64
+          avdType: default
+        Android31-x86_64:
+          avdApiLevel: 31
+          avdAbi: x86_64
+          avdType: default
     pool:
       vmImage: $(HostedMacImage)
     workspace:
@@ -113,15 +126,15 @@ stages:
       inputs:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:InstallAvdImage;AcquireAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-$(avdApiLevel).binlog
+        msbuildArguments: /t:InstallAvdImage;AcquireAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /p:TestAvdType=$(avdType) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-$(avdApiLevel).binlog
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
-        testName: Mono.Android_Tests-$(avdApiLevel)-$(avdAbi)
+        testName: Mono.Android_Tests-$(avdApiLevel)-$(avdAbi)-$(avdType)
         project: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(XA.Build.Configuration).xml
-        extraBuildArgs: /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi)
+        extraBuildArgs: /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /p:TestAvdType=$(avdType)
         artifactSource: bin/Test$(XA.Build.Configuration)/Mono.Android_Tests-Signed.apk
         artifactFolder: Default
 
@@ -130,13 +143,13 @@ stages:
       inputs:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:AcquireAndroidTarget,ReleaseAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+        msbuildArguments: /t:AcquireAndroidTarget,ReleaseAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /p:TestAvdType=$(avdType) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       condition: always()
 
     - template: yaml-templates/upload-results.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
-        artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi) - macOS
+        artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi)-$(avdType) - macOS
 
     - template: yaml-templates/fail-on-issue.yaml
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -996,6 +996,7 @@ stages:
       node_id: 1
       job_name: mac_msbuilddevice_tests_1
       job_suffix: Legacy
+      nunit_categories: '&& cat != Debugger'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
@@ -1003,6 +1004,7 @@ stages:
       node_id: 2
       job_name: mac_msbuilddevice_tests_2
       job_suffix: Legacy
+      nunit_categories: '&& cat != Debugger'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
@@ -1010,6 +1012,16 @@ stages:
       node_id: 3
       job_name: mac_msbuilddevice_tests_3
       job_suffix: Legacy
+      nunit_categories: '&& cat != Debugger'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+
+  - template: yaml-templates/run-msbuild-device-tests.yaml
+    parameters:
+      node_id: 4
+      job_name: mac_msbuilddevice_tests_with_debugger
+      job_suffix: Legacy
+      jdkTestFolder: $(XA.Jdk11.Folder)
+      nunit_categories: '&& cat == Debugger'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
@@ -1035,6 +1047,15 @@ stages:
     parameters:
       node_id: 3
       job_name: mac_dotnetdevice_tests_3
+      job_suffix: One .NET
+      nunit_categories: $(DotNetNUnitCategories)
+      target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+
+  - template: yaml-templates/run-msbuild-device-tests.yaml
+    parameters:
+      node_id: 4
+      job_name: mac_dotnetdevice_tests_4
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -73,8 +73,8 @@ jobs:
           useDotNet: ${{ eq(parameters.target_framework, 'net6.0') }}
           testRunTitle: MSBuildDeviceIntegration On Device - macOS-NoNode - ${{ parameters.job_suffix }}
           testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
-          nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3 && cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
-          dotNetTestExtraArgs: --filter "TestCategory != Node-1 & TestCategory != Node-2 & TestCategory != Node-3 & TestCategory != TimeZoneInfo ${{ parameters.nunit_categories }}"
+          nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3  && cat != Node-4 && cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
+          dotNetTestExtraArgs: --filter "TestCategory != Node-1 & TestCategory != Node-2 & TestCategory != Node-3 & TestCategory != Node-4 & TestCategory != TimeZoneInfo ${{ parameters.nunit_categories }}"
           testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-NoNode-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1

--- a/build-tools/check-boot-times/Program.cs
+++ b/build-tools/check-boot-times/Program.cs
@@ -130,9 +130,10 @@ namespace Xamarin.Android.Tools
 		{
 			var times = new List<long> ();
 			int errors = 0;
+			var timeoutInMS = (int) TimeSpan.FromMinutes (15).TotalMilliseconds;
 
 			Stopwatch sw = new Stopwatch ();
-			var token = coldBoot ? "emulator: INFO: boot time" : "onGuestSendCommand";
+			var token = coldBoot ? "boot completed" : "onGuestSendCommand";
 
 			for (int i = 0; i < executionTimes; i++) {
 				await CloseEmulator ();
@@ -162,7 +163,7 @@ namespace Xamarin.Android.Tools
 				bool hasTimedOut = false;
 				sw.Reset ();
 				sw.Start ();
-				if (!await RunProcess (emulatorPath, $"-avd {deviceName} {bootOptions} -verbose", 300000, validation, async () => {
+				if (!await RunProcess (emulatorPath, $"-avd {deviceName} {bootOptions} -verbose -detect-image-hang", timeoutInMS, validation, async () => {
 					hasTimedOut = true;
 					await ForceKillEmulator ();
 				})) {

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -19,11 +19,14 @@
   <PropertyGroup>
     <TestAvdApiLevel Condition=" '$(TestAvdApiLevel)' == '' ">29</TestAvdApiLevel>
     <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' ">x86_64</TestAvdAbi>
-    <SdkManagerImageName Condition=" '$(SdkManagerImageName)' == '' ">system-images;android-$(TestAvdApiLevel);default;$(TestAvdAbi)</SdkManagerImageName>
+    <TestAvdType Condition=" '$(TestAvdType)' == '' ">default</TestAvdType>
+    <SdkManagerImageName Condition=" '$(SdkManagerImageName)' == '' ">system-images;android-$(TestAvdApiLevel);$(TestAvdType);$(TestAvdAbi)</SdkManagerImageName>
     <TestAvdName>XamarinAndroidTestRunner$(TestAvdApiLevel)-$(TestAvdAbi)</TestAvdName>
     <_AdbEmulatorPort>5570</_AdbEmulatorPort>
+    <_AdbEmulatorShowWindow Condition=" '$(RunningOnCI)' == 'True' And '$(_AdbEmulatorShowWindow)' == '' ">False</_AdbEmulatorShowWindow>
+    <_AdbEmulatorShowWindow Condition=" '$(_AdbEmulatorShowWindow)' == '' ">True</_AdbEmulatorShowWindow>
     <_ApkSizesReferenceDirectory>$(MSBuildThisFileDirectory)..\..\tests\apk-sizes-reference</_ApkSizesReferenceDirectory>
-    <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">5</AvdLaunchTimeoutMinutes>
+    <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">10</AvdLaunchTimeoutMinutes>
     <AvdLaunchTimeoutSeconds>$([MSBuild]::Multiply($(AvdLaunchTimeoutMinutes), 60))</AvdLaunchTimeoutSeconds>
     <AvdLaunchTimeoutMS>$([MSBuild]::Multiply($(AvdLaunchTimeoutSeconds), 1000))</AvdLaunchTimeoutMS>
     <_LogcatFilenameBase>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
@@ -58,6 +61,7 @@
         SdkVersion="$(TestAvdApiLevel)"
         TargetId="$(SdkManagerImageName)"
         ImageName="$(TestAvdName)"
+        ImageType="$(TestAvdType)"
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(CommandLineToolsBinPath)"
         RamSizeMB="3072"
@@ -71,6 +75,7 @@
         ImageName="$(TestAvdName)"
         LogcatFile="$(_LogcatFilenameBase)-full.txt"
         Port="$(_AdbEmulatorPort)"
+        ShowWindow="$(_AdbEmulatorShowWindow)"
         ToolExe="$(EmulatorToolExe)"
         ToolPath="$(EmulatorToolPath)">
       <Output TaskParameter="AdbTarget" PropertyName="_AdbTarget" />
@@ -83,7 +88,7 @@
         Arguments="$(_AdbTarget) wait-for-device"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
-        Timeout="120000"
+        Timeout="$(AvdLaunchTimeoutMS)"
         WriteOutputAsMessage="True"
     />
     <WaitForAndroidEmulator
@@ -254,6 +259,7 @@
         ContinueOnError="ErrorAndContinue"
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
+        ApiLevel="$(TestAvdApiLevel)"
         LogLevel="Verbose"
         PackageName="%(TestApkInstrumentation.Package)"
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",                            destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7", dependencyType: AndroidToolchainComponentType.EmulatorDependency),
+				new AndroidToolchainComponent ($"x86_64-31_r02",                                    destDir: Path.Combine ("system-images", "android-31", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "2", dependencyType: AndroidToolchainComponentType.EmulatorDependency),
 				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}",         destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
 				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"{XABuildTools30PackagePrefix}build-tools_r{XABuildTools30Version}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildTools30Folder), isMultiVersion: true),
@@ -80,7 +81,7 @@ namespace Xamarin.Android.Prepare
 					destDir: Path.Combine ("cmdline-tools", CommandLineToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"{XAPlatformToolsPackagePrefix}platform-tools_r{XAPlatformToolsVersion}-{osTag}", destDir: "platform-tools", pkgRevision: XAPlatformToolsVersion),
 				new AndroidToolchainComponent ($"sdk-tools-{osTag}-4333796",                        destDir: "tools", pkgRevision: "26.1.1"),
-				new AndroidToolchainComponent ($"emulator-{osTag}-{EmulatorVersion}",               destDir: "emulator", pkgRevision: EmulatorPkgRevision, dependencyType: AndroidToolchainComponentType.EmulatorDependency),
+				new AndroidToolchainComponent ($"emulator-{osTag}_x64-{EmulatorVersion}",           destDir: "emulator", pkgRevision: EmulatorPkgRevision, dependencyType: AndroidToolchainComponentType.EmulatorDependency),
 				new AndroidToolchainComponent ($"{AndroidCmakeUrlPrefix}cmake-{AndroidCmakeVersion}-{osTag}",       destDir: Path.Combine ("cmake", AndroidCmakeVersionPath), isMultiVersion: true, noSubdirectory: true, pkgRevision: "3.18.1"),
 			};
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -98,9 +98,17 @@ namespace Xamarin.Android.Prepare
 
 			var testConfigDir = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "bin", $"Test{context.Configuration}");
 			if (Directory.Exists (testConfigDir)) {
+				var matchedFiles = new List<string> ();
 				foreach (var fileMatch in testConfigFiles) {
-					Utilities.CopyFilesSimple (Directory.GetFiles (testConfigDir, fileMatch), destinationRoot, false);
+					// Handle files which might appear in multiple filters
+					// eg logcat-Relase-full.log will appear in both logcat* AND *log
+					foreach (var file in Directory.GetFiles (testConfigDir, fileMatch)) {
+						if (matchedFiles.Contains (file))
+							continue;
+						matchedFiles.Add (file);
+					}
 				}
+				Utilities.CopyFilesSimple (matchedFiles, destinationRoot, false);
 			}
 
 			var testConfigCompatDir = Path.Combine (testConfigDir, "compatibility");

--- a/samples/VSAndroidApp/Properties/AndroidManifest.xml
+++ b/samples/VSAndroidApp/Properties/AndroidManifest.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" 
-          android:versionCode="1" 
-          android:versionName="1.0" 
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          android:versionCode="1"
+          android:versionName="1.0"
           package="com.companyname.vsandroidapp">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+  <uses-sdk android:minSdkVersion="21" />
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme">
   </application>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,37 +5,37 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 54984
+      "Size": 55094
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87771
+      "Size": 87709
     },
     "assemblies/rc.bin": {
-      "Size": 1045
+      "Size": 1083
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10157
+      "Size": 10116
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 521019
+      "Size": 519296
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1184
+      "Size": 1163
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2410
+      "Size": 2369
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3544
+      "Size": 3543
     },
     "classes.dex": {
       "Size": 345328
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382760
+      "Size": 382776
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3176048
+      "Size": 3192432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776216
@@ -44,10 +44,10 @@
       "Size": 84064
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 150024
+      "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12424
+      "Size": 12440
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -83,5 +83,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2705399
+  "PackageSize": 2701303
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -5,184 +5,184 @@
       "Size": 3568
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7251
+      "Size": 7247
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 61908
+      "Size": 62006
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 442164
+      "Size": 441706
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3795
+      "Size": 3798
     },
     "assemblies/netstandard.dll": {
-      "Size": 5495
+      "Size": 5499
     },
     "assemblies/rc.bin": {
       "Size": 1083
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11223
+      "Size": 11227
     },
     "assemblies/System.Collections.dll": {
       "Size": 16736
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 8438
+      "Size": 8439
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 1956
+      "Size": 1961
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2562
+      "Size": 2566
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 5965
+      "Size": 5968
     },
     "assemblies/System.Console.dll": {
-      "Size": 6528
+      "Size": 6530
     },
     "assemblies/System.Core.dll": {
-      "Size": 1924
+      "Size": 1928
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6754
+      "Size": 6756
     },
     "assemblies/System.dll": {
-      "Size": 2271
+      "Size": 2275
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 1954
+      "Size": 1957
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12200
+      "Size": 12199
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 17214
+      "Size": 17218
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10565
+      "Size": 10566
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19471
+      "Size": 19474
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 182079
+      "Size": 182081
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 65835
+      "Size": 65831
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 22366
+      "Size": 22364
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3729
+      "Size": 3731
     },
     "assemblies/System.ObjectModel.dll": {
       "Size": 11970
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 757439
+      "Size": 757425
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
       "Size": 191072
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 43673
+      "Size": 43677
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 220174
+      "Size": 220171
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 17100
+      "Size": 17101
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
       "Size": 1214
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2553
+      "Size": 2557
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1886
+      "Size": 1889
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2632
+      "Size": 2634
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3936
+      "Size": 3940
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 6810
+      "Size": 6809
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
       "Size": 2968
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 76705
+      "Size": 76698
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1777
+      "Size": 1779
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117240
+      "Size": 117239
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6076
+      "Size": 6069
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6099
+      "Size": 6095
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 112593
+      "Size": 112590
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 6816
+      "Size": 6809
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 16609
+      "Size": 16603
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 96724
+      "Size": 96723
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 14275
+      "Size": 14273
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 39933
+      "Size": 39924
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6139
+      "Size": 6132
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6595
+      "Size": 6592
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6675
+      "Size": 6671
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3275
+      "Size": 3273
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 12676
+      "Size": 12671
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 84690
+      "Size": 84688
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5082
+      "Size": 5077
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10390
+      "Size": 10382
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 17994
+      "Size": 17986
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 528450
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 385000
+      "Size": 384996
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56878
@@ -191,16 +191,16 @@
       "Size": 60774
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 40136
+      "Size": 40134
     },
     "classes.dex": {
-      "Size": 3483796
+      "Size": 3458288
     },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 382776
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3171952
+      "Size": 3192432
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776216
@@ -212,7 +212,7 @@
       "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 133232
+      "Size": 133192
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -779,7 +779,7 @@
       "Size": 470
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4762
+      "Size": 4791
     },
     "res/drawable-hdpi-v4/notification_bg_low_normal.9.png": {
       "Size": 212
@@ -1967,5 +1967,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 7938591
+  "PackageSize": 7930399
 }

--- a/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.EmbeddedDSO_Test">
-    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="28" />
+    <uses-sdk android:minSdkVersion="23" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			AddDotNetProfilerNativeLibraries (proj);
 			var port = 9000 + new Random ().Next (1000);
 			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { true },
 		};
 
-		static readonly string [] Abis = new [] { "armeabi-v7a", "arm64-v8a", "x86" };
+		static readonly string [] Abis = new [] { "armeabi-v7a", "arm64-v8a", "x86", "x86_64" };
 		XamarinAndroidLibraryProject lib;
 		XamarinAndroidApplicationProject app;
 		ProjectBuilder libBuilder, appBuilder;

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[Category ("UsesDevice"), Category ("Node-3")]
+	[Category ("UsesDevice")]
 	public class DebuggingTest : DeviceTest {
 		[TearDown]
 		public void ClearDebugProperties ()
@@ -43,15 +43,17 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("Node-3")]
 		public void ApplicationRunsWithoutDebugger ([Values (false, true)] bool isRelease, [Values (false, true)] bool extractNativeLibs, [Values (false, true)] bool useEmbeddedDex)
 		{
 			AssertHasDevices ();
+			SwitchUser ();
 
 			var proj = new XamarinFormsAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			}
 			proj.SetDefaultTargetDevice ();
 			if (Builder.UseDotNet && isRelease) {
@@ -79,9 +81,11 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("Node-3")]
 		public void ClassLibraryMainLauncherRuns ([Values (true, false)] bool preloadAssemblies)
 		{
 			AssertHasDevices ();
+			SwitchUser ();
 
 			var path = Path.Combine ("temp", TestName);
 
@@ -89,7 +93,7 @@ namespace Xamarin.Android.Build.Tests
 				ProjectName = "MyApp",
 			};
 			if (!CommercialBuildAvailable) {
-				app.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+				app.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			}
 			app.SetDefaultTargetDevice ();
 			app.SetProperty ("AndroidEnablePreloadAssemblies", preloadAssemblies.ToString ());
@@ -162,17 +166,26 @@ namespace Xamarin.Android.Build.Tests
 		};
 #pragma warning restore 414
 
-		[Test, Category ("Debugger")]
+		[Test, Category ("Debugger"), Category ("Node-4")]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
+		[Retry(5)]
 		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool activityStarts)
 		{
 			AssertCommercialBuild ();
 			AssertHasDevices ();
+			SwitchUser ();
+
+			var path = Path.Combine (Root, "temp", TestName);
+			if (Directory.Exists (path)) {
+				TestContext.Out.WriteLine ($"Deleting previous run at '{path}'");
+				Directory.Delete (path,recursive:true);
+			}
+
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
 				AndroidFastDeploymentType = fastDevType,
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
 			proj.Sources.Add (new BuildItem.Source ("MyApplication.cs") {
@@ -198,7 +211,7 @@ namespace ${ROOT_NAMESPACE} {
 }
 "),
 			});
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateApkBuilder (path)) {
 				SetTargetFrameworkAndManifest (proj, b);
 				Assert.True (b.Install (proj), "Project should have installed.");
 
@@ -220,7 +233,7 @@ namespace ${ROOT_NAMESPACE} {
 				int port = rnd.Next (10000, 20000);
 				TestContext.Out.WriteLine ($"{port}");
 				var args = new SoftDebuggerConnectArgs ("", IPAddress.Loopback, port) {
-					MaxConnectionAttempts = 10,
+					MaxConnectionAttempts = 2000, // we need a long delay here to get a reliable connection
 				};
 				var startInfo = new SoftDebuggerStartInfo (args) {
 					WorkingDirectory = Path.Combine (b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets"),
@@ -237,18 +250,18 @@ namespace ${ROOT_NAMESPACE} {
 					"AndroidAttachDebugger=True",
 				}), "Project should have run.");
 
-				// do we expect the app to start?
-				Assert.AreEqual (activityStarts, WaitForDebuggerToStart (Path.Combine (Root, b.ProjectDirectory, "logcat.log")), "Activity should have started");
-				if (!activityStarts)
-					return;
-				// we need to give a bit of time for the debug server to start up.
-				WaitFor (2000);
 				session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };
 				session.OutputWriter += (isStderr, text) => { Console.WriteLine (text); };
 				session.DebugWriter += (level, category, message) => { Console.WriteLine (message); };
+				// do we expect the app to start?
+				Assert.AreEqual (activityStarts, WaitForDebuggerToStart (Path.Combine (Root, b.ProjectDirectory, "logcat.log")), "Debugger should have started");
+				if (!activityStarts)
+					return;
+				Assert.False (session.HasExited, "Target should not have exited.");
 				session.Run (startInfo, options);
 				var expectedTime = TimeSpan.FromSeconds (1);
 				var actualTime = ProfileFor (() => session.IsConnected);
+				Assert.True (session.IsConnected, "Debugger should have connected but it did not.");
 				TestContext.Out.WriteLine ($"Debugger connected in {actualTime}");
 				Assert.LessOrEqual (actualTime, expectedTime, $"Debugger should have connected within {expectedTime} but it took {actualTime}.");
 				// we need to wait here for a while to allow the breakpoints to hit
@@ -328,20 +341,29 @@ namespace ${ROOT_NAMESPACE} {
 		};
 #pragma warning restore 414
 
-		[Test, Category ("SmokeTests"), Category ("Debugger")]
+		[Test, Category ("SmokeTests"), Category ("Debugger"), Category ("Node-4")]
 		[TestCaseSource (nameof(DebuggerTestCases))]
+		[Retry (5)]
 		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username, string debugType)
 		{
 			AssertCommercialBuild ();
 			AssertHasDevices ();
+			SwitchUser ();
+			WaitFor (5000);
 
-			var path = Path.Combine ("temp", TestName);
+			var path = Path.Combine (Root, "temp", TestName);
+			if (Directory.Exists (path)) {
+				TestContext.Out.WriteLine ($"Deleting previous run at '{path}'");
+				Directory.Delete (path,recursive:true);
+			}
+
 			int userId = GetUserId (username);
 			List<string> parameters = new List<string> ();
 			if (userId >= 0)
 				parameters.Add ($"AndroidDeviceUserId={userId}");
 			if (SwitchUser (username)) {
-				WaitFor (5);
+				WaitFor (5000);
+				ClearBlockingDialogs ();
 				ClickButton ("", "android:id/button1", "Yes continue");
 			}
 
@@ -368,7 +390,7 @@ namespace ${ROOT_NAMESPACE} {
 			};
 			app.MainPage = app.MainPage.Replace ("InitializeComponent ();", "InitializeComponent (); new Foo ();");
 			app.AddReference (lib);
-			app.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			app.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			app.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
 			if (!string.IsNullOrEmpty (debugType)) {
 				app.SetProperty ("DebugType", debugType);
@@ -412,7 +434,7 @@ namespace ${ROOT_NAMESPACE} {
 				int port = rnd.Next (10000, 20000);
 				TestContext.Out.WriteLine ($"{port}");
 				var args = new SoftDebuggerConnectArgs ("", IPAddress.Loopback, port) {
-					MaxConnectionAttempts = 10,
+					MaxConnectionAttempts = 2000,
 				};
 				var startInfo = new SoftDebuggerStartInfo (args) {
 					WorkingDirectory = Path.Combine (appBuilder.ProjectDirectory, app.IntermediateOutputPath, "android", "assets"),
@@ -431,17 +453,24 @@ namespace ${ROOT_NAMESPACE} {
 				Assert.True (appBuilder.RunTarget (app, "_Run", doNotCleanupOnUpdate: true,
 					parameters: parameters.ToArray ()), "Project should have run.");
 
-				Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, appBuilder.ProjectDirectory, "logcat.log")), "Activity should have started");
-				// we need to give a bit of time for the debug server to start up.
-				WaitFor (2000);
-				session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };
-				session.OutputWriter += (isStderr, text) => { Console.WriteLine (text); };
-				session.DebugWriter += (level, category, message) => { Console.WriteLine (message); };
+				session.LogWriter += (isStderr, text) => {
+					TestContext.Out.WriteLine (text);
+				};
+				session.OutputWriter += (isStderr, text) => {
+					TestContext.Out.WriteLine (text);
+				};
+				session.DebugWriter += (level, category, message) => {
+					TestContext.Out.WriteLine (message);
+				};
+				Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, appBuilder.ProjectDirectory, "logcat.log")), "Debugger should have started");
 				session.Run (startInfo, options);
-				WaitFor (TimeSpan.FromSeconds (30), () => session.IsConnected);
+				TestContext.Out.WriteLine ($"Detected debugger startup in log");
+				Assert.False (session.HasExited, "Target should not have exited.");
+				WaitFor (TimeSpan.FromSeconds (30), () => session.IsConnected );
 				Assert.True (session.IsConnected, "Debugger should have connected but it did not.");
 				// we need to wait here for a while to allow the breakpoints to hit
 				// but we need to timeout
+				TestContext.Out.WriteLine ($"Debugger connected.");
 				TimeSpan timeout = TimeSpan.FromSeconds (60);
 				int expected = 4;
 				while (session.IsConnected && breakcountHitCount < 3 && timeout >= TimeSpan.Zero) {
@@ -452,7 +481,8 @@ namespace ${ROOT_NAMESPACE} {
 				Assert.AreEqual (expected, breakcountHitCount, $"Should have hit {expected} breakpoints. Only hit {breakcountHitCount}");
 				breakcountHitCount = 0;
 				ClearAdbLogcat ();
-				ClickButton (app.PackageName, "myXFButton", "CLICK ME");
+				ClearBlockingDialogs ();
+				Assert.True (ClickButton (app.PackageName, "myXFButton", "CLICK ME"), "Button should have been clicked!");
 				while (session.IsConnected && breakcountHitCount < 1 && timeout >= TimeSpan.Zero) {
 					Thread.Sleep (10);
 					timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));

--- a/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
@@ -50,7 +50,9 @@ namespace Xamarin.Android.Build.Tests
 					"IntermediateOutputPath=" + Path.Combine ("obj", isRelease ? "Release" : "Debug", "90") + Path.DirectorySeparatorChar
 				};
 				if (isRelease || !CommercialBuildAvailable) {
-					parameters.Add (KnownProperties.AndroidSupportedAbis + "=\"armeabi-v7a;x86\"");
+					parameters.Add (KnownProperties.AndroidSupportedAbis + "=\"armeabi-v7a;x86;x86_64\"");
+				} else {
+					parameters.Add (KnownProperties.AndroidSupportedAbis + "=\"armeabi-v7a;arm64-v8a;x86;x86_64\"");
 				}
 				if (HasDevices) {
 					Assert.IsTrue (builder.Install (project, doNotCleanupOnUpdate: true, parameters: parameters.ToArray (), saveProject: false),

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Build.Tests
 				TargetSdkVersion = null,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");
 			}
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
 $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
@@ -190,7 +190,7 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 				ProjectName = testName,
 				IsRelease = true,
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetDefaultTargetDevice ();
 			using (var builder = CreateApkBuilder (Path.Combine (rootPath, proj.ProjectName))){
 				Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
@@ -494,7 +494,7 @@ namespace Library1 {
 			};
 
 			if (isRelease || !CommercialBuildAvailable) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");
 			}
 
 			proj.References.Add (new BuildItem.Reference ("System.Runtime.Serialization"));

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			if (isRelease) {
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			}
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Build.Tests
 			if (isRelease) {
 				// Set debuggable=true to allow run-as command usage with a release build
 				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			}
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageName = "com.xamarin.keytest"
 			};
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			using (var builder = CreateApkBuilder ()) {
 				// Use the default debug.keystore XA generates
 				Assert.IsTrue (builder.Install (proj), "first install should succeed.");
@@ -132,7 +132,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetProperty ("AndroidPackageFormat", "apk");
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Build.Tests
 			} else {
 				proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
 			}
-			var abis = new [] { "armeabi-v7a", "x86" };
+			var abis = new [] { "armeabi-v7a", "x86", "x86_64" };
 			proj.SetAndroidSupportedAbis (abis);
 			using (var builder = CreateApkBuilder ()) {
 				if (RunAdbCommand ("shell pm list packages Mono.Android.DebugRuntime").Trim ().Length != 0)
@@ -277,7 +277,7 @@ namespace Xamarin.Android.Build.Tests
 
 				//Now toggle FastDev to OFF
 				proj.EmbedAssembliesIntoApk = true;
-				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 
 				Assert.IsTrue (builder.Install (proj), "Second install should have succeeded.");
 
@@ -301,7 +301,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
@@ -397,7 +397,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetProperty ("AndroidSigningStorePass", password);
 				proj.SetProperty ("AndroidSigningKeyPass", password);
 			}
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetProperty ("AndroidKeyStore", androidKeyStore);
 			proj.SetProperty ("AndroidSigningKeyStore", "test.keystore");
 			proj.SetProperty ("AndroidSigningKeyAlias", "mykey");

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 			};
-			proj.SetAndroidSupportedAbis ("x86"); // Use a single ABI
+			proj.SetAndroidSupportedAbis (DeviceAbi); // Use a single ABI
 			return proj;
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Build.Tests
 				WebContent = "https://github.com/aosp-mirror/platform_build/raw/master/target/product/security/platform.x509.pem"
 			});
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<manifest ", "<manifest android:sharedUserId=\"android.uid.system\" ");
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 
 
 			proj.SetDefaultTargetDevice ();

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Category ("Debugger")]
+		[Category ("Debugger"), Category ("Node-4")]
 		public void DotNetDebug ()
 		{
 			AssertCommercialBuild ();

--- a/tests/Mono.Android-Tests/Android.App/ApplicationTest.cs
+++ b/tests/Mono.Android-Tests/Android.App/ApplicationTest.cs
@@ -60,6 +60,9 @@ namespace Android.AppTests
 		}
 	}
 
+#if ANDROID_30
+	[Application (Debuggable=true)]
+#endif
 	public class App : Application {
 
 		public static bool            Created;

--- a/tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests.csproj
@@ -17,6 +17,7 @@
     <AssemblyName>Mono.Android-Tests</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis Condition=" '$(TestAvdAbi)' == 'x86_64' ">$(AndroidSupportedAbis);x86_64</AndroidSupportedAbis>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <MandroidI18n>All</MandroidI18n>
     <SignAssembly>true</SignAssembly>
@@ -45,6 +46,7 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -53,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Mono.Android-Tests/Properties/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_Tests">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:debuggable="true" android:label="Xamarin.Android.RuntimeTests" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>

--- a/tests/Mono.Android-Tests/Runtime-AppBundle/Properties/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Runtime-AppBundle/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_TestsAppBundle">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="Xamarin.Android.RuntimeTestsAppBundle" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android.NET_Tests">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="21" />
 	<application android:label="Microsoft.Android.Runtime" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>

--- a/tests/Mono.Android-Tests/Runtime-MultiDex/Properties/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Runtime-MultiDex/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_TestsMultiDex">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="Xamarin.Android.RuntimeTestsMultiDex" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>

--- a/tests/Mono.Android-Tests/System.Net/NetworkInterfaces.cs
+++ b/tests/Mono.Android-Tests/System.Net/NetworkInterfaces.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using Java.Net;
@@ -9,7 +10,7 @@ using NUnit.Framework;
 using MNetworkInterface = System.Net.NetworkInformation.NetworkInterface;
 using JNetworkInterface = Java.Net.NetworkInterface;
 
-namespace System.NetTests 
+namespace System.NetTests
 {
 	[TestFixture]
 	public class NetworkInterfacesTest
@@ -73,7 +74,7 @@ namespace System.NetTests
 					return false;
 				if (one.Count != two.Count)
 					return false;
-					
+
 				foreach (IPAddress addr in one) {
 					if (!two.Contains (addr))
 						return false;
@@ -180,6 +181,9 @@ namespace System.NetTests
 			byte[] bytes = inf.GetPhysicalAddress ().GetAddressBytes ();
 			// Map to android's idea of device address
 			if (bytes.Length == 0 || inf.NetworkInterfaceType == NetworkInterfaceType.Tunnel)
+				return null;
+			// if all the bytes are zero return null like Java does.
+			if (bytes.All (x => x == 0))
 				return null;
 			return bytes;
 		}

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.UnitTests
 
 			if (aname == null)
 				return null;
-			
+
 			foreach (string dir in TestAssemblyDirectories) {
 				if (String.IsNullOrEmpty (dir))
 					continue;
@@ -244,7 +244,7 @@ namespace Xamarin.Android.UnitTests
 			LogPaddedInfo ("VERSION.Release", Build.VERSION.Release, alignColumn);
 			LogPaddedInfo ("VERSION.Sdk", Build.VERSION.Sdk, alignColumn);
 			LogPaddedInfo ("VERSION.SdkInt", Build.VERSION.SdkInt.ToString (), alignColumn);
-			LogPaddedInfo ("Device Date/Time", DateTime.UtcNow.ToString (), alignColumn); 
+			LogPaddedInfo ("Device Date/Time", DateTime.UtcNow.ToString (), alignColumn);
 
 			// FIXME: add data about how the app was compiled (e.g. ARMvX, LLVM, Linker options)
 		}
@@ -285,7 +285,7 @@ namespace Xamarin.Android.UnitTests
 			results.PutLong (ResultInconclusiveTests, runner.InconclusiveTests);
 			results.PutLong (ResultTotalTests, runner.TotalTests);
 			results.PutLong (ResultFilteredTests, runner.FilteredTests);
-			results.PutString (ResultResultsFilePath, ToAdbPath (resultsFilePath));
+			results.PutString (ResultResultsFilePath, ToAdbPath(resultsFilePath));
 
 			Log.Info (LogTag, $"Passed: {runner.PassedTests}, Failed: {runner.FailedTests}, Skipped: {runner.SkippedTests}, Inconclusive: {runner.InconclusiveTests}, Total: {runner.TotalTests}, Filtered: {runner.FilteredTests}");
 
@@ -380,7 +380,7 @@ namespace Xamarin.Android.UnitTests
 				string line = reader.ReadLine ()?.Trim ();
 				if (line == null)
 					return excludedTestNames;
-				
+
 				if (line.Length == 0 || line.StartsWith ("#", StringComparison.Ordinal))
 					continue;
 
@@ -407,7 +407,9 @@ namespace Xamarin.Android.UnitTests
 			string source = global::System.Environment.GetEnvironmentVariable ("EMULATED_STORAGE_SOURCE")?.Trim ();
 			string target = global::System.Environment.GetEnvironmentVariable ("EMULATED_STORAGE_TARGET")?.Trim ();
 
-			if (!String.IsNullOrEmpty (source) && !String.IsNullOrEmpty (target) && path.StartsWith (target, StringComparison.Ordinal)) {
+			if (!String.IsNullOrEmpty (source) && !String.IsNullOrEmpty (target) &&
+					path.StartsWith (target, StringComparison.Ordinal) &&
+					((int)Build.VERSION.SdkInt) <= 28) {
 				return path.Replace (target, source);
 			}
 

--- a/tests/TestRunner.Core/TestRunner.cs
+++ b/tests/TestRunner.Core/TestRunner.cs
@@ -97,18 +97,21 @@ namespace Xamarin.Android.UnitTests
 		{
 			if (String.IsNullOrEmpty (ResultsFileName))
 				throw new InvalidOperationException ("Runner didn't specify a valid results file name");
-			
+
+			string pid = Guid.NewGuid ().ToString ();
+
 			Java.IO.File resultsPathFile = null;
 #if __ANDROID_19__
-			if (((int)Build.VERSION.SdkInt) >= 19)
-				resultsPathFile = Context.GetExternalFilesDir (global::Android.OS.Environment.DirectoryDocuments);
+			int sdk = ((int)Build.VERSION.SdkInt);
+			if (sdk >= 19)
+				resultsPathFile = Context.GetExternalFilesDir (null);
 #endif
 			bool usePathFile = resultsPathFile != null && resultsPathFile.Exists ();
-			string resultsPath = usePathFile ? resultsPathFile.AbsolutePath : Path.Combine (Context.FilesDir.AbsolutePath, ".__override__");
+			string resultsPath = usePathFile ? resultsPathFile.AbsolutePath : Context.FilesDir.AbsolutePath;
 			if (!usePathFile && !Directory.Exists (resultsPath))
 				Directory.CreateDirectory (resultsPath);
 
-			return Path.Combine (resultsPath, ResultsFileName);
+			return Path.Combine (resultsPath, $"{(pid.Replace ("-", "_"))}_{ResultsFileName}");
 		}
 	}
 }


### PR DESCRIPTION
We need to be able to test our build system against newer emulators. So let's include both API 30 and API 30 based emulator images in our nightly tests. 

We will leave the normal development tests running on API 29 for now as the newer emulators seem to be unreliable 
in a CI environment. 

Part of the changes in to use the `Context.GetExternalFilesDir (null);` to get the external files directory. This is due to permissions changes which came into effect from API 30. As a result the older code which we used can no longer be 
used on newer devices. So we shall unify the tests to all use `Context.GetExternalFilesDir (null);`. Then use `Context.FilesDir.AbsolutePath;` as a backup. The result of this change is we MUST use the `run-as` command to retrieve the test log file for processing on API 30. This is because the external directory is no longer readable globally on API 30. It is only readable for the app. As a result we also need to make the API 30 build of the test app debuggable via the `[Application (Debuggable=true)]` attribute. 

Thankfully this change was reverted somewhat in API 31, so we can still `adb pull` from the directory returned by `Context.GetExternalFilesDir (null);`. 

Other changes include updating tests to include the `x86_64` abi. This is because the newer x86_64 emulators no longer appear to be able to run `x86` code. 
