### PR TITLE
Bump to manifest-merger 27.1.1

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -117,7 +117,6 @@
     <XAPlatformToolsVersion>30.0.2</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.2.0</XABundleToolVersion>
-    <XAManifestMergerToolVersion Condition="'$(XAManifestMergerToolVersion)' == ''">26.5.0</XAManifestMergerToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != '' ">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' ">$(XamarinAndroidSourcePath)\packages</XAPackagesDir>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>

--- a/Documentation/release-notes/manifestmerger-27.1.1.md
+++ b/Documentation/release-notes/manifestmerger-27.1.1.md
@@ -1,0 +1,6 @@
+### manifestmerger.jar version update to 27.1.1
+
+The version of the [manifest merger][0] included in Xamarin.Android
+has been updated from 27.0.0 to 27.1.1.
+
+[0]: https://developer.android.com/studio/build/manifest-merge.html

--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    compile group: 'com.android.tools.build', name: 'manifest-merger', version: '27.0.0'
+    compile group: 'com.android.tools.build', name: 'manifest-merger', version: '27.1.1'
 }
 
 sourceSets {

--- a/src/manifestmerger/manifestmerger.csproj
+++ b/src/manifestmerger/manifestmerger.csproj
@@ -8,9 +8,5 @@
   
   <Import Project="..\..\Configuration.props" />
   
-  <ItemGroup>
-    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
-  </ItemGroup>
-  
   <Import Project="manifestmerger.targets" />
 </Project>


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger/27.1.1
Context: https://android.googlesource.com/platform/tools/base/+/master/build-system/manifest-merger

Other changes:

* `manifestmerger.csproj` does not need to reference `r8.csproj`.
* I removed `$(XAManifestMergerToolVersion)` as it was completely unused.