### PR TITLE
[tests] update URL for twitter-core-3.3.0.aar

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3215,9 +3215,9 @@ public class MyReceiver : BroadcastReceiver
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "gson-2.7.jar") {
 				WebContent = "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar"
 			});
-			//Twitter SDK https://mvnrepository.com/artifact/com.twitter.sdk.android/twitter-core/3.3.0
+			//Twitter SDK https://bintray.com/twitteross/twitterkit/twitter-core/3.3.0
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidAarLibrary", "twitter-core-3.3.0.aar") {
-				WebContent = "https://repo.spring.io/libs-release/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
+				WebContent = "https://dl.bintray.com/twitteross/twitterkit/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
 			});
 			/* The source is simple:
 			 *


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4233431&view=ms.vss-test-web.build-test-results-tab&runId=17100812&resultId=100181&paneView=debug

The `Desugar` tests started failing with:

    System.Net.WebException : The remote server returned an error: (401) Unauthorized
        at System.Net.HttpWebRequest.GetResponse()
        at System.Net.WebClient.GetWebResponse(WebRequest request)
        at System.Net.WebClient.DownloadBits(WebRequest request, Stream writeStream)
        at System.Net.WebClient.DownloadFile(Uri address, String fileName)
        at System.Net.WebClient.DownloadFile(String address, String fileName)
        at Xamarin.ProjectTools.DownloadedCache.GetAsFile(String url) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DownloadedCache.cs:line 37
        at Xamarin.ProjectTools.BuildItem.<>c__DisplayClass70_0.<set_WebContent>b__0() in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs:line 129
        at Xamarin.ProjectTools.XamarinProject.<>c.<Save>b__109_1(BuildItem s) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs:line 253
        at System.Linq.Enumerable.SelectListIterator`2.MoveNext()
        at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
        at Xamarin.ProjectTools.XamarinProject.Save(Boolean saveProject) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs:line 252
        at Xamarin.ProjectTools.ProjectBuilder.Save(XamarinProject project, Boolean doNotCleanupOnUpdate, Boolean saveProject) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs:line 46
        at Xamarin.ProjectTools.ProjectBuilder.Build(XamarinProject project, Boolean doNotCleanupOnUpdate, String[] parameters, Boolean saveProject, Dictionary`2 environmentVariables) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs:line 79
        at Xamarin.Android.Build.Tests.BuildTest.Desugar(Boolean isRelease, String dexTool, String linkTool) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs:line 3259

When I try the URL:

    https://repo.spring.io/libs-release/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar

It prompts for a username/password. The link `mvnrepository.com` gives
for this package does not work anymore.

I was able to find the same package on `bintray.com`, so I think we
can use this instead.