### PR TITLE
[build] fix Inputs/Outputs for monodroid.csproj

### DIFF
--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -118,11 +118,24 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_ConfigureRuntimesInputs">
+    <ItemGroup>
+      <_ConfigureRuntimesInputs  Include="CMakeLists.txt" />
+      <_ConfigureRuntimesInputs  Include="..\..\build-tools\scripts\cmake-common.props" />
+      <_ConfigureRuntimesInputs  Include="..\..\build-tools\scripts\Ndk.targets" />
+      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt')" />
+      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')" />
+      <_ConfigureRuntimesOutputs Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Debug\CMakeCache.txt')" />
+      <_ConfigureRuntimesOutputs Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Release\CMakeCache.txt')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_ConfigureRuntimes"
-      DependsOnTargets="_PrepareConfigureRuntimeCommands"
-      Inputs="CMakeLists.txt;..\..\build-tools\scripts\cmake-common.props;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Release\CMakeCache.txt')">
+      DependsOnTargets="_PrepareConfigureRuntimeCommands;_ConfigureRuntimesInputs"
+      Inputs="@(_ConfigureRuntimesInputs)"
+      Outputs="@(_ConfigureRuntimesOutputs)">
     <RunParallelCmds Commands="@(_ConfigureRuntimeCommands)" />
+    <Touch Files="@(_ConfigureRuntimesOutputs)" />
   </Target>
 
   <Target Name="_FindMonoDroidSources">

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -182,6 +182,8 @@
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-ubsan-Release"
     />
+
+    <Touch Files="@(_BuildAndroidRuntimesOutputs)" />
   </Target>
 
   <Target Name="_BuildHostRuntimesInputs"
@@ -221,6 +223,7 @@
         DestinationFiles="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.d.%(NativeLibraryExtension)')"
     />
 
+    <Touch Files="@(_BuildHostRuntimesOutputs)" />
   </Target>
   <Target Name="_CleanRuntimes"
       DependsOnTargets="_GetBuildHostRuntimes"

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -125,9 +125,16 @@
     <RunParallelCmds Commands="@(_ConfigureRuntimeCommands)" />
   </Target>
 
+  <Target Name="_FindMonoDroidSources">
+    <ItemGroup>
+      <_MonoDroidSources Include="jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_BuildAndroidRuntimes"
-      Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
+      DependsOnTargets="_FindMonoDroidSources"
+      Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');@(_MonoDroidSources);..\..\build-tools\scripts\Ndk.targets"
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Release\libxamarin-app.so')">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
@@ -160,8 +167,8 @@
   </Target>
 
   <Target Name="_BuildHostRuntimes"
-      DependsOnTargets="_CreateJavaInteropDllConfigs"
-      Inputs="@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\*.hh;jni\**\*.c;"
+      DependsOnTargets="_CreateJavaInteropDllConfigs;_FindMonoDroidSources"
+      Inputs="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Release\CMakeCache.txt');@(_MonoDroidSources)"
       Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)');@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.%(NativeLibraryExtension)');@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libxamarin-app.%(NativeLibraryExtension)')">
     <Message Text="Building host runtime %(_HostRuntime.Identity) in $(OutputPath)%(_HostRuntime.OutputDirectory)"/>
     <MakeDir Directories="$(OutputPath)%(_HostRuntime.OutputDirectory)" />

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -131,10 +131,28 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_BuildAndroidRuntimesInputs"
+      DependsOnTargets="_FindMonoDroidSources">
+    <ItemGroup>
+      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt')" />
+      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')" />
+      <_BuildAndroidRuntimesInputs  Include="@(_MonoDroidSources)" />
+      <_BuildAndroidRuntimesInputs  Include="..\..\build-tools\scripts\Ndk.targets" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Debug\libxamarin-app.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Release\libxamarin-app.so')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_BuildAndroidRuntimes"
-      DependsOnTargets="_FindMonoDroidSources"
-      Inputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');@(_MonoDroidSources);..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Release\libxamarin-app.so')">
+      DependsOnTargets="_BuildAndroidRuntimesInputs"
+      Inputs="@(_BuildAndroidRuntimesInputs)"
+      Outputs="@(_BuildAndroidRuntimesOutputs)">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
@@ -166,10 +184,22 @@
     />
   </Target>
 
+  <Target Name="_BuildHostRuntimesInputs"
+      DependsOnTargets="_FindMonoDroidSources">
+    <ItemGroup>
+      <_BuildHostRuntimesInputs  Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Debug\CMakeCache.txt')" />
+      <_BuildHostRuntimesInputs  Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Release\CMakeCache.txt')" />
+      <_BuildHostRuntimesInputs  Include="@(_MonoDroidSources)" />
+      <_BuildHostRuntimesOutputs Include="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')" />
+      <_BuildHostRuntimesOutputs Include="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.%(NativeLibraryExtension)')" />
+      <_BuildHostRuntimesOutputs Include="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libxamarin-app.%(NativeLibraryExtension)')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_BuildHostRuntimes"
-      DependsOnTargets="_CreateJavaInteropDllConfigs;_FindMonoDroidSources"
-      Inputs="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Release\CMakeCache.txt');@(_MonoDroidSources)"
-      Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)');@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.%(NativeLibraryExtension)');@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libxamarin-app.%(NativeLibraryExtension)')">
+      DependsOnTargets="_CreateJavaInteropDllConfigs;_BuildHostRuntimesInputs"
+      Inputs="@(_BuildHostRuntimesInputs)"
+      Outputs="@(_BuildHostRuntimesOutputs)">
     <Message Text="Building host runtime %(_HostRuntime.Identity) in $(OutputPath)%(_HostRuntime.OutputDirectory)"/>
     <MakeDir Directories="$(OutputPath)%(_HostRuntime.OutputDirectory)" />
 


### PR DESCRIPTION
On macOS, I noticed this happening on every build:

    $ msbuild src/monodroid -clp:performancesummary
    ...
     2934 ms  _BuildHostRuntimes
    41768 ms  _BuildAndroidRuntimes

The original cause was:

    Building target "_BuildAndroidRuntimes" completely.
    Output file "obj/Debug//armeabi-v7a-Debug/libxamarin-app.so" does not exist.

I updated the `Outputs` to use the correct file path:

```diff
-@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');
-@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')
+@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Debug\libxamarin-app.so');
+@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Release\libxamarin-app.so')
```

Next, I was still hitting the problem, but instead hit:

    Building target "_BuildAndroidRuntimes" completely.
    Input file "jni/*.cc" does not exist.

You can't actually use wildcards in `Inputs`? I made a new
`_FindMonoDroidSources` MSBuild target that created a new
`@(_MonoDroidSources)` item group. I used this in place of wildcards.

The `_BuildHostRuntimes` MSBuild target had a typo which caused:

    Building target "_BuildHostRuntimes" completely.
    Input file "host-Darwin-Debug/CMakeCache.txt" does not exist.

The `Inputs` needed to change:

```diff
-$(IntermediatePath)
+$(IntermediateOutputPath)
```

It also needed to use `@(_MonoDroidSources)` as `Inputs`.

Now things seem to work correctly:

    Skipping target "_BuildAndroidRuntimes" because all outputs are up-to-date with respect to the input files.
    Skipping target "_BuildHostRuntimes" because all outputs are up-to-date with respect to the input files.

This saves ~45s off of incremental builds for me on macOS. The savings
on Windows would not be as high, as it does not run the "checked"
builds at all.