### PR TITLE
[illink] Add StripEmbeddedLibraries step

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Android.Sdk.ILLink
 			string proguardPath;
 			if (Context.TryGetCustomData ("ProguardConfiguration", out proguardPath))
 				InsertAfter (new GenerateProguardConfiguration (proguardPath),  "CleanStep");
+
+			InsertAfter (new StripEmbeddedLibraries (),  "CleanStep");
 		}
 
 		void InsertAfter (IStep step, string stepName)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5287

Turns out we were building the step, but not adding it to the linker
steps pipeline.

With the step added to the pipeline, the right resources are removed
again. The [apkdiff](https://github.com/radekdoulik/apkdiff) output
comparing the apks before and after the change:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      +       7,732 assemblies/Xamarin.Forms.Platform.Android.dll
        +             Resource __AndroidLibraryProjects__.zip
      +       2,013 assemblies/FormsViewGroup.dll
        +             Resource formsviewgroup.jar
      +         192 assemblies/Xamarin.Forms.Platform.dll
        +             Resource __AndroidLibraryProjects__.zip
      ...
      Summary:
      +           0 Other entries 0.00% (of 751,132)
      +           0 Dalvik executables 0.00% (of 3,491,180)
      +       9,937 Assemblies 0.13% (of 7,539,211)
      +           0 Shared libraries 0.00% (of 4,227,272)
      +       9,913 Package size difference 0.09% (of 11,378,731)