### PR TITLE
[One .NET] fix linker output if $(AppendRuntimeIdentifierToOutputPath) is false

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -16,6 +16,7 @@ _ResolveAssemblies MSBuild target.
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>
     <PublishDir>$(OutputPath)</PublishDir>
+    <_AndroidLinkFlag>$(_OuterIntermediateOutputPath)link.flag</_AndroidLinkFlag>
     <BuildDependsOn>_RemoveLegacyDesigner;$(BuildDependsOn)</BuildDependsOn>
     <!-- We don't want IncrementalClean to run here, or files get deleted -->
     <CoreBuildDependsOn>
@@ -48,8 +49,10 @@ _ResolveAssemblies MSBuild target.
       <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true;
+        AppendRuntimeIdentifierToOutputPath=true;
         _OuterIntermediateAssembly=@(IntermediateAssembly);
         _OuterOutputPath=$(OutputPath);
+        _OuterIntermediateOutputPath=$(IntermediateOutputPath);
         _ProguardProjectConfiguration=$(_ProguardProjectConfiguration);
       </_AdditionalProperties>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -279,7 +279,7 @@ class MemTest {
 				Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should *not* include `{className}`!");
 				// FormsAppCompatActivity should inherit the AndroidX C# type
 				var forms = Builder.UseDotNet && isRelease ?
-					b.Output.GetIntermediaryPath (Path.Combine ("linked", "Xamarin.Forms.Platform.Android.dll")) :
+					b.Output.GetIntermediaryPath (Path.Combine ("android.21-arm64", "linked", "Xamarin.Forms.Platform.Android.dll")) :
 					b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", "Xamarin.Forms.Platform.Android.dll"));
 				using (var assembly = AssemblyDefinition.ReadAssembly (forms)) {
 					var activity = assembly.MainModule.GetType ("Xamarin.Forms.Platform.Android.FormsAppCompatActivity");


### PR DESCRIPTION
Many of our existing MSBuild tests set
`$(AppendRuntimeIdentifierToOutputPath)` to false so that the build
output has the same directory structure for "legacy" Xamarin.Android
as for .NET 6.

This causes a problem with the `ILLink` MSBuild target with multiple
`$(RuntimeIdentifiers)`, as linked .NET assemblies are output to:

    obj\Debug\android.21-arm64\linked\Foo.dll
    obj\Debug\android.21-x86\linked\Foo.dll

`AppendRuntimeIdentifierToOutputPath=false` cause both files to be
written to:

    obj\Debug\linked\Foo.dll
    obj\Debug\linked\Foo.dll

And so the last `$(RuntimeIdentifier)` wins, overwriting the linker
output of any previous RIDs. This would cause runtime crashes for some
ABIs, as `System.Private.CoreLib.dll` is different per architecture.

To fix this, we can always force `$(AppendRuntimeIdentifierToOutputPath)`
to be true in the nested build that runs the `ILLink` MSBuild target:

    <PropertyGroup>
      <_AdditionalProperties>
        AppendRuntimeIdentifierToOutputPath=true;
        _OuterIntermediateOutputPath=$(IntermediateOutputPath);
        <!-- ... -->
      </_AdditionalProperties>
    </PropertyGroup>
    <MSBuild
        Projects="$(MSBuildProjectFile)"
        Targets="_ComputeFilesToPublishForRuntimeIdentifiers"
        Properties="RuntimeIdentifier=%(_RIDs.Identity);$(_AdditionalProperties)">
    <!-- ... -->

The only other property to fix up is `$(_AndroidLinkFlag)` to be based
on `$(_OuterIntermediateOutputPath)`, so that the
`_TouchAndroidLinkFlag` MSBuild target has the correct path. This way
the `Inputs/Outputs` of the `_RemoveRegisterAttribute` MSBuild task
will work correctly, as it needs to do its work on the output of the
`ILLink` MSBuild target.

I updated the `AndroidXMigration` test that verifies that we get a
`obj\Debug\android.21-arm64\linked\Xamarin.Forms.Platform.Android.dll`
assembly with the correct AndroidX types present.