### PR TITLE
[illink] Use Crc64Helper class

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -96,6 +96,9 @@
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.cs">
       <Link>Crc64.cs</Link>
     </Compile>
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64Helper.cs">
+      <Link>Crc64Helper.cs</Link>
+    </Compile>
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.Table.cs">
       <Link>Crc64.Table.cs</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -90,7 +90,6 @@ namespace Xamarin.Android.Build.Tests
 					"System.Linq.Expressions.dll",
 					"System.ObjectModel.dll",
 					"System.Runtime.Serialization.Primitives.dll",
-					"System.Security.Cryptography.Primitives.dll",
 					"System.Private.CoreLib.dll",
 					"System.Collections.Concurrent.dll",
 					"System.Collections.dll",

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -26,6 +26,9 @@
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.cs">
       <Link>Crc64.cs</Link>
     </Compile>
+    <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64Helper.cs">
+      <Link>Crc64Helper.cs</Link>
+    </Compile>
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.Table.cs">
       <Link>Crc64.Table.cs</Link>
     </Compile>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5451

apk size comparison, BuildReleaseArm64False test:

    > apkdiff -e dll$ before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -         123 assemblies/Mono.Android.dll
        -             Type Java.Interop.Tools.JavaCallableWrappers.Crc64
        Type Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager
          -             Method static string ToHash (string, System.Security.Cryptography.HashAlgorithm)
          +             Method static string ToCrc64 (string)
        +             Type Java.Interop.Tools.JavaCallableWrappers.Crc64Helper
      -       2,975 assemblies/System.Security.Cryptography.Primitives.dll *1
    Summary:
      -       3,098 Assemblies -0.41% (of 749,039)