### PR TITLE
[tests] Update CheckIncludedAssemblies tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -112,7 +112,6 @@ namespace Xamarin.Android.Build.Tests
 					"System.Security.Cryptography.Encoding.dll",
 					"System.Security.Cryptography.OpenSsl.dll",
 					"System.Security.Cryptography.X509Certificates.dll",
-					"System.Runtime.Serialization.Formatters.dll",
 					"System.Runtime.Serialization.Primitives.dll",
 					"System.Security.Cryptography.Algorithms.dll",
 					"System.Security.Cryptography.Primitives.dll",


### PR DESCRIPTION
https://github.com/xamarin/xamarin-android/commit/881edb3e64b21f65c82809f19307ea6ca5be9abc
improved the linking and now
the `System.Runtime.Serialization.Formatters` is linked away.