### PR TITLE
[illink] Do not preserve IO stream adapter/invoker

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -5,8 +5,6 @@
 		<type fullname="Android.Runtime.GeneratedDummyHost" />
 		<type fullname="Android.Runtime.GeneratedEnumAttribute" />
 		<type fullname="Android.Runtime.IJavaObject" />
-		<type fullname="Android.Runtime.InputStreamAdapter" />
-		<type fullname="Android.Runtime.InputStreamInvoker" />
 		<type fullname="Android.Runtime.JNIEnv">
 			<method name="Exit" />
 			<method name="Initialize" />
@@ -34,8 +32,6 @@
 		<type fullname="Android.Runtime.LogLevel" />
 		<type fullname="Android.Runtime.LogCategories" />
 		<type fullname="Android.Runtime.NamespaceMappingAttribute" />
-		<type fullname="Android.Runtime.OutputStreamAdapter" />
-		<type fullname="Android.Runtime.OutputStreamInvoker" />
 		<type fullname="Android.Runtime.PreserveAttribute" />
 		<type fullname="Android.Runtime.RaiseThrowableEventArgs" />
 		<type fullname="Android.Runtime.RegisterAttribute" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5206
Context: https://github.com/xamarin/xamarin-android/issues/5167

They are only accessed through `CallbackCode` class in M.A.Export with
reflection code, which ILLink is able to detect.

This change reduces the apk size in common situation, when M.A.Export is
not used.

apk size comparison, BuildReleaseArm64False test:

    > apkdiff -f -e dll$ before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -          80 assemblies/System.Console.dll
      -         129 assemblies/Java.Interop.dll
      -       1,237 assemblies/System.Private.CoreLib.dll
      -       6,093 assemblies/Mono.Android.dll
    Summary:
      -       7,539 Assemblies -1.01% (of 749,078)