### PR TITLE
Bump to google/bundletool/1.4.0@f5c6dc66

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -116,7 +116,7 @@
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">b2be9c80582174e645d3736daa0d44d8610b38a8.</XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>30.0.2</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.2.0</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.4.0</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != '' ">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' ">$(XamarinAndroidSourcePath)\packages</XAPackagesDir>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>

--- a/Documentation/release-notes/bundletool-1.4.0.md
+++ b/Documentation/release-notes/bundletool-1.4.0.md
@@ -1,0 +1,8 @@
+### bundletool version update to 1.4.0
+
+The version of the [`bundletool`][bundletool] executable included in
+Xamarin.Android has been updated from 1.2.0 to [1.4.0][bundletool-1.4.0],
+bringing in several improvements and bug fixes.
+
+[bundletool]: https://developer.android.com/studio/command-line/bundletool
+[bundletool-1.4.0]: https://github.com/google/bundletool/releases/tag/1.4.0

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Prepare
 				// BCL: Runs BCL tests on emulator
 				// TimeZone: Runs timezone unit tests on emulator
 				// Designer: Runs designer integration tests
-				if (file == ".external") {
+				if (file == ".external" || file == "Configuration.props") {
 					testAreas.Add ("MSBuild");
 					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("BCL");


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/1.2.0
Changes: https://github.com/google/bundletool/compare/1.2.0...1.4.0

1.3.0

* Support generating and embedding source stamps in APKs generated
  from Android App Bundles.
* `output-format` option for `build-apks` command that allows to
  choose output format for generated APKs: APK Set archive or
  directory.
* `include-metadata` option for `extract-apks` command that allows to
  produce `metadata.json` file which contains information about
  extracted APKs: module name and delivery type of the APK.

1.4.0

* Introduced DexMergingStrategy option in BundleConfig that allows to
  skip dex merging for multidex applications with minSdk below 21.
* Conditional install-time modules can now depend on other
  install-time modules.

Other changes:

* Make `Configuration.props` changes trigger all test runs.