### PR TITLE
Bump to apksigner from platform-tools 30.0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "external/apksig"]
     path = external/apksig
     url = https://android.googlesource.com/platform/tools/apksig
-    branch = platform-tools-30.0.3
+    branch = platform-tools-30.0.5
 [submodule "external/debugger-libs"]
     path = external/debugger-libs
     url = https://github.com/mono/debugger-libs

--- a/Documentation/release-notes/apksigner-30.0.5.md
+++ b/Documentation/release-notes/apksigner-30.0.5.md
@@ -1,0 +1,8 @@
+#### apksigner updated to Android SDK Build-Tools 30.0.5
+
+The version of the [`apksigner`][apksigner] executable included in
+Xamarin.Android has been updated from Android SDK Build-Tools 30.0.3
+to [Android SDK Build-Tools 30.0.5][apksigner-30.0.5].
+
+[apksigner]: https://developer.android.com/studio/command-line/apksigner
+[apksigner-30.0.5]: https://android.googlesource.com/platform/tools/apksig/+/refs/tags/platform-tools-30.0.5

--- a/src/apksigner/build.gradle
+++ b/src/apksigner/build.gradle
@@ -11,6 +11,14 @@ java {
 
 repositories {
     jcenter()
+    mavenCentral()
+}
+
+dependencies {
+    // https://mvnrepository.com/artifact/org.conscrypt/conscrypt-openjdk
+    compile group: 'org.conscrypt', name: 'conscrypt-openjdk', version: '2.5.1', classifier: 'windows-x86_64'
+    compile group: 'org.conscrypt', name: 'conscrypt-openjdk', version: '2.5.1', classifier: 'osx-x86_64'
+    compile group: 'org.conscrypt', name: 'conscrypt-openjdk', version: '2.5.1', classifier: 'linux-x86_64'
 }
 
 sourceSets {
@@ -24,7 +32,7 @@ sourceSets {
             srcDirs '../../external/apksig/src/apksigner/java'
         }
     }
- }
+}
 
 jar {
     duplicatesStrategy = 'exclude'
@@ -33,6 +41,8 @@ jar {
     }
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    } {
+        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
     }
     archiveName 'apksigner.jar'
 }


### PR DESCRIPTION
Context: https://android.googlesource.com/platform/tools/apksig/+/refs/tags/platform-tools-30.0.5
Context: https://developer.android.com/studio/releases/platform-tools#3005_november_2020

Bump to platform/tools/apksig/platform-tools-30.0.5@96e0c65e

As part of this, the `apksig` library has taken a dependency on:

* https://mvnrepository.com/artifact/org.conscrypt/conscrypt-openjdk/2.5.1

We will also need to exclude some files in the `META-INF` directory,
since this dependency is signed.