### PR TITLE
[ci] Use unique storage URLs for installers

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1182,7 +1182,7 @@ stages:
       parameters:
         ArtifactsDirectory: $(System.DefaultWorkingDirectory)\installer-artifacts
         Azure.ContainerName: $(Azure.Container.Name)
-        Azure.BlobPrefix: $(Build.DefinitionName)/public/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        Azure.BlobPrefix: $(Build.DefinitionName)/public/net6/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
         GitHub.Context: .NET 6 Preview Installers
 
     - template: yaml-templates/upload-results.yaml


### PR DESCRIPTION
Commit b864f93d appears to have broken the GitHub status for the .NET 6
installers.  These changes resulted in us attempting to use the same
blob storage location for both legacy and .NET 6 installers, and the
step which ran last (often legacy, as signing takes a while) would write
over the previous status.  Adding `net6` to the .NET 6 installer blob
storage path should fix this.