### PR TITLE
[One .NET] improve default MSBuild item groups

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -29,22 +29,28 @@ project][binding] as a separate project type. Any of the MSBuild item
 groups or build actions that currently work in binding projects will
 be supported through a .NET 6 Android application or library.
 
-For example, a binding library could look like:
+For example, a binding library would be identical to a class library:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-android</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <TransformFile Include="Transforms\Metadata.xml" />
-    <EmbeddedJar Include="Jars\foo.jar" />
-  </ItemGroup>
 </Project>
 ```
 
+Along with the file structure:
+
+    Transforms/
+        Metadata.xml
+    foo.jar
+
+`Transforms\*.xml` files are automatically included as a
+`@(TransformFile)` item, and `.jar` files are automatically included
+as a `@(AndroidLibrary)` item.
+
 This will bind C# types for the Java types found in `foo.jar` using
-the metadata fixups from `Metadata.xml`.
+the metadata fixups from `Transforms\Metadata.xml`.
 
 [binding]: https://docs.microsoft.com/xamarin/android/platform/binding-java-library/
 

--- a/Documentation/guides/OneDotNetEmbeddedResources.md
+++ b/Documentation/guides/OneDotNetEmbeddedResources.md
@@ -179,15 +179,15 @@ Let's simplify this, we could support all of the above with a new
 
 ```xml
 <!-- Include and bind -->
-<AndroidLibrary Include="foo.aar" Bind="true" />
+<AndroidLibrary Include="foo.aar" />
 <!-- Just include, do not bind -->
-<AndroidLibrary Include="bar.aar" />
-<AndroidLibrary Include="baz.jar" />
+<AndroidLibrary Include="bar.aar" Bind="false" />
+<AndroidLibrary Include="baz.jar" Bind="false" />
 <!--
   Bind but do not include in NuGet package.
   %(Pack) is built into NuGet MSBuild targets.
 -->
-<AndroidLibrary Include="bar.aar" Bind="true" Pack="false" />
+<AndroidLibrary Include="bar.aar" Pack="false" />
 <!-- Native libraries need ABI directory -->
 <AndroidLibrary Include="armeabi-v7a\libfoo.so" />
 <AndroidLibrary Include="x86\libfoo.so" />
@@ -195,9 +195,9 @@ Let's simplify this, we could support all of the above with a new
 
 The new `@(AndroidLibrary)` item group will simply translate to the
 old ones for backwards compatibility. The extension of the file can be
-used to determine what kind of library each item is. `%(Bind)` will be
-`false` by default, and `%(Pack)` will be `true` by default. `%(Pack)`
-will not do anything in application projects.
+used to determine what kind of library each item is. `%(Bind)` and
+`%(Pack)` will both be `true` by default. `%(Pack)` will not do
+anything in application projects.
 
 The deprecated item groups will no longer embed, but pack into
 `.nupkg` files instead:

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,9 +16,9 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
-  <!-- Default Resource file inclusion -->
-  <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
   <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
+    <!-- Default Resource file inclusion -->
+    <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.axml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.png" />
@@ -28,11 +28,14 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
-  </ItemGroup>
-
-  <!-- Default Asset file inclusion -->
-  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
+    <!-- Default Asset file inclusion -->
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+    <!-- Default XPath transforms for bindings -->
+    <TransformFile Include="Transforms\**\*.xml" />
+    <!-- Default Java or native libraries -->
+    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -18,7 +18,7 @@ projects.
   </ItemGroup>
   <ItemDefinitionGroup>
     <AndroidLibrary>
-      <Bind>false</Bind>
+      <Bind>true</Bind>
       <Pack>true</Pack>
     </AndroidLibrary>
   </ItemDefinitionGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -259,8 +259,13 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuildBinding ()
 		{
 			var proj = new XASdkProject (outputType: "Library");
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("javaclasses.jar") {
-				MetadataValues = "Bind=true",
+			proj.Sources.Add (new AndroidItem.TransformFile ("Transforms\\Metadata.xml") {
+				TextContent = () =>
+@"<metadata>
+  <attr path=""/api/package[@name='com.xamarin.android.test.msbuildtest']"" name=""managedName"">MSBuildTest</attr>
+</metadata>",
+			});
+			proj.Sources.Add (new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64)
 			});
 			// TODO: bring back when Xamarin.Android.Bindings.Documentation.targets is working
@@ -273,7 +278,7 @@ namespace Xamarin.Android.Build.Tests
 			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "UnnamedProject.dll");
 			FileAssert.Exists (assemblyPath);
 			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
-				var typeName = "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest";
+				var typeName = "MSBuildTest.JavaSourceJarTest";
 				var type = assembly.MainModule.GetType (typeName);
 				Assert.IsNotNull (type, $"{assemblyPath} should contain {typeName}");
 			}


### PR DESCRIPTION
When implementing #5348, I noticed that we could add a wildcard to
make Java bindings simpler:

    <TransformFile Include="Transforms\**\*.xml" />

This way you can just put `.xml` files in the `Transforms` folder so
they will be picked up automatically.

We also need to include some additional wildcards:

    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
    <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
    <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

To make sure we exclude folders like `bin` and `obj`, we can rely on
`$(DefaultItemExcludes)` and `$(DefaultExcludesInProjectFolder)` as
the dotnet/sdk does:

https://github.com/dotnet/sdk/blob/3e9e1d1e3082cab14593b54562c956b155881658/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L37

I updated a test that uses a `Metadata.xml`, and it now relies on the
new defaults.