### PR TITLE
[linker] Add AddKeepAlivesStep

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -50,6 +50,16 @@ processing Android assets and resources.
 
 Added in Xamarin.Android 9.1.
 
+## AndroidAddKeepAlives
+
+A boolean property that controls whether the linker will insert
+`GC.KeepAlive()` invocations within binding projects to prevent premature
+object collection.
+
+Defaults to `True` for Release configuration builds.
+
+Added in Xamarin.Android 11.2.
+
 ## AndroidAotCustomProfilePath
 
 The file that `aprofutil` should create to hold profiler data.

--- a/Documentation/release-notes/5278.md
+++ b/Documentation/release-notes/5278.md
@@ -1,0 +1,5 @@
+#### Application and library build and deployment
+
+  * [GitHub PR 5278](https://github.com/xamarin/xamarin-android/pull/5278):
+    Update the linker in Release builds to insert `GC.KeepAlive()` invocations within
+    JNI marshal methods to prevent premature instance collection.

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -28,6 +28,7 @@
     <Compile Remove="..\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\LinkerOptions.cs" />
 
     <!--Steps that are upstreamed, these are OK to remove-->
+    <Compile Remove="..\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\AddKeepAlivesStep.cs" />
     <Compile Remove="..\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\ApplyPreserveAttribute.cs" />
     <Compile Remove="..\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\OutputStepWithTimestamps.cs" />
     <Compile Remove="..\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\PreserveCode.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -33,15 +33,18 @@ namespace MonoDroid.Tuner
 
 		internal bool AddKeepAlives (AssemblyDefinition assembly)
 		{
-			if (assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
+			if (assembly.Name.Name != "Mono.Android" && !assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
 				return false;
+
 			bool changed = false;
 			List<TypeDefinition> types = assembly.MainModule.Types.ToList ();
 			foreach (TypeDefinition type in assembly.MainModule.Types)
 				AddNestedTypes (types, type);
+
 			foreach (TypeDefinition type in types)
 				if (MightNeedFix (type))
 					changed |= AddKeepAlives (type);
+
 			return changed;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -33,7 +33,7 @@ namespace MonoDroid.Tuner
 
 		internal bool AddKeepAlives (AssemblyDefinition assembly)
 		{
-			if (assembly.Name.Name != "Mono.Android" && !assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
+			if (!assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
 				return false;
 
 			bool changed = false;

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -24,9 +24,12 @@ namespace MonoDroid.Tuner
 
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
 		{
+			var action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
+			if (action == AssemblyAction.Delete)
+				return;
+
 			if (AddKeepAlives (assembly)) {
-				AssemblyAction action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
-				if (action == AssemblyAction.Skip || action == AssemblyAction.Copy || action == AssemblyAction.Delete)
+				if (action == AssemblyAction.Skip || action == AssemblyAction.Copy)
 					Annotations.SetAction (assembly, AssemblyAction.Save);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Mono.Cecil;
+
+using Java.Interop.Tools.Cecil;
+
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+using Mono.Cecil.Cil;
+
+namespace MonoDroid.Tuner
+{
+	public class AddKeepAlivesStep : BaseStep
+	{
+		readonly TypeDefinitionCache cache;
+
+		public AddKeepAlivesStep (TypeDefinitionCache cache)
+		{
+			this.cache = cache;
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (AddKeepAlives (assembly)) {
+				AssemblyAction action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
+				if (action == AssemblyAction.Skip || action == AssemblyAction.Copy || action == AssemblyAction.Delete)
+					Annotations.SetAction (assembly, AssemblyAction.Save);
+			}
+		}
+
+		internal bool AddKeepAlives (AssemblyDefinition assembly)
+		{
+			if (assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
+				return false;
+			bool changed = false;
+			List<TypeDefinition> types = assembly.MainModule.Types.ToList ();
+			foreach (TypeDefinition type in assembly.MainModule.Types)
+				AddNestedTypes (types, type);
+			foreach (TypeDefinition type in types)
+				if (MightNeedFix (type))
+					changed |= AddKeepAlives (type);
+			return changed;
+		}
+
+		// Adapted from `MarkJavaObjects`
+		static void AddNestedTypes (List<TypeDefinition> types, TypeDefinition type)
+		{
+			if (!type.HasNestedTypes)
+				return;
+
+			foreach (var t in type.NestedTypes) {
+				types.Add (t);
+				AddNestedTypes (types, t);
+			}
+		}
+
+		bool MightNeedFix (TypeDefinition type)
+		{
+			return !type.IsAbstract && type.IsSubclassOf ("Java.Lang.Object", cache);
+		}
+
+		bool AddKeepAlives (TypeDefinition type)
+		{
+			bool changed = false;
+			foreach (MethodDefinition method in type.Methods) {
+				if (!method.CustomAttributes.Any (a => a.AttributeType.FullName == "Android.Runtime.RegisterAttribute"))
+					continue;
+				ILProcessor processor = method.Body.GetILProcessor ();
+				ModuleDefinition module = method.DeclaringType.Module;
+				MethodDefinition methodKeepAlive = Context.GetMethod ("mscorlib", "System.GC", "KeepAlive", new string [] { "System.Object" });
+				Instruction end = method.Body.Instructions.Last ();
+				if (end.Previous.OpCode == OpCodes.Endfinally)
+					end = end.Previous;
+				for (int i = 0; i < method.Parameters.Count; i++) {
+					if (method.Parameters [i].ParameterType.IsValueType)
+						continue;
+					changed = true;
+					processor.InsertBefore (end, GetLoadArgumentInstruction (method.IsStatic ? i : i + 1, method.Parameters [i]));
+					processor.InsertBefore (end, Instruction.Create (OpCodes.Call, module.ImportReference (methodKeepAlive)));
+				}
+			}
+			return changed;
+		}
+
+		// Adapted from src/Mono.Android.Export/Mono.CodeGeneration/CodeArgumentReference.cs
+		static Instruction GetLoadArgumentInstruction (int argNum, ParameterDefinition parameter)
+		{
+			switch (argNum) {
+				case 0: return Instruction.Create (OpCodes.Ldarg_0);
+				case 1: return Instruction.Create (OpCodes.Ldarg_1);
+				case 2: return Instruction.Create (OpCodes.Ldarg_2);
+				case 3: return Instruction.Create (OpCodes.Ldarg_3);
+				default: return Instruction.Create (OpCodes.Ldarg, parameter);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -46,12 +46,29 @@ namespace MonoDroid.Tuner {
 			return td != null ? td.FullName + "," + td.Module.Assembly.FullName : arg.Value;
 		}
 
+#if !NETCOREAPP
 		public static AssemblyDefinition GetAssembly (this LinkContext context, string assemblyName)
 		{
 			AssemblyDefinition ad;
 			context.TryGetLinkedAssembly (assemblyName, out ad);
 			return ad;
 		}
+
+		public static TypeDefinition GetType (this LinkContext context, string assemblyName, string typeName)
+		{
+			AssemblyDefinition ad = context.GetAssembly (assemblyName);
+			return ad == null ? null : GetType (ad, typeName);
+		}
+
+		public static MethodDefinition GetMethod (this LinkContext context, string ns, string typeName, string name, string [] parameters)
+		{
+			var type = context.GetType (ns, typeName);
+			if (type == null)
+				return null;
+
+			return GetMethod (type, name, parameters);
+		}
+#endif
 
 		public static MethodDefinition GetMethod (TypeDefinition td, string name)
 		{
@@ -64,15 +81,6 @@ namespace MonoDroid.Tuner {
 			}
 
 			return method;
-		}
-
-		public static MethodDefinition GetMethod (this LinkContext context, string ns, string typeName, string name, string [] parameters)
-		{
-			var type = context.GetType (ns, typeName);
-			if (type == null)
-				return null;
-
-			return GetMethod (type, name, parameters);
 		}
 
 		public static MethodDefinition GetMethod (TypeDefinition type, string name, string [] parameters)
@@ -101,12 +109,6 @@ namespace MonoDroid.Tuner {
 			}
 
 			return method;
-		}
-
-		public static TypeDefinition GetType (this LinkContext context, string assemblyName, string typeName)
-		{
-			AssemblyDefinition ad = context.GetAssembly (assemblyName);
-			return ad == null ? null : GetType (ad, typeName);
 		}
 
 		public static TypeDefinition GetType (AssemblyDefinition assembly, string typeName)

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -46,6 +46,74 @@ namespace MonoDroid.Tuner {
 			return td != null ? td.FullName + "," + td.Module.Assembly.FullName : arg.Value;
 		}
 
+		public static AssemblyDefinition GetAssembly (this LinkContext context, string assemblyName)
+		{
+			AssemblyDefinition ad;
+			context.TryGetLinkedAssembly (assemblyName, out ad);
+			return ad;
+		}
+
+		public static MethodDefinition GetMethod (TypeDefinition td, string name)
+		{
+			MethodDefinition method = null;
+			foreach (var md in td.Methods) {
+				if (md.Name == name) {
+					method = md;
+					break;
+				}
+			}
+
+			return method;
+		}
+
+		public static MethodDefinition GetMethod (this LinkContext context, string ns, string typeName, string name, string [] parameters)
+		{
+			var type = context.GetType (ns, typeName);
+			if (type == null)
+				return null;
+
+			return GetMethod (type, name, parameters);
+		}
+
+		public static MethodDefinition GetMethod (TypeDefinition type, string name, string [] parameters)
+		{
+			MethodDefinition method = null;
+			foreach (var md in type.Methods) {
+				if (md.Name != name)
+					continue;
+
+				if (md.Parameters.Count != parameters.Length)
+					continue;
+
+				var equal = true;
+				for (int i = 0; i < parameters.Length; i++) {
+					if (md.Parameters [i].ParameterType.FullName != parameters [i]) {
+						equal = false;
+						break;
+					}
+				}
+
+				if (!equal)
+					continue;
+
+				method = md;
+				break;
+			}
+
+			return method;
+		}
+
+		public static TypeDefinition GetType (this LinkContext context, string assemblyName, string typeName)
+		{
+			AssemblyDefinition ad = context.GetAssembly (assemblyName);
+			return ad == null ? null : GetType (ad, typeName);
+		}
+
+		public static TypeDefinition GetType (AssemblyDefinition assembly, string typeName)
+		{
+			return assembly.MainModule.GetType (typeName);
+		}
+
 		public static bool Implements (this TypeReference self, string interfaceName)
 		{
 			if (interfaceName == null)

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -65,6 +65,8 @@ namespace MonoDroid.Tuner
 
 			if (options.LinkNone) {
 				pipeline.AppendStep (new FixAbstractMethodsStep (cache));
+				if (options.AddKeepAlives)
+					pipeline.AppendStep (new AddKeepAlivesStep (cache));
 				pipeline.AppendStep (new OutputStepWithTimestamps ());
 				return pipeline;
 			}
@@ -118,6 +120,8 @@ namespace MonoDroid.Tuner
 			if (!string.IsNullOrWhiteSpace (options.ProguardConfiguration))
 				pipeline.AppendStep (new GenerateProguardConfiguration (options.ProguardConfiguration));
 			pipeline.AppendStep (new StripEmbeddedLibraries ());
+			if (options.AddKeepAlives)
+				pipeline.AppendStep (new AddKeepAlivesStep (cache));
 			// end monodroid specific
 			pipeline.AppendStep (new RegenerateGuidStep ());
 			pipeline.AppendStep (new OutputStepWithTimestamps ());

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -22,6 +22,7 @@ namespace MonoDroid.Tuner
 		public bool DumpDependencies { get; set; }
 		public string HttpClientHandlerType { get; set; }
 		public string TlsProvider { get; set; }
+		public bool AddKeepAlives { get; set; }
 		public bool PreserveJniMarshalMethods { get; set; }
 		public bool DeterministicOutput { get; set; }
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -49,6 +49,8 @@ namespace Xamarin.Android.Tasks
 
 		public string TlsProvider { get; set; }
 
+		public bool AddKeepAlives { get; set; }
+
 		public bool PreserveJniMarshalMethods { get; set; }
 
 		public bool Deterministic { get; set; }
@@ -100,6 +102,7 @@ namespace Xamarin.Android.Tasks
 			options.DumpDependencies = DumpDependencies;
 			options.HttpClientHandlerType = HttpClientHandlerType;
 			options.TlsProvider = TlsProvider;
+			options.AddKeepAlives = AddKeepAlives;
 			options.PreserveJniMarshalMethods = PreserveJniMarshalMethods;
 			options.DeterministicOutput = Deterministic;
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -288,5 +288,73 @@ $@"			var myButton = new AttributedButtonStub (this);
 				Assert.IsTrue (b.Build (proj), "Building a project with a null attribute value should have succeded.");
 			}
 		}
+
+		[Test]
+		[Category ("DotNetIgnore")]
+		public void AndroidAddKeepAlives ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+				OtherBuildItems = {
+					new BuildItem ("Compile", "Method.cs") { TextContent = () => @"
+using System;
+using Java.Interop;
+
+namespace UnnamedProject {
+	public class MyClass : Java.Lang.Object
+	{
+		[Android.Runtime.Register(""MyMethod"")]
+		public unsafe bool MyMethod (Android.OS.IBinder windowToken, [global::Android.Runtime.GeneratedEnum] Android.Views.InputMethods.HideSoftInputFlags flags)
+        {
+            const string __id = ""hideSoftInputFromWindow.(Landroid/os/IBinder;I)Z"";
+            try {
+                JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+                __args [0] = new JniArgumentValue ((windowToken == null) ? IntPtr.Zero : ((global::Java.Lang.Object) windowToken).Handle);
+                __args [1] = new JniArgumentValue ((int) flags);
+                var __rm = JniPeerMembers.InstanceMethods.InvokeAbstractBooleanMethod (__id, this, __args);
+                return __rm;
+            } finally {
+            }
+        }
+	}
+}"
+					},
+				}
+			};
+
+			proj.SetProperty ("AllowUnsafeBlocks", "True");
+
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");
+
+				var assemblyPath = b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", "UnnamedProject.dll"));
+				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
+					Assert.IsTrue (assembly != null);
+
+					var td = assembly.MainModule.GetType ("UnnamedProject.MyClass");
+					Assert.IsTrue (td != null);
+
+					var mr = td.GetMethods ().Where (m => m.Name == "MyMethod").FirstOrDefault ();
+					Assert.IsTrue (mr != null);
+
+					var md = mr.Resolve ();
+					Assert.IsTrue (md != null);
+
+					bool hasKeepAliveCall = false;
+					foreach (var i in md.Body.Instructions) {
+						if (i.OpCode.Code != Mono.Cecil.Cil.Code.Call)
+							continue;
+
+						if (!i.Operand.ToString ().Contains ("System.GC::KeepAlive"))
+							continue;
+
+						hasKeepAliveCall = true;
+						break;
+					}
+
+					Assert.IsTrue (hasKeepAliveCall);
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -29,6 +29,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
         <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
         <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
+        <AndroidAddKeepAlives Condition="'$(AndroidAddKeepAlives)' == ''">True</AndroidAddKeepAlives>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -29,7 +29,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
         <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v5.0</TargetFrameworkVersion>
         <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
-        <AndroidAddKeepAlives Condition="'$(AndroidAddKeepAlives)' == ''">True</AndroidAddKeepAlives>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1327,6 +1327,7 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
       DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"
+      AddKeepAlives="$(AndroidAddKeepAlives)"
       Deterministic="$(Deterministic)"
   />
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -842,6 +842,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion;_ResolveMonoAndroidSdks">
 	<PropertyGroup>
+		<AndroidAddKeepAlives Condition="'$(AndroidAddKeepAlives)' == '' And '$(AndroidIncludeDebugSymbols)' != 'True'">True</AndroidAddKeepAlives>
 		<_AndroidBuildPropertiesCacheExists Condition=" Exists('$(_AndroidBuildPropertiesCache)') ">True</_AndroidBuildPropertiesCacheExists>
 		<_NuGetAssetsFile      Condition=" Exists('$(ProjectLockFile)') ">$(ProjectLockFile)</_NuGetAssetsFile>
 		<_NuGetAssetsFile      Condition=" '$(_NuGetAssetsFile)' == '' and Exists('packages.config') ">packages.config</_NuGetAssetsFile>
@@ -854,6 +855,7 @@ because xbuild doesn't support framework reference assemblies.
 		<!-- List of items we want to trigger a build if changed -->
 		<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
 		<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
+		<_PropertyCacheItems Include="AndroidAddKeepAlives=$(AndroidAddKeepAlives)" />
 		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
 		<_PropertyCacheItems Include="AndroidEmbedProfilers=$(AndroidEmbedProfilers)" />
 		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -599,6 +599,7 @@ projects. .NET 5 projects will not import this file.
         LinkSkip="$(AndroidLinkSkip)"
         LinkDescriptions="@(LinkDescription)"
         ProguardConfiguration="$(_ProguardProjectConfiguration)"
+        AddKeepAlives="$(AndroidAddKeepAlives)"
         PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
         EnableProguard="$(AndroidEnableProguard)"
         Deterministic="$(Deterministic)"


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/719

Modify "old" bindings, so that they hold the object reference
long enough to avoid above issue.

It is implemented as linker step, which looks for offended methods
and injects call to `System.GC.KeepAlive` to prevent premature
collection.

The injection can be disabled with `AndroidAddKeepAlives` property
set to false.

The property's default value depends on `AndroidIncludeDebugSymbols`
property and is thus true for release builds and false for debug.

The impact on release build of XA forms template (flyout variety) is
cca 137ms on my machine.

Disabled:

    12079 ms  LinkAssemblies                             1 calls

Enabled:

    12216 ms  LinkAssemblies                             1 calls

Example updated method body:
```
try {
	JniArgumentValue* ptr = stackalloc JniArgumentValue[1];
	*ptr = new JniArgumentValue((windowToken == null) ? IntPtr.Zero : ((Java.Lang.Object)windowToken).Handle);
	ptr[1] = new JniArgumentValue((int)flags);
	bool result = JniPeerMembers.InstanceMethods.InvokeAbstractBooleanMethod("...", this, ptr);
} finally {
	GC.KeepAlive(windowToken);
	return result;
}
```

Added new `AndroidAddKeepAlives ` test to `LinkerTests.cs` to check
whether registered method was updated.
