### PR TITLE
Revert "[Mono.Android] Add [Category] for IDE completion of string props

### DIFF
--- a/Documentation/release-notes/5375.md
+++ b/Documentation/release-notes/5375.md
@@ -1,0 +1,25 @@
+### Application size improvements
+
+  * [GitHub PR 5375](https://github.com/xamarin/xamarin-android/pull/5375):
+    Removed decoration of `System.ComponentModel.CategoryAttribute` to
+    improve linker behavior. This reduced the .NET assembly size of a
+    .NET 6 application by 3,271 bytes.
+
+`CategoryAttribute` was removed from properties on types such as
+`Android.App.ActivityAttribute`:
+
+```diff
+-[Category ("@drawable;@mipmap")]
+public string? Icon { get; set; }
+-[Category ("@string")]
+public string? Label { get; set; }
+```
+
+A full list of types changed:
+
+* `Android.App.ActivityAttribute`
+* `Android.App.ApplicationAttribute`
+* `Android.App.InstrumentationAttribute`
+* `Android.App.ServiceAttribute`
+* `Android.Content.BroadcastReceiverAttribute`
+* `Android.Content.ContentProviderAttribute`

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;
@@ -53,9 +52,7 @@ namespace Android.App
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon                    {get; set;}
-		[Category ("@string")]
 		public string?                Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
 #if ANDROID_23
@@ -102,7 +99,6 @@ namespace Android.App
 		public WindowRotationAnimation      RotationAnimation    {get; set;}
 #endif
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
@@ -124,7 +120,6 @@ namespace Android.App
 #endif
 		public bool                   StateNotNeeded          {get; set;}
 		public string?                TaskAffinity            {get; set;}
-		[Category ("@style")]
 		public string?                Theme                   {get; set;}
 #if ANDROID_27
 		public bool                   TurnScreenOn            {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;
@@ -31,7 +30,6 @@ namespace Android.App {
 		public string?                Banner                  {get; set;}
 #endif
 		public bool                   Debuggable              {get; set;}
-		[Category ("@string")]
 		public string?                Description             {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
@@ -48,16 +46,13 @@ namespace Android.App {
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
 		public bool                   HasCode                 {get; set;}
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon                    {get; set;}
 		public bool                   KillAfterRestore        {get; set;}
 #if ANDROID_11
 		public bool                   LargeHeap               {get; set;}
 #endif
-		[Category ("@string")]
 		public string?                Label                   {get; set;}
 #if ANDROID_11
-		[Category ("@drawable;@mipmap")]
 		public string?                Logo                    {get; set;}
 #endif
 		public Type?                  ManageSpaceActivity     {get; set;}
@@ -75,14 +70,12 @@ namespace Android.App {
 		public string?                RestrictedAccountType   {get; set;}
 #endif
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 #if ANDROID_17
 		public bool                   SupportsRtl             {get; set;}
 #endif
 		public string?                TaskAffinity            {get; set;}
-		[Category ("@style")]
 		public string?                Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 namespace Android.App {
 
@@ -15,13 +14,10 @@ namespace Android.App {
 
 		public bool                   FunctionalTest  {get; set;}
 		public bool                   HandleProfiling {get; set;}
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon            {get; set;}
-		[Category ("@string")]
 		public string?                Label           {get; set;}
 		public string?                Name            {get; set;}
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 		public string?                TargetPackage   {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;
@@ -26,17 +25,14 @@ namespace Android.App {
 #if ANDROID_29
 		public ForegroundService      ForegroundServiceType   {get; set;}
 #endif
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon                    {get; set;}
 #if ANDROID_16
 		public bool                   IsolatedProcess         {get; set;}
 #endif
-		[Category ("@string")]
 		public string?                Label                   {get; set;}
 		public string?                Permission              {get; set;}
 		public string?                Process                 {get; set;}
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 namespace Android.Content {
 
@@ -16,17 +15,13 @@ namespace Android.Content {
 		public bool                   DirectBootAware         {get; set;}
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
-		[Category ("@string")]
 		public string?                Description             {get; set;}
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon                    {get; set;}
-		[Category ("@string")]
 		public string?                Label                   {get; set;}
 		public string?                Name                    {get; set;}
 		public string?                Permission              {get; set;}
 		public string?                Process                 {get; set;}
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 namespace Android.Content {
 
@@ -25,10 +24,8 @@ namespace Android.Content {
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
 		public bool                   GrantUriPermissions     {get; set;}
-		[Category ("@drawable;@mipmap")]
 		public string?                Icon                    {get; set;}
 		public int                    InitOrder               {get; set;}
-		[Category ("@string")]
 		public string?                Label                   {get; set;}
 		public bool                   MultiProcess            {get; set;}
 		public string?                Name                    {get; set;}
@@ -36,7 +33,6 @@ namespace Android.Content {
 		public string?                Process                 {get; set;}
 		public string?                ReadPermission          {get; set;}
 #if ANDROID_25
-		[Category ("@drawable;@mipmap")]
 		public string?                RoundIcon               {get; set;}
 #endif
 		public bool                   Syncable                {get; set;}

--- a/tests/api-compatibility/acceptable-breakages-vReference.txt
+++ b/tests/api-compatibility/acceptable-breakages-vReference.txt
@@ -1,0 +1,24 @@
+Compat issues with assembly Mono.Android:
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ActivityAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ActivityAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ActivityAttribute.RoundIcon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ActivityAttribute.Theme' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.Description' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.Logo' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.RoundIcon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ApplicationAttribute.Theme' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.InstrumentationAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.InstrumentationAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.InstrumentationAttribute.RoundIcon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ServiceAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ServiceAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.App.ServiceAttribute.RoundIcon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.BroadcastReceiverAttribute.Description' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.BroadcastReceiverAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.BroadcastReceiverAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.BroadcastReceiverAttribute.RoundIcon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.ContentProviderAttribute.Icon' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.ContentProviderAttribute.Label' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.CategoryAttribute' exists on 'Android.Content.ContentProviderAttribute.RoundIcon' in the contract but not the implementation.


### PR DESCRIPTION
This reverts commit d548ec9ca5746e7ef2f4bd5f0ea11bd58b09ae3b.

Decoration of `ApplicationAttribute.Label` with:

    [System.ComponentModel.Category ("@string")]
    public string?                Label                   {get; set;}

Allowed an experimental feature in Visual Studio to offer `@string`
`AndroidResource` completion when changing the `Label` property in C#.

Unfortunately, the presence of this attribute causes the linker to
preserve various dependencies of `System.ComponentModel` in .NET 6.

It appears that this completion feature never shipped in the IDE, so
we can completely remove this. If we ever want to bring the feature
back, we should create a new `internal` attribute to be used instead.

Results of this change:

    > apkdiff before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    -          56 lib/armeabi-v7a/libxamarin-app.so
    Section size difference
    -           8 .rel.dyn
    -          12 .data
    -       6,144 .bss
    -          77 assemblies/Mono.Android.dll
    -       3,194 assemblies/System.ComponentModel.Primitives.dll *1
    Summary:
    +           0 Other entries 0.00% (of 6,484)
    +           0 Dalvik executables 0.00% (of 317,508)
    -       3,271 Assemblies -0.15% (of 2,139,234)
    -          56 Shared libraries -0.00% (of 20,674,428)
    -       3,468 Package size difference -0.04% (of 9,485,287)