### PR TITLE
[tests] added .resx localization to .NET 6 test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -339,7 +339,15 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuild (string runtimeIdentifiers, bool isRelease)
 		{
 			var proj = new XASdkProject {
-				IsRelease = isRelease
+				IsRelease = isRelease,
+				Sources = {
+					new BuildItem ("EmbeddedResource", "Foo.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+					},
+					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
+						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+					},
+				}
 			};
 			proj.OtherBuildItems.Add (new AndroidItem.InputJar ("javaclasses.jar") {
 				BinaryContent = () => Convert.FromBase64String (InlineData.JavaClassesJarBase64)
@@ -372,6 +380,7 @@ namespace Xamarin.Android.Build.Tests
 				.OrderBy (f => f)
 				.ToArray ();
 			CollectionAssert.AreEqual (new [] {
+				"es",
 				$"{proj.ProjectName}.dll",
 				$"{proj.ProjectName}.pdb",
 				$"{proj.PackageName}.apk",
@@ -393,6 +402,7 @@ namespace Xamarin.Android.Build.Tests
 				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
 				apk.AssertContainsEntry (apkPath, $"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !CommercialBuildAvailable && !isRelease);
 				apk.AssertContainsEntry (apkPath, $"assemblies/System.Linq.dll",        shouldContainEntry: expectEmbeddedAssembies);
+				apk.AssertContainsEntry (apkPath, $"assemblies/es/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
 				var rids = runtimeIdentifiers.Split (';');
 				foreach (var abi in rids.Select (MonoAndroidHelper.RuntimeIdentifierToAbi)) {
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonodroid.so");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5437

In testing was I thought might be broken in #5437, everything seemed
to work fine! It will be good to include `.resx` files in a NET 6
test, however.