### PR TITLE
[CI] Migrate to ESRP macOS notarization

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1204,48 +1204,48 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
-  - powershell: |
-      # We require at a minimum version 2.8.0 of the azure cli installed for the ESRP signing
-      # First, check for what version is currently installed on the machine
-      & brew link azure-cli
-      $Versions = & az --version 
-      $AzureVersion = $Versions[0]
-      $AzureVersionFields = $AzureVersion.split(" ", [StringSplitOptions]::RemoveEmptyEntries)
-      $CurrentVersion = New-Object -TypeName System.Version -ArgumentList $AzureVersionFields[1]
-      $Version280 = New-Object -TypeName System.Version -ArgumentList "2.8.0"
+    - powershell: |
+        # We require at a minimum version 2.8.0 of the azure cli installed for the ESRP signing
+        # First, check for what version is currently installed on the machine
+        & brew link azure-cli
+        $Versions = & az --version 
+        $AzureVersion = $Versions[0]
+        $AzureVersionFields = $AzureVersion.split(" ", [StringSplitOptions]::RemoveEmptyEntries)
+        $CurrentVersion = New-Object -TypeName System.Version -ArgumentList $AzureVersionFields[1]
+        $Version280 = New-Object -TypeName System.Version -ArgumentList "2.8.0"
 
-      Write-Host "Current Version of azure-cli is $CurrentVersion"
+        Write-Host "Current Version of azure-cli is $CurrentVersion"
 
-      # Check if version 2.8 is higher than the current version.
-      # If it is then we need to do work and download and install the 2.8.0 version of the azure cli in
-      # a really really freaked out non-intuitive way using brew. Why is this so hard to do???
-      # https://stackoverflow.com/questions/62785290/installing-previous-versions-of-a-formula-with-brew-extract
-      if ($Version280 -gt $CurrentVersion)
-      {
-          Write-Host "Version $CurrentVersion of azure-cli is lower than 2.8.0.  Installing the 2.8.0 version of azure-cli..."
+        # Check if version 2.8 is higher than the current version.
+        # If it is then we need to do work and download and install the 2.8.0 version of the azure cli in
+        # a really really freaked out non-intuitive way using brew. Why is this so hard to do???
+        # https://stackoverflow.com/questions/62785290/installing-previous-versions-of-a-formula-with-brew-extract
+        if ($Version280 -gt $CurrentVersion)
+        {
+            Write-Host "Version $CurrentVersion of azure-cli is lower than 2.8.0.  Installing the 2.8.0 version of azure-cli..."
 
-          & brew untap builder/azure-cli
+            & brew untap builder/azure-cli
 
-          # unlink the current version
-          & brew unlink azure-cli
+            # unlink the current version
+            & brew unlink azure-cli
 
-          # Create a new tap
-          & brew tap-new builder/azure-cli
+            # Create a new tap
+            & brew tap-new builder/azure-cli
 
-          # Extract version 2.8.0 to the tap
-          & brew extract --force --version 2.8.0 azure-cli builder/azure-cli
+            # Extract version 2.8.0 to the tap
+            & brew extract --force --version 2.8.0 azure-cli builder/azure-cli
 
-          # Install this version 
-          & brew install builder/azure-cli/azure-cli@2.8.0
+            # Install this version 
+            & brew install builder/azure-cli/azure-cli@2.8.0
 
-          # link this version to start using it
-          & brew link azure-cli@2.8.0
-      }
-      else 
-      {
-          Write-Host "Version $CurrentVersion of azure-cli is higher than 2.8.0.  Nothin to do..."
-      }
-    displayName: 'Install Azure CLI >= 2.8.0'
+            # link this version to start using it
+            & brew link azure-cli@2.8.0
+        }
+        else 
+        {
+            Write-Host "Version $CurrentVersion of azure-cli is higher than 2.8.0.  Nothin to do..."
+        }
+      displayName: 'Install Azure CLI >= 2.8.0'
 
     - task: MicroBuildSigningPlugin@3
       displayName: Install Signing Plugin

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
   - repository: release_scripts
     type: github
     name: xamarin/release-scripts
-    ref: refs/heads/sign-and-notarized
+    ref: refs/heads/dev/trevors/sign-and-notarized/logging
     endpoint: xamarin
   - repository: uitools
     type: github
@@ -1258,6 +1258,7 @@ stages:
     - script: >
         cd $(System.DefaultWorkingDirectory)/release-scripts &&
         pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/storage-artifacts
+      failOnStderr: true
       displayName: Notarize PKG
 
     - powershell: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1207,7 +1207,7 @@ stages:
     - powershell: |
         # We require at a minimum version 2.8.0 of the azure cli installed for the ESRP signing
         # First, check for what version is currently installed on the machine
-        & brew link azure-cli
+        & az --version
         $Versions = & az --version 
         $AzureVersion = $Versions[0]
         $AzureVersionFields = $AzureVersion.split(" ", [StringSplitOptions]::RemoveEmptyEntries)
@@ -1260,10 +1260,6 @@ stages:
         pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/storage-artifacts
       failOnStderr: true
       displayName: Notarize PKG
-
-    - powershell: |
-        & brew link azure-cli
-      displayName: 'Link azure-cli'
 
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)
       displayName: validate notarized pkg

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1163,6 +1163,8 @@ stages:
       clean: all
     variables:
     - group: Xamarin Notarization
+    - name: TeamName
+      value: XamarinAndroid
     steps:
     - checkout: self
 
@@ -1204,8 +1206,7 @@ stages:
         signType: real
         azureSubscription: MicroBuild Signing Task (DevDiv)
       env:
-        TeamName: XamarinAndroid
-        SYSTEM_ACCESSTOKEN: $(system.accesstoken)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - script: >
         cd $(System.DefaultWorkingDirectory)/release-scripts &&

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,6 +21,7 @@ resources:
   - repository: release_scripts
     type: github
     name: xamarin/release-scripts
+    ref: refs/heads/sign-and-notarized
     endpoint: xamarin
   - repository: uitools
     type: github
@@ -1197,11 +1198,15 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
+    - task: MicroBuildSigningPlugin@3
+      displayName: Install Signing Plugin
+      inputs:
+        signType: real
+        azureSubscription: MicroBuild Signing Task (DevDiv)
+
     - script: >
         cd $(System.DefaultWorkingDirectory)/release-scripts &&
-        git checkout $(ReleaseScriptsBranch) &&
-        sudo xcode-select -s /Applications/$(NotarizationXcode) &&
-        ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
+        pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/storage-artifacts
       displayName: Notarize PKG
 
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1163,8 +1163,6 @@ stages:
       clean: all
     variables:
     - group: Xamarin Notarization
-    - name: TeamName
-      value: XamarinAndroid
     steps:
     - checkout: self
 
@@ -1205,6 +1203,9 @@ stages:
       inputs:
         signType: real
         azureSubscription: MicroBuild Signing Task (DevDiv)
+      env:
+        TeamName: XamarinAndroid
+        SYSTEM_ACCESSTOKEN: $(system.accesstoken)
 
     - script: >
         cd $(System.DefaultWorkingDirectory)/release-scripts &&

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1260,9 +1260,9 @@ stages:
         pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/storage-artifacts
       displayName: Notarize PKG
 
-  - powershell: |
-      & brew link azure-cli
-    displayName: 'Link azure-cli'
+    - powershell: |
+        & brew link azure-cli
+      displayName: 'Link azure-cli'
 
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)
       displayName: validate notarized pkg

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1172,6 +1172,10 @@ stages:
       clean: true
       persistCredentials: true
 
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNetCoreVersion)
+
     - template: install-certificates.yml@yaml
       parameters:
         DeveloperIdApplication: $(developer-id-application)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
   - repository: release_scripts
     type: github
     name: xamarin/release-scripts
-    ref: refs/heads/dev/trevors/sign-and-notarized/logging
+    ref: refs/heads/sign-and-notarized
     endpoint: xamarin
   - repository: uitools
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
   - repository: release_scripts
     type: github
     name: xamarin/release-scripts
-    ref: refs/heads/sign-and-notarized
+    ref: refs/heads/dev/trevors/sign-and-notarized/azversioncheck
     endpoint: xamarin
   - repository: uitools
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
   - repository: release_scripts
     type: github
     name: xamarin/release-scripts
-    ref: refs/heads/dev/trevors/sign-and-notarized/azversioncheck
+    ref: refs/heads/sign-and-notarized
     endpoint: xamarin
   - repository: uitools
     type: github
@@ -1204,6 +1204,49 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
+  - powershell: |
+      # We require at a minimum version 2.8.0 of the azure cli installed for the ESRP signing
+      # First, check for what version is currently installed on the machine
+      & brew link azure-cli
+      $Versions = & az --version 
+      $AzureVersion = $Versions[0]
+      $AzureVersionFields = $AzureVersion.split(" ", [StringSplitOptions]::RemoveEmptyEntries)
+      $CurrentVersion = New-Object -TypeName System.Version -ArgumentList $AzureVersionFields[1]
+      $Version280 = New-Object -TypeName System.Version -ArgumentList "2.8.0"
+
+      Write-Host "Current Version of azure-cli is $CurrentVersion"
+
+      # Check if version 2.8 is higher than the current version.
+      # If it is then we need to do work and download and install the 2.8.0 version of the azure cli in
+      # a really really freaked out non-intuitive way using brew. Why is this so hard to do???
+      # https://stackoverflow.com/questions/62785290/installing-previous-versions-of-a-formula-with-brew-extract
+      if ($Version280 -gt $CurrentVersion)
+      {
+          Write-Host "Version $CurrentVersion of azure-cli is lower than 2.8.0.  Installing the 2.8.0 version of azure-cli..."
+
+          & brew untap builder/azure-cli
+
+          # unlink the current version
+          & brew unlink azure-cli
+
+          # Create a new tap
+          & brew tap-new builder/azure-cli
+
+          # Extract version 2.8.0 to the tap
+          & brew extract --force --version 2.8.0 azure-cli builder/azure-cli
+
+          # Install this version 
+          & brew install builder/azure-cli/azure-cli@2.8.0
+
+          # link this version to start using it
+          & brew link azure-cli@2.8.0
+      }
+      else 
+      {
+          Write-Host "Version $CurrentVersion of azure-cli is higher than 2.8.0.  Nothin to do..."
+      }
+    displayName: 'Install Azure CLI >= 2.8.0'
+
     - task: MicroBuildSigningPlugin@3
       displayName: Install Signing Plugin
       inputs:
@@ -1216,6 +1259,10 @@ stages:
         cd $(System.DefaultWorkingDirectory)/release-scripts &&
         pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/storage-artifacts
       displayName: Notarize PKG
+
+  - powershell: |
+      & brew link azure-cli
+    displayName: 'Link azure-cli'
 
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)
       displayName: validate notarized pkg

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1163,6 +1163,8 @@ stages:
       clean: all
     variables:
     - group: Xamarin Notarization
+    - name: TeamName
+      value: XamarinAndroid
     steps:
     - checkout: self
 


### PR DESCRIPTION
Context: https://github.com/xamarin/release-scripts/blob/ce33e71cfe75f4ad098aa5f66c475e60582ccafb/notarize.ps1

We have received a request to migrate away from our Xamarin Notarization
logic and instead use a new ESRP Notarization script.  To do this we
need to first install the required MicroBuild plugin, and then call the
new `notarize.ps1` script.