### PR TITLE
[illink] Use @(LinkDescription) items

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -53,6 +53,7 @@ This file contains the .NET 5-specific targets to customize ILLink
       <TrimmerRootDescriptor
           Condition=" '@(ResolvedFileToPublish->Count())' != '0' and '%(Filename)' != '' "
           Include="@(_PreserveLists)" />
+      <TrimmerRootDescriptor Include="@(LinkDescription)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Use the user custom linker files with ILLink on .NET5/6.

Fixes: https://github.com/xamarin/xamarin-android/issues/5288

It should fix `CustomLinkDescriptionPreserve` test as well.
Context: https://github.com/xamarin/xamarin-android/pull/5035#discussion_r522201211