### PR TITLE
[illink] Do not preserve A.R.Extensions

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -5,7 +5,6 @@
 		<type fullname="Android.Runtime.AnnotationAttribute" />
 		<type fullname="Android.Runtime.CharSequence" />
 		<type fullname="Android.Runtime.ConstructorBuilder" />
-		<type fullname="Android.Runtime.Extensions" />
 		<type fullname="Android.Runtime.GeneratedDummyHost" />
 		<type fullname="Android.Runtime.GeneratedEnumAttribute" />
 		<type fullname="Android.Runtime.IJavaObject" />


### PR DESCRIPTION
Part of https://github.com/xamarin/xamarin-android/issues/5167

The type is not accessed through reflection.

It is preserved by the linker when needed like:

    illinkanalyzer -r Android.Runtime.Extensions linker-dependencies.xml.gz
    ...
    --- Method:TResult Android.Runtime.Extensions::JavaCast(Android.Runtime.IJavaObject) dependencies ---
    Dependency #1
            Method:TResult Android.Runtime.Extensions::JavaCast(Android.Runtime.IJavaObject)
            | MethodSpec:TResult Android.Runtime.Extensions::JavaCast<T>(Android.Runtime.IJavaObject) [1 deps]
            | Method:T Android.App.Activity::FindViewById(System.Int32) [1 deps]
            | MethodSpec:!!0 Android.App.Activity::FindViewById<Android.Widget.Button>(System.Int32) [1 deps]
            | Method:System.Void UnnamedProject.MainActivity::OnCreate(Android.OS.Bundle) [2 deps]
            | Assembly:UnnamedProject, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null [1 deps]
            | Other:Copy
    ...