### PR TITLE
[Xamarin.Android.Build.Tasks] fix build error for class library

### DIFF
--- a/Documentation/release-notes/5477.md
+++ b/Documentation/release-notes/5477.md
@@ -1,0 +1,5 @@
+### Application and library build and deployment
+
+  * [GitHub PR 5477](https://github.com/xamarin/xamarin-android/pull/5477):
+    *error MSB3375: The file `__AndroidLibraryProjects__.zip` does not exist.*
+    could occur when building certain Xamarin.Android class library projects.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1793,6 +1793,17 @@ namespace App1
 			}
 		}
 
+		[Test]
+		public void AndroidXClassLibraryNoResources ()
+		{
+			var proj = new XamarinAndroidLibraryProject ();
+			proj.AndroidResources.Clear ();
+			proj.PackageReferences.Add (KnownPackages.AndroidXLegacySupportV4);
+			using (var b = CreateDllBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
 #pragma warning disable 414
 		static object [] BuildApplicationWithJavaSourceChecks = new object [] {
 			new object[] {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -440,7 +440,7 @@ projects. .NET 5 projects will not import this file.
         OutputDirectory="$(IntermediateOutputPath)$(_NativeLibraryImportsDirectoryName)"
         EmbeddedNativeLibraries="@(EmbeddedNativeLibrary)"
     />
-    <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
+    <Touch Files="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip" />
       <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
@@ -464,7 +464,7 @@ projects. .NET 5 projects will not import this file.
         FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
         RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
     />
-    <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
+    <Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
       <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">


### PR DESCRIPTION
@PureWeen ran into an error building this project in Xamarin.Forms:

https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android%20(Forwarders).csproj

    Xamarin.Android.Legacy.targets(467,5): error MSB3375: The file "obj\Debug\monoandroid10.0\__AndroidLibraryProjects__.zip" does not exist.

I could reproduce with VS 2019 16.9, but not 16.8.

The file did not actually exist?

    > ls 'C:\src\Xamarin.Forms\Stubs\Xamarin.Forms.Platform.Android\obj\Debug\monoandroid10.0\__AndroidLibraryProjects__.zip'
    ls : Cannot find path 'C:\src\Xamarin.Forms\Stubs\Xamarin.Forms.Platform.Android\obj\Debug\monoandroid10.0\__AndroidLibraryProjects__.zip' because it does not exist.

If you have a class library with 0 `@(AndroidResource)` files and use
AndroidX, this seems to trigger the issue. I could create an MSBuild
test that hits the issue.

Using 16.8, the `__AndroidLibraryProjects__.zip` file contained *only*
directories:

    library_project_imports\assets
    library_project_imports\bin
    library_project_imports\java
    library_project_imports\res

So I think what's happening is the changes in 17e13bc4 caused
directories to not be included in `.zip` files. And so the `.zip`
isn't created at all!

Why are the `@(AndroidJavaLibrary)` items not added?

In the example:

https://github.com/xamarin/AndroidX/blob/1679307092d8aea27d0a6af40f103305f5331075/source/AndroidXTargets.cshtml#L51-L53

    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\com.foo.jar">

This would hit the following code:

    if (AndroidJavaSources != null)
        foreach (var item in AndroidJavaSources)
            MonoAndroidHelper.CopyIfChanged (item.ItemSpec, Path.Combine (outDirInfo.FullName, item.ItemSpec));

If `ItemSpec` is a full path, then `Path.Combine()` will just return
the full path:

https://docs.microsoft.com/dotnet/api/system.io.path.combine#System_IO_Path_Combine_System_String_System_String_

So then the code effectively copies the file to itself, such as:

    MonoAndroidHelper.CopyIfChanged (item.ItemSpec, item.ItemSpec);

This does *nothing*, it is a no-op...

We don't want to actually *fix* the underlying problem, or we would
introduce possible duplicate Java libraries. If a NuGet package
depends on AndroidX, and starts redistributing these `.jar` files, any
Xamarin.Android application project consuming the package would get an
error from d8/r8 saying there are duplicate Java types.

To solve the problem for now, let's just add `AlwaysCreate="true"`,
this is an easy fix for the breakage in 16.9.

Future considerations:

* We need to fix the AndroidX NuGet packages.
* For .NET 6 projects, we probably should look into improving error
  messages for duplicate Java libraries.