### PR TITLE
[installer] extra copy of libMonoPosixHelper.dylib for libZipSharp.dll

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -21,10 +21,6 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
     <IncludeMonoBundleComponents>false</IncludeMonoBundleComponents>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" GeneratePathProperty="true" PrivateAssets="all" />
-  </ItemGroup>
-
  <PropertyGroup>
     <BeforePack>
       _GenerateXASdkContent;
@@ -49,15 +45,8 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
       <AndroidSdkBuildTools Include="@(_MSBuildFilesWin)" Condition=" '$(AndroidHostRID)' == 'win-x64' ">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
-      <!-- Exclude host-os specific native libraries, aside from libMonoPosixHelper.dylib which is required by LibZipSharp on macOS. -->
       <AndroidSdkBuildTools Include="@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)" Condition=" '$(AndroidHostRID)' == 'linux-x64' or '$(AndroidHostRID)' == 'osx-x64' ">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
-      </AndroidSdkBuildTools>
-      <AndroidSdkBuildTools Include="$(PkgMono_Posix_NETStandard)\runtimes\osx\native\libMonoPosixHelper.dylib" Condition=" '$(AndroidHostRID)' == 'osx-x64' ">
-        <RelativePath>libMonoPosixHelper.dylib</RelativePath>
-      </AndroidSdkBuildTools>
-      <AndroidSdkBuildTools Include="$(PkgMono_Posix_NETStandard)\runtimes\linux-x64\native\libMonoPosixHelper.so" Condition=" '$(AndroidHostRID)' == 'linux-x64' " >
-        <RelativePath>libMonoPosixHelper.so</RelativePath>
       </AndroidSdkBuildTools>
       <!-- Remove items with '%(ExcludeFromAndroidNETSdk)' == 'true' metadata -->
       <AndroidSdkBuildTools Remove="@(AndroidSdkBuildTools)" Condition=" '%(AndroidSdkBuildTools.ExcludeFromAndroidNETSdk)' == 'true' " />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -359,6 +359,8 @@
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)"           ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxa-internal-api.$(LibExtension)"       ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\libzip.$(LibExtension)" />
+    <!-- A second libMonoPosixHelper.dylib is needed for libZipSharp.dll to load -->
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\libMonoPosixHelper.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
   </ItemGroup>
   <!-- Allow us to exclude mono bundle files for PR builds -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -367,6 +367,12 @@
     <None Include="startup-xf.aotprofile">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(PkgMono_Posix_NETStandard)\runtimes\osx\native\libMonoPosixHelper.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(PkgMono_Posix_NETStandard)\runtimes\linux-x64\native\libMonoPosixHelper.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/foo/blob/Microsoft.NET.Sdk/foo.csproj

I've been experimenting with trying to multi-target "legacy"
Xamarin.Android and .NET 6 with:

    <Project Sdk="Microsoft.NET.Sdk">
      <PropertyGroup>
        <TargetFrameworks>monoandroid11.0;net6.0-android</TargetFrameworks>
      </PropertyGroup>
    </Project>

I got this to work fairly well on Windows with some hacks, but it
completely fails on macOS:

    error XACML7000: System.DllNotFoundException: Unable to load shared library 'MonoPosixHelper' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(libMonoPosixHelper, 1): image not found
    error XACML7000:    at Mono.Unix.Native.Syscall.lstat(String file_name, Stat& buf)
    error XACML7000:    at Xamarin.Tools.Zip.Utilities.StatFile(String path, Boolean followSymlinks, Stat& sbuf) in /Users/runner/work/1/s/Utilities.Unix.cs:line 58
    error XACML7000:    at Xamarin.Tools.Zip.Utilities.GetFileType(String path, Boolean followSymlinks, FilePermissions& fileType) in /Users/runner/work/1/s/Utilities.Unix.cs:line 147
    error XACML7000:    at Xamarin.Tools.Zip.UnixPlatformServices.IsFileOfType(String path, FilePermissions mode, Boolean& result) in /Users/runner/work/1/s/UnixPlatformServices.cs:line 428
    error XACML7000:    at Xamarin.Tools.Zip.UnixPlatformServices.IsDirectory(ZipArchive archive, String path, Boolean& result) in /Users/runner/work/1/s/UnixPlatformServices.cs:line 40
    error XACML7000:    at Xamarin.Tools.Zip.PlatformServices.<>c__DisplayClass9_0.<IsDirectory>b__0(IPlatformServices services) in /Users/runner/work/1/s/PlatformServices.cs:line 73
    error XACML7000:    at Xamarin.Tools.Zip.PlatformServices.CallServices(Func`2 code) in /Users/runner/work/1/s/PlatformServices.cs:line 165
    error XACML7000:    at Xamarin.Tools.Zip.PlatformServices.IsDirectory(ZipArchive archive, String path) in /Users/runner/work/1/s/PlatformServices.cs:line 73
    error XACML7000:    at Xamarin.Tools.Zip.ZipArchive.AddFile(String sourcePath, String archivePath, EntryPermissions permissions, CompressionMethod compressionMethod, Boolean overwriteExisting) in /Users/runner/work/1/s/ZipArchive.cs:line 397
    error XACML7000:    at Xamarin.Android.Tasks.ZipArchiveEx.AddFiles(String folder, String folderInArchive, CompressionMethod method)
    error XACML7000:    at Xamarin.Android.Tasks.ZipArchiveEx.AddDirectory(String folder, String folderInArchive, CompressionMethod method)
    error XACML7000:    at Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive.<>c__DisplayClass39_0.<RunTask>b__0(String f)
    error XACML7000:    at Xamarin.Android.Tools.Files.ArchiveZipUpdate(String target, Action`1 archiver)
    error XACML7000:    at Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive.RunTask()
    error XACML7000:    at Xamarin.Android.Tasks.AndroidTask.Execute()

Comparing a regular .NET 6 build, it works because
`libMonoPosixHelper.dylib` is sitting right next to `libZipSharp.dll`.

Comparing a regular "legacy" Xamarin.Android build, it works because
`libMonoPosixHelper.dylib` is loaded via:

    Mono: DllImport loaded library '/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/../lib/libMonoPosixHelper.dylib'

We're *lucky* this works, as it is using a Mono system
`libMonoPosixHelper.dylib` instead of the one from Xamarin.Android.

I could solve the problem locally by running:

    cd /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xbuild/Xamarin/Android/lib/host-Darwin/
    sudo cp libMonoPosixHelper.dylib ../../

I updated our installer to include the copy of
`libMonoPosixHelper.dylib` that `libZipSharp.dll` expects.