### PR TITLE
[Xamarin.Android.Build.Tasks] Make Proguard mapping.txt opt-in

### DIFF
--- a/Documentation/release-notes/5304.md
+++ b/Documentation/release-notes/5304.md
@@ -7,3 +7,12 @@
         "This App Bundle contains Java/Kotlin code, which might be obfuscated."
 
     when uploading packages to the Google Play Store.
+
+    In order to opt-in to this behavior, set the `$(AndroidProguardMappingFile)`
+    property in your project file to the path of the file you want generated:
+
+    ```xml
+    <PropertyGroup>
+      <AndroidProguardMappingFile>$(OutputPath)\mapping.txt</AndroidProguardMappingFile>
+    </PropertyGroup>
+    ```

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -2,10 +2,6 @@
 
 -dontobfuscate
 
-# required for publishing proguard mapping file
--keepattributes SourceFile
--keepattributes LineNumberTable
-
 -keep class android.support.multidex.MultiDexApplication { <init>(); }
 -keep class com.xamarin.java_interop.** { *; <init>(); }
 -keep class mono.MonoRuntimeProvider* { *; <init>(...); }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -118,12 +118,16 @@ namespace Xamarin.Android.Tasks
 						// skip invalid lines
 					}
 
-			if (!string.IsNullOrWhiteSpace (ProguardCommonXamarinConfiguration))
+			if (!string.IsNullOrWhiteSpace (ProguardCommonXamarinConfiguration)) {
 				using (var xamcfg = File.CreateText (ProguardCommonXamarinConfiguration)) {
 					GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg.BaseStream);
-					if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+					if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
+						xamcfg.WriteLine ("-keepattributes SourceFile");
+						xamcfg.WriteLine ("-keepattributes LineNumberTable");
 						xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+					}
 				}
+			}
 
 			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -100,8 +100,11 @@ namespace Xamarin.Android.Tasks
 						if (IgnoreWarnings) {
 							xamcfg.WriteLine ("-ignorewarnings");
 						}
-						if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+						if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
+							xamcfg.WriteLine ("-keepattributes SourceFile");
+							xamcfg.WriteLine ("-keepattributes LineNumberTable");
 							xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+						}
 					}
 				}
 			} else {
@@ -118,8 +121,11 @@ namespace Xamarin.Android.Tasks
 				if (IgnoreWarnings) {
 					lines.Add ("-ignorewarnings");
 				}
-				if (!string.IsNullOrEmpty (ProguardMappingFileOutput))
+				if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
+					lines.Add ("-keepattributes SourceFile");
+					lines.Add ("-keepattributes LineNumberTable");
 					lines.Add ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+				}
 				File.WriteAllLines (temp, lines);
 				tempFiles.Add (temp);
 				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -56,11 +56,11 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidDexTool, "d8");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+			// Projects must provide a $(AndroidProguardMappingFile) value to opt in
+			proj.SetProperty (proj.ReleaseProperties, "AndroidProguardMappingFile", @"$(OutputPath)\mapping.txt");
 
 			using (var b = CreateApkBuilder ()) {
 				string mappingFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "mapping.txt");
-				// Projects must provide a $(AndroidProguardMappingFile) value to opt in
-				proj.SetProperty (proj.ReleaseProperties, "AndroidProguardMappingFile", mappingFile);
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				FileAssert.Exists (mappingFile, $"'{mappingFile}' should have been generated.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -56,9 +56,12 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidDexTool, "d8");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
+
 			using (var b = CreateApkBuilder ()) {
-				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				string mappingFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "mapping.txt");
+				// Projects must provide a $(AndroidProguardMappingFile) value to opt in
+				proj.SetProperty (proj.ReleaseProperties, "AndroidProguardMappingFile", mappingFile);
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				FileAssert.Exists (mappingFile, $"'{mappingFile}' should have been generated.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -275,7 +275,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == '' And '$(AndroidEnableProguard)' == 'True' ">proguard</AndroidLinkTool>
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidEnableDesugar)' == 'True' ">r8</AndroidLinkTool>
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
-  <AndroidProguardMappingFile Condition=" '$(AndroidProguardMappingFile)' == '' ">$(OutputPath)mapping.txt</AndroidProguardMappingFile>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5304

The Proguard mapping.txt PR was not quite ready for prime time and has
seemingly caused some new proguard test failures and an .apk size
regression in our Xamarin.Forms baseline.  Let's disable this by default
for now until we can fix these issues.