### PR TITLE
[Xamarin.Android.Build.Tasks] Enable NRT for bindings projects.

### DIFF
--- a/Documentation/release-notes/5431.md
+++ b/Documentation/release-notes/5431.md
@@ -1,0 +1,9 @@
+### Binding Projects Nullable Reference Types Support
+
+  * [GitHub PR 5431](https://github.com/xamarin/xamarin-android/pull/5431):
+    [Xamarin.Android.Build.Tasks] Enable NRT for bindings projects.
+
+Adding `<Nullable>enable</Nullable>` to an Android Bindings project
+that has `<LangVersion>` of at least C# 8 will cause the generated
+code to include nullable reference types.  Many Nullable annotations from the
+Java/Android ecosystem are supported. ([Supported List](https://github.com/xamarin/java.interop/pull/526))

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
@@ -39,6 +39,7 @@ This file is only used by binding projects.
         MonoAndroidFrameworkDirectories="$(_XATargetFrameworkDirectories)"
         ToolPath="$(MonoAndroidToolsDirectory)"
         ToolExe="$(BindingsGeneratorToolExe)"
+        Nullable="$(Nullable)"
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -60,6 +60,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         ToolExe="$(BindingsGeneratorToolExe)"
         LangVersion="$(LangVersion)"
         EnableInterfaceMembersPreview="$(_EnableInterfaceMembers)"
+        Nullable="$(Nullable)"
     />
 
     <!-- Write a flag so we won't redo this target if nothing changed -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -168,9 +168,12 @@ namespace Xamarin.Android.Tasks
 				if (SupportsCSharp8) {
 					var features = new List<string> ();
 
-					if (EnableInterfaceMembersPreview)
-						features.AddRange (new [] { "interface-constants", "default-interface-methods" });
-					if (Nullable == "enable")
+					if (EnableInterfaceMembersPreview) {
+						features.Add ("interface-constants");
+						features.Add ("default-interface-methods");
+					}
+
+					if (string.Equals (Nullable, "enable", StringComparison.OrdinalIgnoreCase))
 						features.Add ("nullable-reference-types");
 
 					if (features.Any ())

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Android.Tasks
 		public string LangVersion { get; set; }
 
 		public bool EnableInterfaceMembersPreview { get; set; }
+		public string Nullable { get; set; }
 
 		public ITaskItem[] TransformFiles { get; set; }
 		public ITaskItem[] ReferencedManagedLibraries { get; set; }
@@ -164,8 +165,17 @@ namespace Xamarin.Android.Tasks
 				if (UseShortFileNames)
 					WriteLine (sw, "--use-short-file-names");
 
-				if (EnableInterfaceMembersPreview && SupportsCSharp8)
-					WriteLine (sw, "--lang-features=interface-constants,default-interface-methods");
+				if (SupportsCSharp8) {
+					var features = new List<string> ();
+
+					if (EnableInterfaceMembersPreview)
+						features.AddRange (new [] { "interface-constants", "default-interface-methods" });
+					if (Nullable == "enable")
+						features.Add ("nullable-reference-types");
+
+					if (features.Any ())
+						WriteLine (sw, $"--lang-features={string.Join (",", features)}");
+				}
 			}
 
 			cmd.AppendSwitch (ApiXmlInput);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -515,6 +515,29 @@ namespace Foo {
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
+		public void NullableReferenceTypes (string classParser)
+		{
+			var proj = new XamarinAndroidBindingProject {
+				AndroidClassParser = classParser,
+				Jars = {
+					new AndroidItem.EmbeddedJar ("foo.jar") {
+						BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64),
+					}
+				}
+			};
+			proj.SetProperty ("Nullable", "enable");
+			using (var b = CreateDllBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var cs_file = b.Output.GetIntermediaryPath (
+					Path.Combine ("generated", "src", "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest.cs"));
+				FileAssert.Exists (cs_file);
+				StringAssert.Contains ("string? Greet", File.ReadAllText (cs_file));
+			}
+		}
+
+		[Test]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BindDefaultInterfaceMethods (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject {


### PR DESCRIPTION
Apparently when we did NRT `generator` support for binding projects we did not actually update our MSBuild tasks to give `generator` the "enable NRT" flag.  Whoops.

The way this should work is if the binding project is using at least `<LangVersion>8</LangVersion>` and contains `<Nullable>enable</Nullable>`, this should trigger `generator` to generate binding code with nullable annotations.

The flag needed to pass to `generator` to trigger this is `--lang-features=nullable-reference-types`.