### PR TITLE
Bump to aapt2 4.1.1-6503028

### DIFF
--- a/Documentation/release-notes/aapt2-4.1.1.md
+++ b/Documentation/release-notes/aapt2-4.1.1.md
@@ -1,0 +1,4 @@
+### aapt2 update to 4.1.1
+
+The version of the [aapt2](https://developer.android.com/studio/command-line/aapt2)
+command-line tool has been updated from 4.0.0 to 4.1.1.

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <Aapt2Version>4.0.0-6051327</Aapt2Version>
+    <Aapt2Version>4.1.1-6503028</Aapt2Version>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools.build/aapt2/4.1.1-6503028
Context: https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/tools/aapt2/

The result of `aapt2 version` changed:

```diff
-Android Asset Packaging Tool (aapt) 2.19-6051327
+Android Asset Packaging Tool (aapt) 2.19-6503028
```

The best release note I could find are:

https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt2/readme.md

However, I don't see how any of these map to the versions on Maven:

```diff
-compile group: 'com.android.tools.build', name: 'aapt2', version: '4.0.0-6051327', ext: 'pom'
+compile group: 'com.android.tools.build', name: 'aapt2', version: '4.1.1-6503028', ext: 'pom'
```