### PR TITLE
Remove brew/openssl workaround

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -405,7 +405,7 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
-    - script: 'brew uninstall openssl@1.0.2t && rm -rf /usr/local/etc/openssl && rm -rf /usr/local/etc/openssl@1.1'
+    - script: 'brew uninstall -f openssl@1.0.2t && rm -rf /usr/local/etc/openssl && rm -rf /usr/local/etc/openssl@1.1'
       displayName: fix Homebrew
 
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -405,9 +405,6 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
-    - script: 'brew uninstall -f openssl@1.0.2t && rm -rf /usr/local/etc/openssl && rm -rf /usr/local/etc/openssl@1.1'
-      displayName: fix Homebrew
-
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
       displayName: install required brew tools and prepare java.interop
 


### PR DESCRIPTION
The homebrew/openssl related workaround/fix started failing recently with:

    Error: No available formula or cask with the name "openssl@1.0.2t".

When running:

    brew uninstall openssl@1.0.2t && rm -rf /usr/local/etc/openssl && rm -rf /usr/local/etc/openssl@1.1

@pjcollins thinks the original issue was fixed meanwhile, so we can remove it,
instead of fixing it by forcing the uninstall.