### PR TITLE
[ci] Install .NET 5 stable and stable VS

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -27,6 +27,7 @@ variables:
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.201
+  DotNet5Version: 5.0.100
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 
 stages:
@@ -51,8 +52,12 @@ stages:
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:
-        version: $(DotNetCoreVersion)
+        version: $(DotNet5Version)
         remove_dotnet: true
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNetCoreVersion)
 
     - bash: |
         keychains=`security list-keychains`

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -52,10 +52,11 @@ variables:
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
+  DotNet5Version: 5.0.100
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: Xamarin-Android-Win2019
+  VSEngWinVS2019: Xamarin-Android-Win2019-1120
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
@@ -137,8 +138,12 @@ stages:
 
     - template: yaml-templates/use-dot-net.yaml
       parameters:
-        version: $(DotNetCoreVersion)
+        version: $(DotNet5Version)
         remove_dotnet: true
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNetCoreVersion)
 
     - template: install-certificates.yml@yaml
       parameters:
@@ -277,14 +282,19 @@ stages:
 
     - template: yaml-templates\clean.yaml
 
+    - template: yaml-templates\update-vs.yaml
+
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)
       displayName: set JI_JAVA_HOME
 
     - template: yaml-templates\use-dot-net.yaml
       parameters:
+        version: $(DotNet5Version)
+
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
-        remove_dotnet: true
 
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
     # The VS installer will attempt to resume any failed or partial installation before trying to downgrade Xamarin.Android.
@@ -310,8 +320,6 @@ stages:
         Remove-Item "${env:TEMP}\$log"
       displayName: downgrade XA to stable
       ignoreLASTEXITCODE: true
-
-    - template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Prepare

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -23,6 +23,12 @@ jobs:
 
     - template: clean.yaml
 
+    - checkout: self
+      clean: true
+      submodules: recursive
+
+    - template: update-vs.yaml
+
     - template: setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@1

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -23,13 +23,9 @@ jobs:
 
     - template: clean.yaml
 
-    - checkout: self
-      clean: true
-      submodules: recursive
-
-    - template: update-vs.yaml
-
     - template: setup-test-environment.yaml
+      parameters:
+        updateVS: true
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -23,11 +23,7 @@ jobs:
 
     - template: clean.yaml
 
-    - template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
-
     - template: setup-test-environment.yaml
-      parameters:
-        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)" -f
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -2,11 +2,17 @@ parameters:
   configuration: $(XA.Build.Configuration)
   provisionExtraArgs: -vv -f
   xaSourcePath: $(System.DefaultWorkingDirectory)
+  updateVS: false
 
 steps:
 - checkout: self
   clean: true
   submodules: recursive
+
+- ${{ if eq(parameters.updateVS, true) }}:
+  - template: update-vs.yaml
+    parameters: 
+      xasourcePath: ${{ parameters.xaSourcePath }}
 
 - template: run-installer.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -8,6 +8,10 @@ steps:
   clean: true
   submodules: recursive
 
+- template: update-vs.yaml
+  parameters:
+    xaSourcePath: ${{ parameters.xaSourcePath }}
+
 - template: run-installer.yaml
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
@@ -23,8 +27,12 @@ steps:
 
 - template: use-dot-net.yaml
   parameters:
-    version: $(DotNetCoreVersion)
+    version: $(DotNet5Version)
     remove_dotnet: true
+
+- template: use-dot-net.yaml
+  parameters:
+    version: $(DotNetCoreVersion)
 
 - script: |
     dotnet tool install --global boots
@@ -90,4 +98,4 @@ steps:
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: /t:ExtractWorkloadPacks /restore /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog
+    msbuildArguments: /t:ExtractWorkloadPacks /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -8,10 +8,6 @@ steps:
   clean: true
   submodules: recursive
 
-- template: update-vs.yaml
-  parameters:
-    xaSourcePath: ${{ parameters.xaSourcePath }}
-
 - template: run-installer.yaml
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}

--- a/build-tools/automation/yaml-templates/update-vs.yaml
+++ b/build-tools/automation/yaml-templates/update-vs.yaml
@@ -1,0 +1,17 @@
+parameters:
+  xaSourcePath: $(System.DefaultWorkingDirectory)
+  condition: eq(variables['agent.os'], 'Windows_NT')
+
+steps:
+- task: provisionator@2
+  displayName: update VS 2019
+  timeoutInMinutes: 60
+  inputs:
+    github_token: $(Github.Token)
+    provisioning_script: ${{ parameters.xaSourcePath }}\build-tools\provisioning\vs2019.csx
+    provisioning_extra_args: -vv
+  condition: ${{ parameters.condition }}
+
+- template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
+  parameters:
+    condition: ${{ parameters.condition }}

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -18,7 +18,7 @@ steps:
       & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
       & dotnet --list-sdks
     displayName: install .NET Core ${{ parameters.version }}
-    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - bash: >
       DOTNET_ROOT=~/.dotnet/ &&

--- a/build-tools/provisioning/vs2019.csx
+++ b/build-tools/provisioning/vs2019.csx
@@ -1,0 +1,3 @@
+VisualStudio (VisualStudioChannel.Stable, VisualStudioTier.Enterprise, 16, @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise", true)
+    .Workload (VisualStudioWorkload.ManagedDesktop)
+    .Workload (VisualStudioWorkload.NetCrossPlat);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -382,7 +382,7 @@ class MemTest {
 			}
 		}
 
-		[Test]
+		[Test, Ignore ("Deprecated CodeAnalysis feature is broken in 16.8: https://developercommunity.visualstudio.com/solutions/1255925/view.html")]
 		public void CodeAnalysis ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -308,6 +308,12 @@ namespace Xamarin.Android.Build
 					if (!Directory.Exists (sdksDir))
 						sdksDir = Path.Combine (dir, "bin", "Sdks");
 					if (version != null && version > latest) {
+						// Mono does not yet support MSBuild 16.8 and .NET 5+.  If we want xabuild to be aware of .NET 5+ in the future, 
+						// we will need to workaround the fact that the .NET 5 targets now require a version of `NuGet.Frameworks.dll` next to `MSBuildExeTempPath`:
+						// https://github.com/dotnet/msbuild/blob/755d4d1e3d2a89f72f659fc3d7d2933cab619828/src/Build/Utilities/NuGetFrameworkWrapper.cs#L32
+						if (version >= new Version (5, 0, 100)) {
+							continue;
+						}
 						if (Directory.Exists (sdksDir) && File.Exists (Path.Combine (sdksDir, "Microsoft.NET.Sdk", "Sdk", "Sdk.props"))) {
 							latest = version;
 							Sdk = sdksDir;


### PR DESCRIPTION
All build and test jobs have been updated to install both .NET Core
3.1.201 and .NET 5.0.100.  Eventually, we should be able to remove the
3.1.201 installation after we migrate everything targeting .NET Core to
.NET 5.  Windows jobs will now update the Visual Studio 2019 instance
on disk to the latest available stable version. The base image has been
updated to speed up update performance.  See below for more info:

https://github.com/xamarin/monodroid/wiki/Azure-Pipelines-and-DevOps#windows-scale-set-agent-pool-management

There are currently multiple issues with .NET 5 and `xabuild`.  First
off, the system Mono that we are using contains a version of MSBuild
that is not compatible with .NET 5 targets, which attempt to use a
static property method that does not exist in Mono's MSBuild:

    /Users/builder/azdo/_work/_tool/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(54,5): error MSB4186: Invalid static method invocation syntax: "[MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')". Method '[MSBuild]::GetTargetFrameworkIdentifier' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order.

Once this issue is resolved (or in the case of our Windows builds), we
hit the second issue:

    C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(54,5): error MSB4184: The expression "[MSBuild]::GetTargetFrameworkIdentifier(netstandard2.0)" cannot be evaluated. MSB0001: Internal MSBuild Error: A required NuGet assembly was not found. Expected Path: C:\Users\Peter\AppData\Local\Temp\ktbpeg2z.b31

If we decide that xabuild should support .NET 5+ in the future, we'll
need to copy a version of `NuGet.Frameworks.dll` next to
`MSBuildExeTempPath` to work around this issue.