### PR TITLE
[Xamarin.Android.Build.Tasks] Fix crash in BuildBaseAppBundle

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Android.Tasks
 		/// </summary>
 		protected override void FixupArchive (ZipArchiveEx zip)
 		{
+			if (!zip.Archive.ContainsEntry ("AndroidManifest.xml"))
+				return;
 			var entry = zip.Archive.ReadEntry ("AndroidManifest.xml");
 			using (var stream = new MemoryStream ()) {
 				entry.Extract (stream);


### PR DESCRIPTION
When building an app bundle incrementally we get the following crash

    error XABBA7000: Xamarin.Tools.Zip.ZipException: Invalid argument [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Tools.Zip.ZipArchive.ReadEntry (System.UInt64 index, System.Boolean throwIfDeleted) [0x00047] in <88e5f87310fc4b0cbcadde89bab7fe3c>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Tools.Zip.ZipArchive.ReadEntry (System.UInt64 index) [0x00000] in <88e5f87310fc4b0cbcadde89bab7fe3c>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Tools.Zip.ZipArchive.ReadEntry (System.String entryName, System.Boolean caseSensitive) [0x00009] in <88e5f87310fc4b0cbcadde89bab7fe3c>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Android.Tasks.BuildBaseAppBundle.FixupArchive (Xamarin.Android.Tasks.ZipArchiveEx zip) [0x00006] in <331267c8bd6c4f46a93dbb66d4ef5c11>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi (System.String[] supportedAbis, System.String apkInputPath, System.String apkOutputPath, System.Boolean debug, System.Boolean compress, System.Collections.Generic.IDictionary`2[TKey,TValue] compressedAssembliesInfo) [0x00801] in <331267c8bd6c4f46a93dbb66d4ef5c11>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Android.Tasks.BuildApk.RunTask () [0x000de] in <331267c8bd6c4f46a93dbb66d4ef5c11>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2079,3): error XABBA7000:   at Xamarin.Android.Tasks.AndroidTask.Execute () [0x00000] in <331267c8bd6c4f46a93dbb66d4ef5c11>:0  [/Users/dean/Projects/MonoGameAndroidAds/MonoGameAndroidAds.csproj]

This is because the AndroidManifest.xml has already been moved. To fix
this we need to check the file exists before trying to move it.