### PR TITLE
[Xamarin.Android.Build.Tasks] Fix up ZipArchiveEx to handle updates.

### DIFF
--- a/Documentation/release-notes/5266.md
+++ b/Documentation/release-notes/5266.md
@@ -1,0 +1,6 @@
+### Build and deployment performance
+
+  * [GitHub PR 5266](https://github.com/xamarin/xamarin-android/pull/5266):
+  Minor improvements to the way zip archives are created. Do not create
+  folders in the classes.zip file and allow the auto flushing of
+  a zip file to be switched off.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ("\tAdding {0}", file.filePath);
 					apk.Archive.AddFile (file.filePath, item, compressionMethod: compressionMethod);
 					count++;
-					if (count == ZipArchiveEx.ZipFlushLimit) {
+					if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
 						apk.Flush();
 						count = 0;
 					}
@@ -257,7 +257,7 @@ namespace Xamarin.Android.Tasks
 						}
 					}
 					count++;
-					if (count == ZipArchiveEx.ZipFlushLimit) {
+					if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
 						apk.Flush();
 						count = 0;
 					}
@@ -353,7 +353,7 @@ namespace Xamarin.Android.Tasks
 						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 				}
 				count++;
-				if (count == ZipArchiveEx.ZipFlushLimit) {
+				if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
 					apk.Flush();
 					count = 0;
 				}
@@ -389,7 +389,7 @@ namespace Xamarin.Android.Tasks
 						AddFileToArchiveIfNewer (apk, symbols, assemblyPath + Path.GetFileName (symbols), compressionMethod: UncompressedMethod);
 				}
 				count++;
-				if (count == ZipArchiveEx.ZipFlushLimit) {
+				if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
 					apk.Flush();
 					count = 0;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -39,7 +39,6 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (ClassesZip)) {
 				using (var zip = new ZipArchiveEx (ClassesZip, FileMode.OpenOrCreate)) {
 					zip.AutoFlush = false;
-					zip.CreateDirectoriesInZip = false;
 					zip.AddDirectory (ClassesOutputDirectory, "", CompressionMethod.Store);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Android.Tasks
 			// compress all the class files
 			if (!string.IsNullOrEmpty (ClassesZip)) {
 				using (var zip = new ZipArchiveEx (ClassesZip, FileMode.OpenOrCreate)) {
+					zip.AutoFlush = false;
+					zip.CreateDirectoriesInZip = false;
 					zip.AddDirectory (ClassesOutputDirectory, "", CompressionMethod.Store);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
@@ -51,13 +51,13 @@ namespace Xamarin.Android.Build.Tests
 		public string TestPath {
 			get {
 				paths.TryGetValue (TestContext.CurrentContext.Test.Name, out string value);
-				return value; 
+				return value;
 			}
 		}
 
 		public string Zip {
 			get {
-				return Path.Combine (root, "temp", $"{TestContext.CurrentContext.Test.Name}.zip"); 
+				return Path.Combine (root, "temp", $"{TestContext.CurrentContext.Test.Name}.zip");
 			}
 		}
 
@@ -115,7 +115,6 @@ namespace Xamarin.Android.Build.Tests
 
 			AssertZip (
 @"temp/A.txt
-temp/B/
 temp/B/B.txt");
 		}
 
@@ -130,7 +129,6 @@ temp/B/B.txt");
 
 			AssertZip (
 @"temp/A.txt
-temp/B/
 temp/B/B.txt");
 		}
 
@@ -149,7 +147,6 @@ temp/B/B.txt");
 
 				AssertZip (
 @"temp/A.txt
-temp/B/
 temp/B/B.txt");
 			} finally {
 				Directory.SetCurrentDirectory (cwd);
@@ -168,7 +165,6 @@ temp/B/B.txt");
 
 			AssertZip (
 @"A.txt
-B/
 B/B.txt");
 			AssertSkipExisting (Path.Combine (TestPath, "A.txt"), "A.txt", expected: true);
 			AssertSkipExisting (Path.Combine (TestPath, "B", "B.txt"), "B/B.txt", expected: true);
@@ -188,7 +184,6 @@ B/B.txt");
 
 			AssertZip (
 @"A.txt
-B/
 B/B.txt");
 			var file = Path.Combine (TestPath, "A.txt");
 			File.SetLastWriteTimeUtc (file, DateTime.UtcNow.AddSeconds (1));

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 			else {
 				pathName = Path.Combine (directoryPathInZip, Path.GetFileName (filename));
 			}
-			return pathName.Replace ("\\", "/");
+			return pathName.Replace ("\\", "/").TrimStart ('/');
 		}
 
 		string TrimEntryName (string entryName, bool appendSeparator = false)
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Tasks
 				var fi = new FileInfo (fileName);
 				if ((fi.Attributes & FileAttributes.Hidden) != 0)
 					continue;
-				var archiveFileName = TrimEntryName (ArchiveNameForFile (fileName, folderInArchive));
+				var archiveFileName = ArchiveNameForFile (fileName, folderInArchive);
 				long index = -1;
 				if (zip.ContainsEntry (archiveFileName, out index)) {
 					var e = zip.First (x => x.FullName == archiveFileName);
@@ -115,7 +115,7 @@ namespace Xamarin.Android.Tasks
 				try {
 					string dirPathInZip = TrimEntryName (fullDirPath, appendSeparator: true);
 					if (CreateDirectoriesInZip && !zip.ContainsEntry (dirPathInZip))
-						zip.CreateDirectory (fullDirPath);
+						zip.CreateDirectory (dirPathInZip);
 				} catch (ZipException) {
 
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tasks
 	{
 
 		public static int ZipFlushSizeLimit = 50 * 1024 * 1024;
-		public static int ZipFlushFilesLimit = 200;
+		public static int ZipFlushFilesLimit = 50;
 
 		ZipArchive zip;
 		string archive;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tasks
 		{
 			filesWrittenTotalSize += fileLength;
 			zip.AddFile (filename, archiveFileName, compressionMethod: compressionMethod);
-			if ((filesWrittenTotalSize > ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount > ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
 				Flush ();
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -8,11 +8,13 @@ namespace Xamarin.Android.Tasks
 	public class ZipArchiveEx : IDisposable
 	{
 
-		public static int ZipFlushLimit = 500 * 1024 * 1024;
+		public static int ZipFlushSizeLimit = 50 * 1024 * 1024;
+		public static int ZipFlushFilesLimit = 200;
 
 		ZipArchive zip;
 		string archive;
 		long filesWrittenTotalSize = 0;
+		long filesWrittenTotalCount = 0;
 
 		public ZipArchive Archive {
 			get { return zip; }
@@ -41,6 +43,7 @@ namespace Xamarin.Android.Tasks
 			}
 			zip = ZipArchive.Open (archive, FileMode.Open);
 			filesWrittenTotalSize = 0;
+			filesWrittenTotalCount = 0;
 		}
 
 		string ArchiveNameForFile (string filename, string directoryPathInZip)
@@ -62,7 +65,7 @@ namespace Xamarin.Android.Tasks
 		{
 			filesWrittenTotalSize += fileLength;
 			zip.AddFile (filename, archiveFileName, compressionMethod: compressionMethod);
-			if (filesWrittenTotalSize > ZipArchiveEx.ZipFlushLimit && AutoFlush) {
+			if ((filesWrittenTotalSize > ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount > ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
 				Flush ();
 			}
 		}


### PR DESCRIPTION
While investigating another bug, I found that the code to look up
an existing entry in the zip was not working at all.

The problem was the filename we were looking up included a `/` at
the start of the path. The zip entires in the zip do not include a
`/` at the start. So the code was never finding a match. As a result
we were always trying to add a file rather than skipping those which
were up to date.

In addition I found that we do not always need to create entires in
the zip for directories. So when we create the `classes.zip` in the
`Javac` task we dont need to create directory entires. So we should
have a property to allow us to skip directories.

Also we should have the ability to turn the auto flush on/off.

There seems to be a small performance boost with these changes.

Old
```
749 ms  Javac                     
746 ms  Javac                   
```

New
```
728 ms  Javac 
724 ms  Javac 
```
