### PR TITLE
[Xamarin.Android.Build.Tasks] Link Resource Nested Types from assemblies

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -696,6 +696,27 @@ used in Android Application projects. The default value is
 <AndroidLinkMode>SdkOnly</AndroidLinkMode>
 ```
 
+## AndroidLinkResources
+
+When `true` this will make the build system link out the Nested Types
+of the Resource.Designer.cs `Resource` class in all assemblies. The
+IL code that uses those types will be updated to use the values
+directly rather than accessing fields.
+
+This can have a small impact on reducing the apk size, it might also
+help slightly with startup performance. This will only effect "Release"
+based builds.
+
+***Experimental***.  Only designed to work with code such as
+
+```
+var view = FindViewById(Resources.Ids.foo);
+```
+
+Any other scenarios (such as reflection) will not be supported.
+
+Added in Xamarin.Android 11.3.
+
 ## AndroidLinkSkip
 
 Specifies a semicolon-delimited (`;`)

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Android.Sdk.ILLink
 			if (Context.TryGetCustomData ("AddKeepAlivesStep", out addKeepAlivesStep) && bool.TryParse (addKeepAlivesStep, out var bv) && bv)
 				InsertAfter (new AddKeepAlivesStep (cache), "CleanStep");
 
+			string androidLinkResources;
+			if (Context.TryGetCustomData ("AndroidLinkResources", out androidLinkResources) && bool.TryParse (androidLinkResources, out var linkResources) && linkResources) {
+				InsertAfter (new RemoveResourceDesignerStep (),  "CleanStep");
+				InsertAfter (new GetAssembliesStep (), "CleanStep");
+			}
 			InsertAfter (new StripEmbeddedLibraries (),  "CleanStep");
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AndroidLinkConfiguration.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AndroidLinkConfiguration.cs
@@ -1,0 +1,27 @@
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+using System;
+using System.Linq;
+using Xamarin.Android.Tasks;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Mono.Cecil.Cil;
+
+namespace MonoDroid.Tuner
+{
+	public class AndroidLinkConfiguration {
+		public List<AssemblyDefinition> Assemblies { get; private set; } = new List<AssemblyDefinition> ();
+
+		static ConditionalWeakTable<LinkContext, AndroidLinkConfiguration> configurations = new ConditionalWeakTable<LinkContext, AndroidLinkConfiguration> ();
+
+		public static AndroidLinkConfiguration GetInstance (LinkContext context)
+		{
+			if (!configurations.TryGetValue (context, out AndroidLinkConfiguration config)) {
+				config = new AndroidLinkConfiguration ();
+				configurations.Add (context, config);
+			}
+			return config;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 using Mono.Linker;
 
@@ -326,6 +327,40 @@ namespace MonoDroid.Tuner {
 				}
 
 			return false;
+		}
+
+		public static Instruction CreateLoadArraySizeOrOffsetInstruction (int intValue)
+		{
+			if (intValue < 0)
+				throw new ArgumentException ($"{nameof (intValue)} cannot be negative");
+
+			if (intValue < 9) {
+				switch (intValue) {
+				case 0:
+					return Instruction.Create (OpCodes.Ldc_I4_0);
+				case 1:
+					return Instruction.Create (OpCodes.Ldc_I4_1);
+				case 2:
+					return Instruction.Create (OpCodes.Ldc_I4_2);
+				case 3:
+					return Instruction.Create (OpCodes.Ldc_I4_3);
+				case 4:
+					return Instruction.Create (OpCodes.Ldc_I4_4);
+				case 5:
+					return Instruction.Create (OpCodes.Ldc_I4_5);
+				case 6:
+					return Instruction.Create (OpCodes.Ldc_I4_6);
+				case 7:
+					return Instruction.Create (OpCodes.Ldc_I4_7);
+				case 8:
+					return Instruction.Create (OpCodes.Ldc_I4_8);
+				}
+			}
+
+			if (intValue < 128)
+				return Instruction.Create (OpCodes.Ldc_I4_S, (sbyte)intValue);
+
+			return Instruction.Create (OpCodes.Ldc_I4, intValue);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/GetAssembliesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/GetAssembliesStep.cs
@@ -1,0 +1,28 @@
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+using System;
+using System.Linq;
+using Xamarin.Android.Tasks;
+using System.Collections.Generic;
+using Mono.Cecil.Cil;
+
+namespace MonoDroid.Tuner
+{
+	public class GetAssembliesStep : BaseStep
+	{
+		AndroidLinkConfiguration config = null;
+
+		protected override void Process ()
+		{
+			config = AndroidLinkConfiguration.GetInstance (Context);
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (config == null)
+				return;
+			config.Assemblies.Add (assembly);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -77,7 +77,7 @@ namespace MonoDroid.Tuner
 				pipeline.AppendStep (new LoadI18nAssemblies (options.I18nAssemblies));
 
 			pipeline.AppendStep (new BlacklistStep ());
-			
+
 			foreach (var desc in options.LinkDescriptions)
 				pipeline.AppendStep (new ResolveFromXmlStep (new XPathDocument (desc)));
 
@@ -121,6 +121,11 @@ namespace MonoDroid.Tuner
 			pipeline.AppendStep (new StripEmbeddedLibraries ());
 			if (options.AddKeepAlives)
 				pipeline.AppendStep (new AddKeepAlivesStep (cache));
+
+			if (options.LinkResources) {
+				pipeline.AppendStep (new GetAssembliesStep ());
+				pipeline.AppendStep (new RemoveResourceDesignerStep ());
+			}
 			// end monodroid specific
 			pipeline.AppendStep (new RegenerateGuidStep ());
 			pipeline.AppendStep (new OutputStepWithTimestamps ());

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -25,5 +25,6 @@ namespace MonoDroid.Tuner
 		public bool AddKeepAlives { get; set; }
 		public bool PreserveJniMarshalMethods { get; set; }
 		public bool DeterministicOutput { get; set; }
+		public bool LinkResources { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
@@ -1,0 +1,210 @@
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+using System;
+using System.Linq;
+using Xamarin.Android.Tasks;
+using System.Collections.Generic;
+using Mono.Cecil.Cil;
+using System.Text.RegularExpressions;
+
+namespace MonoDroid.Tuner
+{
+	public class RemoveResourceDesignerStep : BaseStep
+	{
+		TypeDefinition mainDesigner = null;
+		AssemblyDefinition mainAssembly = null;
+		CustomAttribute mainDesignerAttribute;
+		Dictionary<string, int> designerConstants;
+		Regex opCodeRegex = new Regex (@"([\w]+): ([\w]+) ([\w.]+) ([\w:./]+)");
+
+		protected override void Process ()
+		{
+			// resolve the MainAssembly Resource designer TypeDefinition
+			AndroidLinkConfiguration config = AndroidLinkConfiguration.GetInstance (Context);
+			if (config == null)
+				return;
+			foreach(var asm in config.Assemblies) {
+				if (FindResourceDesigner (asm, mainApplication: true, designer: out mainDesigner, designerAttribute: out mainDesignerAttribute)) {
+					mainAssembly = asm;
+				 	break;
+				}
+			}
+			if (mainDesigner == null) {
+				Context.LogMessage ($"  Main Designer not found.");
+				return;
+			}
+			Context.LogMessage ($"  Main Designer found {mainDesigner.FullName}.");
+			designerConstants = BuildResourceDesignerFieldLookup (mainDesigner);
+		}
+
+		protected override void EndProcess ()
+		{
+			if (mainDesigner != null) {
+				Context.LogMessage ($"  Setting Action on {mainAssembly.Name} to Save.");
+				Annotations.SetAction (mainAssembly, AssemblyAction.Save);
+			}
+		}
+
+		bool FindResourceDesigner (AssemblyDefinition assembly, bool mainApplication, out TypeDefinition designer, out CustomAttribute designerAttribute)
+		{
+			string designerFullName = null;
+			designer = null;
+			designerAttribute = null;
+			foreach (CustomAttribute attribute in assembly.CustomAttributes)
+			{
+				if (attribute.AttributeType.FullName == "Android.Runtime.ResourceDesignerAttribute")
+				{
+					designerAttribute = attribute;
+					if (attribute.HasProperties)
+					{
+						foreach (var p in attribute.Properties)
+						{
+							if (p.Name == "IsApplication" && (bool)p.Argument.Value == (mainApplication ? mainApplication : (bool)p.Argument.Value))
+							{
+								designerFullName = attribute.ConstructorArguments[0].Value.ToString ();
+								break;
+							}
+						}
+					}
+					break;
+
+				}
+			}
+			if (string.IsNullOrEmpty(designerFullName))
+				return false;
+
+			foreach (ModuleDefinition module in assembly.Modules)
+			{
+				foreach (TypeDefinition type in module.Types)
+				{
+					if (type.FullName == designerFullName)
+					{
+						designer = type;
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		Dictionary<string, int> BuildResourceDesignerFieldLookup (TypeDefinition type)
+		{
+			var output = new Dictionary<string, int> ();
+			foreach (TypeDefinition definition in type.NestedTypes)
+			{
+				foreach (FieldDefinition field in definition.Fields)
+				{
+					string key = $"{definition.Name}::{field.Name}";
+					if (!output.ContainsKey (key))
+						output.Add(key, int.Parse (field.Constant?.ToString () ?? "0"));
+				}
+			}
+			return output;
+		}
+
+		void ClearDesignerClass (TypeDefinition designer)
+		{
+			Context.LogMessage ($"    TryRemoving {designer.FullName}");
+			designer.NestedTypes.Clear ();
+			designer.Methods.Clear ();
+			designer.Fields.Clear ();
+			designer.Properties.Clear ();
+			designer.CustomAttributes.Clear ();
+			designer.Interfaces.Clear ();
+			designer.Events.Clear ();
+		}
+
+		void FixBody (MethodBody body, TypeDefinition localDesigner)
+		{
+			Dictionary<Instruction, int> instructions = new Dictionary<Instruction, int>();
+			var processor = body.GetILProcessor ();
+			string designerFullName = $"{localDesigner.FullName}/";
+			foreach (var i in body.Instructions)
+			{
+				string line = i.ToString ();
+				if (line.Contains (designerFullName) && !instructions.ContainsKey (i))
+				{
+					var match = opCodeRegex.Match (line);
+					if (match.Success && match.Groups.Count == 5) {
+						string key = match.Groups[4].Value.Replace (designerFullName, string.Empty);
+						if (designerConstants.ContainsKey (key) && !instructions.ContainsKey (i))
+							instructions.Add(i, designerConstants [key]);
+					}
+				}
+			}
+			if (instructions.Count > 0)
+				Context.LogMessage ($"    Fixing up {body.Method.FullName}");
+			foreach (var i in instructions)
+			{
+				var newCode = Extensions.CreateLoadArraySizeOrOffsetInstruction (i.Value);
+				Context.LogMessage ($"      Replacing {i.Key}");
+				Context.LogMessage ($"      With {newCode}");
+				processor.Replace(i.Key, newCode);
+			}
+		}
+
+		void FixType (TypeDefinition type, TypeDefinition localDesigner)
+		{
+			foreach (MethodDefinition method in type.Methods)
+			{
+				if (!method.HasBody)
+					continue;
+				FixBody (method.Body, localDesigner);
+			}
+			foreach (PropertyDefinition property in type.Properties)
+			{
+				if (property.GetMethod != null && property.GetMethod.HasBody)
+				{
+					FixBody (property.GetMethod.Body, localDesigner);
+				}
+				if (property.SetMethod != null && property.SetMethod.HasBody)
+				{
+					FixBody (property.SetMethod.Body, localDesigner);
+				}
+			}
+			foreach (TypeDefinition nestedType in type.NestedTypes)
+			{
+				FixType (nestedType, localDesigner);
+			}
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			if (mainDesigner == null)
+				return;
+			var fileName = assembly.Name.Name + ".dll";
+			if (MonoAndroidHelper.IsFrameworkAssembly (fileName))
+				return;
+
+			Context.LogMessage ($"  Fixing up {assembly.Name.Name}");
+			TypeDefinition localDesigner = null;
+			CustomAttribute designerAttribute;
+			if (assembly != mainAssembly) {
+				Context.LogMessage ($"   {assembly.Name.Name} is not the main assembly. ");
+				if (!FindResourceDesigner (assembly, mainApplication: false, designer: out localDesigner, designerAttribute: out designerAttribute)) {
+					Context.LogMessage ($"   {assembly.Name.Name} does not have a designer file.");
+					return;
+				}
+			} else {
+				Context.LogMessage ($"   {assembly.Name.Name} is the main assembly. ");
+				localDesigner = mainDesigner;
+				designerAttribute = mainDesignerAttribute;
+			}
+
+			Context.LogMessage ($"   {assembly.Name.Name} has designer {localDesigner.FullName}.");
+
+			foreach (var mod in assembly.Modules) {
+				foreach (var type in mod.Types) {
+					if (type == localDesigner)
+						continue;
+					FixType (type, localDesigner);
+				}
+			}
+			ClearDesignerClass (localDesigner);
+			if (designerAttribute != null) {
+				assembly.CustomAttributes.Remove (designerAttribute);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -50,6 +50,10 @@ This file contains the .NET 5-specific targets to customize ILLink
       <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data ProguardConfiguration="$(_ProguardProjectConfiguration)"</_ExtraTrimmerArgs>
     </PropertyGroup>
     <PropertyGroup
+        Condition=" '$(AndroidLinkResources)' != '' ">
+      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --custom-data AndroidLinkResources="$(AndroidLinkResources)"</_ExtraTrimmerArgs>
+    </PropertyGroup>
+    <PropertyGroup
         Condition=" '$(LinkerDumpDependencies)' == 'true' ">
       <_ExtraTrimmerArgs>--dump-dependencies $(_ExtraTrimmerArgs)"</_ExtraTrimmerArgs>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -56,6 +56,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool Deterministic { get; set; }
 
+		public bool LinkResources { get; set; }
+
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
 			List<AssemblyDefinition> retainList = null;
@@ -106,6 +108,7 @@ namespace Xamarin.Android.Tasks
 			options.AddKeepAlives = AddKeepAlives;
 			options.PreserveJniMarshalMethods = PreserveJniMarshalMethods;
 			options.DeterministicOutput = Deterministic;
+			options.LinkResources = LinkResources;
 
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -860,6 +860,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion;_ResolveMonoAndroidSdks">
 	<PropertyGroup>
 		<AndroidAddKeepAlives Condition="'$(AndroidAddKeepAlives)' == '' And '$(AndroidIncludeDebugSymbols)' != 'True'">True</AndroidAddKeepAlives>
+		<AndroidLinkResources Condition="'$(AndroidLinkResources)' == '' And '$(AndroidIncludeDebugSymbols)' != 'True'">False</AndroidLinkResources>
 		<_AndroidBuildPropertiesCacheExists Condition=" Exists('$(_AndroidBuildPropertiesCache)') ">True</_AndroidBuildPropertiesCacheExists>
 		<_NuGetAssetsFile      Condition=" Exists('$(ProjectLockFile)') ">$(ProjectLockFile)</_NuGetAssetsFile>
 		<_NuGetAssetsFile      Condition=" '$(_NuGetAssetsFile)' == '' and Exists('packages.config') ">packages.config</_NuGetAssetsFile>
@@ -878,6 +879,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />
 		<_PropertyCacheItems Include="AndroidLinkTool=$(AndroidLinkTool)" />
+		<_PropertyCacheItems Include="AndroidLinkResources=$(AndroidLinkResources)" />
 		<_PropertyCacheItems Include="AndroidPackageFormat=$(AndroidPackageFormat)" />
 		<_PropertyCacheItems Include="EmbedAssembliesIntoApk=$(EmbedAssembliesIntoApk)" />
 		<_PropertyCacheItems Include="AndroidLinkMode=$(AndroidLinkMode)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -399,7 +399,7 @@ projects. .NET 5 projects will not import this file.
 
   <Target Name="_ConvertDebuggingFiles"
       Inputs="$(OutDir)$(TargetFileName);$(_IntermediatePdbFile)"
-      Outputs="$(OutDir)$(TargetFileName).mdb" 
+      Outputs="$(OutDir)$(TargetFileName).mdb"
       DependsOnTargets="_ValidateAndroidPackageProperties">
     <ConvertDebuggingFiles Files="$(OutDir)$(TargetFileName)" />
     <Touch Files="$(OutDir)$(TargetFileName).mdb" />
@@ -638,6 +638,7 @@ projects. .NET 5 projects will not import this file.
         LinkDescriptions="@(LinkDescription)"
         ProguardConfiguration="$(_ProguardProjectConfiguration)"
         AddKeepAlives="$(AndroidAddKeepAlives)"
+        LinkResources="$(AndroidLinkResources)"
         PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
         EnableProguard="$(AndroidEnableProguard)"
         Deterministic="$(Deterministic)"


### PR DESCRIPTION
The idea is to remove the `Resource` class NestedTypes from the final
linked assemblies in release mode. We do this by examining all the
locations where the fields are used and replacing those IL calls with a
call which specifies the actual resource id directly. This will remove
the need to call `global::Android.Runtime.ResourceIdManager.UpdateIdValues();`
completely. It will also allow us to completely remove the `Resource`
class sub classes. Due to an odd linker failure we cannot completely
remove the `Resource` class itself. However it will be completely empty.

As mentioned the call to `UpdateIdValues` will no  longer be required.
This should reduce startup time slightly. One thing to note is this will
only be true for Release apps when enabled. Debug apps will still
call `UpdateIdValues`. This is due to the time is takes to run
the Linker Step. Applying this to a Debug build would effect the  build
times during development.

A new MSBuild property `AndroidLinkResources` has been added to control
this feature. It is turned off by default for now.

This seems to save between 100-280kb for an apk. This is dependent on
how many assemblies are Android assemblies and contain or use Resources.

Xamarin.Forms base app apkdiff results

```
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  -          10 assemblies/Mono.Android.dll
  -       4,001 assemblies/Xamarin.Essentials.dll
  -      45,426 assemblies/Xamarin.Forms.Platform.Android.dll
  -     102,839 assemblies/formstest.Android.dll
Summary:
  +           0 Other entries 0.00% (of 887,808)
  +           0 Dalvik executables 0.00% (of 3,341,152)
  -     152,276 Assemblies -3.23% (of 4,709,077)
  +           0 Shared libraries 0.00% (of 41,693,796)
  -     151,552 Package size difference -0.73% (of 20,820,695)
```

Maps sample apkdiff results

```
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  -           4 lib/armeabi-v7a/libxamarin-app.so
  -          14 assemblies/Mono.Android.dll
  -       4,757 assemblies/Xamarin.Essentials.dll
  -      46,051 assemblies/Xamarin.Forms.Platform.dll
  -      47,586 assemblies/Xamarin.Forms.Platform.Android.dll
  -      48,470 assemblies/Xamarin.Forms.Maps.Android.dll
  -     135,589 assemblies/FormsMapsSample.Android.dll
Summary:
  +           0 Other entries 0.00% (of 1,137,209)
  +           0 Dalvik executables 0.00% (of 2,519,972)
  -     282,467 Assemblies -5.51% (of 5,123,833)
  -           4 Shared libraries -0.00% (of 41,843,596)
  -     282,624 Package size difference -1.34% (of 21,075,664)
```