### PR TITLE
[illink] Enable @LinkDescription test on DotNet

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -193,7 +193,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Category ("DotNetIgnore")] //TODO: @(LinkDescription) is not implemented yet
 		public void LinkDescription ()
 		{
 			string assembly_name = Builder.UseDotNet ? "System.Console" : "mscorlib";


### PR DESCRIPTION
The feature was added in https://github.com/xamarin/xamarin-android/commit/286a0aa3b5a4a01b5f51bcf65a5b21c3bb0265f4