### PR TITLE
[ci] Produce installers with public download links

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1232,7 +1232,7 @@ stages:
       parameters:
         BuildPackages: $(System.DefaultWorkingDirectory)/storage-artifacts
         AzureContainerName: $(Azure.Container.Name)
-        AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        AzureUploadLocation: $(Build.DefinitionName)/public/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
         SourceDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
 
     - script: cp $(System.DefaultWorkingDirectory)/storage-artifacts/*.pkg $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/68be8d810e3f87865d88467ae593048297bf3e60

We can produce public facing download links for our installers by adding
`/public/` to our blob storage upload path.