### PR TITLE
Bump to r8 2.1.75

### DIFF
--- a/Documentation/release-notes/r8-2.1.75.md
+++ b/Documentation/release-notes/r8-2.1.75.md
@@ -1,0 +1,4 @@
+### D8/R8 version update to 2.1.75
+
+The version of the [D8 dexer and R8 shrinker](https://r8.googlesource.com/r8)
+included in Xamarin.Android has been updated from 2.1.67 to 2.1.75.

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '2.1.67'
+    compile group: 'com.android.tools', name: 'r8', version: '2.1.75'
 }
 
 jar {


### PR DESCRIPTION
Context: https://r8.googlesource.com/r8/+/refs/tags/2.1.75/
Context: https://mvnrepository.com/artifact/com.android.tools/r8/2.1.75

Bump r8 from 2.1.67 to 2.1.75.