### PR TITLE
[ci] Include updateinfo in artifacts.json

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1205,6 +1205,7 @@ stages:
         patterns: |
           xamarin.android*.pkg
           Xamarin.Android*.vsix
+          updateinfo
 
     - powershell: |
         $pkg = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/storage-artifacts/*" -Include *.pkg -File


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_releaseProgress?_a=release-environment-logs&releaseId=877224&environmentId=4657763

A recent VS Mac insertion attempt failed due to the fact that we were
no longer publishing information from an `updateinfo` file required by
that tooling.  This was accidentially removed in 68be8d81 via the
addition of the `patterns` filter on the [installer artifact download
task][1].  This addition prevented the `updateinfo` file from being
downloaded and processed during the notarize + sign job, which left a
couple of key fields in our installers `artifact.json` empty:

    "tag": "",
    "productId": "",
    "releaseId": "",

We can fix this by making sure the `updateinfo` file is downloaded and
sitting side by side the `.pkg` file when the build-tasks [artifacts][2]
tool runs.  When the `updateinfo` file is processed by this tool, the
missing json elements are restored:

    "tag": "v11.1.99.215",
    "productId": "d1ec039f-f3db-468b-a508-896d7c382999",
    "releaseId": "1605550351",

[1]: https://github.com/xamarin/xamarin-android/commit/68be8d810e3f87865d88467ae593048297bf3e60#diff-9c2ad70133b42c412283fe563f9e33708c0622a6a81171ee1f9cecf6bd6b4dbbR1205
[2]: https://github.com/xamarinhq/build-tasks/blob/1aa22f29f654a364162740d40c3d9f0dfc1e2b04/ArtifactsLib/Processor.fs#L20
