### PR TITLE
[issues] fix instructions for 'adb logcat -d' on Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,11 +23,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->

--- a/.github/ISSUE_TEMPLATE/01-building-an-application.md
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.md
@@ -32,11 +32,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.md
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.md
@@ -32,11 +32,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->

--- a/.github/ISSUE_TEMPLATE/04-mono-android-api.md
+++ b/.github/ISSUE_TEMPLATE/04-mono-android-api.md
@@ -46,11 +46,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->

--- a/.github/ISSUE_TEMPLATE/05-binding-a-java-library.md
+++ b/.github/ISSUE_TEMPLATE/05-binding-a-java-library.md
@@ -32,11 +32,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->

--- a/.github/ISSUE_TEMPLATE/07-other.md
+++ b/.github/ISSUE_TEMPLATE/07-other.md
@@ -32,11 +32,16 @@ If you have a repro project, you may drag & drop the .zip/etc. onto the issue ed
 ### Log File
 
 <!--
-1. On macOS and within Visual Studio:
-    a. Click **Tools** > **SDK Command Prompt**.
-    b. Within the launched `Terminal.app` window, run:
+1. Within Visual Studio:
+    a. Click **Tools** > **SDK Command Prompt** on macOS or
+       **Tools** > **Android** > **Android Adb Command Prompt** on Windows
+    b. On macOS, in the launched `Terminal.app` window, run:
 
             adb logcat -d | pbcopy
+
+       On Windows, in the launched `cmd.exe` window, run:
+
+            adb logcat -d | clip
 
 2. Paste below this comment block
 -->


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5389

The instructions did not specify how to do an equivalent of:

    $ adb logcat -d | pbcopy

On Windows, it can be:

    > adb logcat -d | clip