### PR TITLE
[One .NET] update user-facing messages from .NET 5 to .NET 6

### DIFF
--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -79,7 +79,7 @@ installer.
 
 # Creating a local .NET 6 Workload
 
-`make prepare` provisions a specific build of .NET 5/6 to
+`make prepare` provisions a specific build of .NET 6 to
 `~/android-toolchain/dotnet`.
 
 Once `make all` or `make jenkins` have completed, you can build the .NET 6
@@ -100,7 +100,6 @@ To use the Android workload, you will need a `NuGet.config`:
 <configuration>
   <packageSources>
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="local-xa" value="/full/path/to/bin/BuildDebug/nupkgs" />
   </packageSources>
 </configuration>

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -90,7 +90,7 @@ So for example:
 # Creating a local .NET 6 Workload
 
 `msbuild Xamarin.Android.sln /t:Prepare` provisions a specific build
-of .NET 5/6 to `%USERPROFILE%\android-toolchain\dotnet`.
+of .NET 6 to `%USERPROFILE%\android-toolchain\dotnet`.
 
 Once `msbuild Xamarin.Android.sln /t:Build` is complete, you can build
 the .NET 6 packages with:
@@ -110,7 +110,6 @@ To use the Android workload, you will need a `NuGet.config`:
 <configuration>
   <packageSources>
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="local-xa" value="C:\full\path\to\bin\BuildDebug\nupkgs" />
   </packageSources>
 </configuration>

--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -140,6 +140,13 @@ all default item inclusion behavior can be disabled by setting `$(EnableDefaultI
 
 [autoimport]: https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/accepted/2020/workloads/workload-resolvers.md#workload-props-files
 
+## Runtime behavior
+
+There is some behavioral changes to the `String.IndexOf()` method in
+.NET 5 and higher on different platforms, see details [here][indexof].
+
+[indexof]: https://docs.microsoft.com/dotnet/standard/globalization-localization/globalization-icu
+
 ## Linker (ILLink)
 
 .NET 5 and higher has new [settings for the linker][linker]:
@@ -220,39 +227,10 @@ device or emulator via the `--project` switch:
 
 ### Preview testing
 
-The following instructions can be used for early preview testing.
+For the latest instructions on preview testing and sample projects,
+see the [net6-samples][net6-samples] repo.
 
-  1) Install the [latest .NET 5 preview][0]. Preview 4 or later is required.
-
-  2) Create a `nuget.config` file that has a package source pointing to
-     local packages or `xamarin-impl` feed, as well as the .NET 5 feed:
-
-```xml
-<configuration>
-  <packageSources>
-    <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
-  </packageSources>
-</configuration>
-```
-
-  3) Open an existing Android project (ideally something minimal) and
-    tweak it as shown below. The version should match the version of the
-    packages you want to use:
-
-```xml
-<Project Sdk="Microsoft.Android.Sdk/10.0.100">
-  <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
-    <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-</Project>
-```
-
-  4) Build (and optionally run) the project:
-
-    dotnet build *.csproj -t:Run
+[net6-samples]: https://github.com/xamarin/net6-samples
 
 ## Package Versioning Scheme
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -47,7 +47,7 @@ ms.date: 01/24/2020
 + [XA0033](xa0033.md): Failed to get the Java SDK version because the returned value does not appear to contain a valid version number.
 + [XA0034](xa0034.md): Failed to get the Java SDK version.
 + [XA0035](xa0035.md): Failed to determine the Android ABI for the project.
-+ [XA0036](xa0036.md): $(AndroidSupportedAbis) is not supported in .NET 5 and higher.
++ [XA0036](xa0036.md): $(AndroidSupportedAbis) is not supported in .NET 6 and higher.
 + XA0100: EmbeddedNativeLibrary is invalid in Android Application projects. Please use AndroidNativeLibrary instead.
 + [XA0101](xa0101.md): warning XA0101: @(Content) build action is not supported.
 + [XA0102](xa0102.md): Generic `lint` Warning.
@@ -105,13 +105,13 @@ Please disable fast deployment in the Visual Studio project property pages or ed
 + XA1021: Specified source Java library not found: {file}
 + XA1022: Specified reference Java library not found: {file}
 + [XA1023](xa1023.md): Using the DX DEX Compiler is deprecated.
-+ [XA1024](xa1024.md): Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.
++ [XA1024](xa1024.md): Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.
 + [XA1027](xa1027.md): The 'EnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.
 + [XA1028](xa1028.md): The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.
 
 ## XA2xxx: Linker
 
-+ [XA2000](xa2000.md): Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.
++ [XA2000](xa2000.md): Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.
 + [XA2001](xa2001.md): Source file '{filename}' could not be found.
 + [XA2002](xa2002.md): Can not resolve reference: \`{missing}\`, referenced by {assembly}. Perhaps it doesn't exist in the Mono for Android profile?
 + XA2006: Could not resolve reference to '{member}' (defined in assembly '{assembly}') with scope '{scope}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.

--- a/Documentation/guides/messages/xa0036.md
+++ b/Documentation/guides/messages/xa0036.md
@@ -8,7 +8,7 @@ ms.date: 06/17/2020
 ## Issue
 
 The `$(AndroidSupportedAbis)` MSBuild property is no longer supported
-in .NET 5 and higher.
+in .NET 6 and higher.
 
 ## Solution
 

--- a/Documentation/guides/messages/xa1023.md
+++ b/Documentation/guides/messages/xa1023.md
@@ -12,7 +12,7 @@ warning XA1023: Using the DX DEX Compiler is deprecated. Please set the DEX comp
 ```
 
 ```
-error XA1023: Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.
+error XA1023: Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.
 ```
 
 ## Issue
@@ -21,7 +21,7 @@ Google has deprecated the DX DEX Compiler in favor of the [D8 DEX
 Compiler][d8]. On [February 1, 2021][dx], DX will no longer be a part
 of Android SDK or Android Studio.
 
-The DX DEX Compiler will not supported in .NET 5 or higher.
+The DX DEX Compiler will not supported in .NET 6 or higher.
 
 [d8]: https://developer.android.com/studio/command-line/d8
 [dx]: https://android-developers.googleblog.com/2020/02/the-path-to-dx-deprecation.html

--- a/Documentation/guides/messages/xa1024.md
+++ b/Documentation/guides/messages/xa1024.md
@@ -8,15 +8,15 @@ ms.date: 07/08/2020
 ## Example messages
 
 ```
-warning XA1024: Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.
+warning XA1024: Ignoring configuration file 'Foo.dll.config'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.
 ```
 
 ## Issue
 
 No support for [configuration files][config] such as `Foo.dll.config`
 or `Foo.exe.config` is available in Xamarin.Android projects targeting
-.NET 5 or higher. [`<dllmap>`][dllmap] configuration elements are not
-supported in .NET 5 at all, and other element types for compatibility
+.NET 6 or higher. [`<dllmap>`][dllmap] configuration elements are not
+supported in .NET 6 at all, and other element types for compatibility
 packages like [System.Configuration.ConfigurationManager][nuget] have
 never been supported in Xamarin.Android projects.
 

--- a/Documentation/guides/messages/xa1026.md
+++ b/Documentation/guides/messages/xa1026.md
@@ -12,7 +12,7 @@ warning XA1026: Using AAPT is deprecated in favor of AAPT2. Please enable 'Use i
 ```
 
 ```
-error XA1026: Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.
+error XA1026: Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.
 ```
 
 ## Issue

--- a/Documentation/guides/messages/xa2000.md
+++ b/Documentation/guides/messages/xa2000.md
@@ -8,7 +8,7 @@ ms.date: 1/13/2019
 ## Example messages
 
 ```
-Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.
+Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.
 ```
 
 ## Solution

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -37,9 +37,9 @@
   <Target Name="_GenerateFrameworkListFile" >
     <!-- Hardcode framework attributes -->
     <ItemGroup>
-      <FrameworkListRootAttributes Include="Name" Value=".NET 5.0 - Android" />
+      <FrameworkListRootAttributes Include="Name" Value=".NET 6.0 - Android" />
       <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value=".NETCoreApp" />
-      <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="5.0" />
+      <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="6.0" />
       <FrameworkListRootAttributes Include="FrameworkName" Value="Microsoft.Android" />
     </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -425,11 +425,11 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</comment>
   </data>
   <data name="XA1023_dotnet" xml:space="preserve">
-    <value>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</value>
-    <comment>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</comment>
+    <value>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</value>
+    <comment>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</comment>
   </data>
   <data name="XA1024" xml:space="preserve">
-    <value>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</value>
+    <value>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</value>
     <comment>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</comment>
   </data>
@@ -438,7 +438,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</comment>
   </data>
   <data name="XA1026_dotnet" xml:space="preserve">
-    <value>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</value>
+    <value>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</value>
     <comment>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</comment>
   </data>
   <data name="XA1027" xml:space="preserve">
@@ -450,7 +450,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">
-    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</value>
+    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">Používání kompilátoru DX DEX se v projektech Xamarin.Androidu, které cílí na .NET 5 nebo vyšší, nepodporuje. Nastavte prosím na stránkách vlastností projektu sady Visual Studio kompilátor DEX na d8, nebo upravte soubor projektu v textovém editoru a nastavte vlastnost MSBuildu AndroidDexTool na d8.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">Používání kompilátoru DX DEX se v projektech Xamarin.Androidu, které cílí na .NET 5 nebo vyšší, nepodporuje. Nastavte prosím na stránkách vlastností projektu sady Visual Studio kompilátor DEX na d8, nebo upravte soubor projektu v textovém editoru a nastavte vlastnost MSBuildu AndroidDexTool na d8.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Ignoruje se konfigurační soubor {0}. Konfigurační soubory .NET se v projektech Xamarin.Androidu, které cílí na .NET 5 nebo vyšší, nepodporují.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Ignoruje se konfigurační soubor {0}. Konfigurační soubory .NET se v projektech Xamarin.Androidu, které cílí na .NET 5 nebo vyšší, nepodporují.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">V sestavení {0} se zjistilo, že se používá AppDomain.CreateDomain(). .NET 5 bude podporovat jen jednu doménu AppDomain, proto toto rozhraní API už nebude po vydání rozhraní .NET 5 v Xamarin.Androidu k dispozici.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">V sestavení {0} se zjistilo, že se používá AppDomain.CreateDomain(). .NET 5 bude podporovat jen jednu doménu AppDomain, proto toto rozhraní API už nebude po vydání rozhraní .NET 5 v Xamarin.Androidu k dispozici.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">Die Verwendung des DX DEX-Compilers wird in Xamarin.Android-Projekten für .NET 5 oder höher nicht unterstützt. Legen Sie den DEX-Compiler in den Visual Studio-Projekteigenschaftenseiten auf "d8" fest, oder bearbeiten Sie die Projektdatei in einem Text-Editor, und legen Sie die MSBuild-Eigenschaft "AndroidDexTool" auf "d8" fest.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">Die Verwendung des DX DEX-Compilers wird in Xamarin.Android-Projekten für .NET 5 oder höher nicht unterstützt. Legen Sie den DEX-Compiler in den Visual Studio-Projekteigenschaftenseiten auf "d8" fest, oder bearbeiten Sie die Projektdatei in einem Text-Editor, und legen Sie die MSBuild-Eigenschaft "AndroidDexTool" auf "d8" fest.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Die Konfigurationsdatei "{0}" wird ignoriert. .NET-Konfigurationsdateien werden in Xamarin.Android-Projekten für .NET 5 oder höher nicht unterstützt.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Die Konfigurationsdatei "{0}" wird ignoriert. .NET-Konfigurationsdateien werden in Xamarin.Android-Projekten für .NET 5 oder höher nicht unterstützt.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">In der Assembly "{0}" wurde die Verwendung von "AppDomain.CreateDomain()" festgestellt. .NET 5 unterstützt nur eine einzelne AppDomain, sodass diese API nach dem Release von .NET 5 nicht mehr in Xamarin.Android verfügbar ist.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">In der Assembly "{0}" wurde die Verwendung von "AppDomain.CreateDomain()" festgestellt. .NET 5 unterstützt nur eine einzelne AppDomain, sodass diese API nach dem Release von .NET 5 nicht mehr in Xamarin.Android verfügbar ist.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">No se admite el uso del compilador DX DEX en los proyectos de Xamarin.Android destinados a .NET 5 o versiones posteriores. Establezca el compilador DEX en "d8" en las páginas de propiedades del proyecto de Visual Studio o edite el archivo de proyecto en un editor de texto y establezca la propiedad "AndroidDexTool" de MSBuild en "d8".</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">No se admite el uso del compilador DX DEX en los proyectos de Xamarin.Android destinados a .NET 5 o versiones posteriores. Establezca el compilador DEX en "d8" en las páginas de propiedades del proyecto de Visual Studio o edite el archivo de proyecto en un editor de texto y establezca la propiedad "AndroidDexTool" de MSBuild en "d8".</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Omitiendo el archivo de configuración "{0}". Los archivos de configuración .NET no se admiten en proyectos Xamarin. Android destinados a .NET 5 o versiones posteriores.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Omitiendo el archivo de configuración "{0}". Los archivos de configuración .NET no se admiten en proyectos Xamarin. Android destinados a .NET 5 o versiones posteriores.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">Se detectó el uso de AppDomain.CreateDomain() en el ensamblado: {0}. En .NET 5 solo se admitirá una instancia de AppDomain, por lo que esta API ya no estará disponible en Xamarin.Android una vez que se haya lanzado .NET 5.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">Se detectó el uso de AppDomain.CreateDomain() en el ensamblado: {0}. En .NET 5 solo se admitirá una instancia de AppDomain, por lo que esta API ya no estará disponible en Xamarin.Android una vez que se haya lanzado .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">L'utilisation du compilateur DEX DX n'est pas prise en charge dans les projets Xamarin.Android qui ciblent .NET 5 ou une version ultérieure. Affectez au compilateur DEX la valeur 'd8' dans les pages de propriétés de projet Visual Studio, ou modifiez le fichier projet dans un éditeur de texte, puis affectez la valeur 'd8' à la propriété MSBuild 'AndroidDexTool'.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">L'utilisation du compilateur DEX DX n'est pas prise en charge dans les projets Xamarin.Android qui ciblent .NET 5 ou une version ultérieure. Affectez au compilateur DEX la valeur 'd8' dans les pages de propriétés de projet Visual Studio, ou modifiez le fichier projet dans un éditeur de texte, puis affectez la valeur 'd8' à la propriété MSBuild 'AndroidDexTool'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Fichier config '{0}' ignoré. Les fichiers config .NET ne sont pas pris en charge dans les projets Xamarin.Android qui ciblent .NET 5 ou une version ultérieure.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Fichier config '{0}' ignoré. Les fichiers config .NET ne sont pas pris en charge dans les projets Xamarin.Android qui ciblent .NET 5 ou une version ultérieure.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">Utilisation de AppDomain.CreateDomain() détectée dans l'assembly {0}. .NET 5 prend uniquement en charge un seul AppDomain. Cette API ne sera donc plus disponible dans Xamarin.Android après la publication de .NET 5.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">Utilisation de AppDomain.CreateDomain() détectée dans l'assembly {0}. .NET 5 prend uniquement en charge un seul AppDomain. Cette API ne sera donc plus disponible dans Xamarin.Android après la publication de .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">L'uso del compilatore DEX DX non è supportato in progetti Xamarin.Android destinati a .NET 5 o versione successiva. Impostare il compilatore DEX su 'd8' nelle pagine delle proprietà del progetto di Visual Studio o modificare il file di progetto in un editor di testo e impostare la proprietà 'AndroidDexTool' di MSBuild su 'd8'.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">L'uso del compilatore DEX DX non è supportato in progetti Xamarin.Android destinati a .NET 5 o versione successiva. Impostare il compilatore DEX su 'd8' nelle pagine delle proprietà del progetto di Visual Studio o modificare il file di progetto in un editor di testo e impostare la proprietà 'AndroidDexTool' di MSBuild su 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Il file di configurazione '{0}' verrà ignorato. I file di configurazione .NET non sono supportati in progetti Xamarin.Android destinati a .NET 5 o versione successiva.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Il file di configurazione '{0}' verrà ignorato. I file di configurazione .NET non sono supportati in progetti Xamarin.Android destinati a .NET 5 o versione successiva.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">È stato rilevato l'uso di AppDomain.CreateDomain() nell'assembly: {0}. .NET 5 supporterà solo un'unica istanza di AppDomain, di conseguenza questa API non sarà più disponibile in Xamarin.Android dopo il rilascio di .NET 5.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">È stato rilevato l'uso di AppDomain.CreateDomain() nell'assembly: {0}. .NET 5 supporterà solo un'unica istanza di AppDomain, di conseguenza questa API non sarà più disponibile in Xamarin.Android dopo il rilascio di .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">.NET 5 以降を対象とする Xamarin.Android プロジェクトでは、DX DEX コンパイラの使用はサポートされていません。Visual Studio プロジェクトのプロパティ ページで DEX コンパイラを 'd8' に設定するか、テキスト エディターでプロジェクト ファイルを編集して 'AndroidDexTool' MSBuild プロパティを 'd8' に設定してください。</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">.NET 5 以降を対象とする Xamarin.Android プロジェクトでは、DX DEX コンパイラの使用はサポートされていません。Visual Studio プロジェクトのプロパティ ページで DEX コンパイラを 'd8' に設定するか、テキスト エディターでプロジェクト ファイルを編集して 'AndroidDexTool' MSBuild プロパティを 'd8' に設定してください。</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">構成ファイル '{0}' を無視しています。.NET 構成ファイルは、.NET 5 以降を対象とする Xamarin.Android プロジェクトではサポートされていません。</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">構成ファイル '{0}' を無視しています。.NET 構成ファイルは、.NET 5 以降を対象とする Xamarin.Android プロジェクトではサポートされていません。</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">アセンブリ {0} で AppDomain.CreateDomain() が使用されていることが検出されました。.NET 5 では単一の AppDomain のみがサポートされる予定のため、.NET 5 がリリースされるとこの API は Xamarin.Android では使用できなくなります。</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">アセンブリ {0} で AppDomain.CreateDomain() が使用されていることが検出されました。.NET 5 では単一の AppDomain のみがサポートされる予定のため、.NET 5 がリリースされるとこの API は Xamarin.Android では使用できなくなります。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">DX DEX 컴파일러는 .NET 5 이상을 대상으로 하는 Xamarin.Android 프로젝트에서 사용할 수 없습니다. Visual Studio 프로젝트 속성 페이지에서 DEX 컴파일러를 'd8'로 설정하거나 텍스트 편집기에서 프로젝트 파일을 편집하고 'AndroidDexTool' MSBuild 속성을 'd8'로 설정하세요.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">DX DEX 컴파일러는 .NET 5 이상을 대상으로 하는 Xamarin.Android 프로젝트에서 사용할 수 없습니다. Visual Studio 프로젝트 속성 페이지에서 DEX 컴파일러를 'd8'로 설정하거나 텍스트 편집기에서 프로젝트 파일을 편집하고 'AndroidDexTool' MSBuild 속성을 'd8'로 설정하세요.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">구성 파일 '{0}'을(를) 무시합니다. .Net 5 이상을 대상으로 Xamarin.Android 프로젝트에서 .NET 구성 파일은 지원되지 않습니다.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">구성 파일 '{0}'을(를) 무시합니다. .Net 5 이상을 대상으로 Xamarin.Android 프로젝트에서 .NET 구성 파일은 지원되지 않습니다.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">{0} 어셈블리에서 AppDomain.CreateDomain() 사용이 검색되었습니다. .NET 5는 단일 AppDomain만 지원하므로 .NET 5가 릴리스되면 이 API는 Xamarin.Android에서 더는 사용할 수 없습니다.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">{0} 어셈블리에서 AppDomain.CreateDomain() 사용이 검색되었습니다. .NET 5는 단일 AppDomain만 지원하므로 .NET 5가 릴리스되면 이 API는 Xamarin.Android에서 더는 사용할 수 없습니다.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">Używanie kompilatora DX DEX nie jest obsługiwane w projektach Xamarin.Android, których elementem docelowym jest platforma .NET 5 lub nowsza. Ustaw kompilator DEX na „d8” na stronach właściwości projektu w programie Visual Studio lub edytuj plik projektu w edytorze tekstów i ustaw właściwość programu MSBuild o nazwie „AndroidDexTool” na wartość „d8”.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">Używanie kompilatora DX DEX nie jest obsługiwane w projektach Xamarin.Android, których elementem docelowym jest platforma .NET 5 lub nowsza. Ustaw kompilator DEX na „d8” na stronach właściwości projektu w programie Visual Studio lub edytuj plik projektu w edytorze tekstów i ustaw właściwość programu MSBuild o nazwie „AndroidDexTool” na wartość „d8”.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Ignorowanie pliku konfiguracji „{0}”. Pliki konfiguracji .NET nie są obsługiwane w projektach Xamarin.Android, których elementem docelowym jest platforma .NET 5 lub nowsza.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Ignorowanie pliku konfiguracji „{0}”. Pliki konfiguracji .NET nie są obsługiwane w projektach Xamarin.Android, których elementem docelowym jest platforma .NET 5 lub nowsza.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">Wykryto użycie metody AppDomain.CreateDomain() w następującym zestawie: {0}. Program .NET 5 obsługuje tylko jeden obiekt AppDomain, dlatego ten interfejs API nie będzie już dostępny w interfejsie Xamarin.Android po wydaniu programu .NET 5.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">Wykryto użycie metody AppDomain.CreateDomain() w następującym zestawie: {0}. Program .NET 5 obsługuje tylko jeden obiekt AppDomain, dlatego ten interfejs API nie będzie już dostępny w interfejsie Xamarin.Android po wydaniu programu .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">Não há suporte para o uso do Compilador DX DEX nos projetos do Xamarin.Android direcionados ao .NET 5 ou superior. Defina o compilador DEX para 'd8' nas páginas de propriedades do projeto do Visual Studio ou edite o arquivo de projeto em um editor de texto e defina a propriedade 'AndroidDexTool' do MSBuild como 'd8'.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">Não há suporte para o uso do Compilador DX DEX nos projetos do Xamarin.Android direcionados ao .NET 5 ou superior. Defina o compilador DEX para 'd8' nas páginas de propriedades do projeto do Visual Studio ou edite o arquivo de projeto em um editor de texto e defina a propriedade 'AndroidDexTool' do MSBuild como 'd8'.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Ignorando o arquivo de configuração '{0}'. Não há suporte para arquivos de configuração do .NET em projetos do Xamarin.Android direcionados ao .NET 5 ou posterior.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Ignorando o arquivo de configuração '{0}'. Não há suporte para arquivos de configuração do .NET em projetos do Xamarin.Android direcionados ao .NET 5 ou posterior.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">O uso de AppDomain.CreateDomain() foi detectado no assembly: {0}. O .NET 5 dá suporte apenas a um único AppDomain, portanto, essa API não estará mais disponível no Xamarin.Android quando o .NET 5 for lançado.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">O uso de AppDomain.CreateDomain() foi detectado no assembly: {0}. O .NET 5 dá suporte apenas a um único AppDomain, portanto, essa API não estará mais disponível no Xamarin.Android quando o .NET 5 for lançado.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">Использование DEX-компилятора DX больше не поддерживается в проектах Xamarin.Android для .NET 5 и более поздних версий. Установите компилятор DEX "d8" на страницах свойств проекта в Visual Studio или измените файл проекта в текстовом редакторе, задав значение "d8" для свойства MSBuild "AndroidDexTool".</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">Использование DEX-компилятора DX больше не поддерживается в проектах Xamarin.Android для .NET 5 и более поздних версий. Установите компилятор DEX "d8" на страницах свойств проекта в Visual Studio или измените файл проекта в текстовом редакторе, задав значение "d8" для свойства MSBuild "AndroidDexTool".</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">Пропуск файла конфигурации "{0}". Файлы конфигурации .NET не поддерживаются в проектах Xamarin.Android для .NET 5 и более поздних версий.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">Пропуск файла конфигурации "{0}". Файлы конфигурации .NET не поддерживаются в проектах Xamarin.Android для .NET 5 и более поздних версий.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">В сборке обнаружено использование AppDomain.CreateDomain(): {0}. .NET 5 поддерживает только один домен AppDomain, поэтому этот API не будет доступен в Xamarin.Android после выпуска .NET 5.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">В сборке обнаружено использование AppDomain.CreateDomain(): {0}. .NET 5 поддерживает только один домен AppDomain, поэтому этот API не будет доступен в Xamarin.Android после выпуска .NET 5.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">.NET 5 veya üzeri bir sürümü hedefleyen Xamarin.Android projelerinde DX DEX Derleyicisinin kullanılması desteklenmiyor. Lütfen Visual Studio projesi özellik sayfalarında DEX derleyicisini 'd8' olarak ayarlayın veya proje dosyasını bir metin düzenleyicide düzenleyip 'AndroidDexTool' MSBuild özelliğini 'd8' olarak ayarlayın.</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">.NET 5 veya üzeri bir sürümü hedefleyen Xamarin.Android projelerinde DX DEX Derleyicisinin kullanılması desteklenmiyor. Lütfen Visual Studio projesi özellik sayfalarında DEX derleyicisini 'd8' olarak ayarlayın veya proje dosyasını bir metin düzenleyicide düzenleyip 'AndroidDexTool' MSBuild özelliğini 'd8' olarak ayarlayın.</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">'{0}' yapılandırma dosyası yoksayılıyor. .NET yapılandırma dosyaları, .NET 5 veya üzeri bir sürümü hedefleyen Xamarin.Android projelerinde desteklenmiyor.</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">'{0}' yapılandırma dosyası yoksayılıyor. .NET yapılandırma dosyaları, .NET 5 veya üzeri bir sürümü hedefleyen Xamarin.Android projelerinde desteklenmiyor.</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">Bütünleştirilmiş kodda AppDomain.CreateDomain() metodunun kullanıldığı saptandı: {0}. .NET 5 yalnızca tek bir AppDomain'i destekleyeceğinden bu API, .NET 5 yayımlandıktan sonra artık Xamarin.Android içinde kullanılamayacak.</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">Bütünleştirilmiş kodda AppDomain.CreateDomain() metodunun kullanıldığı saptandı: {0}. .NET 5 yalnızca tek bir AppDomain'i destekleyeceğinden bu API, .NET 5 yayımlandıktan sonra artık Xamarin.Android içinde kullanılamayacak.</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">在面向 .NET 5 或更高版本的 Xamarin.Android 项目中不支持使用 DX DEX 编译器。请在 Visual Studio 项目属性页中将 DEX 编译器设置为 "d8"，或者在文本编辑器中编辑项目文件，并将 "AndroidDexTool" MSBuild 属性设置为 "d8"。</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">在面向 .NET 5 或更高版本的 Xamarin.Android 项目中不支持使用 DX DEX 编译器。请在 Visual Studio 项目属性页中将 DEX 编译器设置为 "d8"，或者在文本编辑器中编辑项目文件，并将 "AndroidDexTool" MSBuild 属性设置为 "d8"。</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">将忽略配置文件“{0}”。在面向 .NET 5 或更高版本的 Xamarin.Android 项目中不支持 .NET 配置文件。</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">将忽略配置文件“{0}”。在面向 .NET 5 或更高版本的 Xamarin.Android 项目中不支持 .NET 配置文件。</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">在程序集 {0} 中检测到使用了 AppDomain.CreateDomain()。.NET 5 将仅支持一个 AppDomain，因此 .NET 5 发布后，将无法再在 Xamarin.Android 中使用此 API。</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">在程序集 {0} 中检测到使用了 AppDomain.CreateDomain()。.NET 5 将仅支持一个 AppDomain，因此 .NET 5 发布后，将无法再在 Xamarin.Android 中使用此 API。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -44,8 +44,8 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <note>The following are literal names and should not be translated: AAPT, AAPT2, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1026_dotnet">
-        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
-        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 5 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
+        <source>Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</source>
+        <target state="new">Using AAPT is not supported in Xamarin.Android projects that target .NET 6 or higher. Please enable 'Use incremental Android packaging system (aapt2)' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidUseAapt2' MSBuild property to 'true'.</target>
         <note>The following are literal names and should not be translated: AAPT, Android, AndroidUseAapt2, true.</note>
       </trans-unit>
       <trans-unit id="XA1027">
@@ -414,19 +414,19 @@ In this message, the term "binding" means a piece of generated code that makes i
         <note>The following are literal names and should not be translated: DX, DEX, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1023_dotnet">
-        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 5 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
-        <target state="translated">以 .NET 5 或更新版本為目標的 Xamarin.Android 專案不支援使用 DX DEX 編譯器。請在 [Visual Studio 專案] 屬性頁中將 DEX 編譯器設為 'd8'，或在文字編輯器中編輯專案檔，並將 'AndroidDexTool' MSBuild 屬性設為 'd8'。</target>
-        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 5, d8, AndroidDexTool.</note>
+        <source>Using the DX DEX Compiler is not supported in Xamarin.Android projects that target .NET 6 or higher. Please set the DEX compiler to 'd8' in the Visual Studio project property pages or edit the project file in a text editor and set the 'AndroidDexTool' MSBuild property to 'd8'.</source>
+        <target state="needs-review-translation">以 .NET 5 或更新版本為目標的 Xamarin.Android 專案不支援使用 DX DEX 編譯器。請在 [Visual Studio 專案] 屬性頁中將 DEX 編譯器設為 'd8'，或在文字編輯器中編輯專案檔，並將 'AndroidDexTool' MSBuild 屬性設為 'd8'。</target>
+        <note>The following are literal names and should not be translated: DX, DEX, Xamarin.Android, .NET 6, d8, AndroidDexTool.</note>
       </trans-unit>
       <trans-unit id="XA1024">
-        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 5 or higher.</source>
-        <target state="translated">忽略組態檔 '{0}'。以 .NET 5 或更新版本為目標的 Xamarin.Android 專案不支援 .NET 組態檔。</target>
+        <source>Ignoring configuration file '{0}'. .NET configuration files are not supported in Xamarin.Android projects that target .NET 6 or higher.</source>
+        <target state="needs-review-translation">忽略組態檔 '{0}'。以 .NET 5 或更新版本為目標的 Xamarin.Android 專案不支援 .NET 組態檔。</target>
         <note>The following are literal names and should not be translated: .NET, Xamarin.Android.
 {0} - The file name such as 'Foo.dll.config'</note>
       </trans-unit>
       <trans-unit id="XA2000">
-        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.</source>
-        <target state="translated">在下列組件中偵測到使用 AppDomain.CreateDomain(): {0}。.NET 5 只支援單一 AppDomain，因此在 .NET 5 發行之後，此 API 就無法再於 Xamarin.Android 中使用。</target>
+        <source>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</source>
+        <target state="needs-review-translation">在下列組件中偵測到使用 AppDomain.CreateDomain(): {0}。.NET 5 只支援單一 AppDomain，因此在 .NET 5 發行之後，此 API 就無法再於 Xamarin.Android 中使用。</target>
         <note>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</note>
       </trans-unit>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -92,7 +92,7 @@ $@"<Project>
 				// Feeds only needed for .NET 5+
 				ExtraNuGetConfigSources = new List<string> {
 					Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
-					"https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				};
 			} else {
 				SetProperty (KnownProperties.Configuration, () => Configuration);


### PR DESCRIPTION
Since 6f761ea8 gets us on a build of .NET 6, we can update all
user-facing messaging to say .NET 6 instead of .NET 5.

* Documentation around building `xamarin-android`
* Error/warning messages

I also updated a few things other things that should say .NET 6:

* `NuGet.config` sources in MSBuild tests
* `@(FrameworkListRootAttributes)` for our .NET 6 packages

I did not update various code comments, as most of them say .NET 5+
and are not user-facing.

Other changes in `OneDotNet.md`:

* Started a new `Runtime behavior` section with a link to
  `String.IndexOf()` behavior.
* Link to `net6-samples` as the source for .NET 6 example projects and
  installation instructions.