### PR TITLE
 Bump to xamarin/java.interop@99897b2 

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/DimBindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/DimBindingTests.cs
@@ -83,6 +83,12 @@ namespace Xamarin.Android.JcwGenTests
 			Assert.AreEqual (6, iface.InvokeFoo ());
 		}
 
+		[Test]
+		public void TestStaticInterfaceMethods ()
+		{
+			Assert.AreEqual (0, IDefaultMethodsInterface.StaticFoo ());
+		}
+
 		class ManagedEmptyDefault : Java.Lang.Object, IDefaultMethodsInterface
 		{
 		}

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/DefaultMethodsInterface.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/DefaultMethodsInterface.java
@@ -7,4 +7,5 @@ public interface DefaultMethodsInterface
     default void setBar (int value) { }
     default int toImplement () { throw new UnsupportedOperationException (); }
     default int invokeFoo () { return foo (); }
+    static int staticFoo () { return 0; }
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5251
Context: https://github.com/xamarin/java.interop/pull/745

https://github.com/xamarin/java.interop/compare/c3c35753b6e1b9e8e682adf37fc9d9e531114cf7...99897b24eada3b68fa1eedae41efd15fbf128ae1

Adds a test for `static` methods on an interface that is implemented by a class.  Our existing `static` test was an interface that only contained `static` members, and thus we did not try to implement the interface.  Implementing the interface exposed a JCW error.