### PR TITLE
[xaprepare] Fix for newer homebrew on macOs

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Android.Prepare
 {
 	class HomebrewProgram : Program
 	{
+		static readonly char[] lineSplit = new [] { '\n' };
+
 		string cachedVersionOutput;
 		bool brewNeedsSudo = false;
 		bool multipleVersionsPickle = false;
@@ -204,13 +206,21 @@ namespace Xamarin.Android.Prepare
 
 		string GetPackageVersion ()
 		{
-			return Utilities.GetStringFromStdout (
+			string output = Utilities.GetStringFromStdout (
 				Context.Instance.Tools.BrewPath,
 				false, // throwOnErrors
 				true,  // trimTrailingWhitespace
 				true,  // quietErrors
-				"ls", "--versions", "-1", Name
+				"ls", "--versions", Name
 			);
+
+			if (String.IsNullOrEmpty (output))
+				return output;
+
+			string[] lines = output.Split (lineSplit, StringSplitOptions.RemoveEmptyEntries);
+			if (lines.Length == 0)
+				return String.Empty;
+			return lines [0];
 		}
 	}
 }


### PR DESCRIPTION
The latest version of homebrew introduced a breaking change in the
way it handles certain combinations of its command-line arguments.
Namely, what affects us, is the combination `--versions -1` to
limit the number of package's versions to a single line. Right
now it is not allowed and causes the following failure:

    Error: Invalid usage: Options --versions and -1 are mutually exclusive.
     [MISSING]
    Checking automake                                   Usage: brew list, ls [options] [formula|cask]

Instead of passing `-1`, do the processing ourselves.