### PR TITLE
 [illink] Don't initialize managed peer

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	{
 		const string Content = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <!-- This is a GENERATED FILE -->
-<!-- See build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs -->
+<!-- See https://github.com/xamarin/xamarin-android/tree/master/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs -->
 <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <JavaInteropDefineConstants>XA_JI_EXCLUDE</JavaInteropDefineConstants>

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
@@ -20,15 +20,13 @@ namespace Xamarin.Android.Prepare
 
 		public override void Generate (Context context)
 		{
-			string dir = Path.GetDirectoryName (OutputPath);
+			var dir = Path.GetDirectoryName (OutputPath);
 			if (!Directory.Exists (dir))
 				Directory.CreateDirectory (dir);
 
-			using (var fs = File.Open (OutputPath, FileMode.Create)) {
-				using (var sw = new StreamWriter (fs)) {
-					sw.Write (Content);
-				}
-			}
+			using var fs = File.Open (OutputPath, FileMode.Create);
+			using var sw = new StreamWriter (fs);
+			sw.Write (Content);
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Xamarin.Android.Prepare
 {

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
@@ -20,6 +20,10 @@ namespace Xamarin.Android.Prepare
 
 		public override void Generate (Context context)
 		{
+			string dir = Path.GetDirectoryName (OutputPath);
+			if (!Directory.Exists (dir))
+				Directory.CreateDirectory (dir);
+
 			using (var fs = File.Open (OutputPath, FileMode.Create)) {
 				using (var sw = new StreamWriter (fs)) {
 					sw.Write (Content);

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.Android.Prepare
+{
+	class GeneratedJavaInteropConfigPropsFile : GeneratedFile
+	{
+		const string Content = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<!-- This is a GENERATED FILE -->
+<!-- See build-tools/xaprepare/xaprepare/Application/GeneratedJavaInteropConfigPropsFile.cs -->
+<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <JavaInteropDefineConstants>XA_JI_EXCLUDE</JavaInteropDefineConstants>
+  </PropertyGroup>
+</Project>
+";
+
+		public GeneratedJavaInteropConfigPropsFile (Context context)
+			: base (Path.Combine (Configurables.Paths.ExternalJavaInteropDir, "bin", $"Build{context.Configuration}", "XAConfig.props"))
+		{}
+
+		public override void Generate (Context context)
+		{
+			using (var fs = File.Open (OutputPath, FileMode.Create)) {
+				using (var sw = new StreamWriter (fs)) {
+					sw.Write (Content);
+				}
+			}
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Android.Prepare
 			var steps = new List <GeneratedFile> {
 				new GeneratedProfileAssembliesProjitemsFile (Configurables.Paths.ProfileAssembliesProjitemsPath),
 				new GeneratedMonoAndroidProjitemsFile (),
+				new GeneratedJavaInteropConfigPropsFile (context),
 			};
 
 			AddOSSpecificSteps (context, steps);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -87,11 +87,8 @@ namespace Xamarin.Android.Build.Tests
 					"Java.Interop.dll",
 					"Mono.Android.dll",
 					"System.Console.dll",
-					"System.Linq.Expressions.dll",
-					"System.ObjectModel.dll",
 					"System.Private.CoreLib.dll",
 					"System.Collections.Concurrent.dll",
-					"System.Collections.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",
 				} :


### PR DESCRIPTION
Context: #5400
Context: xamarin/java.interop#761

Generate `XAConfig.props` file in Java.Interop to define `XA_JI_EXCLUDE`
compilation constant.

The generated file contains properties set for Java.Interop by XA. So
far it is only setting one property, and thus doesn't necessarily be
generated. I still wanted to be written by `xaprep`, plus it might be
handy in future for other configuration.

The currently set `JavaInteropDefineConstants` property is used
to disable `ManagedPeer` initialization.

We don't really use `ManagedPeer` today and it is duplicating
functionality of `ConstructorBuilder` class. The unwanted effect of
having it in JI is that it is pulling in `System.Linq.Expressions`, which
greatly increase assemblies size after linking.

The size reduction for simple XA app is cca 135kbytes of compressed
size.

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -          27 assemblies/Mono.Android.dll
      -          30 assemblies/System.Collections.Concurrent.dll
      -         989 assemblies/System.Linq.dll
      -       2,930 assemblies/Java.Interop.dll
      -       4,514 assemblies/System.Collections.dll *1
      -       4,874 assemblies/System.ObjectModel.dll *1
      -       7,987 assemblies/System.Private.CoreLib.dll
      -     115,284 assemblies/System.Linq.Expressions.dll *1
    Summary:
      -     136,635 Assemblies -14.87% (of 918,689)
      -     139,506 Package size difference -1.79% (of 7,780,819)