### PR TITLE
[tests] check PerformanceTest for .NET 6

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -50,17 +50,15 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Fail ($"No timeout value found for a key of {caller}");
 			}
 
-			if (Builder.UseDotNet) {
-				//TODO: there is currently a slight performance regression in .NET 6
-				expected += 500;
-			}
-
 			action (builder);
 			var actual = GetDurationFromBinLog (builder);
 			TestContext.Out.WriteLine($"expected: {expected}ms, actual: {actual}ms");
 			if (actual > expected) {
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {actual}ms");
 			}
+
+			//TODO: remove this
+			Assert.Fail ("Fail on purpose to compare times.");
 		}
 
 		double GetDurationFromBinLog (ProjectBuilder builder)


### PR DESCRIPTION
I cherry-picked some commits to see how close we will get to the exact
same build performance in .NET 6.

For now I triggered every `PerformanceTest` to fail, so I can compare
.NET 6 `.binlog` files against the "legacy" Xamarin.Android ones.