### PR TITLE
[One .NET] fix parallel .sln builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -50,6 +50,7 @@ _ResolveAssemblies MSBuild target.
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true;
         AppendRuntimeIdentifierToOutputPath=true;
+        SkipCompilerExecution=true;
         _OuterIntermediateAssembly=@(IntermediateAssembly);
         _OuterOutputPath=$(OutputPath);
         _OuterIntermediateOutputPath=$(IntermediateOutputPath);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5280

A test has been randomly failing with:

    (CoreCompile target) ->
    CSC : error CS2012: Cannot open 'C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib6\obj\Debug\Lib6.dll' for writing -- 'The process cannot access the file 'C:\a\1\s\bin\TestRelease\temp\SolutionBuildSeveralProjects\Lib6\obj\Debug\Lib6.dll' because it is being used by another process.'

I could reproduce this by putting `[Repeat(10)]` on the test. We
shouldn't commit this change, since the test took 5+ minutes.

The problem happens when:

* Build a `.sln` with two Android head projects that reference library
  projects.
* Use `-m:4` to build with multiple MSBuild nodes.
* One of the head projects is running `<Csc/>` of a referenced project
  at the same time another.

The two `<Csc/>` calls can only occur because of the way we have inner
builds setup for `$(RuntimeIdentifier)` in 51fb93e1. One project is
building the referenced library normally, while another is doing an
inner build for a `$(RuntimeIdentifier)`.

We don't really want `<Csc/>` to compile things *at all* in an inner
build. It should just be "finding" paths to assemblies for each
`$(RuntimeIdentifier)` and not doing actual work.

Let's set `$(SkipCompilerExecution)` to `true` for the inner build:

* https://github.com/dotnet/roslyn/blob/4929b2e60abbdbb6cbe72c856d6f370c8cf13b35/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets#L132
* https://github.com/dotnet/project-system/blob/e217c5fc9f5ec06f593f74762a3bf4d750475a67/docs/well-known-project-properties.md#skipcompilerexecution-bool

This property is set during design-time builds in Visual Studio, so it
should be something we can rely on here.

I *think* this solved the problem, as I was unable to reproduce it
anymore after a few tries. It's possible it didn't, though!