### PR TITLE
[Xamarin.Android.Build.Tasks] Make $(AndroidUseInterpreter) public

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1106,6 +1106,15 @@ To suppress the default AOT profiles, set the property to `false`.
 
 Added in Xamarin.Android 10.1.
 
+## AndroidUseInterpreter
+
+A boolean property which causes the `.apk` to contain the mono
+*interpreter*, and not the normal JIT.
+
+***Experimental***.  Does not work on the x86 ABI.
+
+Added in Xamarin.Android 11.3.
+
 ## AndroidUseLegacyVersionCode
 
 A boolean property which allows

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -159,7 +159,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_XAMajorVersionNumber>1</_XAMajorVersionNumber>
 	<_XASupportsFastDev Condition=" Exists ('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets') ">True</_XASupportsFastDev>
 	<_XASupportsFastDev Condition=" '$(_XASupportsFastDev)' == '' ">False</_XASupportsFastDev>
-	<_AndroidUseInterpreter Condition=" '$(_AndroidUseInterpreter)' == '' ">False</_AndroidUseInterpreter>
+	<AndroidUseInterpreter Condition=" '$(AndroidUseInterpreter)' == '' ">False</AndroidUseInterpreter>
 	<AndroidApplication Condition="'$(AndroidApplication)' == ''">false</AndroidApplication>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' == ''">False</AndroidNeedsInternetPermission>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' != ''">True</AndroidNeedsInternetPermission>
@@ -186,7 +186,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 	<!-- Ahead-of-time compilation properties -->
 	<AotAssemblies Condition=" '$(AndroidEnableProfiledAot)' == 'True' ">True</AotAssemblies>
-	<AndroidAotMode Condition=" '$(_AndroidUseInterpreter)' != 'False' ">Interpreter</AndroidAotMode>
+	<AndroidAotMode Condition=" '$(AndroidUseInterpreter)' != 'False' ">Interpreter</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' ">None</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' ">True</AotAssemblies>
@@ -2012,7 +2012,7 @@ because xbuild doesn't support framework reference assemblies.
     LibraryProjectJars="@(ExtractedJarImports)"
     TlsProvider="$(AndroidTlsProvider)"
     UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-    InterpreterEnabled="$(_AndroidUseInterpreter)"
+    InterpreterEnabled="$(AndroidUseInterpreter)"
     ProjectFullPath="$(MSBuildProjectFullPath)"
     IncludeWrapSh="$(AndroidIncludeWrapSh)"
     CheckedBuild="$(_AndroidCheckedBuild)">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -495,7 +495,7 @@ projects. .NET 5 projects will not import this file.
   <Target Name="_IncludeNativeSystemLibraries">
     <PropertyGroup>
       <_Assemblies>@(_ResolvedFrameworkAssemblies)</_Assemblies>
-      <_TargetInterpreterPrefix Condition=" '$(_AndroidUseInterpreter)' != 'False' ">interpreter-</_TargetInterpreterPrefix>
+      <_TargetInterpreterPrefix Condition=" '$(AndroidUseInterpreter)' != 'False' ">interpreter-</_TargetInterpreterPrefix>
       <_AndroidDebugNativeLibraries Condition=" '$(_AndroidDebugNativeLibraries)' == '' ">False</_AndroidDebugNativeLibraries>
     </PropertyGroup>
     <SplitProperty Value="$(AndroidEmbedProfilers)" Condition=" '$(AndroidEmbedProfilers)' != '' ">


### PR DESCRIPTION
Rename the `$(_AndroidUseInterpreter)` MSBuild property (42822e04)
to `$(AndroidUseInterpreter)`.

The property remains experimental.