### PR TITLE
Bump to lz4/lz4/release@d4437184 [v1.9.3]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git
-    branch = master
+    branch = release
 [submodule "external/mman-win32"]
     path = external/mman-win32
     url = https://github.com/witwall/mman-win32.git


### PR DESCRIPTION
Bump from lz4 v1.9.2 to v1.9.3.

Changes: https://github.com/lz4/lz4/compare/fdf2ef5809ca875c454510610764d9125ef2ebbd...d44371841a2f1728a3f36839fd4b7e872d0927d3

	% git diff --shortstat fdf2ef58...d4437184
	 94 files changed, 2917 insertions(+), 1377 deletions(-)

Note: lz4/lz4 has no `master` branch.  Release tags are for commits
on the `release` branch.  Update `.gitmodules` accordingly.