### PR TITLE
[Xamarin.Android.Build.Tasks] Use Proguard config files from .aar files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -45,6 +45,8 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <JavaSourceJar        Include="**\*-source.jar;**\*-sources.jar;**\*-src.jar"   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidJavaSource    Include="**\*.java" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <ProguardConfiguration Include="**\proguard.cfg" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <ProguardConfiguration Include="**\proguard.txt" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -49,6 +49,7 @@ projects.
       <_CreateAarInputs Include="@(AndroidJavaLibrary)" />
       <_CreateAarInputs Include="@(EmbeddedJar)" />
       <_CreateAarInputs Include="@(EmbeddedNativeLibrary)" />
+      <_CreateAarInputs Include="@(ProguardConfiguration)" />
     </ItemGroup>
     <Hash
         ItemsToHash="@(_CreateAarInputs)"
@@ -80,6 +81,7 @@ projects.
         AndroidEnvironment="@(AndroidEnvironment)"
         JarFiles="@(AndroidJavaLibrary);@(EmbeddedJar)"
         NativeLibraries="@(EmbeddedNativeLibrary)"
+        ProguardConfigurationFiles="@(ProguardConfiguration)"
         OutputFile="$(_AarOutputPath)"
     />
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] NativeLibraries { get; set; }
 
+		public ITaskItem [] ProguardConfigurationFiles { get; set; }
+
 		[Required]
 		public string AssetDirectory { get; set; }
 
@@ -102,6 +104,13 @@ namespace Xamarin.Android.Tasks
 						aar.AddStream (File.OpenRead (lib.ItemSpec), archivePath);
 						existingEntries.Remove (archivePath);
 					}
+				}
+				if (ProguardConfigurationFiles != null) {
+					var sb = new StringBuilder ();
+					foreach (var file in ProguardConfigurationFiles) {
+						sb.AppendLine (File.ReadAllText (file.ItemSpec));
+					}
+					aar.AddEntry ("proguard.txt", sb.ToString (), Files.UTF8withoutBOM);
 				}
 				foreach (var entry in existingEntries) {
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
@@ -1,21 +1,21 @@
-// 
+//
 // ReadLibraryProjectImportsCache.cs
-//  
+//
 // Author:
 //       Dean Ellis <dean.ellis@xamarin.com>
-// 
+//
 // Copyright (c) 2015 Xamarin Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RLC";
 
 		[Required]
-		public string CacheFile { get; set;} 
+		public string CacheFile { get; set;}
 
 		[Output]
 		public ITaskItem [] Jars { get; set; }
@@ -55,6 +55,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ResolvedResourceDirectoryStamps { get; set; }
 
+		[Output]
+		public ITaskItem [] ProguardConfigFiles { get; set; }
+
 		public override bool RunTask ()
 		{
 			Log.LogDebugMessage ("Task ReadLibraryProjectImportsCache");
@@ -70,12 +73,14 @@ namespace Xamarin.Android.Tasks
 			ResolvedEnvironmentFiles = doc.GetPathsAsTaskItems ("ResolvedEnvironmentFiles", "ResolvedEnvironmentFile");
 			ResolvedResourceDirectoryStamps = doc.GetPathsAsTaskItems ("ResolvedResourceDirectoryStamps"
 				, "ResolvedResourceDirectoryStamp");
-			
+			ProguardConfigFiles = doc.GetPathsAsTaskItems ("ProguardConfigFiles", "ProguardConfigFile");
+
 			Log.LogDebugTaskItems ("  Jars: ", Jars);
 			Log.LogDebugTaskItems ("  ResolvedAssetDirectories: ", ResolvedAssetDirectories);
 			Log.LogDebugTaskItems ("  ResolvedResourceDirectories: ", ResolvedResourceDirectories);
 			Log.LogDebugTaskItems ("  ResolvedEnvironmentFiles: ", ResolvedEnvironmentFiles);
 			Log.LogDebugTaskItems ("  ResolvedResourceDirectoryStamps: ", ResolvedResourceDirectoryStamps);
+			Log.LogDebugTaskItems ("  ProguardConfigFiles: ", ProguardConfigFiles);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -55,6 +55,7 @@ This file is used by all project types, including binding projects.
       <Output TaskParameter="ResolvedAssetDirectories" ItemName="LibraryAssetDirectories" />
       <Output TaskParameter="ResolvedEnvironmentFiles" ItemName="LibraryEnvironments" />
       <Output TaskParameter="ResolvedResourceDirectoryStamps" ItemName="_LibraryResourceDirectoryStamps" />
+      <Output TaskParameter="ProguardConfigFiles" ItemName="ProguardConfiguration" />
     </ReadLibraryProjectImportsCache>
     <ItemGroup>
       <FileWrites Include="@(ResolvedResourceDirectories->'%(ResourceDirectoryArchive)')"


### PR DESCRIPTION
Fixes #3752

Add support for using `proguard.txt` file from `aar` files. 
Also add support for including `proguard.txt` files in our generated `aar` files when we build a Library project
in .net 6. This will merge all `ProguardConfiguration` Items into one `proguard.txt` file and include that in the 
root of the `aar`. 

Update the Unit Tests to include test for this functionality. 