### PR TITLE
[One .NET] put bundletool.jar in separate workload pack

### DIFF
--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -35,6 +35,7 @@
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.osx-x64\**\*" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.BundleTool\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\template-packs\Microsoft.Android.Templates.*.nupkg" />
     </ItemGroup>
     <MakeDir Directories="$(PkgOutputPath);$(PayloadDir);$(PkgResourcesPath);$(LicenseDestination)"/>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -81,6 +81,7 @@
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=linux-x64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=osx-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Darwin' " />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=win-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BundleTool.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Workload.Android.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
   </Target>
@@ -92,6 +93,7 @@
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.linux-x64.*.nupkg"   Condition=" '$(HostOS)' == 'Linux' " />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.osx-x64.*.nupkg"     Condition=" '$(HostOS)' == 'Darwin' " />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.win-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.BundleTool.*.nupkg" />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Ref.*.nupkg" />
       <_WLTemplates Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Templates.*.nupkg" />
       <!-- Runtime packs are not yet supported by workloads -->

--- a/build-tools/create-packs/Microsoft.Android.Sdk.BundleTool.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.BundleTool.proj
@@ -1,0 +1,36 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.BundleTool.proj
+
+This project file is used to create the Microsoft.Android.Sdk.BundleTool NuGet.
+Since bundletool.jar is quite large (and optional), it is in a separate pack.
+***********************************************************************************************
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <PackageId>Microsoft.Android.Sdk.BundleTool</PackageId>
+    <Authors>Microsoft</Authors>
+    <Description>Contains tooling for Android App Bundles.</Description>
+    <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
+    <MSBuildSrcDir>$(RootBuildDir)lib\xamarin.android\xbuild\Xamarin\Android\</MSBuildSrcDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BeforePack>
+      _GetPackItems;
+      _GetDefaultPackageVersion;
+      $(BeforePack);
+    </BeforePack>
+  </PropertyGroup>
+
+  <Target Name="_GetPackItems"
+      DependsOnTargets="_GetLicense">
+    <ItemGroup>
+      <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk.BundleTool\Sdk\*" PackagePath="Sdk" />
+      <_PackageFiles Include="$(MSBuildSrcDir)\bundletool.jar" PackagePath="tools" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -220,7 +220,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup-xf.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\r8.jar" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\bundletool.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\bundletool.jar" ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime_fastdev.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime.dex" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk.BundleTool/Sdk/Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk.BundleTool/Sdk/Sdk.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <AndroidBundleToolJarPath Condition=" '$(AndroidBundleToolJarPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\bundletool.jar</AndroidBundleToolJarPath>
+  </PropertyGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
@@ -5,6 +5,7 @@
       "description": "Android SDK",
       "packs": [
         "Microsoft.Android.Sdk",
+        "Microsoft.Android.Sdk.BundleTool",
         "Microsoft.Android.Ref",
         "Microsoft.Android.Templates"
       ]
@@ -18,6 +19,10 @@
         "osx-x64": "Microsoft.Android.Sdk.osx-x64",
         "win-x64": "Microsoft.Android.Sdk.win-x64"
       }
+    },
+    "Microsoft.Android.Sdk.BundleTool": {
+      "kind": "sdk",
+      "version": "@SDK_PACK_VERSION@"
     },
     "Microsoft.Android.Ref": {
       "kind": "framework",

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.targets
@@ -1,4 +1,6 @@
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk"
       Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
+  <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.BundleTool"
+      Condition=" '$(AndroidPackageFormat)' == 'aab' " />
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5438

This only implements half of #5438.

`bundletool.jar` is quite large:

    24755974 bundletool.jar

Since this isn't needed for every build, only when
`$(AndroidPackageFormat)` is `aab`, we can put `bundletool.jar` in its
own "workload" pack.

The way this works is for `WorkloadManifest.targets` to define an
optional Sdk import:

    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.BundleTool"
        Condition=" '$(AndroidPackageFormat)' == 'aab' " />

If the SDK is missing, for a build using `AndroidPackageFormat=aab`
you get the error:

    Microsoft.NET.Workload.Android\WorkloadManifest.targets(4,33): error MSB4236: The SDK 'Microsoft.Android.Sdk.BundleTool' specified could not be found.

Our .NET 6 installers will include `Microsoft.Android.Sdk.BundleTool`
and install it to the correct location to avoid this error.

Down the road, `Microsoft.Android.Sdk.BundleTool` would be acquired by
a future `dotnet workload` command that does not exist yet.

The resulting size of the two Sdk packs are:

    22881359 Microsoft.Android.Sdk.BundleTool.11.0.200.nupkg
    49970851 Microsoft.Android.Sdk.win-x64.11.0.200.nupkg