### PR TITLE
[tests] add delay to DotNetLibraryAarChanges

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -248,6 +248,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			// Change res/raw/bar.txt contents
+			WaitFor (1000);
 			var bar_txt = Path.Combine (FullProjectDirectory, "Resources", "raw", "bar.txt");
 			File.WriteAllText (bar_txt, contents: "baz");
 			Assert.IsTrue (dotnet.Build (), "second build should succeed");


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4304485&view=ms.vss-test-web.build-test-results-tab&runId=17685428&resultId=100245&paneView=debug

Similar to what we saw in c7f1ccb8, the `DotNetLibraryAarChanges` test
can fail with:

    res/raw/bar.txt should contain baz
    String lengths are both 3. Strings differ at index 2.
    Expected: "baz"
    But was:  "bar"

Reviewing the build log, the `_GenerateAndroidResourceDir` and
`_CreateAar` MSBuild targets are skipped:

    Skipping target "_GenerateAndroidResourceDir" because all output files are up-to-date with respect to the input files.
    Input files: /Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/UnnamedProject.csproj.nuget.g.props;/Users/runner/Library/Android/dotnet/sdk/6.0.100-alpha.1.20562.2/NuGet.targets;/Users/runner/Library/Android/dotnet/sdk/6.0.100-alpha.1.20562.2/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/UnnamedProject.csproj.nuget.g.targets;/Users/runner/Library/Android/dotnet/sdk/6.0.100-alpha.1.20562.2/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets;Resources/values/Strings.xml;Resources/layout/Main.axml;Resources/drawable-mdpi/Icon.png;Resources/raw/bar.txt;Resources/raw/foo.txt;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/UnnamedProject.csproj;obj/Debug/net6.0-android/build.props
    Output files: obj/Debug/net6.0-android/res.flag
    ...
    Skipping target "_CreateAar" because all output files are up-to-date with respect to the input files.
    Input files: /Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/Debug/net6.0-android/res/values/strings.xml;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/Debug/net6.0-android/res/layout/main.xml;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/Debug/net6.0-android/res/drawable-mdpi/icon.png;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/Debug/net6.0-android/res/raw/bar.txt;/Users/runner/work/1/s/bin/TestRelease/temp/DotNetLibraryAarChanges/obj/Debug/net6.0-android/res/raw/foo.txt;obj/Debug/net6.0-android/UnnamedProject.aar.cache
    Output files: bin/Debug/net6.0-android/UnnamedProject.aar

Even though the file was written directly:

    var bar_txt = Path.Combine (FullProjectDirectory, "Resources", "raw", "bar.txt");
    File.WriteAllText (bar_txt, contents: "baz");
    Assert.IsTrue (dotnet.Build (), "second build should succeed");

I think a one second delay will make this test 100% reliable.