### PR TITLE
[One .NET] better logic for deduplication of architecture-specific assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			var output = new Dictionary<Guid, ITaskItem> ();
+			var output = new List<ITaskItem> ();
 			var symbols = new Dictionary<string, ITaskItem> ();
 
 			if (ResolvedSymbols != null) {
@@ -47,52 +47,59 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			foreach (var assembly in InputAssemblies) {
-				if (!File.Exists (assembly.ItemSpec)) {
-					Log.LogDebugMessage ($"Skipping non-existent dependency '{assembly.ItemSpec}'.");
-					continue;
-				}
-				using (var pe = new PEReader (File.OpenRead (assembly.ItemSpec))) {
-					var reader = pe.GetMetadataReader ();
-					var module = reader.GetModuleDefinition ();
-					var mvid = reader.GetGuid (module.Mvid);
-					if (!output.ContainsKey (mvid)) {
-						output.Add (mvid, assembly);
+			// Group by assembly file name
+			foreach (var group in InputAssemblies.Where (Filter).GroupBy (a => Path.GetFileName (a.ItemSpec))) {
+				// Get the unique list of MVIDs
+				var mvids = new HashSet<Guid> ();
+				bool? frameworkAssembly = null, hasMonoAndroidReference = null;
+				foreach (var assembly in group) {
+					using (var pe = new PEReader (File.OpenRead (assembly.ItemSpec))) {
+						var reader = pe.GetMetadataReader ();
+						var module = reader.GetModuleDefinition ();
+						var mvid = reader.GetGuid (module.Mvid);
+						mvids.Add (mvid);
 
-						// Set metadata, such as %(FrameworkAssembly) and %(HasMonoAndroidReference)
-						string packageId = assembly.GetMetadata ("NuGetPackageId");
-						bool frameworkAssembly = packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
-							packageId.StartsWith ("Microsoft.Android.Runtime.");
+						// Calculate %(FrameworkAssembly) and %(HasMonoAndroidReference) for the first
+						if (frameworkAssembly == null) {
+							string packageId = assembly.GetMetadata ("NuGetPackageId") ?? "";
+							frameworkAssembly = packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
+								packageId.StartsWith ("Microsoft.Android.Runtime.");
+						}
+						if (hasMonoAndroidReference == null) {
+							hasMonoAndroidReference = MonoAndroidHelper.HasMonoAndroidReference (reader);
+						}
 						assembly.SetMetadata ("FrameworkAssembly", frameworkAssembly.ToString ());
-						assembly.SetMetadata ("HasMonoAndroidReference", MonoAndroidHelper.HasMonoAndroidReference (reader).ToString ());
-					} else {
-						symbols.Remove (Path.ChangeExtension (assembly.ItemSpec, ".pdb"));
+						assembly.SetMetadata ("HasMonoAndroidReference", hasMonoAndroidReference.ToString ());
 					}
 				}
-			}
-
-			OutputAssemblies = output.Values.ToArray ();
-			ResolvedSymbols = symbols.Values.ToArray ();
-
-			// Set %(DestinationSubDirectory) and %(DestinationSubPath) for architecture-specific assemblies
-			var fileNames = new Dictionary<string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
-			foreach (var assembly in OutputAssemblies) {
-				var fileName = Path.GetFileName (assembly.ItemSpec);
-				symbols.TryGetValue (Path.ChangeExtension (assembly.ItemSpec, ".pdb"), out var symbol);
-				if (fileNames.TryGetValue (fileName, out ITaskItem other)) {
-					SetDestinationSubDirectory (assembly, fileName, symbol);
-					if (other != null) {
-						symbols.TryGetValue (Path.ChangeExtension (other.ItemSpec, ".pdb"), out symbol);
-						SetDestinationSubDirectory (other, fileName, symbol);
-						// We don't need to check "other" again
-						fileNames [fileName] = null;
+				// If we end up with more than 1 unique mvid, we need *all* assemblies
+				if (mvids.Count > 1) {
+					foreach (var assembly in group) {
+						symbols.TryGetValue (Path.ChangeExtension (assembly.ItemSpec, ".pdb"), out var symbol);
+						SetDestinationSubDirectory (assembly, group.Key, symbol);
+						output.Add (assembly);
 					}
 				} else {
-					fileNames.Add (fileName, assembly);
-					assembly.SetDestinationSubPath ();
-					symbol?.SetDestinationSubPath ();
+					// Otherwise only include the first assembly
+					bool first = true;
+					foreach (var assembly in group) {
+						var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
+						if (first) {
+							first = false;
+							if (symbols.TryGetValue (symbolPath, out var symbol)) {
+								symbol.SetDestinationSubPath ();
+							}
+							assembly.SetDestinationSubPath ();
+							output.Add (assembly);
+						} else {
+							symbols.Remove (symbolPath);
+						}
+					}
 				}
 			}
+
+			OutputAssemblies = output.ToArray ();
+			ResolvedSymbols = symbols.Values.ToArray ();
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
 			if (!string.IsNullOrEmpty (LinkMode) && !string.Equals (LinkMode, "None", StringComparison.OrdinalIgnoreCase) && !IncludeDebugSymbols) {
@@ -106,6 +113,15 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return !Log.HasLoggedErrors;
+		}
+
+		bool Filter (ITaskItem assembly)
+		{
+			if (!File.Exists (assembly.ItemSpec)) {
+				Log.LogDebugMessage ($"Skipping non-existent dependency '{assembly.ItemSpec}'.");
+				return false;
+			}
+			return true;
 		}
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -305,6 +305,10 @@ namespace Xamarin.Android.Build.Tests
 				/* isRelease */          false,
 			},
 			new object [] {
+				/* runtimeIdentifiers */ "android.21-arm;android.21-arm64;android.21-x86",
+				/* isRelease */          true,
+			},
+			new object [] {
 				/* runtimeIdentifiers */ "android.21-arm;android.21-arm64;android.21-x86;android.21-x64",
 				/* isRelease */          true,
 			},
@@ -374,14 +378,17 @@ namespace Xamarin.Android.Build.Tests
 			using (var apk = ZipHelper.OpenZip (apkPath)) {
 				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
 				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !CommercialBuildAvailable && !isRelease);
+				apk.AssertContainsEntry (apkPath, $"assemblies/System.Linq.dll",        shouldContainEntry: expectEmbeddedAssembies);
 				var rids = runtimeIdentifiers.Split (';');
 				foreach (var abi in rids.Select (MonoAndroidHelper.RuntimeIdentifierToAbi)) {
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonodroid.so");
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonosgen-2.0.so");
 					if (rids.Length > 1) {
-						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll", shouldContainEntry: expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Collections.Concurrent.dll", shouldContainEntry: expectEmbeddedAssembies);
 					} else {
-						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll", shouldContainEntry: expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
+						apk.AssertContainsEntry (apkPath, "assemblies/System.Collections.Concurrent.dll", shouldContainEntry: expectEmbeddedAssembies);
 					}
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5263

In .NET 6, we currently run the `ILLink` MSBuild target for each
`$(RuntimeIdentifier)`, as the Mono runtime packs have some .NET
assemblies that differ per architecture.

To make this happen, the `<ProcessAssemblies/>` MSBuild task works
with input such as:

* `android.21-arm\linked\Foo.dll`
* `android.21-x86\linked\Foo.dll`
* `android.21-arm\linked\System.Private.CoreLib.dll`
* `android.21-x86\linked\System.Private.CoreLib.dll`

And "merges" this to what we need in the output of the `.apk`:

* `assemblies\Foo.dll`
* `assemblies\armeabi-v7a\System.Private.CoreLib.dll`
* `assemblies\x86\System.Private.CoreLib.dll`

`Foo.dll` is identical for all architectures, so we only need to use a
single copy of it.

A bug in our implementation was for an assembly when building for
three RIDs:

* `android.21-arm\linked\System.Collections.Concurrent.dll`
* `android.21-arm64\linked\System.Collections.Concurrent.dll`
* `android.21-x86\linked\System.Collections.Concurrent.dll`

Two of these assemblies have the same MVID... This didn't quite work.

So I reworked the logic to instead do:

* Group by assembly file name
* Count the unique MVIDs
* If we have only 1 MVID, we just need the first assembly.
* Otherwise, place the assemblies in architecture-specific directories.

The resulting code seems like it is a bit simpler, and likely a little
faster. I was able to call `MonoAndroidHelper.HasMonoAndroidReference()`
once per file name, which should help performance.

I updated `XASdkTests` to check the broken scenario.