### PR TITLE
[Xamarin.Andrid.Build.Tests] Add MultiUser unit tests

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@cfa21d57b22a9c5bc51d7720a0f830e166381000
+xamarin/monodroid:master@f38dbc7abe462887c4d4b6e99affd0f2eb31ab62
 mono/mono:2020-02@ac596375c762c6b8dbe3c802f0ce626004eab51c

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@f38dbc7abe462887c4d4b6e99affd0f2eb31ab62
+xamarin/monodroid:master@27736a7ffc48d606ab45598f761e873f8572f46a
 mono/mono:2020-02@ac596375c762c6b8dbe3c802f0ce626004eab51c

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@0eef889156e92ff0d47e62477f10798b6d5b5c29
+xamarin/monodroid:master@5bb29971bebc1b8f7ef9aacd8e68aebac43302d2
 mono/mono:2020-02@ac596375c762c6b8dbe3c802f0ce626004eab51c

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@5bb29971bebc1b8f7ef9aacd8e68aebac43302d2
+xamarin/monodroid:master@cfa21d57b22a9c5bc51d7720a0f830e166381000
 mono/mono:2020-02@ac596375c762c6b8dbe3c802f0ce626004eab51c

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -274,6 +274,30 @@ to `pkcs12`.
 
 Added in Xamarin.Android 10.2.
 
+
+## AndroidDeviceUserId
+
+Allows deploying and debugging the application under guest
+or work accounts. The value is the `uid` value you get
+from the following adb command
+
+```
+adb shell pm list users
+```
+
+This will return the following data
+
+```
+Users:
+	UserInfo{0:Owner:c13} running
+	UserInfo{10:Guest:404}
+```
+
+The `uid` is the first integer value. In the example they
+are `0` and `10`.
+
+Added in Xamarin.Android 11.2
+
 ## AndroidDexTool
 
 An enum-style property with valid

--- a/Documentation/release-notes/5311.md
+++ b/Documentation/release-notes/5311.md
@@ -1,0 +1,33 @@
+### Build and deployment performance
+
+* [GitHub PR 5311](https://github.com/xamarin/xamarin-android/pull/5311):
+  Add support for deploying and debugging against different user accounts
+  on Android Devices. In order to use this you need to specify the
+  `AndroidDeviceUserId` in either your csproj or on the command line.
+
+   ```xml
+    <PropertyGroup>
+      <AndroidDeviceUserId>10</AndroidDeviceUserId>
+    </PropertyGroup>
+    ```
+
+    ```
+    msbuild foo.csproj /t:Install /p:AndroidDeviceUserId=10
+    ```
+
+    The value is the `uid` value you get from the following adb command
+
+    ```
+    adb shell pm list users
+    ```
+
+    This will return the following data
+
+    ```
+    Users:
+      UserInfo{0:Owner:c13} running
+      UserInfo{10:Guest:404}
+    ```
+
+    The `uid` is the first integer value. In the example they
+    are `0` and `10`.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class DeviceTest: BaseTest
 	{
-		public readonly const string GuestUserName = "guest1";
+		public const string GuestUserName = "guest1";
 
 		[OneTimeSetUp]
 		public void DeviceSetup ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class DeviceTest: BaseTest
 	{
-		public static string GuestUserName = "guest1";
+		public readonly const string GuestUserName = "guest1";
 
 		[OneTimeSetUp]
 		public void DeviceSetup ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -287,14 +287,14 @@ namespace Xamarin.Android.Build.Tests
 			if (match.Success) {
 				return int.Parse (match.Groups ["userId"].Value);
 			}
-			if (username == "Owner")
-				return 0;
 			return -1;
 		}
 
 		protected static bool SwitchUser (string username)
 		{
 			int userId = GetUserId (username);
+			if (userId == -1)
+				userId = 0;
 			if (userId >= 0) {
 				RunAdbCommand ($"shell am switch-user {userId}");
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -13,11 +13,14 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class DeviceTest: BaseTest
 	{
+		public static string GuestUserName = "guest1";
+
 		[OneTimeSetUp]
 		public void DeviceSetup ()
 		{
 			SetAdbLogcatBufferSize (64);
 			RunAdbCommand ("logcat -c");
+			CreateGuestUser (GuestUserName);
 		}
 
 		[TearDown]
@@ -41,6 +44,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			ClearAdbLogcat ();
+
 
 			base.CleanupTest ();
 		}
@@ -259,6 +263,43 @@ namespace Xamarin.Android.Build.Tests
 				$"/mnt/shell/emulated/0/Android/data/{packageName}/files/.__override__",
 				$"/storage/sdcard/Android/data/{packageName}/files/.__override__",
 			};
+		}
+
+		protected static void CreateGuestUser (string username)
+		{
+			if (GetUserId (username) != -1)
+				RunAdbCommand ($"shell pm create-user --guest {username}");
+		}
+
+		protected static void DeleteGuestUser (string username)
+		{
+			int userId = GetUserId (username);
+			if (userId > 0)
+				RunAdbCommand ($"shell pm remove-user --guest {userId}");
+		}
+
+		protected static int GetUserId (string username)
+		{
+			string output = RunAdbCommand ($"shell pm list users");
+			Regex regex = new Regex (@"UserInfo{(?<userId>\d+):" + username, RegexOptions.Compiled);
+			Console.WriteLine (output);
+			var match = regex.Match (output);
+			if (match.Success) {
+				return int.Parse (match.Groups ["userId"].Value);
+			}
+			if (username == "Owner")
+				return 0;
+			return -1;
+		}
+
+		protected static bool SwitchUser (string username)
+		{
+			int userId = GetUserId (username);
+			if (userId >= 0) {
+				RunAdbCommand ($"shell am switch-user {userId}");
+				return true;
+			}
+			return false;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -40,6 +40,7 @@ namespace Xamarin.ProjectTools
 			if (Builder.UseDotNet) {
 				SetProperty (KnownProperties.OutputType, "Exe");
 				SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
+				SetProperty ("_FastDeploymentDiagnosticLogging", "True");
 
 				// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
 				Imports.Add (new Import (() => "Directory.Build.targets") {
@@ -51,6 +52,7 @@ namespace Xamarin.ProjectTools
 						</Project>"
 				});
 			} else {
+				SetProperty ("_FastDeploymentDiagnosticLogging", "True");
 				SetProperty ("AndroidApplication", "True");
 				SetProperty ("AndroidResgenClass", "Resource");
 				SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -253,6 +253,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			AssertHasDevices ();
 
+			appBuilder.BuildLogFile = "install.log";
 			Assert.IsTrue (appBuilder.RunTarget (app, "Install"), "App should have installed.");
 
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.apks");

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -300,9 +300,9 @@ namespace ${ROOT_NAMESPACE} {
 			AssertHasDevices ();
 
 			int userId = GetUserId (username);
-			string [] parameters = null;
+			List<string> parameters = new List<string>;
 			if (userId >= 0)
-				parameters = new string [] { $"AndroidDeviceUserId={userId}" };
+				parameters.Add ($"AndroidDeviceUserId={userId}");
 			if (SwitchUser (username)) {
 				WaitFor (5);
 				ClickButton ("", "android:id/button1", "Yes continue");
@@ -318,7 +318,7 @@ namespace ${ROOT_NAMESPACE} {
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				Assert.True (b.Install (proj, parameters: parameters), "Project should have installed.");
+				Assert.True (b.Install (proj, parameters: parameters.ToArray ()), "Project should have installed.");
 
 				int breakcountHitCount = 0;
 				ManualResetEvent resetEvent = new ManualResetEvent (false);
@@ -351,12 +351,13 @@ namespace ${ROOT_NAMESPACE} {
 				options.EvaluationOptions.UseExternalTypeResolver = true;
 				ClearAdbLogcat ();
 				b.BuildLogFile = "run.log";
-				Assert.True (b.RunTarget (proj, "_Run", doNotCleanupOnUpdate: true, parameters: new string [] {
-					$"AndroidSdbTargetPort={port}",
-					$"AndroidSdbHostPort={port}",
-					"AndroidAttachDebugger=True",
-					$"AndroidDeviceUserId={userId}"
-				}), "Project should have run.");
+
+				parameters.Add ($"AndroidSdbTargetPort={port}");
+				parameters.Add ($"AndroidSdbHostPort={port}");
+				parameters.Add ("AndroidAttachDebugger=True");
+
+				Assert.True (b.RunTarget (proj, "_Run", doNotCleanupOnUpdate: true,
+					parameters: parameters.ToArray ()), "Project should have run.");
 
 				Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, b.ProjectDirectory, "logcat.log")), "Activity should have started");
 				// we need to give a bit of time for the debug server to start up.

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -8,6 +8,7 @@ using Mono.Debugging.Client;
 using Mono.Debugging.Soft;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
+using System.Collections.Generic;
 
 namespace Xamarin.Android.Build.Tests
 {

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -300,7 +300,7 @@ namespace ${ROOT_NAMESPACE} {
 			AssertHasDevices ();
 
 			int userId = GetUserId (username);
-			List<string> parameters = new List<string>;
+			List<string> parameters = new List<string> ();
 			if (userId >= 0)
 				parameters.Add ($"AndroidDeviceUserId={userId}");
 			if (SwitchUser (username)) {

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -251,31 +251,31 @@ namespace ${ROOT_NAMESPACE} {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
-				/* user */		 "Owner",
+				/* user */		 null,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
-				/* user */		 "Owner",
+				/* user */		 null,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  true,
-				/* user */		 "Owner",
+				/* user */		 null,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  false,
-				/* user */		 "Owner",
+				/* user */		 null,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  true,
-				/* user */		 "Owner",
+				/* user */		 null,
 			},
 			new object[] {
 				/* embedAssemblies */    true,
@@ -300,6 +300,9 @@ namespace ${ROOT_NAMESPACE} {
 			AssertHasDevices ();
 
 			int userId = GetUserId (username);
+			string [] parameters = null;
+			if (userId >= 0)
+				parameters = new string [] { $"AndroidDeviceUserId={userId}" };
 			if (SwitchUser (username)) {
 				WaitFor (5);
 				ClickButton ("", "android:id/button1", "Yes continue");
@@ -315,7 +318,7 @@ namespace ${ROOT_NAMESPACE} {
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				Assert.True (b.Install (proj, parameters: new string [] { $"AndroidDeviceUserId={userId}" }), "Project should have installed.");
+				Assert.True (b.Install (proj, parameters: parameters), "Project should have installed.");
 
 				int breakcountHitCount = 0;
 				ManualResetEvent resetEvent = new ManualResetEvent (false);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -357,9 +357,9 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { false, false , "apk"     , "True"         , "file:android", "-keystore test.keystore", true},
 			new object[] { false, true  , "apk"     , "True"         , "file:android", "-keystore test.keystore", true},
 			// aab signing tests
-			new object[] { true,  true  , "aab"     , "True"         , "android",      "-ks test.keystore"      , true},
-			new object[] { true,  true  , "aab"     , "True"         , "file:android", "-ks test.keystore"      , true},
-			new object[] { true,  true  , "aab"     , "True"         , "env:android",  "-ks test.keystore"      , false},
+			new object[] { true,  true  , "aab"     , "True"         , "android",      "-keystore test.keystore"      , true},
+			new object[] { true,  true  , "aab"     , "True"         , "file:android", "-keystore test.keystore"      , true},
+			new object[] { true,  true  , "aab"     , "True"         , "env:android",  "-keystore test.keystore"      , false},
 		};
 #pragma warning restore 414
 
@@ -412,16 +412,10 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (path, false, false)) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj, environmentVariables: envVar), "Build should have succeeded.");
-				if (packageFormat == "apk") {
-					StringAssertEx.Contains (expected, b.LastBuildOutput,
-					"The Wrong keystore was used to sign the apk");
-				}
+				StringAssertEx.Contains (expected, b.LastBuildOutput,
+					"The Wrong keystore was used to sign the ${packageFormat}");
 				b.BuildLogFile = "install.log";
 				Assert.AreEqual (shouldInstall, b.Install (proj, doNotCleanupOnUpdate: true), $"Install should have {(shouldInstall ? "succeeded" : "failed")}.");
-				if (packageFormat == "aab") {
-					StringAssertEx.Contains (expected, b.LastBuildOutput,
-						"The Wrong keystore was used to sign the apk");
-				}
 				if (!shouldInstall)
 					return;
 				b.BuildLogFile = "uninstall.log";

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -357,9 +357,9 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { false, false , "apk"     , "True"         , "file:android", "-keystore test.keystore", true},
 			new object[] { false, true  , "apk"     , "True"         , "file:android", "-keystore test.keystore", true},
 			// aab signing tests
-			new object[] { true,  true  , "aab"     , "True"         , "android",      "-keystore test.keystore"      , true},
-			new object[] { true,  true  , "aab"     , "True"         , "file:android", "-keystore test.keystore"      , true},
-			new object[] { true,  true  , "aab"     , "True"         , "env:android",  "-keystore test.keystore"      , false},
+			new object[] { true,  true  , "aab"     , "True"         , "android",      "-ks test.keystore"      , true},
+			new object[] { true,  true  , "aab"     , "True"         , "file:android", "-ks test.keystore"      , true},
+			new object[] { true,  true  , "aab"     , "True"         , "env:android",  "-ks test.keystore"      , false},
 		};
 #pragma warning restore 414
 
@@ -412,10 +412,16 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (path, false, false)) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj, environmentVariables: envVar), "Build should have succeeded.");
-				StringAssertEx.Contains (expected, b.LastBuildOutput,
-					"The Wrong keystore was used to sign the ${packageFormat}");
+				if (packageFormat == "apk") {
+					StringAssertEx.Contains (expected, b.LastBuildOutput,
+					"The Wrong keystore was used to sign the apk");
+				}
 				b.BuildLogFile = "install.log";
 				Assert.AreEqual (shouldInstall, b.Install (proj, doNotCleanupOnUpdate: true), $"Install should have {(shouldInstall ? "succeeded" : "failed")}.");
+				if (packageFormat == "aab") {
+					StringAssertEx.Contains (expected, b.LastBuildOutput,
+						"The Wrong keystore was used to sign the apk");
+				}
 				if (!shouldInstall)
 					return;
 				b.BuildLogFile = "uninstall.log";


### PR DESCRIPTION
This commit adds support for running multi user tests on device.
It makes use of various adb commands to create test users and
remove them.

`shell pm create-user --guest {name}` will create a guest user of a
specific name.

`shell pm remove-user --guest {userId}` will remove a userId.

The userId can be retrieved via `shell pm list users`. This command
will return results as follows

    Users:
	    UserInfo{0:Owner:c13} running
	    UserInfo{10:guest1:414}

We can then use a RegEx to pull out the required `userId` for a specific
user.

Finally `shell am switch-user {userId}` can be used to switch between
users on the device.

Emulators seem to create the main user with the name "Owner" so that should
be the default name we use for the main user. In the unit tests if we
cannot find a user named "Owner" when looking for "Owner" we will default
to a `userId` of `0`. This always means the default user. This is to handle
the case where we are testing locally on devices where the main user is
not called "Owner".