### PR TITLE
[Mono.Android] Bind AccessibilityNodeInfo.AddAction (AccessibilityAction action)

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1073,9 +1073,11 @@
   <!-- This is required because "System" causes several namespace resolution problem... -->
   <attr api-since="21" path="/api/package[@name='android.system']" name="managedName">Android.Systems</attr>
   <attr api-since="21" path="/api/package[@name='android.app.job']/class[@name='JobInfo']/method[@name='getBackoffPolicy']" name="managedName">GetBackoffPolicyValue</attr>
-  <!-- Thanks to the deprecated API, somehow we cannot add binding for the non-deprecated version of the API.
-       FIXME: It might be overkill, we can revisit here later. -->
-  <remove-node api-since="21" path="/api/package[@name='android.view.accessibility']/class[@name='AccessibilityNodeInfo']/method[@name='addAction'][parameter/@type='android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction']" name="eventName" />
+
+  <!-- We have 2 methods with the same name and the same parameter name.  The original one used an int which we mapped to an enum.
+       Our methodmap.csv isn't capable of only choosing 1 of the methods, so it sets them both as the enum, making both have  the
+       same signature.  So we are going to set the enum transformation here instead, where we can specify a path that only affects a single method. -->
+  <attr api-since="14" path="/api/package[@name='android.view.accessibility']/*[@name='AccessibilityNodeInfo']/method[@name='addAction' and count(parameter)=1 and parameter[1][@type='int']]/parameter[@name='action']" name="enumType">Android.Views.Accessibility.Action</attr>
 
   <!-- FIXME: this should be fixed in generator ("Raw" method resolution is complicated). Since we can call base method, it can be even ignored... -->
   <remove-node api-since="21" path="/api/package[@name='java.util.concurrent']/class[@name='RecursiveAction']/method[@name='getRawResult']" />

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -1133,7 +1133,6 @@
 0, android.view.accessibility, [Interface]AccessibilityEventSource, sendAccessibilityEvent, eventType, Android.Views.Accessibility.EventTypes
 0, android.view.accessibility, AccessibilityManager, getEnabledAccessibilityServiceList, feedbackTypeFlags, Android.AccessibilityServices.FeedbackFlags
 0, android.view.accessibility, AccessibilityNodeInfo, getActions, return, Android.Views.Accessibility.Action
-0, android.view.accessibility, AccessibilityNodeInfo, addAction, action, Android.Views.Accessibility.Action
 0, android.view.accessibility, AccessibilityNodeInfo, performAction, action, Android.Views.Accessibility.Action
 
 0, android.view.animation, RotateAnimation, ctor, pivotXType, Android.Views.Animations.Dimension


### PR DESCRIPTION
Fixes: #5368 

The class [`AccessibilityNodeInfo`](https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo) has the following methods:
```
// Added in API-14, deprecated in API-21
public void addAction (int action)

// Added in API-21
public void addAction (AccessibilityNodeInfo.AccessibilityAction action)
```

We are converting the `int action` to an enum using `methodmap.csv`:
```
0, android.view.accessibility, AccessibilityNodeInfo, addAction, action, Android.Views.Accessibility.Action
```

However this mechanism does not specify parameter types, so both methods are getting their parameter enum-ified:
```
public void AddAction (Android.Views.Accessibility.Action action)
public void AddAction (Android.Views.Accessibility.Action action)
```

This isn't allowed, so we disabled binding the new overload to allow `Mono.Android` to build.

In order to properly bind the new overload, this commit removes the line from `methodmap.csv` and adds the specification directly to `metadata`, where the `path` can be made more specific to only affect a single method, allowing the new method to be bound with its original parameter type.

```
public void AddAction (Android.Views.Accessibility.Action action)
public void AddAction (AccessibilityNodeInfo.AccessibilityAction action)
```