### PR TITLE
[Xamarin.Android.Build.Tasks] Allow users to specify modules for apk sets.

### DIFF
--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -146,6 +146,13 @@ you can use the following to add this for a debug build.
 
 Introduced in Xamarin.Android 11.2
 
+## AndroidInstallModules
+
+Specifies the modules which get installed by **bundletool** command when
+installing app bundles.
+
+Introduced in Xamarin.Android 11.3
+
 ## AndroidNativeLibrary
 
 [Native libraries](~/android/platform/native-libraries.md)

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -151,7 +151,7 @@ Introduced in Xamarin.Android 11.2
 Specifies the modules which get installed by **bundletool** command when
 installing app bundles.
 
-Introduced in Xamarin.Android 11.3
+This build action was introduced in Xamarin.Android 11.3.
 
 ## AndroidNativeLibrary
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -204,6 +204,8 @@ Specifies additional
 command-line options to pass to the **bundletool** command when
 build app bundles.
 
+This property was added in Xamarin.Android 11.3.
+
 ## AndroidClassParser
 
 A string property which controls how

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -198,6 +198,12 @@ Added in Xamarin.Android 10.3.
 
 [bundle-config-format]: https://developer.android.com/studio/build/building-cmdline#bundleconfig
 
+## AndroidBundleToolExtraArgs
+
+Specifies additional
+command-line options to pass to the **bundletool** command when
+build app bundles.
+
 ## AndroidClassParser
 
 A string property which controls how

--- a/Documentation/release-notes/5327.md
+++ b/Documentation/release-notes/5327.md
@@ -1,0 +1,6 @@
+### Build and deployment performance
+
+    * [GitHub PR 5327](https://github.com/xamarin/xamarin-android/pull/5327):
+      Allow users to specify additional app bundle "modules" when
+      building using `$(AndroidPackageFormat)` set to `aab`. In the
+      future this will help us support [Dynamic Features](https://developer.android.com/guide/app-bundle/play-feature-delivery)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Tasks
 {
 	/// <summary>
 	/// Invokes `bundletool` to create an APK set (.apks file)
-	/// 
+	///
 	/// Usage: bundletool build-apks --bundle=foo.aab --output=foo.apks
 	/// </summary>
 	public class BuildApkSet : BundleToolAdbTask
@@ -39,6 +39,8 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string StorePass { get; set; }
+
+		public string ExtraArgs { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -77,6 +79,8 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
 			AddStorePass (cmd, "--key-pass", KeyPass);
 			AddStorePass (cmd, "--ks-pass", StorePass);
+			if (!string.IsNullOrEmpty (ExtraArgs))
+				cmd.AppendSwitch (ExtraArgs);
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Tasks
 {
 	/// <summary>
 	/// Invokes `bundletool` to install an APK set to an attached device
-	/// 
+	///
 	/// Usage: bundletool install-apks --apks=foo.apks
 	/// </summary>
 	public class InstallApkSet : BundleToolAdbTask
@@ -16,6 +16,8 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string ApkSet { get; set; }
+
+		public string[] Modules  { get; set; }
 
 		internal override CommandLineBuilder GetCommandLineBuilder ()
 		{
@@ -28,8 +30,11 @@ namespace Xamarin.Android.Tasks
 			// --modules: List of modules to be installed, or "_ALL_" for all modules.
 			// Defaults to modules installed during first install, i.e. not on-demand.
 			// Xamarin.Android won't support on-demand modules yet.
-			cmd.AppendSwitchIfNotNull ("--modules ", "_ALL_");
-			
+			if (Modules == null)
+				cmd.AppendSwitchIfNotNull ("--modules ", "_ALL_");
+			else
+				cmd.AppendSwitchIfNotNull ("--modules ", $"\"{string.Join ("\",\"", Modules)}\"");
+
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2513,6 +2513,7 @@ because xbuild doesn't support framework reference assemblies.
       KeyAlias="$(_ApkKeyAlias)"
       KeyPass="$(_ApkKeyPass)"
       StorePass="$(_ApkStorePass)"
+      ExtraArgs="$(AndroidBundleToolExtraArgs)"
   />
   <InstallApkSet
       ToolPath="$(JavaToolPath)"
@@ -2522,6 +2523,7 @@ because xbuild doesn't support framework reference assemblies.
       AdbToolPath="$(AdbToolPath)"
       AdbTarget="$(AdbTarget)"
       ApkSet="$(_ApkSetIntermediate)"
+      Modules="@(AndroidInstallModules)"
   />
 </Target>
 


### PR DESCRIPTION
Context #4810

When using app bundles users install the application from an `apkset`.
At this time this only contains the base application. However we might
in the future support dynamic features in some fashion. In this case
developers should be able to pick which features they want installed.

This commit adds an `AndroidInstallModules` ItemGroup which will allow
developers to specify which modules to install. By default it will be
empty. This means all modules which are to be installed on first install
will be installed. So there is no change in the current behavior.

This commit also adds support for passing additional arguments to 
`bundle tool` via the new `AndroidBundleToolExtraArgs` property.