### PR TITLE
[build] Pass more information regarding the build to the signing job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1251,6 +1251,6 @@ stages:
         branchToUse: 'full-esrp-integration'
         waitForQueuedBuildsToFinish: true
         storeInEnvironmentVariable: true
-        buildParameters: '{ "REPO": "$(Build.Repository.Name)", "COMMIT": "$(Build.SourceVersion)", "SIGN_TYPE": "Real", "GITHUB_CONTEXT": "$(GitHub.Artifacts.Context)" }'
+        buildParameters: '{ "REPO": "$(Build.Repository.Name)", "COMMIT": "$(Build.SourceVersion)", "SIGN_TYPE": "Real", "GITHUB_CONTEXT": "$(GitHub.Artifacts.Context)", "BUILD_DEFINITIONNAME": "$(Build.DefinitionName)", "BUILD_ID": "$(Build.BuildId)", "BUILD_NUMBER": "$(Build.BuildNumber)", "BUILD_URI": "$(Build.BuildUri)" }'
         authenticationMethod: 'OAuth Token'
         password: $(System.AccessToken)     # Equivalent to the 'Allow scripts to access OAuth token option': https://stackoverflow.com/questions/52837980/how-to-allow-scripts-to-access-oauth-token-from-yaml-builds


### PR DESCRIPTION
Follow up change to https://github.com/xamarin/xamarin-android/pull/5370

Provides useful information regarding the build who's calling the signing job.  When the build definition name and build number is passed, the signing job will set the build number to reflect the calling build.  This makes it much more convenient to immediately tell which build launched the signing job without having to dig into the logs.  It also leads to better information in our telemetry regarding the calling build.

Note: This change has also been applied to the d16-8 PR