### PR TITLE
[One .NET] apps default $(PublishReferencesDocumentationFiles) to false

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -47,6 +47,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' ">
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <PublishReferencesDocumentationFiles Condition=" '$(PublishReferencesDocumentationFiles)' == '' ">false</PublishReferencesDocumentationFiles>
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and ('$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full') ">true</PublishTrimmed>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>


### PR DESCRIPTION
In `PerformanceTest`, I've been seeing the
`_ComputeResolvedCopyLocalPublishAssets` MSBuild target from the
dotnet/sdk take time on our CI on macOS:

    _ComputeResolvedCopyLocalPublishAssets 183ms

This is in a build with no changes, and the target doesn't actually do
anything besides emit an `<ItemGroup/>`:

https://github.com/dotnet/sdk/blob/955c0fc7b06e2fa34bacd076ed39f61e4fb61716/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L708-L726

In application projects, we should be able to set
`$(PublishReferencesDocumentationFiles)` to `false`, so this target
will skip most of its work.

I have not found any proper documentation for
`$(PublishReferencesDocumentationFiles)`, but I believe the intention
is that `.xml` documentation files are copied to the build output from
all dependencies. We shouldn't need this behavior for an Android
application.

See: https://github.com/dotnet/sdk/pull/1062

`_ComputeResolvedCopyLocalPublishAssets` now shows 0ms, so this seems
to save ~183ms for all .NET 6 app builds.