### PR TITLE
[illink] Do not preserve whole JNIEnv class

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -7,7 +7,12 @@
 		<type fullname="Android.Runtime.IJavaObject" />
 		<type fullname="Android.Runtime.InputStreamAdapter" />
 		<type fullname="Android.Runtime.InputStreamInvoker" />
-		<type fullname="Android.Runtime.JNIEnv" />
+		<type fullname="Android.Runtime.JNIEnv">
+			<method name="Exit" />
+			<method name="Initialize" />
+			<method name="PropagateUncaughtException" />
+			<method name="RegisterJniNatives" />
+		</type>
 		<type fullname="Android.Runtime.JniNativeInterfaceStruct" />
 		<type fullname="Android.Runtime.JniNativeInterfaceInvoker" />
 		<type fullname="Android.Runtime.JNINativeWrapper" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -86,7 +86,6 @@ namespace Xamarin.Android.Build.Tests
 				new [] {
 					"Java.Interop.dll",
 					"Mono.Android.dll",
-					"System.ComponentModel.Primitives.dll",
 					"System.Console.dll",
 					"System.Linq.Expressions.dll",
 					"System.Net.Primitives.dll",


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5167

Instead preserve just methods accessed
from [native code](https://github.com/xamarin/xamarin-android/blob/master/src/monodroid/jni/monodroid-glue.cc).
