### PR TITLE
[illink] Preserve Java interface methods

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveJavaInterfaces.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveJavaInterfaces.cs
@@ -1,0 +1,31 @@
+using Mono.Cecil;
+using Mono.Linker.Steps;
+using MonoDroid.Tuner;
+
+namespace Microsoft.Android.Sdk.ILLink
+{
+	class PreserveJavaInterfaces : BaseSubStep
+	{
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			return assembly.Name.Name == "Mono.Android" || assembly.MainModule.HasTypeReference ("Android.Runtime.IJavaObject");
+		}
+
+		public override SubStepTargets Targets { get { return SubStepTargets.Type;  } }
+
+		public override void ProcessType (TypeDefinition type)
+		{
+			// If we are preserving a Mono.Android interface,
+			// preserve all members on the interface.
+			if (!type.IsInterface)
+				return;
+
+			// Mono.Android interfaces will always inherit IJavaObject
+			if (!type.ImplementsIJavaObject ())
+				return;
+
+			foreach (MethodReference method in type.Methods)
+				Annotations.AddPreservedMethod (type, method.Resolve ());
+		}
+	}
+}

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Android.Sdk.ILLink
 			subSteps2.Add (new PreserveJavaTypeRegistrations ());
 			subSteps2.Add (new PreserveApplications ());
 			subSteps2.Add (new PreserveRegistrations (cache));
+			subSteps2.Add (new PreserveJavaInterfaces ());
 			subSteps2.Add (new RemoveAttributes ());
 
 			InsertAfter (new FixAbstractMethodsStep (cache), "RemoveUnreachableBlocksStep");


### PR DESCRIPTION
When comparing monodroid and net5 apks of `BuildReleaseArm64True` test
I noticed some of the methods and related fields were missing.

Create `PreserveJavaInterfaces` substep to add more preservation,
similar as we do in `MonodroidMarkStep.DoAdditionalTypeProcessing`.

Example additional preserved API in `Android.App.Activity` and summary
of additions to `Mono.Android.dll`:

    Type Android.App.Activity
      +             Field static System.Delegate cb_onProvideKeyboardShortcuts_Ljava_util_List_Landroid_view_Menu_I
      +             Method static System.Delegate GetOnProvideKeyboardShortcuts_Ljava_util_List_Landroid_view_Menu_IHandler ()
      +             Method static void n_OnProvideKeyboardShortcuts_Ljava_util_List_Landroid_view_Menu_I (IntPtr, IntPtr, IntPtr, IntPtr, int)
      +             Method public void OnProvideKeyboardShortcuts (System.Collections.Generic.IList`1<Android.Views.KeyboardShortcutGroup>, Android.Views.IMenu, int)
    ...
    Summary:
      +      19,456 File size 1.08% (of 1,796,608)
      +      13,348 Metadata size 1.11% (of 1,202,456)
      +           6 Types count