### PR TITLE
[One .NET] include Java.Interop.Tools.Generator.dll in installer

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -145,8 +145,8 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Cecil.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Diagnostics.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Diagnostics.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Generator.dll"  ExcludeFromAndroidNETSdk="true" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Generator.pdb"  ExcludeFromAndroidNETSdk="true" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Generator.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Generator.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.JavaCallableWrappers.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.JavaCallableWrappers.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -183,6 +183,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var dotnet = CreateDotNetBuilder ();
 			Assert.IsTrue (dotnet.New (template), $"`dotnet new {template}` should succeed");
+			File.WriteAllBytes (Path.Combine (dotnet.ProjectDirectory, "foo.jar"), Convert.FromBase64String (InlineData.JavaClassesJarBase64));
 			Assert.IsTrue (dotnet.New ("android-activity"), "`dotnet new android-activity` should succeed");
 			Assert.IsTrue (dotnet.New ("android-layout", Path.Combine (dotnet.ProjectDirectory, "Resources", "layout")), "`dotnet new android-layout` should succeed");
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5402

Some .NET 6 binding projects are failing with:

    Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Java.Interop.Tools.Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
    Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Java.Interop.Tools.Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
    File name: 'Java.Interop.Tools.Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
    File name: 'Java.Interop.Tools.Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
       at MonoDroid.Generation.EnumMappings.ParseFieldMappings(TextReader source, String[] enumFlags, Int32 filter_version, IList`1 remove_nodes)
       at MonoDroid.Generation.EnumMappings.ParseFieldMappings(TextReader source, String[] enumFlags, Int32 filter_version, IList`1 remove_nodes)
       at MonoDroid.Generation.EnumMappings.Process(String fieldMap, String flagsFile, String methodMap)
       at MonoDroid.Generation.EnumMappings.Process(String fieldMap, String flagsFile, String methodMap)
       at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options, DirectoryAssemblyResolver resolver)
       at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options, DirectoryAssemblyResolver resolver)
       at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options)
       at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options)
       at Xamarin.Android.Binder.CodeGenerator.Main(String[] args)
       at Xamarin.Android.Binder.CodeGenerator.Main(String[] args)
    error MSB6006: "dotnet" exited with code -532462766.

Oddly enough, *some* bindings worked like in the `DotNetBuildBinding`
test. The default template from `dotnet new android-bindinglib` did
*not* work. I could reproduce the problem by adding a `.jar` file to
the `DotNetNew` test.

Reviewing `create-installers.targets`, this assembly file is indeed
excluded for .NET 6 packages since it was introduced in 91970b17. It
seems like we should be including this file?