### PR TITLE
[One .NET] <FilterAssemblies/> can skip over @(FrameworkReference)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -35,6 +35,10 @@ namespace Xamarin.Android.Tasks
 
 			var output = new List<ITaskItem> (InputAssemblies.Length);
 			foreach (var assemblyItem in InputAssemblies) {
+				// Skip .NET 6.0 <FrameworkReference/> assemblies
+				if (!string.IsNullOrEmpty (assemblyItem.GetMetadata ("FrameworkReferenceName"))) {
+					continue;
+				}
 				if (!File.Exists (assemblyItem.ItemSpec)) {
 					Log.LogDebugMessage ($"Skipping non-existent dependency '{assemblyItem.ItemSpec}'.");
 					continue;


### PR DESCRIPTION
In .NET 6, I noticed many of the `PerformanceTest` tests are about
150ms-300ms slower than in "legacy" Xamarin.Android.

`PerformanceTest.Build_No_Changes` spends a lot of
time in the `<FilterAssemblies/>` MSBuild task:

    FilterAssemblies = 220 ms

This was running on our CI on macOS.

For a "Hello World" app, this task had an input of 155 assemblies.
`Mono.Android.Export.dll` was the only assembly added to
`@(_MonoAndroidReferencePath)`, but it doesn't actually need to be.

Reviewing build logs, I saw the following metadata:

    C:\Users\myuser\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-rtm.20508.7\ref\net5.0\mscorlib.dll
        FrameworkReferenceName = Microsoft.NETCore.App
        FrameworkReferenceVersion = 5.0.0-rtm.20508.7

Every assembly that came from a `@(FrameworkReference)` has this
metadata. We can simply check if `%(FrameworkReferenceName)` is not
blank to skip any framework assemblies.

I also checked "legacy" Xamarin.Android, and I saw `%(FrameworkFile)`
metadata:

    C:\src\xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll
        FrameworkFile = true

However, I don't think we can use the same check, as
`Xamarin.Android.NUnitLite` contains `@(AndroidResource)` files and
would have `%(FrameworkFile)` set.

We would need to reconsider this improvement if
`Xamarin.Android.NUnitLite` becomes part of .NET 6.

## Results ##

On my Windows PC:

    Before:
    57 ms  FilterAssemblies                           2 calls
    After:
     3 ms  FilterAssemblies                           2 calls

I'm thinking this change might get us closer to the `PerformanceTest`
tests passing on .NET 6. I'm hopeful the 220ms might take 90% less
time.