### PR TITLE
[illink] Do not preserve GeneratedEnumAttribute

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -3,7 +3,6 @@
 	<assembly fullname="Mono.Android">
 		<type fullname="Android.Runtime.AnnotationAttribute" />
 		<type fullname="Android.Runtime.GeneratedDummyHost" />
-		<type fullname="Android.Runtime.GeneratedEnumAttribute" />
 		<type fullname="Android.Runtime.IJavaObject" />
 		<type fullname="Android.Runtime.InputStreamAdapter" />
 		<type fullname="Android.Runtime.InputStreamInvoker" />

--- a/src/Mono.Android/ILLink/ILLink.LinkAttributes.xml
+++ b/src/Mono.Android/ILLink/ILLink.LinkAttributes.xml
@@ -6,5 +6,8 @@
     <type fullname="Android.Runtime.IntDefinitionAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="Android.Runtime.GeneratedEnumAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5167

The attribute itself doesn't need to be preserved.

I didn't find any usage of the attribute instances during runtime, so
this change removes them during linking.

apk size comparison, BuildReleaseArm64False test:

    > apkdiff -f -e dll$ before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -          39 assemblies/Mono.Android.dll
        +         132 Resource Android.ILLink.ILLink.LinkAttributes.xml
        -             Type Android.Runtime.GeneratedEnumAttribute
    Summary:
      -          39 Assemblies -0.01% (of 749,078)

Note that the attribute instances removal doesn't work yet, we need
net6 illink for that.