### PR TITLE
[One .NET] fix Release builds with AndroidLinkMode=None

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -77,9 +77,9 @@ _ResolveAssemblies MSBuild target.
         InputAssemblies="@(_ResolvedAssemblyFiles->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles->Distinct())"
         PublishTrimmed="$(PublishTrimmed)">
-      <Output TaskParameter="OutputAssemblies"    ItemName="_ProcessedAssemblies" />
-      <Output TaskParameter="ResolvedSymbols"     ItemName="ResolvedSymbols" />
-      <Output TaskParameter="ShrunkAssemblies"    ItemName="_ProcessedShrunkAssemblies" />
+      <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
+      <Output TaskParameter="ResolvedSymbols"  ItemName="ResolvedSymbols" />
+      <Output TaskParameter="ShrunkAssemblies" ItemName="_ProcessedShrunkAssemblies" />
     </ProcessAssemblies>
     <AppendCustomMetadataToItemGroup
         Inputs="@(_ProcessedAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -76,11 +76,10 @@ _ResolveAssemblies MSBuild target.
     <ProcessAssemblies
         InputAssemblies="@(_ResolvedAssemblyFiles->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles->Distinct())"
-        IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
-        LinkMode="$(AndroidLinkMode)">
-      <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
-      <Output TaskParameter="ResolvedSymbols"  ItemName="ResolvedSymbols" />
-      <Output TaskParameter="ShrunkAssemblies" ItemName="_ProcessedShrunkAssemblies" />
+        PublishTrimmed="$(PublishTrimmed)">
+      <Output TaskParameter="OutputAssemblies"    ItemName="_ProcessedAssemblies" />
+      <Output TaskParameter="ResolvedSymbols"     ItemName="ResolvedSymbols" />
+      <Output TaskParameter="ShrunkAssemblies"    ItemName="_ProcessedShrunkAssemblies" />
     </ProcessAssemblies>
     <AppendCustomMetadataToItemGroup
         Inputs="@(_ProcessedAssemblies)"
@@ -127,7 +126,7 @@ _ResolveAssemblies MSBuild target.
 
   <Target Name="_PrepareAssemblies"
       DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
-    <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' And '$(AndroidIncludeDebugSymbols)' == 'true'  ">
+    <ItemGroup Condition=" '$(PublishTrimmed)' != 'true' ">
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"          Condition=" '%(DestinationSubPath)' != '' " />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"      Condition=" '%(DestinationSubPath)' != '' " />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')" Condition=" '%(DestinationSubPath)' != '' " />
@@ -136,7 +135,7 @@ _ResolveAssemblies MSBuild target.
       <_ShrunkUserAssemblies        Include="@(_ResolvedUserAssemblies)" />
       <_ShrunkFrameworkAssemblies   Include="@(_ResolvedFrameworkAssemblies)" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(AndroidLinkMode)' != 'None' And '$(AndroidIncludeDebugSymbols)' != 'true'  ">
+    <ItemGroup Condition=" '$(PublishTrimmed)' == 'true' ">
       <_ResolvedAssemblies          Include="@(ResolvedAssemblies)" />
       <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies)" />
       <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -23,7 +23,6 @@
 
   <!--  User-facing configuration-specific defaults -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <!--FIXME: Disable fast deployment by default -->
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -44,6 +43,7 @@
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>
     <TrimMode Condition=" '$(PublishTrimmed)' == 'true' and '$(TrimMode)' == '' ">link</TrimMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -21,9 +21,7 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "PRAS";
 
-		public string LinkMode { get; set; }
-
-		public bool IncludeDebugSymbols { get; set; }
+		public bool PublishTrimmed { get; set; }
 
 		public ITaskItem [] InputAssemblies { get; set; }
 
@@ -95,7 +93,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
-			if (!string.IsNullOrEmpty (LinkMode) && !string.Equals (LinkMode, "None", StringComparison.OrdinalIgnoreCase) && !IncludeDebugSymbols) {
+			if (PublishTrimmed) {
 				ShrunkAssemblies = OutputAssemblies.Select (a => {
 					var dir = Path.GetDirectoryName (a.ItemSpec);
 					var file = Path.GetFileName (a.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -16,6 +16,7 @@ namespace Xamarin.ProjectTools
 		public const string AndroidSupportedAbis = "AndroidSupportedAbis";
 		public const string RuntimeIdentifier = "RuntimeIdentifier";
 		public const string RuntimeIdentifiers = "RuntimeIdentifiers";
+		public const string PublishTrimmed = "PublishTrimmed";
 
 		public const string Deterministic = "Deterministic";
 		public const string BundleAssemblies = "BundleAssemblies";

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -16,8 +16,37 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("UsesDevices"), Category ("SmokeTests"), Category ("DotNetIgnore")] // These don't need to run under `dotnet test`
 	public class XASdkDeployTests : DeviceTest
 	{
+		static object [] DotNetInstallAndRunSource = new object [] {
+			new object[] {
+				/* isRelease */      false,
+				/* xamarinForms */   false,
+				/* publishTrimmed */ default (bool?),
+			},
+			new object[] {
+				/* isRelease */      true,
+				/* xamarinForms */   false,
+				/* publishTrimmed */ default (bool?),
+			},
+			new object[] {
+				/* isRelease */      false,
+				/* xamarinForms */   true,
+				/* publishTrimmed */ default (bool?),
+			},
+			new object[] {
+				/* isRelease */      true,
+				/* xamarinForms */   true,
+				/* publishTrimmed */ default (bool?),
+			},
+			new object[] {
+				/* isRelease */      true,
+				/* xamarinForms */   false,
+				/* publishTrimmed */ false,
+			},
+		};
+
 		[Test]
-		public void DotNetInstallAndRun ([Values (false, true)] bool isRelease, [Values (false, true)] bool xamarinForms)
+		[TestCaseSource (nameof (DotNetInstallAndRunSource))]
+		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, bool? publishTrimmed)
 		{
 			AssertHasDevices ();
 
@@ -30,6 +59,9 @@ namespace Xamarin.Android.Build.Tests
 				proj = new XASdkProject {
 					IsRelease = isRelease
 				};
+			}
+			if (publishTrimmed != null) {
+				proj.SetProperty (KnownProperties.PublishTrimmed, publishTrimmed.ToString ());
 			}
 			proj.SetRuntimeIdentifier (DeviceAbi);
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5274

In 51fb93e1, I had logic checking for `$(AndroidLinkMode)` and
`$(AndroidIncludeDebugSymbols)` in two places:

* The `<ProcessAssemblies/>` MSBuild task, which eventually populates
  a `@(_ShrunkAssemblies)` item group.
* The `_PrepareAssemblies` MSBuild target, which fills out various
  item groups such as `@(_ShrunkFrameworkAssemblies)` and
  `@(_ShrunkUserAssemblies)`.

The logic did not match exactly, and so building a `Release` app with
`AndroidLinkMode=None` would result in all of these item groups being
empty.

I switched to checking `$(PublishTrimmed)` as it is the only property
that needs to be checked here:

* if `$(PublishTrimmed)` is `true`, `ILLink` runs and we need to use
  the assemblies that the `_RemoveRegisterAttribute` MSBuild target
  outputs to the `shrunk` directory.
* if `$(PublishTrimmed)` is `false`, we need to use the assemblies
  that `_LinkAssembliesNoShrink` puts in `obj\Debug\android\assets`.

I updated a test to check a `Release` build with `$(PublishTrimmed)`
set to `false`. This should now be the same as setting
`$(AndroidLinkMode)` to `None`. We will likely need to support both
sets of linker properties.