### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for Proguard `mapping.txt` file

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -806,6 +806,17 @@ with build environments that have FIPS compliance enforced.
 
 Added in Xamarin.Android 10.1.
 
+## AndroidProguardMappingFile
+
+Specifies the `-printmapping` proguard rule for `r8`. This will
+mean the `mapping.txt` file will be produced in the `$(OutputPath)`
+folder. This file can then be used when uploading packages to the
+Google Play Store.
+
+Default value is `$(OutputPath)mapping.txt`
+
+Added in Xamarin.Android 11.2
+
 ## AndroidR8IgnoreWarnings
 
 Specifies

--- a/Documentation/release-notes/5304.md
+++ b/Documentation/release-notes/5304.md
@@ -1,0 +1,9 @@
+### Build and deployment performance
+
+  * [GitHub PR 5304](https://github.com/xamarin/xamarin-android/pull/5304):
+    Add support for producing a proguard `mapping.txt` file to the
+    build system. This file can be used by users to remove this warning
+
+        "This App Bundle contains Java/Kotlin code, which might be obfuscated."
+
+    when uploading packages to the Google Play Store.

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -2,6 +2,10 @@
 
 -dontobfuscate
 
+# required for publishing proguard mapping file
+-keepattributes SourceFile
+-keepattributes LineNumberTable
+
 -keep class android.support.multidex.MultiDexApplication { <init>(); }
 -keep class com.xamarin.java_interop.** { *; <init>(); }
 -keep class mono.MonoRuntimeProvider* { *; <init>(...); }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -48,14 +48,15 @@ namespace Xamarin.Android.Tasks
 		public string ProguardGeneratedReferenceConfiguration { get; set; }
 		public string ProguardGeneratedApplicationConfiguration { get; set; }
 		public string ProguardCommonXamarinConfiguration { get; set; }
+		public string ProguardMappingFileOutput { get; set; }
 
 		[Required]
 		public string [] ProguardConfigurationFiles { get; set; }
 
 		public ITaskItem[] JavaLibrariesToEmbed { get; set; }
-		
+
 		public ITaskItem[] JavaLibrariesToReference { get; set; }
-		
+
 		public bool UseProguard { get; set; }
 
 		public string JavaOptions { get; set; }
@@ -92,11 +93,11 @@ namespace Xamarin.Android.Tasks
 				// Add the JavaOptions if they are not null
 				// These could be any of the additional options
 				if (!string.IsNullOrEmpty (JavaOptions)) {
-					cmd.AppendSwitch (JavaOptions);		
+					cmd.AppendSwitch (JavaOptions);
 				}
 
 				// Add the specific -XmxN to override the default heap size for the JVM
-				// N can be in the form of Nm or NGB (e.g 100m or 1GB ) 
+				// N can be in the form of Nm or NGB (e.g 100m or 1GB )
 				cmd.AppendSwitchIfNotNull ("-Xmx", JavaMaximumHeapSize);
 
 				cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (ProguardJarPath));
@@ -118,9 +119,12 @@ namespace Xamarin.Android.Tasks
 					}
 
 			if (!string.IsNullOrWhiteSpace (ProguardCommonXamarinConfiguration))
-				using (var xamcfg = File.Create (ProguardCommonXamarinConfiguration))
-					GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg);
-			
+				using (var xamcfg = File.CreateText (ProguardCommonXamarinConfiguration)) {
+					GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg.BaseStream);
+					if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+						xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+				}
+
 			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 
 			foreach (var file in ProguardConfigurationFiles) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Android.Tasks
 		public string ProguardGeneratedReferenceConfiguration { get; set; }
 		public string ProguardGeneratedApplicationConfiguration { get; set; }
 		public string ProguardCommonXamarinConfiguration { get; set; }
+		public string ProguardMappingFileOutput { get; set; }
 		public string [] ProguardConfigurationFiles { get; set; }
 
 		protected override string MainClass => "com.android.tools.r8.R8";
@@ -99,6 +100,8 @@ namespace Xamarin.Android.Tasks
 						if (IgnoreWarnings) {
 							xamcfg.WriteLine ("-ignorewarnings");
 						}
+						if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+							xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
 					}
 				}
 			} else {
@@ -115,6 +118,8 @@ namespace Xamarin.Android.Tasks
 				if (IgnoreWarnings) {
 					lines.Add ("-ignorewarnings");
 				}
+				if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+					lines.Add ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
 				File.WriteAllLines (temp, lines);
 				tempFiles.Add (temp);
 				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);
@@ -131,5 +136,5 @@ namespace Xamarin.Android.Tasks
 			return cmd;
 		}
 	}
-	
+
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -49,6 +49,21 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void CheckProguardMappingFileExists ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidDexTool, "d8");
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+				string mappingFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "mapping.txt");
+				FileAssert.Exists (mappingFile, $"'{mappingFile}' should have been generated.");
+			}
+		}
+
+		[Test]
 		public void CheckIncludedAssemblies ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -275,6 +275,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == '' And '$(AndroidEnableProguard)' == 'True' ">proguard</AndroidLinkTool>
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidEnableDesugar)' == 'True' ">r8</AndroidLinkTool>
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
+  <AndroidProguardMappingFile Condition=" '$(AndroidProguardMappingFile)' == '' ">$(OutputPath)mapping.txt</AndroidProguardMappingFile>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -67,6 +67,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
         ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
         ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
+        ProguardMappingFileOutput="$(AndroidProguardMappingFile)"
         ProguardConfigurationFiles="@(_ProguardConfiguration)"
         EnableShrinking="$(_R8EnableShrinking)"
         EnableMultiDex="$(AndroidEnableMultiDex)"
@@ -96,6 +97,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(_AndroidIntermediateDexOutputDirectory)*.dex" />
+      <FileWrites Include="$(AndroidProguardMappingFile)" />
     </ItemGroup>
 
   </Target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -26,7 +26,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <ItemGroup>
       <_JarsToProguard Include="@(_JavaLibrariesToCompile)" />
     </ItemGroup>
-    
+
     <MakeDir Directories="$(IntermediateOutputPath)proguard" />
 
     <Proguard
@@ -42,6 +42,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
         ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
         ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"
+        ProguardMappingFileOutput="$(AndroidProguardMappingFile)"
         ProguardConfigurationFiles="@(_ProguardConfiguration)"
         JavaLibrariesToEmbed="@(_JarsToProguard);@(_InstantRunJavaReference)"
         JavaLibrariesToReference="@(AndroidExternalJavaLibrary)"
@@ -79,7 +80,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <Delete Files="@(_DexesToDelete)" />
 
     <!-- Compile java code to dalvik -->
-    <CompileToDalvik 
+    <CompileToDalvik
         DxJarPath="$(DxJarPath)"
         DxExtraArguments="$(DxExtraArguments)"
         JavaToolPath="$(JavaToolPath)"
@@ -98,6 +99,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(_AndroidIntermediateDexOutputDirectory)*.dex" />
+      <FileWrites Include="$(AndroidProguardMappingFile)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
Fixes #5186

When uploading a package to the Google Play Store users are seeing
the following warning.

    This App Bundle contains Java/Kotlin code, which might be obfuscated.

To fix this users need to provide a `mapping.txt` file which contains
the Java class mappings from their plain versions to the ones which
are obfuscated. By default we do not obfuscate the java code but the
warning still shows.

To fix this issue we have a new property `$(AndroidProguardMappingFile)`
which defaults to `$(OutputPath)mapping.txt`. This file will be produced
as part of the build process. In order for this mapping file to be
generated the following lines needed to be added to the `proguard_xamarin.cfg`
file.

    -keepattributes SourceFile
    -keepattributes LineNumberTable