### PR TITLE
Bump to .NET 6.0.100-alpha.1.20562.2

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -70,8 +70,8 @@
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">5.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-rtm.20509.5</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-alpha.1.20562.2</DotNetPreviewVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.10.2</AndroidCmakeVersion>
     <AndroidCmakeVersionPath Condition=" '$(AndroidCmakeVersionPath)' == '' ">$(AndroidCmakeVersion).4988404</AndroidCmakeVersionPath>

--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -34,7 +34,7 @@ For example, a binding library could look like:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\Metadata.xml" />
@@ -243,7 +243,7 @@ The following instructions can be used for early preview testing.
 ```xml
 <Project Sdk="Microsoft.Android.Sdk/10.0.100">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,8 +5,7 @@
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="dotnet internal feed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" protocolVersion="3" />
-    <add key="illink" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
 
      <!-- This is needed (currently) for the Xamarin.Android.Deploy.Installer dependency, getting the installer -->
      <!-- Android binary, to support delta APK install -->

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				packWriter.WriteAttributeString ("Id", "sdk_manifests");
 				packWriter.WriteAttributeString ("Name", "sdk-manifests");
 
-				// 5.0.100
+				// $(DotNetPreviewVersionBand) 6.0.100
 				var sdk_manifests = Directory.EnumerateDirectories (sdk_manifests_root).FirstOrDefault ();
 				if (string.IsNullOrEmpty (sdk_manifests)) {
 					Log.LogError ($"Cannot find child directory of: {sdk_manifests_root}");

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -80,7 +80,7 @@
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=linux-x64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=osx-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=windows-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=win-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Workload.Android.proj&quot;" />
   </Target>
 
@@ -90,7 +90,7 @@
       <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.NET.Workload.Android.*.nupkg" />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.linux-x64.*.nupkg"   Condition=" '$(HostOS)' == 'Linux' " />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.osx-x64.*.nupkg"     Condition=" '$(HostOS)' == 'Darwin' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.windows-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.win-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Ref.*.nupkg" />
       <!-- Runtime packs are not yet supported by workloads -->
       <!-- <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Runtime.*.nupkg" /> -->

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -10,12 +10,12 @@ by projects that use the Microsoft.Android framework in .NET 5.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Microsoft.Android.Ref</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Microsoft.Android reference assemblies. Please do not reference directly.</Description>
     <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
-    <_AndroidRefPackAssemblyPath>ref\net5.0</_AndroidRefPackAssemblyPath>
+    <_AndroidRefPackAssemblyPath>ref\net6.0</_AndroidRefPackAssemblyPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -10,14 +10,14 @@ projects that use the Microsoft.Android framework in .NET 5.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AndroidRID Condition=" '$(AndroidRID)' == '' ">android.21-arm64</AndroidRID>
     <AndroidABI Condition=" '$(AndroidABI)' == '' ">arm64-v8a</AndroidABI>
     <PackageId>Microsoft.Android.Runtime.$(AndroidRID)</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Microsoft.Android runtime components. Please do not reference directly.</Description>
     <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
-    <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\net5.0</_AndroidRuntimePackAssemblyPath>
+    <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\net6.0</_AndroidRuntimePackAssemblyPath>
     <_AndroidRuntimePackNativePath>runtimes\$(AndroidRID)\native</_AndroidRuntimePackNativePath>
   </PropertyGroup>
 

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -9,10 +9,10 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Linux' ">linux-x64</AndroidHostRID>
     <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Darwin' ">osx-x64</AndroidHostRID>
-    <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Windows' ">windows-x64</AndroidHostRID>
+    <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Windows' ">win-x64</AndroidHostRID>
     <PackageId>Microsoft.Android.Sdk.$(AndroidHostRID)</PackageId>
     <Authors>Microsoft</Authors>
     <Description>C# Tools and Bindings for the Android SDK</Description>
@@ -46,7 +46,7 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
       <AndroidSdkBuildTools Include="@(_MSBuildTargetsSrcFiles)" >
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
-      <AndroidSdkBuildTools Include="@(_MSBuildFilesWin)" Condition=" '$(AndroidHostRID)' == 'windows-x64' ">
+      <AndroidSdkBuildTools Include="@(_MSBuildFilesWin)" Condition=" '$(AndroidHostRID)' == 'win-x64' ">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
       <!-- Exclude host-os specific native libraries, aside from libMonoPosixHelper.dylib which is required by LibZipSharp on macOS. -->
@@ -91,7 +91,7 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
   <Target Name="_GenerateBundledVersions"
       DependsOnTargets="_GetDefaultPackageVersion" >
     <PropertyGroup>
-      <_AndroidNETAppTargetFramework>net5.0</_AndroidNETAppTargetFramework>
+      <_AndroidNETAppTargetFramework>net6.0</_AndroidNETAppTargetFramework>
       <BundledVersionsFileName>Microsoft.Android.Sdk.BundledVersions.targets</BundledVersionsFileName>
     </PropertyGroup>
 

--- a/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
@@ -9,7 +9,7 @@ workload manifest pack containing information about the various Microsoft.Androi
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Microsoft.NET.Workload.Android</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Microsoft.Android workload manifest. Please do not reference directly.</Description>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -1,0 +1,28 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.After.targets
+
+This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
+
+***********************************************************************************************
+-->
+<Project>
+  <PropertyGroup>
+    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
+  </PropertyGroup>
+
+  <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
+  <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' " />
+
+  <Import Project="..\tools\Xamarin.Android.Common.targets" />
+  <Import Project="..\tools\Xamarin.Android.Bindings.Core.targets" />
+  <Import Project="..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
+  <Import Project="Microsoft.Android.Sdk.AndroidLibraries.targets" />
+  <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
+  <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
+  <Import Project="Microsoft.Android.Sdk.ILLink.targets" />
+  <Import Project="Microsoft.Android.Sdk.NuGet.targets" />
+  <Import Project="Microsoft.Android.Sdk.ProjectCapabilities.targets" />
+  <Import Project="Microsoft.Android.Sdk.Publish.targets" />
+  <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -13,12 +13,15 @@
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
+    <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
+    <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' ">false</GenerateRuntimeConfigurationFiles>
+    <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>
+    <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' ">false</ComputeNETCoreBuildOutputFiles>
     <!-- jar2xml is not supported -->
     <AndroidClassParser>class-parse</AndroidClassParser>
     <!-- mono-symbolicate is not supported -->
     <MonoSymbolArchive>false</MonoSymbolArchive>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
-    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">$(EnableDefaultItems)</EnableDefaultAndroidItems>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->
@@ -38,6 +41,7 @@
     <OutputType Condition=" '$(OutputType)' == 'Exe' ">Library</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and ('$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full') ">true</PublishTrimmed>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -7,6 +7,7 @@
     <!-- Enable nuget package conflict resolution -->
     <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     <_AndroidResourceDesigner>Resource.designer.cs</_AndroidResourceDesigner>
+    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.After.targets</AfterMicrosoftNETSdkTargets>
   </PropertyGroup>
 
   <!-- Default References -->
@@ -24,20 +25,5 @@
   <Import Project="Microsoft.Android.Sdk.DefaultProperties.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props"
       Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props')"/>
-
-  <!-- Build ordering, should be imported before Xamarin.Android.Common.targets -->
-  <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' " />
-
-  <Import Project="..\tools\Xamarin.Android.Common.targets" />
-  <Import Project="..\tools\Xamarin.Android.Bindings.Core.targets" />
-  <Import Project="..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
-  <Import Project="Microsoft.Android.Sdk.AndroidLibraries.targets" />
-  <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
-  <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
-  <Import Project="Microsoft.Android.Sdk.ILLink.targets" />
-  <Import Project="Microsoft.Android.Sdk.NuGet.targets" />
-  <Import Project="Microsoft.Android.Sdk.ProjectCapabilities.targets" />
-  <Import Project="Microsoft.Android.Sdk.Publish.targets" />
-  <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "workloads": {
     "microsoft-android-sdk-full": {
       "description": "Android SDK",
@@ -15,7 +15,7 @@
       "version": "@SDK_PACK_VERSION@",
       "alias-to": {
         "osx-x64": "Microsoft.Android.Sdk.osx-x64",
-        "windows-x64": "Microsoft.Android.Sdk.windows-x64"
+        "win-x64": "Microsoft.Android.Sdk.win-x64"
       }
     },
     "Microsoft.Android.Ref": {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Android.Build.Tests
 					"System.Net.NameResolution.dll",
 					"System.Net.NetworkInformation.dll",
 					"System.Net.Primitives.dll",
+					"System.Net.Quic.dll",
 					"System.Net.Security.dll",
 					"System.Net.Sockets.dll",
 					"System.ObjectModel.dll",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void DotNetPack ([Values ("net5.0-android", "net5.0-android30")] string targetFramework)
+		public void DotNetPack ([Values ("net6.0-android", "net6.0-android30")] string targetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
@@ -209,8 +209,8 @@ namespace Xamarin.Android.Build.Tests
 			var nupkgPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "..", $"{proj.ProjectName}.1.0.0.nupkg");
 			FileAssert.Exists (nupkgPath);
 			using (var nupkg = ZipHelper.OpenZip (nupkgPath)) {
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net5.0-android30.0/{proj.ProjectName}.dll");
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net5.0-android30.0/{proj.ProjectName}.aar");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android30.0/{proj.ProjectName}.dll");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android30.0/{proj.ProjectName}.aar");
 			}
 		}
 
@@ -348,21 +348,16 @@ namespace Xamarin.Android.Build.Tests
 				outputPath = Path.Combine (outputPath, runtimeIdentifiers);
 			}
 
-			// TODO: With workloads we don't control the import of Microsoft.NET.Sdk/Sdk.targets.
-			//  We can no longer change the default values of `$(GenerateDependencyFile)` and `$(ProduceReferenceAssembly)` as a result.
-			//  We should update Microsoft.NET.Sdk to default both of these properties to false when the `$(TargetPlatformIdentifier)` is "mobile" (Android, iOS, etc).
-			//  Alternatively, the workload concept could be updated to support some sort of `Before.Microsoft.NET.targets` hook.
-
-			/* var files = Directory.EnumerateFileSystemEntries (outputPath)
+			var files = Directory.EnumerateFileSystemEntries (outputPath)
 				.Select (Path.GetFileName)
-				.OrderBy (f => f);
+				.OrderBy (f => f)
+				.ToArray ();
 			CollectionAssert.AreEqual (new [] {
 				$"{proj.ProjectName}.dll",
 				$"{proj.ProjectName}.pdb",
 				$"{proj.PackageName}.apk",
 				$"{proj.PackageName}-Signed.apk",
 			}, files);
-			*/
 
 			var assemblyPath = Path.Combine (outputPath, $"{proj.ProjectName}.dll");
 			FileAssert.Exists (assemblyPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -54,7 +54,7 @@ namespace Xamarin.ProjectTools
 		public XASdkProject (string outputType = "Exe")
 		{
 			Sdk = "Microsoft.NET.Sdk";
-			TargetFramework = "net5.0-android";
+			TargetFramework = "net6.0-android";
 
 			TargetSdkVersion = AndroidSdkResolver.GetMaxInstalledPlatform ().ToString ();
 			PackageName = PackageName ?? string.Format ("{0}.{0}", ProjectName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -26,7 +26,7 @@ namespace Xamarin.ProjectTools
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
 
 			if (Builder.UseDotNet) {
-				SetProperty ("TargetFramework", "net5.0-android");
+				SetProperty ("TargetFramework", "net6.0-android");
 				SetProperty ("EnableDefaultItems", "false");
 				SetProperty ("AppendTargetFrameworkToOutputPath", "false");
 				SetProperty ("AppendRuntimeIdentifierToOutputPath", "false");

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTestsDotNet.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTestsDotNet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <RootNamespace>Xamarin.Android.Tests.CodeBehindBuildTests</RootNamespace>
     <OutputType>Exe</OutputType>
     <AndroidGenerateLayoutBindings>True</AndroidGenerateLayoutBindings>

--- a/tests/CodeBehind/CommonSampleLibrary/CommonSampleLibraryDotNet.csproj
+++ b/tests/CodeBehind/CommonSampleLibrary/CommonSampleLibraryDotNet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <RootNamespace>CommonSampleLibrary</RootNamespace>
     <AssemblyName>CommonSampleLibrary</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Changes: https://github.com/dotnet/installer/compare/53e0c8c7...efac3f25

This version of .NET 6 includes support for
`$(AfterMicrosoftNETSdkTargets)`, and so we now have a slightly
different import ordering:

1. `AutoImport.props`
2. The user's `.csproj` file
3. Some early parts of `Microsoft.NET.Sdk` / `Sdk.targets`
4. `Microsoft.Android.Sdk.targets`
5. The rest of `Microsoft.NET.Sdk` / `Sdk.targets`
6. `Microsoft.Android.Sdk.After.targets`

Anything that needs to happen *after* the `Microsoft.NET.Sdk` targets
can go in `After.targets`.

This allows us to set up some defaults that we lost in 91498d55 when
implementing Android as a .NET "workload":

* `$(GenerateDependencyFile)` defaults to `false`
* `$(ProduceReferenceAssembly)` defaults to `false` for application
  projects.

Using `$(SelfContained)` also triggers new behavior in .NET 6 that we
need to turn off:

* `$(GenerateRuntimeConfigurationFiles)` to `false` or we get a
  `*.runtimeconfig.dev.json` file generated for Android applications.
* `$(CopyLocalLockFileAssemblies)` to `false` - otherwise every `.dll`
  file is copied to `$(OutputPath)`, and we don't need this behavior.
  This appears to be new behavior in .NET 6 when `$(SelfContained)` is
  `true`.
* `$(ComputeNETCoreBuildOutputFiles)` to `false` or we get a `*.exe`
  .NET app host in the output directory.

I also adjusted the naming for `windows-x64` to `win-x64`, as
described in 011a7713.