### PR TITLE
[Xamarin.Android.Build.Tasks] Something leaves classes.jar files open until MSBuild exits

### DIFF
--- a/Documentation/release-notes/5457.md
+++ b/Documentation/release-notes/5457.md
@@ -1,0 +1,4 @@
+#### Application and library build and deployment
+
+* [GitHub Issue 5424](https://github.com/xamarin/xamarin-android/issues/5424):
+  Fixed a file lock on `classes.jar` when building on Windows.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -229,7 +229,8 @@ namespace Xamarin.Android.Tasks
 
 				count = 0;
 				foreach (var jarFile in jarFilePaths) {
-					using (var jar = ZipArchive.Open (File.OpenRead (jarFile))) {
+					using (var stream = File.OpenRead (jarFile))
+					using (var jar = ZipArchive.Open (stream)) {
 						foreach (var jarItem in jar) {
 							if (jarItem.IsDirectory)
 								continue;


### PR DESCRIPTION
Fixes #5424

There is a bug in BuildApk where the Stream being passed to LibZipSharp
is NOT being disposed of. This is probably the cause of the classes.jar
file being left open.