### PR TITLE
[Xamarin.Android.Build.Tasks] fix incremental _ManifestMerger target

### DIFF
--- a/Documentation/release-notes/5314.md
+++ b/Documentation/release-notes/5314.md
@@ -1,0 +1,8 @@
+### Build and deployment performance
+
+  * [GitHub PR 5314](https://github.com/xamarin/xamarin-android/pull/5314):
+    Fixed an issue that could cause the Android [manifest
+    merger][manifest-merger] to always run on incremental builds. This
+    reduced incremental build times by 296ms in a small test project.
+
+[manifest-merger]: https://developer.android.com/studio/build/manifest-merge

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
@@ -44,7 +44,10 @@ namespace Xamarin.Android.Tasks
 				var ms = MemoryStreamPool.Shared.Rent ();
 				try {
 					m.Save (Log, ms, removeNodes: true);
-					MonoAndroidHelper.CopyIfStreamChanged (ms, OutputManifestFile);
+					if (!MonoAndroidHelper.CopyIfStreamChanged (ms, OutputManifestFile)) {
+						// NOTE: We still need to update the timestamp on this file, or the target would run again
+						File.SetLastWriteTimeUtc (OutputManifestFile, DateTime.UtcNow);
+					}
 					return result;
 				} finally {
 					MemoryStreamPool.Shared.Return (ms);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -519,6 +519,27 @@ namespace Lib2
 		}
 
 		[Test]
+		public void ManifestMergerIncremental ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				ManifestMerger = "manifestmerger.jar"
+			};
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "first build should succeed");
+				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");
+
+				// Change .csproj & build again
+				proj.SetProperty ("Foo", "Bar");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should succeed");
+				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");
+
+				// Build with no changes
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build should succeed");
+				b.Output.AssertTargetIsSkipped ("_ManifestMerger");
+			}
+		}
+
+		[Test]
 		[Category ("SmokeTests")]
 		public void ProduceReferenceAssembly ()
 		{


### PR DESCRIPTION
When testing a .NET 6 project using AndroidX and
`$(AndroidManifestMerger)` = `manifestmerger.jar`, I noticed:

1. I edited the `.csproj` file and did various incremental builds.
2. During `dotnet build`, the `_ManifestMerger` MSBuild target was
   always running--even if there were no changes.

I was able to reproduce the issue in a test, even in "legacy"
Xamarin.Android:

    Building target "_ManifestMerger" completely.
    Input file "obj\Debug\AndroidManifest.xml" is newer than output file "obj\Debug\android\AndroidManifest.xml".

What appears to be happening is:

1. The `Inputs` to `_ManifestMerger` changed.
2. The `Outputs` had identical contents and so
   `MonoAndroidHelper.CopyIfStreamChanged()` did not actually write a
   file.

At this point you are stuck in a place where the `Inputs` will be
perpetually newer than the `Outputs`.

To solve the issue, we can simply call `File.SetLastWriteTimeUtc()`
when `CopyIfStreamChanged()` returns `false` in the `<ManifestMerger/>`
MSBuild task.

This saved ~296ms for incremental builds of a "Hello World" project on
my Windows PC.