### PR TITLE
[tests] enable sqlite-net-pcl test in .NET 6

### DIFF
--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
@@ -116,9 +116,7 @@ namespace UnnamedProject
 			Android.Util.Log.Info(TAG, cldt.TryAccessNonXmlPreservedMethodOfLinkerModeFullClass());
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug21578.MulticastOption_ShouldNotBeStripped());
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug21578.MulticastOption_ShouldNotBeStripped2());
-#if !NET
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug35195.AttemptCreateTable());
-#endif
 			Android.Util.Log.Info(TAG, LinkTestLib.Bug36250.SerializeSearchRequestWithDictionary());
 
 			Android.Util.Log.Info(TAG, "All regression tests completed.");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5319

This test was originally failing in 6e3e3831 with:

    android.runtime.JavaProxyThrowable: System.TypeInitializationException: The type initializer for 'SQLite.SQLiteConnection' threw an exception.
    ---> System.DllNotFoundException: e_sqlite3
        at System.Runtime.InteropServices.NativeLibrary.LoadLibraryByName(String libraryName, Assembly assembly, Nullable`1 searchPath, Boolean throwOnError)
        at System.Runtime.InteropServices.NativeLibrary.Load(String libraryName, Assembly assembly, Nullable`1 searchPath)
        at SQLitePCL.NativeLibrary.Load(String libraryName, Assembly assy, Int32 flags)
        at SQLitePCL.Batteries_V2.MakeDynamic(String name, Int32 flags)
        at SQLitePCL.Batteries_V2.DoDynamic_cdecl(String name, Int32 flags)
        at SQLitePCL.Batteries_V2.Init()
        at SQLite.SQLiteConnection..cctor()

The problem being one of the transitive dependencies of `sqlite-net-pcl`:

https://www.nuget.org/packages/SQLitePCLRaw.bundle_green/

This package pulls in even more packages:

    .NETCoreApp 3.1
        SQLitePCLRaw.core (>= 2.0.4)
        SQLitePCLRaw.lib.e_sqlite3 (>= 2.0.4)
        SQLitePCLRaw.provider.dynamic_cdecl (>= 2.0.4)
    MonoAndroid 8.0
        SQLitePCLRaw.core (>= 2.0.4)
        SQLitePCLRaw.lib.e_sqlite3.android (>= 2.0.4)
        SQLitePCLRaw.provider.e_sqlite3 (>= 2.0.4)

`SQLitePCLRaw.lib.e_sqlite3.android` contains the `libe_sqlite3.so`
native library for Android. In .NET 6, NuGet is preferring the
`.NETCoreApp 3.1` packages over the `MonoAndroid 8.0` ones.

What we can do to workaround the problem is manually add an additional
`@(PackageReference)` to the Android head project:

    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3.android" Version="2.0.4" />

Then the test works as expected.

Eventually, `SQLitePCLRaw.bundle_green` will need to include
dependencies for .NET 6, such as:

    net6.0-android
        SQLitePCLRaw.core (>= 2.0.4)
        SQLitePCLRaw.lib.e_sqlite3.android (>= 2.0.4)
        SQLitePCLRaw.provider.e_sqlite3 (>= 2.0.4)
    net6.0-ios
        SQLitePCLRaw.core (>= 2.0.4)
        SQLitePCLRaw.provider.dynamic_cdecl (>= 2.0.4)

This will solve the problem for customers going forward.