### PR TITLE
[build] Replace Jenkins-based signing step with Azure DevOps step

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1237,7 +1237,7 @@ stages:
     workspace:
       clean: all
     steps:
-
+      # Signing job is run here: https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13878
       # https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
       displayName: 'xamarin vsix codesign - run Azure DevOps job'

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1150,8 +1150,7 @@ stages:
 - stage: finalize_installers
   displayName: Finalize Installers
   dependsOn: mac_build
-  # UNDONE: DO NOT MERGE: Allow this stage to run when triggered from the Xamarin.Android-Test pipeline
-  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Test'))
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android'))
   jobs:
   # Check - "Xamarin.Android (Finalize Installers Notarize and Upload to Storage)"
   - job: notarize_pkg_upload_storage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1238,15 +1238,16 @@ stages:
       clean: all
     steps:
 
-    - task: JenkinsQueueJob@2
-      displayName: xamarin vsix codesign - run jenkins job
+      # https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md
+    - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
+      displayName: 'Trigger sign-from-github-esrp YAML build'
       inputs:
-        serverEndpoint: $(Signing.Endpoint)
-        jobName: $(Signing.Job)
-        isParameterizedJob: true
-        jobParameters: |
-          REPO=$(Build.Repository.Name)
-          COMMIT=$(Build.SourceVersion)
-          SIGN_TYPE=Real
-          GITHUB_CONTEXT=$(GitHub.Artifacts.Context)
-          ENABLE_JAR_SIGNING=true
+        buildDefinition: $(Signing.Job)
+        useSameSourceVersion: false
+        useSameBranch: false
+        branchToUse: 'full-esrp-integration'
+        waitForQueuedBuildsToFinish: true
+        storeInEnvironmentVariable: true
+        buildParameters: '{ "REPO": "$(Build.Repository.Name)", "COMMIT": "$(Build.SourceVersion)", "SIGN_TYPE": "Real", "GITHUB_CONTEXT": "$(GitHub.Artifacts.Context)" }'
+        authenticationMethod: 'OAuth Token'
+        password: $(System.AccessToken)     # Equivalent to the 'Allow scripts to access OAuth token option': https://stackoverflow.com/questions/52837980/how-to-allow-scripts-to-access-oauth-token-from-yaml-builds

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1150,7 +1150,8 @@ stages:
 - stage: finalize_installers
   displayName: Finalize Installers
   dependsOn: mac_build
-  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android'))
+  # UNDONE: DO NOT MERGE: Allow this stage to run when triggered from the Xamarin.Android-Test pipeline
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Test'))
   jobs:
   # Check - "Xamarin.Android (Finalize Installers Notarize and Upload to Storage)"
   - job: notarize_pkg_upload_storage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1240,7 +1240,7 @@ stages:
 
       # https://github.com/huserben/TfsExtensions/blob/master/BuildTasks/overview.md
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@3
-      displayName: 'Trigger sign-from-github-esrp YAML build'
+      displayName: 'xamarin vsix codesign - run Azure DevOps job'
       inputs:
         buildDefinition: $(Signing.Job)
         useSameSourceVersion: false


### PR DESCRIPTION
As part of the transition off Jenkins-based operations, transition to using the Azure DevOps-based signing pipeline. The Azure DevOps solution is functionally equivalent to the Jenkins-based solution.

This change queues the signing job here:
https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13878

Because the PR build does not include signing, a special manual build was launched (and passed) as follows:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4275293&view=results

Which in turn launched the following Azure DevOps signing job
https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4275526&view=results