### PR TITLE
[ci] Fix check-boot-times configuration name

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -855,27 +855,27 @@ stages:
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
     - task: MSBuild@1
-      displayName: start emulator
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
-
-    - task: MSBuild@1
       displayName: build check-boot-times.csproj
       inputs:
         solution: build-tools/check-boot-times/check-boot-times.csproj
-        configuration: $(ApkTestConfiguration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/build-check-boot-times.binlog
       continueOnError: true
 
     - task: MSBuild@1
       displayName: Run check-boot-times
       inputs:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(ApkTestConfiguration)
-        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:CheckBootTimes /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/run-check-boot-times.binlog
       continueOnError: true
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:


### PR DESCRIPTION
Fixes commit 9429b54c which attempted to use a Configuration
related variable name that didn't exist in the context of the new
job responsible for running check-boot-times.