### PR TITLE
[One .NET] cleanup BuildOrder.targets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -30,12 +30,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CopyPackage;
       _Sign;
     </BuildDependsOn>
-    <_BeforeIncrementalClean>
+    <IncrementalCleanDependsOn>
       _PrepareAssemblies;
       _CompileDex;
       $(_AfterCompileDex);
       _AddFilesToFileWrites;
-    </_BeforeIncrementalClean>
+      $(IncrementalCleanDependsOn);
+    </IncrementalCleanDependsOn>
     <_PackageForAndroidDependsOn>
       Build;
       _CopyPackage;
@@ -83,13 +84,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       AddLibraryJarsToBind;
       $(BuildDependsOn);
     </BuildDependsOn>
-    <_BeforeIncrementalClean>
+    <IncrementalCleanDependsOn>
       _AddFilesToFileWrites;
-    </_BeforeIncrementalClean>
+      $(IncrementalCleanDependsOn);
+    </IncrementalCleanDependsOn>
   </PropertyGroup>
 
-  <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
-  <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">
+  <PropertyGroup>
     <CoreResolveReferencesDependsOn>
       _SeparateAppExtensionReferences;
       $(ResolveReferencesDependsOn);
@@ -110,12 +111,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _UpdateAndroidResgen;
       _CreateAar;
     </_UpdateAndroidResourcesDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <CoreBuildDependsOn>
-      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
-    </CoreBuildDependsOn>
     <CompileDependsOn>
       _SetupMSBuildAllProjects;
       _SetupDesignTimeBuildForCompile;


### PR DESCRIPTION
Context: https://github.com/dotnet/msbuild/pull/5499

In .NET 6, we can rely on `$(IncrementalCleanDependsOn)`. This means
we can remove the expression:

    <CoreBuildDependsOn>
      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
    </CoreBuildDependsOn>

And simply use `$(IncrementalCleanDependsOn)` instead of
`$(_BeforeIncrementalClean)`.

I also found a block of targets defined with:

    <!-- Targets that run unless we are running _ComputeFilesToPublishForRuntimeIdentifiers -->
    <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' ">

But this file is no longer imported at all:

    <Import Project="Microsoft.Android.Sdk.BuildOrder.targets" Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' " />

So we can delete the `Condition` now.