### PR TITLE
[ci] Bump check-boot-times timeout, exclude from smoke tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -408,22 +408,6 @@ stages:
         script: 'dotnet tool update apkdiff -g'
       continueOnError: true
 
-    - task: MSBuild@1
-      displayName: build check-boot-times.csproj
-      inputs:
-        solution: build-tools/check-boot-times/check-boot-times.csproj
-        configuration: $(ApkTestConfiguration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
-      continueOnError: true
-
-    - task: MSBuild@1
-      displayName: Run check-boot-times
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(ApkTestConfiguration)
-        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
-      continueOnError: true
-
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(ApkTestConfiguration)
@@ -876,6 +860,22 @@ stages:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - task: MSBuild@1
+      displayName: build check-boot-times.csproj
+      inputs:
+        solution: build-tools/check-boot-times/check-boot-times.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
+      continueOnError: true
+
+    - task: MSBuild@1
+      displayName: Run check-boot-times
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
+      continueOnError: true
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4231349&view=logs&j=cd6eb242-2e57-569b-620a-eaaded8e9a51&t=e2ddc662-66d6-5931-5787-f44b56aa5ee1

The "Run check-boot-times" step has been failing intermittently on CI.
After reviewing the logs, it appears that the issue is due to a process
timeout:

    2020-11-16T22:55:32.7941780Z CheckBootTimes:
    2020-11-16T22:55:32.7942560Z   Task RunAndroidEmulatorCheckBootTimes
    2020-11-16T22:55:32.7944830Z        CheckBootTimesPath: /Users/runner/work/1/s/build-tools/scripts/../../bin/BuildRelease/check-boot-times.exe
    2020-11-16T22:55:32.7945930Z        DeviceName: XamarinAndroidTestRunner64
    2020-11-16T22:55:32.7947410Z   CheckBootTimesPath:  /Users/runner/work/1/s/bin/BuildRelease/check-boot-times.exe
    2020-11-16T22:55:33.0955770Z   CheckBootTimes (11/16/2020 10:55:33 PM): Testing emulator startup times for 1 execution(s). This may take several minutes.
    2020-11-16T22:55:33.1032090Z   CheckBootTimes (11/16/2020 10:55:33 PM): Running adb from: '/Users/runner/Library/Android/sdk/platform-tools/adb'
    2020-11-16T22:55:33.1034270Z   CheckBootTimes (11/16/2020 10:55:33 PM): Running avdmanager from: '/Users/runner/Library/Android/sdk/cmdline-tools/1.0/bin/avdmanager'
    2020-11-16T22:55:33.1036120Z   CheckBootTimes (11/16/2020 10:55:33 PM): Running emulator from: '/Users/runner/Library/Android/sdk/emulator/emulator'
    2020-11-16T22:55:33.1037940Z   CheckBootTimes (11/16/2020 10:55:33 PM): Running sdkmanager from: '/Users/runner/Library/Android/sdk/cmdline-tools/1.0/bin/sdkmanager'
    2020-11-16T22:55:33.2283650Z   CheckBootTimes (11/16/2020 10:55:33 PM): Acceleration type: 0, HAXM version 7.5.1 (4) is installed and usable.
    2020-11-16T22:55:33.5575630Z   CheckBootTimes (11/16/2020 10:55:33 PM): Android emulator version 30.0.12.0 (build_id 6466327) (CL:N/A)
    2020-11-16T22:57:29.0419610Z   CheckBootTimes (11/16/2020 10:57:29 PM): Average Cold Boot Time for 1 run(s) out of 1 request(s) on Virtual device 'XamarinAndroidTestRunner64': 57854 ms
    2020-11-16T23:00:32.8205480Z /Users/runner/work/1/s/build-tools/scripts/TestApks.targets(338,5): error : check-boot-times did not run as expected, please see logs for more info. [/Users/runner/work/1/s/tests/Mono.Android-Tests/Mono.Android-Tests.csproj]

The check-boot-times.exe process invocation is currently set to time out
after 5 minutes, and the timestamps above show that the task is failing
right at the 5 minute mark.

I've bumped the timeout from 5 minutes to 12 minutes, and improved the
error messaging when a timeout does occur.  I've also moved this step
to the MSBuild Emulator Tests job, as it does not to run as part of the
Smoke Tests stage.