### PR TITLE
Bump to mono/mono/2020-02@5e9cb6d1

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-8@dc18583a9bc43557b99c056c90767ff800ad1ace
-mono/mono:2020-02@be2226b5a1c57df065efc4c1cf008d581e5cec7d
+mono/mono:2020-02@5e9cb6d1c1de430965312927d5aed7fcb27bfa73


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/pull/35008#issuecomment-657402155
Context: https://github.com/mono/mono/issues/15418
Context: https://github.com/mono/mono/issues/16763
Context: https://github.com/mono/mono/issues/20490
Context: https://github.com/mono/mono/issues/20533
Context: https://github.com/xamarin/xamarin-macios/issues/9949

Changes: https://github.com/mono/mono/compare/be2226b5a1c57df065efc4c1cf008d581e5cec7d...5e9cb6d1c1de430965312927d5aed7fcb27bfa73

  * mono/mono@5e9cb6d1c1d: Use explicit arithmetic checks in the amd64 watchOS simulator. (#20647)
  * mono/mono@4fdfb5b1fd5: Bump bockbuild for gtk+ patch
  * mono/mono@6f6c3286b66: [runtime] Avoid checking for hardened runtime on ios, its not needed, and it causes alerts because of PROT_WRITE|PROT_EXEC. (#20623)
  * mono/mono@124f1157141: Fix iOS sdks build on Xcode 12 (#20574)
  * mono/mono@dfbfe5eed19: [2020-02] Build makefile to support Mac Catalyst (#20566)
  * mono/mono@ac596375c76: Add support for OP_FCONV_TO_I to mini-arm64.c. (#20548)
  * mono/mono@392fe5b87b2: [2020-02][watchOS] Add simwatch64 support (#20552)
  * mono/mono@a22ed3f094e: Fix potential crash for Encoder.Convert (#20522)
  * mono/mono@970783731fc: Bump to F# 5.0 (#20511)
  * mono/mono@32ab5066f72: Bump msbuild to fix a build issue
  * mono/mono@93a7fe77e8e: Ensure special static slots respect alignment. (#20506)
  * mono/mono@3db5b358413: [debugger] Switch to GC Unsafe in signal handler callbacks (#20495)
  * mono/mono@af315f44c40: [2020-02][corlib] ThreadAbortException protection for ArraySortHelper (#20468)
  * mono/mono@ca11fb0fd81: [2020-02] Bump ikvm-fork to include https://github.com/mono/ikvm-fork/pull/20 (#20452)