### PR TITLE
[One .NET] ignore @(Content) from @(ProjectReference)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -22,6 +22,11 @@
     <!-- mono-symbolicate is not supported -->
     <MonoSymbolArchive>false</MonoSymbolArchive>
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
+    <!--
+      Disable @(Content) from referenced projects 
+      See: https://github.com/dotnet/sdk/blob/955c0fc7b06e2fa34bacd076ed39f61e4fb61716/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L16
+    -->
+    <_GetChildProjectCopyToPublishDirectoryItems>false</_GetChildProjectCopyToPublishDirectoryItems>
   </PropertyGroup>
 
   <!--  User-facing configuration-specific defaults -->

--- a/tests/Mono.Android-Tests/Directory.Build.targets
+++ b/tests/Mono.Android-Tests/Directory.Build.targets
@@ -33,18 +33,6 @@
       DependsOnTargets="_CreateJavaInteropDllConfigs">
   </Target>
 
-  <!-- When we build the multitargeted Java.Interop project as a dependency of this test project we hit the following error:
-  error NETSDK1148: Found multiple publish output files with the same relative path: external\Java.Interop\bin\Release\java-interop.jar, \external\Java.Interop\bin\Release-netcoreapp3.1\java-interop.jar.
-    We do not need to include any of this content in the output directory, so remove it here:
-  -->
-  <Target Name="RemoveJavaInteropJarContent"
-      Condition=" '$(TargetFramework)' == 'net6.0-android' "
-      BeforeTargets="ComputeResolvedFilesToPublishList" >
-    <ItemGroup>
-      <ResolvedFileToPublish Remove="$(JavaInteropSourceDirectory)\bin\**\java-interop.jar" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="GenerateNuGetConfig" >
     <PropertyGroup>
       <LocalNupkgDirectory Condition=" '$(LocalNupkgDirectory)' == '' ">$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\</LocalNupkgDirectory>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5299

When setting up `Mono.Android.NET-Tests`, we had to workaround an
error with duplicate `@(Content)` files:

    error NETSDK1148: Found multiple publish output files with the same relative path: external\Java.Interop\bin\Release\java-interop.jar, \external\Java.Interop\bin\Release-netcoreapp3.1\java-interop.jar.

Android doesn't support the `@(Content)` build action *at all*, and we
emit a `XA0101` warning if it is used. We even have a test for this.

However, it appears that any `@(Content)` from `@(ProjectReference)`
items are currently brought over in .NET 6, as they get added to the
`@(ResolvedFileToPublish)` item group by the dotnet/sdk.

Luckily there appears to be a `$(_GetChildProjectCopyToPublishDirectoryItems)`
MSBuild property we can set to skip this behavior:

https://github.com/dotnet/sdk/blob/955c0fc7b06e2fa34bacd076ed39f61e4fb61716/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L783-L794

We can set this by default, as we don't need to compute `@(Content)`
items in referenced projects. The library project will emit `XA0101`
and that is enough. I also updated a test that would have triggered
`NETSDK1148` which now works.

I could also see a perf improvement in the `Mono.Android.NET-Tests`
project on Windows:

    Before:
    GetCopyToPublishDirectoryItems 21ms
    After:
    GetCopyToPublishDirectoryItems 0ms