### PR TITLE
[Xamarin.ProjectTools] log ExitCode when MSBuild exits

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -399,12 +399,17 @@ namespace Xamarin.ProjectTools
 					if (psi.RedirectStandardError)
 						err.WaitOne ();
 					result = ranToCompletion && p.ExitCode == 0;
+					if (processLog != null) {
+						if (ranToCompletion) {
+							File.AppendAllText (processLog, $"ExitCode: {p.ExitCode}{Environment.NewLine}");
+						} else {
+							File.AppendAllText (processLog, $"Build Timed Out!{Environment.ExitCode}");
+						}
+					}
 				}
 
 				LastBuildTime = DateTime.UtcNow - start;
 
-				if (processLog != null && !ranToCompletion)
-					File.AppendAllText (processLog, "Build Timed Out!");
 				if (buildLogFullPath != null && File.Exists (buildLogFullPath)) {
 					foreach (var line in LastBuildOutput) {
 						if (line.StartsWith ("Time Elapsed", StringComparison.OrdinalIgnoreCase)) {


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4291650&view=ms.vss-test-web.build-test-results-tab&runId=17600706&resultId=100198&paneView=attachments

We have occasionally seen failures under `dotnet build` such as:

    Project should have built.
    Expected: True
    But was:  False

But then the diagnostic MSBuild log says:

    Build succeeded.
        0 Warning(s)
        0 Error(s)

Looking at the logic in `Builder.BuildInternal()`, it seems like this
means the `ExitCode` was non-zero. There was no `Build Timed Out!` log
message either.

We should log the exit code, which might help diagnose the issue.