### PR TITLE
[Xamarin.Android.Build.Tasks] bump XA0113 warning to 29

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -59,7 +59,7 @@ ms.date: 01/24/2020
 + [XA0109](xa0109.md): Unsupported or invalid `$(TargetFrameworkVersion)` value of 'v4.5'.
 + [XA0111](xa0111.md): Could not get the `aapt2` version. Please check it is installed correctly.
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
-+ [XA0113](xa0113.md): Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
++ [XA0113](xa0113.md): Google Play requires that new applications and updates must use a TargetFrameworkVersion of v10.0 (API level 29) or above.
 + [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties to remove the old value. If the properties page does not show an 'armeabi' checkbox, un-check and re-check one of the other ABIs and save the changes.
 + [XA0116](xa0116.md): Unable to find `EmbeddedResource` named `{ResourceName}`.
 + [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -7,13 +7,13 @@ ms.date: 02/28/2019
 
 ## Issue
 
-As of August 1st 2019, new applications and application updates uploaded
-to the Google Play store need to target v9.0 (API 28) or above.
+As of November 2nd 2020, new applications and application updates uploaded
+to the Google Play store need to target v10.0 (API 29) or above.
 
 ## Solution
 
 If you are seeing this warning, you should update the
-`$(TargetFrameworkVersion)` of your projects to be v9.0 or above.
+`$(TargetFrameworkVersion)` of your projects to be v10.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
 warnings, you can make use of the `/warnasmessage:XA0113` command line
@@ -28,3 +28,4 @@ switch.  Alternatively, add
 to your *.csproj* file.
 
 [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
+[Target API level requirements for the Play Console](https://support.google.com/googleplay/android-developer/answer/9859152?#targetsdk)

--- a/Documentation/release-notes/google-play-29.md
+++ b/Documentation/release-notes/google-play-29.md
@@ -1,0 +1,15 @@
+### Other warning and error changes
+
+#### Updated XA0113 warning for Google Play submission requirements
+
+The XA0113 warning has been updated to reflect [a more recent minimum target
+version of Android 10 (API level 29)][targetsdk] for submissions to the Google
+Play store.  The following warning will now appear for projects that have an
+earlier version set under **Compile using Android version: (Target Framework)**
+in the Visual Studio project property pages:
+
+```
+warning XA0113: Google Play requires that new applications and updates must use a TargetFrameworkVersion of v10.0 (API level 29) or above. You are currently targeting v9.0 (API level 28).
+```
+
+[targetsdk]: https://support.google.com/googleplay/android-developer/answer/9859152?#targetsdk

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -244,10 +244,12 @@ In this message, the phrase "should not be reached" means that this error messag
     <comment>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</comment>
   </data>
   <data name="XA0113" xml:space="preserve">
-    <value>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</value>
-    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</comment>
+    <value>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</value>
+    <comment>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</comment>
   </data>
   <data name="XA0116" xml:space="preserve">
     <value>Unable to find `EmbeddedResource` named `{0}`.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play vyžaduje, aby nové aplikace a aktualizace používaly TargetFrameworkVersion verze 9.0 (rozhraní API úrovně 28) nebo vyšší. Aktuálně cílíte na verzi {0} (rozhraní API úrovně {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play erfordert, dass neue Anwendungen und Updates die TargetFrameworkVersion v9.0 (API-Ebene 28) oder höher verwenden müssen. Sie verwenden als Ziel aktuell Version {0} (API-Ebene {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play requiere que las nuevas aplicaciones y actualizaciones usen un valor de TargetFrameworkVersion de v9.0 (nivel de API 28) o superior. Actualmente se dirige a {0} (nivel de API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play impose aux nouvelles applications et aux mises à jour d'utiliser le TargetFrameworkVersion version 9.0 (niveau d'API 28) ou une version ultérieure. Vous ciblez {0} (niveau d'API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Con Google Play le nuove applicazioni e gli aggiornamenti devono usare TargetFrameworkVersion 9.0 (livello API 28) o versione successiva. La versione di destinazione impostata attualmente è {0} (livello API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play では、新しいアプリケーションと更新プログラムで v9.0 (API レベル 28) 以上の TargetFrameworkVersion を使用する必要があります。現在は、{0} (API レベル {1}) をターゲットにしています。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play에서는 새 애플리케이션 및 업데이트가 v9.0(API 레벨 28) 이상의 TargetFrameworkVersion을 사용하도록 요구합니다. 현재 {0}(API 레벨 {1})을(를) 대상으로 하고 있습니다.</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Sklep Google Play wymaga, aby nowe aplikacje i aktualizacje używały elementu TargetFrameworkVersion o wartości v9.0 (poziom 28 lub nowszy interfejsu API). Obecna wersja docelowa to {0} (poziom interfejsu API: {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">O Google Play exige que novos aplicativos e atualizações usem a TargetFrameworkVersion v9.0 (nível 28 da API) ou superior. No momento, você está direcionando à {0} (nível {1} da API).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play требует, чтобы новые приложения и обновления использовали версию TargetFrameworkVersion v9.0 (уровень API 28) или выше. Текущая целевая версия — {0} (уровень API {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play, yeni uygulamaların ve güncelleştirmelerin v9.0 (API düzeyi 28) veya üzeri bir TargetFrameworkVersion kullanmasını gerektiriyor. Şu anda hedeflediğiniz: {0} (API düzeyi {1}).</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play 要求新应用程序和更新必须使用 TargetFrameworkVersion of v9.0 (API 级别 28)或更高版本。当前目标是 {0} (API 级别 {1})。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -205,11 +205,13 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The following are literal names and should not be translated: AAPT2, Aapt2ToolPath, MSBuild</note>
       </trans-unit>
       <trans-unit id="XA0113">
-        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above. You are currently targeting {0} (API level {1}).</source>
-        <target state="translated">Google Play 要求新的應用程式和更新必須使用 v9.0 (API 層級 28) 以上的 TargetFrameworkVersion。您目前使用的版本為 {0} (API 層級 {1})。</target>
-        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v9.0
-{0} - The current value of TargetFrameworkVersion
-{1} - The corresponding API level number</note>
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of {0} (API level {1}) or above. You are currently targeting {2} (API level {3}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion
+{0} - The required minimum TargetFrameworkVersion, such as 'v10.0'
+{1} - The required minimum API level number, such as '29'
+{2} - The specified TargetFrameworkVersion
+{3} - The specified API level number</note>
       </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
@@ -44,8 +44,8 @@ namespace Xamarin.Android.Tasks.Legacy
 
 			int apiLevel;
 			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
-				if (apiLevel < 28)
-					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, TargetFrameworkVersion, AndroidApiLevel);
+				if (apiLevel < 29)
+					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, "v10.0", "29", TargetFrameworkVersion, AndroidApiLevel);
 				if (apiLevel < 21)
 					Log.LogCodedWarning ("XA0117", Properties.Resources.XA0117, TargetFrameworkVersion);
 			}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4977
Context: https://support.google.com/googleplay/android-developer/answer/9859152?visit_id=637424522037563363-1219346479&rd=1#targetsdk

We currently warn if `$(TargetFrameworkVersion)` is less than 28:

    Google Play requires that new applications and updates must use a TargetFrameworkVersion of v9.0 (API level 28) or above.

Since November 2, 2020, Google Play requires API 29, so we need to
update this warning.