### PR TITLE
[illink] Do not preserve all in J.I namespace

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <linker>
 	<assembly fullname="Mono.Android">
-		<namespace fullname="Java.Interop" />
 		<type fullname="Android.Runtime.AndroidEnvironment" />
 		<type fullname="Android.Runtime.AnnotationAttribute" />
 		<type fullname="Android.Runtime.CharSequence" />
@@ -47,6 +46,7 @@
 		<type fullname="Android.Runtime.XmlReaderResourceParser" />
 		<type fullname="Android.Runtime.XmlReaderPullParser" />
 		-->
+		<type fullname="Java.Interop.TypeManager*JavaTypeManager" />
 		<type fullname="Java.Lang.Object">
 			<field name="handle" />
 			<field name="handle_type" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5339

Instead preserve just the known API accessed by reflection.