### PR TITLE
[illink] Do not preserve A.R.AndroidEnvironment

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <linker>
 	<assembly fullname="Mono.Android">
-		<type fullname="Android.Runtime.AndroidEnvironment" />
 		<type fullname="Android.Runtime.AnnotationAttribute" />
 		<type fullname="Android.Runtime.CharSequence" />
 		<type fullname="Android.Runtime.ConstructorBuilder" />


### PR DESCRIPTION
Part of https://github.com/xamarin/xamarin-android/issues/5167

Removed API from `BuildReleaseArm64False` test (ignore the SIGERR's in place of return types):

    Type Android.Runtime.AndroidEnvironment
      -             Field public static string AndroidLogAppName
      -             Field static Javax.Net.Ssl.IX509TrustManager sslTrustManager
      -             Field static Java.Security.KeyStore certStore
      -             Method static SIGERR SetupTrustManager ()
      -             Method static SIGERR SetupCertStore ()
      -             Method public static SIGERR add_UnhandledExceptionRaiser (System.EventHandler`1<Android.Runtime.RaiseThrowableEventArgs>)
      -             Method public static SIGERR remove_UnhandledExceptionRaiser (System.EventHandler`1<Android.Runtime.RaiseThrowableEventArgs>)
      -             Method static SIGERR TrustEvaluateSsl (System.Collections.Generic.List`1<byte[]>)
      -             Method static SIGERR CertStoreLookup (long, bool)
      -             Method static SIGERR GetX509CertificateFactory ()
      -             Method static SIGERR ConvertCertificate (Java.Security.Cert.CertificateFactory, byte[])
      -             Method static SIGERR NotifyTimeZoneChanged ()
      -             Method static SIGERR GetDisplayDPI (float&, float&)
      -             Method static SIGERR GetDefaultTimeZone ()
      -             Method static SIGERR _monodroid_timezone_get_default_id ()
      -             Method static SIGERR GetDefaultSyncContext ()
      -             Method static SIGERR _monodroid_getifaddrs (IntPtr&)
      -             Method static SIGERR GetInterfaceAddresses (IntPtr&)
      -             Method static SIGERR _monodroid_freeifaddrs (IntPtr)
      -             Method static SIGERR FreeInterfaceAddresses (IntPtr)
      -             Method static SIGERR _monodroid_detect_cpu_and_architecture (ushort&, ushort&, byte&)
      -             Method static SIGERR DetectCPUAndArchitecture (ushort&, ushort&, bool&)
      -             Method static SIGERR GetDefaultProxy ()
      -             Method static SIGERR GetHttpMessageHandler ()
      -             Type _Proxy

Some of the removed API is obsolete on .NET5/6. Opened https://github.com/xamarin/xamarin-android/issues/5361
for it.

The template tests run OK on device after the removal.