### PR TITLE
[illink] Do not preserve whole JavaObject

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -21,7 +21,6 @@
 		<type fullname="Android.Runtime.JavaDictionary`2" />
 		<type fullname="Android.Runtime.JavaList" />
 		<type fullname="Android.Runtime.JavaList`1" />
-		<type fullname="Android.Runtime.JavaObject" />
 		<type fullname="Android.Runtime.JavaSet" />
 		<type fullname="Android.Runtime.JavaSet`1" />
 		<type fullname="Android.Runtime.JavaTypeConverter`1" />

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -92,8 +92,8 @@ namespace Android.Runtime {
 
 		protected override Java.Lang.Object Clone ()
 		{
-			if (inst is ICloneable c)
-				return new JavaObject (c.Clone ());
+			if (inst is ICloneable)
+				return new JavaObject (((ICloneable)inst).Clone ());
 			else
 				return new JavaObject (inst);
 		}

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -90,14 +90,6 @@ namespace Android.Runtime {
 			get { return inst; }
 		}
 
-		protected override Java.Lang.Object Clone ()
-		{
-			if (inst is ICloneable)
-				return new JavaObject (((ICloneable)inst).Clone ());
-			else
-				return new JavaObject (inst);
-		}
-
 		public override bool Equals (Java.Lang.Object? obj)
 		{
 			if (obj is JavaObject jobj) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5167

Also remove `JavaObject.Clone ()` method, which should not be
needed.

This `Clone ()` method was pulling in a lot of API, through `ICloneable` iface.
When removed, it saves more than 900kbytes of compressed assembly size.

    Summary:
      -     942,460 Assemblies -43.72% (of 2,155,792)
      -     947,763 Package size difference -10.50% (of 9,024,291)

Interestingly, it was pulling it in through the serialization code preserved
by the old `ApplyPreserveAttributeStep`. After https://github.com/xamarin/xamarin-android/commit/89edafcb17c61572f5ffaf1ae2a3bb7609979ae2
was merged, the difference is much smaller.

    Summary:
      -       3,382 Assemblies -0.36% (of 934,139)
      -       4,096 Package size difference -0.05% (of 7,797,203)

In the end we are now smaller in assembly size comparing simple XA app "legacy" and net6:

    Summary:
      -     356,408 Assemblies -27.69% (of 1,287,165)
      +   2,646,694 Package size difference 51.43% (of 5,146,413)

And still a bit larger comparing XA XForms app:

    Summary:
      +   1,001,148 Assemblies 21.01% (of 4,765,097)
      +   4,013,739 Package size difference 37.75% (of 10,633,264)
