### PR TITLE
Build with net5.0 TFM instead of netcoreapp3.1

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		static readonly string assemblyToValidate = "Mono.Android.dll";
 
-		static readonly string netCoreAppVersion = "netcoreapp3.1";
+		static readonly string netCoreAppVersion = "net5.0";
 		static string compatApiCommand = null;
 
 		// Path where Microsoft.DotNet.ApiCompat nuget package is located

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -51,7 +51,7 @@ variables:
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.11.1
-  DotNetCoreVersion: 3.1.201
+  DotNetCoreVersion: 5.0.100-rc.2.20479.15
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
@@ -782,7 +782,7 @@ stages:
       job_name: mac_dotnet_tests_1
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -790,7 +790,7 @@ stages:
       job_name: mac_dotnet_tests_2
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -798,7 +798,7 @@ stages:
       job_name: mac_dotnet_tests_3
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
   # Xamarin.Android (Test MSBuild One .NET - Windows)
   - template: yaml-templates\run-msbuild-win-tests.yaml
@@ -807,7 +807,7 @@ stages:
       job_name: win_dotnet_tests_1
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -815,7 +815,7 @@ stages:
       job_name: win_dotnet_tests_2
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -823,7 +823,7 @@ stages:
       job_name: win_dotnet_tests_3
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
-      target_framework: 'netcoreapp3.1'
+      target_framework: 'net5.0'
 
 - stage: msbuilddevice_tests
   displayName: MSBuild Emulator Tests

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     workspace:
       clean: all
     variables:
-      UseDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}
+      UseDotNet: ${{ eq(parameters.target_framework, 'net5.0') }}
     steps:
     - template: setup-test-environment.yaml
 

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     cancelTimeoutInMinutes: 5
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
-      UseDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}
+      UseDotNet: ${{ eq(parameters.target_framework, 'net5.0') }}
     steps:
 
     - template: kill-processes.yaml

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -11,7 +11,7 @@
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
 
   <PropertyGroup>
-    <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\</_MonoAndroidNETOutputDir>
+    <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net5.0\</_MonoAndroidNETOutputDir>
     <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(DotNetPreviewVersionFull)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
   </PropertyGroup>
 

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -34,7 +34,7 @@ by projects that use the Microsoft.Android framework in .NET 5.
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-netcoreapp3.1\ref\Java.Interop.dll" />
+      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net5.0\ref\Java.Interop.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.Export.dll" />
       <FrameworkListFileClass Include="@(_AndroidRefPackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -36,7 +36,7 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
       DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions;_GetLicense">
     <PropertyGroup>
       <ToolsSourceDir>$(XamarinAndroidSourcePath)bin\Build$(Configuration)\packs\tools\</ToolsSourceDir>
-      <NetCoreAppToolsSourceDir>$(XamarinAndroidSourcePath)bin\$(Configuration)-netcoreapp3.1\</NetCoreAppToolsSourceDir>
+      <NetCoreAppToolsSourceDir>$(XamarinAndroidSourcePath)bin\$(Configuration)-net5.0\</NetCoreAppToolsSourceDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/build-tools/scripts/Configuration.Java.Interop.Override.props
+++ b/build-tools/scripts/Configuration.Java.Interop.Override.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CecilSourceDirectory>$(MSBuildThisFileDirectory)..\..\external\mono\external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\</UtilityOutputFullPath>
-    <UtilityOutputFullPathCoreApps>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)-netcoreapp3.1\</UtilityOutputFullPathCoreApps>
+    <UtilityOutputFullPathCoreApps>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)-net5.0\</UtilityOutputFullPathCoreApps>
     <XamarinAndroidToolsDirectory>$(MSBuildThisFileDirectory)..\..\external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
 </Project>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -14,8 +14,8 @@
       <OutputPathAbs Condition=" '$(OutputPathAbs)' == '' ">$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
       <JcwGen>"$(XAInstallPrefix)xbuild\Xamarin\Android\jcw-gen.exe" -v10</JcwGen>
       <_LibDirs>-L "$(OutputPathAbs.TrimEnd('\'))"</_LibDirs>
-      <_LibDirs Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">$(_LibDirs) -L "$(OutputPathAbs)..\v1.0" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
-      <_LibDirs Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">$(_LibDirs) -L "$(_CorlibDir.TrimEnd('\'))"</_LibDirs>
+      <_LibDirs Condition=" '$(TargetFramework)' != 'net5.0' ">$(_LibDirs) -L "$(OutputPathAbs)..\v1.0" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
+      <_LibDirs Condition=" '$(TargetFramework)' == 'net5.0' ">$(_LibDirs) -L "$(_CorlibDir.TrimEnd('\'))"</_LibDirs>
       <_Out>-o "$(MSBuildProjectDirectory)\$(IntermediateOutputPath)jcw\src"</_Out>
     </PropertyGroup>
     <Exec

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -312,7 +312,7 @@ namespace Xamarin.Android.Prepare
 
 			public static string TestBinDir                          => GetCachedPath (ref testBinDir, ()                          => Path.Combine (Configurables.Paths.BinDirRoot, $"Test{ctx.Configuration}"));
 			public static string BinDir                              => GetCachedPath (ref binDir, ()                              => Path.Combine (Configurables.Paths.BinDirRoot, ctx.Configuration));
-			public static string NetCoreBinDir                       => GetCachedPath (ref netCoreBinDir, ()                       => Path.Combine (Configurables.Paths.BinDirRoot, $"{ctx.Configuration}-netcoreapp3.1"));
+			public static string NetCoreBinDir                       => GetCachedPath (ref netCoreBinDir, ()                       => Path.Combine (Configurables.Paths.BinDirRoot, $"{ctx.Configuration}-net5.0"));
 			public static string BuildBinDir                         => GetCachedPath (ref buildBinDir, ()                         => Path.Combine (Configurables.Paths.BinDirRoot, $"Build{ctx.Configuration}"));
 			public static string MingwBinDir                         => GetCachedPath (ref mingwBinDir, ()                         => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidMxeFullPath), "bin"));
 			public static string ProfileAssembliesProjitemsPath      => GetCachedPath (ref profileAssembliesProjitemsPath, ()      => Path.Combine (BuildBinDir, "ProfileAssemblies.projitems"));

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <DefineConstants>NET5_LINKER</DefineConstants>
+    <TargetFramework>net5.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -3,9 +3,9 @@
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <!-- Only build for netcoreapp3.1 for $(AndroidLatestStableFrameworkVersion) -->
+    <!-- Only build for net5.0 for $(AndroidLatestStableFrameworkVersion) -->
     <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoStdLib>true</NoStdLib>
@@ -21,7 +21,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <OutputPath>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\</OutputPath>
   </PropertyGroup>
 
@@ -52,7 +52,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
   </ItemGroup>
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>monoandroid10;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>monoandroid10;net5.0</TargetFrameworks>
     <RootNamespace>Android</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -32,7 +32,7 @@
     <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <OutputPath>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\$(TargetFramework)\</OutputPath>
   </PropertyGroup>
 
@@ -83,7 +83,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
   </ItemGroup>
 
@@ -360,8 +360,8 @@
   <Target Name="GetTargetPath" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <!-- Only build the 'netcoreapp3.1' version of 'Mono.Android.dll' once for the latest stable Android version. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' And '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">
+  <!-- Only build the 'net5.0' version of 'Mono.Android.dll' once for the latest stable Android version. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' And '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
 

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -43,7 +43,7 @@
       <_PackageVersion>$(ProductVersion)</_PackageVersion>
       <_PackageVersionBuild>$(XAVersionCommitCount)</_PackageVersionBuild>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
       <_PackageVersion>$(AndroidPackVersion)</_PackageVersion>
       <_PackageVersionBuild>$(PackVersionCommitCount)</_PackageVersionBuild>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Linker/Mobile.Tuner/MobileProfile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/Mobile.Tuner/MobileProfile.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Mono.Cecil;
 
 using Mono.Tuner;
-#if NET5_LINKER
+#if NET5_0
 using Microsoft.Android.Sdk.ILLink;
 #endif
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/ApplyPreserveAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/ApplyPreserveAttribute.cs
@@ -8,7 +8,7 @@ using Mono.Tuner;
 
 using Mono.Cecil;
 
-#if NET5_LINKER
+#if NET5_0
 using Microsoft.Android.Sdk.ILLink;
 #endif
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -10,7 +10,7 @@ using Mono.Linker;
 using Mono.Linker.Steps;
 
 using Mono.Tuner;
-#if NET5_LINKER
+#if NET5_0
 using Microsoft.Android.Sdk.ILLink;
 #endif
 
@@ -36,12 +36,12 @@ namespace MonoDroid.Tuner
 			if (IsProductOrSdkAssembly (assembly))
 				return;
 
-#if !NET5_LINKER
+#if !NET5_0
 			CheckAppDomainUsageUnconditional (assembly, (string msg) => Context.LogMessage (MessageImportance.High, msg));
 #endif
 
 			if (FixAbstractMethodsUnconditional (assembly)) {
-#if !NET5_LINKER
+#if !NET5_0
 				Context.SafeReadSymbols (assembly);
 #endif
 				AssemblyAction action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
@@ -55,7 +55,7 @@ namespace MonoDroid.Tuner
 		}
 
 
-#if !NET5_LINKER
+#if !NET5_0
 		internal void CheckAppDomainUsage (AssemblyDefinition assembly, Action<string> warn)
 		{
 			if (IsProductOrSdkAssembly (assembly))
@@ -304,7 +304,7 @@ namespace MonoDroid.Tuner
 
 		protected virtual AssemblyDefinition GetMonoAndroidAssembly ()
 		{
-#if !NET5_LINKER
+#if !NET5_0
 			foreach (var assembly in Context.GetAssemblies ()) {
 				if (assembly.Name.Name == "Mono.Android")
 					return assembly;

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveExportedTypes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveExportedTypes.cs
@@ -8,7 +8,7 @@ using Mono.Linker.Steps;
 
 using Mono.Cecil;
 
-#if NET5_LINKER
+#if NET5_0
 using Microsoft.Android.Sdk.ILLink;
 #endif
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Mono.Linker;
 using Mono.Linker.Steps;
 
-#if NET5_LINKER
+#if NET5_0
 using Microsoft.Android.Sdk.ILLink;
 #endif
 
@@ -21,7 +21,7 @@ namespace MonoDroid.Tuner {
 
 		protected virtual bool DebugBuild {
 			get {
-#if NET5_LINKER
+#if NET5_0
 				return true;
 #else
 				return context.LinkSymbols;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Build.Tests
 
 			static SetUp ()
 			{
-#if NETCOREAPP3_1
+#if NET5_0
 				Builder.UseDotNet = true;
 #else
 				Builder.UseDotNet = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <OutputPath>..\..\..\..\bin\Test$(Configuration)</OutputPath>
   </PropertyGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <!-- Required packages for .NET Core -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>

--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools.JavadocToMDoc</RootNamespace>


### PR DESCRIPTION
 Build with net5.0 TFM instead of netcoreapp3.1

 That would allow use of new NET5 API like the new dynamic dependency
 [attribute](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.dynamicdependencyattribute?view=net-5.0).

 Also replace NET5_LINKER define with NET5_0.