### PR TITLE
[ci] Restore custom use-dot-net task

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -49,10 +49,10 @@ stages:
       clean: true             # Executes: git clean -ffdx && git reset --hard HEAD
       submodules: recursive
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCoreVersion)
-      inputs:
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
+        remove_dotnet: true
 
     - bash: |
         keychains=`security list-keychains`

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -135,10 +135,10 @@ stages:
     - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
       displayName: set JI_JAVA_HOME
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCoreVersion)
-      inputs:
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
+        remove_dotnet: true
 
     - template: install-certificates.yml@yaml
       parameters:
@@ -281,10 +281,10 @@ stages:
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)
       displayName: set JI_JAVA_HOME
 
-    - task: UseDotNet@2
-      displayName: install .NET Core $(DotNetCoreVersion)
-      inputs:
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
         version: $(DotNetCoreVersion)
+        remove_dotnet: true
 
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
     # The VS installer will attempt to resume any failed or partial installation before trying to downgrade Xamarin.Android.

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -21,10 +21,10 @@ steps:
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
-- task: UseDotNet@2
-  displayName: install .NET Core $(DotNetCoreVersion)
-  inputs:
+- template: use-dot-net.yaml
+  parameters:
     version: $(DotNetCoreVersion)
+    remove_dotnet: true
 
 - script: |
     dotnet tool install --global boots

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -1,0 +1,34 @@
+# This template enables installation of stable and master/nighly builds of .NET.
+# We prefer this over the UseDotNet task so that we can always clean up old/unstable versions on disk.
+
+parameters:
+  version: $(DotNetCoreVersion)
+  remove_dotnet: false
+
+steps:
+
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+      $ProgressPreference = 'SilentlyContinue'
+      $DotNetRoot = "$env:ProgramFiles\dotnet\"
+      if ("${{ parameters.remove_dotnet }}" -eq $true) {
+        Remove-Item -Recurse $DotNetRoot -Verbose
+      }
+      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
+      & dotnet --list-sdks
+    displayName: install .NET Core ${{ parameters.version }}
+    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
+  - bash: >
+      DOTNET_ROOT=~/.dotnet/ &&
+      (if [[ "${{ parameters.remove_dotnet }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT; fi) &&
+      curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
+      chmod +x dotnet-install.sh &&
+      ./dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&
+      PATH="$DOTNET_ROOT:$PATH" &&
+      dotnet --list-sdks &&
+      echo "##vso[task.setvariable variable=DOTNET_ROOT]$DOTNET_ROOT" &&
+      echo "##vso[task.setvariable variable=PATH]$PATH"
+    displayName: install .NET Core ${{ parameters.version }}
+    condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5293
Context: https://github.com/xamarin/xamarin-android/blob/f5680e783fe45d4f536f8199372ff504ebfdc393/build-tools/automation/yaml-templates/use-dot-net.yaml

PR #5293 introduced an incompatibility with xabuild, and it appears to
be causing issues with other stable builds.  The [UseDotNet][1] task has
a caching feature to improve "installation" times for certain versions,
however this can cause issues for our non-hosted build machines.

       /Users/builder/azdo/_work/_tool/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(54,5): error MSB4186: Invalid static method invocation syntax: "[MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')". Method '[MSBuild]::GetTargetFrameworkIdentifier' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order. [/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.GenericMarshaler/Java.Interop.GenericMarshaler.csproj]

We should continue to use the custom `use-dot-net` task that Jonathan
Peppers added for us during earlier .NET 5 preview work.  This template
was removed in PR #5191 but in hindsight it should not have been.

[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops