### PR TITLE
[illink] Set TrimMode of support assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -22,7 +22,7 @@ This file contains the .NET 5-specific targets to customize ILLink
       />
       <!-- TODO: remove setting the trim mode here, once the support packages are updated to NET6 and compatability packages not needed -->
       <ResolvedFileToPublish
-          Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('System.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android')) ) ">
+          Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.AndroidX.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android.Support.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Google.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.GooglePlayServices.')) ) ">
         <TrimMode>link</TrimMode>
       </ResolvedFileToPublish>
       <!-- Mark our entry assembly as a root assembly. -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -20,6 +20,11 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition=" '$(AndroidLinkMode)' == 'Full' and '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.AssetType)' != 'native' "
           TrimMode="link"
       />
+      <!-- TODO: remove setting the trim mode here, once the support packages are updated to NET6 and compatability packages not needed -->
+      <ResolvedFileToPublish
+          Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('System.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android')) ) ">
+        <TrimMode>link</TrimMode>
+      </ResolvedFileToPublish>
       <!-- Mark our entry assembly as a root assembly. -->
       <TrimmerRootAssembly Include="$(AssemblyName)" />
     </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5271

Temporarily set trim mode of support assemblies to `link`.

apk size comparison of XF BuildReleaseArm64True test after the change, current monodroid vs net5:
```
Summary:
  +          29 Other entries 0.00% (of 750,919)
  -         116 Dalvik executables -0.00% (of 3,455,436)
  +   1,604,215 Assemblies 33.66% (of 4,765,637)
  -   6,488,608 Shared libraries -61.38% (of 10,570,992)
  -     394,325 Package size difference -3.73% (of 10,572,124)
```
apk size comparison of XF BuildReleaseArm64True test before and after the change (net5):
```
Summary:
  -         184 Other entries -0.02% (of 751,132)
  -      35,860 Dalvik executables -1.03% (of 3,491,180)
  -   1,179,296 Assemblies -15.62% (of 7,549,148)
  -     144,888 Shared libraries -3.43% (of 4,227,272)
  -   1,210,846 Package size difference -10.63% (of 11,388,645)
```
So it reduces the apk size by cca 1.2M.

For completeness, the difference between monodroid and net5 before the change:
```
Summary:
  +         213 Other entries 0.03% (of 750,919)
  +      35,744 Dalvik executables 1.03% (of 3,455,436)
  +   2,783,443 Assemblies 58.41% (of 4,765,705)
  -   6,360,784 Shared libraries -60.08% (of 10,588,056)
  +     815,915 Package size difference 7.72% (of 10,572,730)
```
Note that the apk is now smaller in net5 compared to monodroid. OTOH the assembly size is still larger by cca 16%. That could be later partially improved by linking the compatibility assemblies coming from nugets.
