### PR TITLE
[illink] Update CheckIncludedAssemblies test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -86,10 +86,8 @@ namespace Xamarin.Android.Build.Tests
 				new [] {
 					"Java.Interop.dll",
 					"Mono.Android.dll",
-					"System.ComponentModel.Primitives.dll",
 					"System.Console.dll",
 					"System.Linq.Expressions.dll",
-					"System.Net.Primitives.dll",
 					"System.ObjectModel.dll",
 					"System.Runtime.Serialization.Primitives.dll",
 					"System.Security.Cryptography.Primitives.dll",


### PR DESCRIPTION
Two more assemblies are linked away, that is probably result of multiple
linker related fixes going in together yesterday.