### PR TITLE
[Linux] Properly parse single-digit Ubuntu version

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -749,6 +749,7 @@ namespace Xamarin.Android.Prepare
 
 			Log.StatusLine ();
 			Log.StatusLine ("   OS type: ", OS.Type, tailColor: Log.InfoColor);
+			Log.StatusLine (" OS flavor: ", OS.Flavor, tailColor: Log.InfoColor);
 			Log.StatusLine ("   OS name: ", OS.Name, tailColor: Log.InfoColor);
 			Log.StatusLine ("OS release: ", OS.Release, tailColor: Log.InfoColor);
 			Log.StatusLine ("   OS bits: ", OS.Architecture, tailColor: Log.InfoColor);

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
@@ -42,8 +42,12 @@ namespace Xamarin.Android.Prepare
 		{
 			Version ubuntuRelease;
 			if (!Version.TryParse (Release, out ubuntuRelease)) {
-				Log.ErrorLine ($"Unable to parse string '{Release}' as a valid Ubuntu release version");
-				return false;
+				if (Int32.TryParse (Release, out int singleNumberVersion)) {
+					ubuntuRelease = new Version (singleNumberVersion, 0);
+				} else {
+					Log.ErrorLine ($"Unable to parse string '{Release}' as a valid {Name} release version");
+					return false;
+				}
 			}
 			UbuntuRelease = ubuntuRelease;
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4929

Some releases of Ubuntu use only a single digit for their version, which
the `Version` class is not able to parse properly.  Add a special case
to handle it.

Additionally, don't hardcode `Ubuntu` into error message, use the
actual (derived) distro name instead.