### PR TITLE
[build] Fix Homebrew/openssl

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -404,6 +404,9 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
+    - script: 'brew uninstall openssl@1.0.2t && rm -rf /usr/local/etc/openssl && rm -rf /usr/local/etc/openssl@1.1'
+      displayName: fix Homebrew
+
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
       displayName: install required brew tools and prepare java.interop
 


### PR DESCRIPTION
Recently some CI builds are ending early, because Homebrew is failing
like this:

    Installing automake
    ...
    stderr | Error: Not a directory @ dir_s_rmdir - /usr/local/Cellar/openssl
     | Removing: /usr/local/Cellar/openssl/1.0.2t... (1,787 files, 12MB)

    Error: Installation of automake failed