### PR TITLE
[Xamarin.Android.Build.Tasks] cast with `as` for GetRegisteredTaskObject

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -462,11 +462,17 @@ Instead we can use an API provided by MSBuild:
 string key = "foo";
 BuildEngine4.RegisterTaskObject (key, "bar", RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
 // To retrieve a value
-string value = (string)BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build);
+string value = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build) as string;
 ```
 
 Or if you want to cache across multiple-builds, use
 `RegisteredTaskObjectLifetime.AppDomain` instead.
+
+> NOTE!
+> Use `as` for casts to avoid any unexpected `InvalidCastException`'s.
+> Use the `RegisterTaskObjectAssemblyLocal()` or
+> `GetRegisteredTaskObjectAssemblyLocal()` extension methods within
+> the Xamarin.Android codebase.
 
 To *test* and validate your MSBuild task's use of
 `RegisteredTaskObjectLifetime.AppDomain` you have two choices:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -289,7 +289,7 @@ namespace Xamarin.Android.Tasks
 			if (compress) {
 				string key = CompressedAssemblyInfo.GetKey (ProjectFullPath);
 				Log.LogDebugMessage ($"Retrieving assembly compression info with key '{key}'");
-				compressedAssembliesInfo = BuildEngine4.UnregisterTaskObject (key, RegisteredTaskObjectLifetime.Build) as IDictionary<string, CompressedAssemblyInfo>;
+				compressedAssembliesInfo = BuildEngine4.UnregisterTaskObjectAssemblyLocal<IDictionary<string, CompressedAssemblyInfo>> (key, RegisteredTaskObjectLifetime.Build);
 				if (compressedAssembliesInfo == null)
 					throw new InvalidOperationException ($"Assembly compression info not found for key '{key}'. Compression will not be performed.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -21,7 +21,6 @@ namespace Xamarin.Android.Tasks
 
 		const string TargetFrameworkIdentifier = "MonoAndroid";
 		const RegisteredTaskObjectLifetime Lifetime = RegisteredTaskObjectLifetime.AppDomain;
-		const bool AllowEarlyCollection = false;
 
 		public ITaskItem [] InputAssemblies { get; set; }
 
@@ -48,7 +47,7 @@ namespace Xamarin.Android.Tasks
 					// Check in-memory cache
 					var module = reader.GetModuleDefinition ();
 					var key = (nameof (FilterAssemblies), reader.GetGuid (module.Mvid));
-					var value = BuildEngine4.GetRegisteredTaskObject (key, Lifetime);
+					var value = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal (key, Lifetime);
 					if (value is bool isMonoAndroidAssembly) {
 						if (isMonoAndroidAssembly) {
 							Log.LogDebugMessage ($"Cached: {assemblyItem.ItemSpec}");
@@ -61,25 +60,25 @@ namespace Xamarin.Android.Tasks
 					var targetFrameworkIdentifier = GetTargetFrameworkIdentifier (assemblyDefinition, reader);
 					if (string.Compare (targetFrameworkIdentifier, TargetFrameworkIdentifier, StringComparison.OrdinalIgnoreCase) == 0) {
 						output.Add (assemblyItem);
-						BuildEngine4.RegisterTaskObject (key, true, Lifetime, AllowEarlyCollection);
+						BuildEngine4.RegisterTaskObjectAssemblyLocal (key, value: true, Lifetime);
 						continue;
 					}
 					// Fallback to looking for a Mono.Android reference
 					if (MonoAndroidHelper.HasMonoAndroidReference (reader)) {
 						Log.LogDebugMessage ($"Mono.Android reference found: {assemblyItem.ItemSpec}");
 						output.Add (assemblyItem);
-						BuildEngine4.RegisterTaskObject (key, true, Lifetime, AllowEarlyCollection);
+						BuildEngine4.RegisterTaskObjectAssemblyLocal (key, value: true, Lifetime);
 						continue;
 					}
 					// Fallback to looking for *.jar or __Android EmbeddedResource files
 					if (HasEmbeddedResource (reader)) {
 						Log.LogDebugMessage ($"EmbeddedResource found: {assemblyItem.ItemSpec}");
 						output.Add (assemblyItem);
-						BuildEngine4.RegisterTaskObject (key, true, Lifetime, AllowEarlyCollection);
+						BuildEngine4.RegisterTaskObjectAssemblyLocal (key, value: true, Lifetime);
 						continue;
 					}
 					// Not a MonoAndroid assembly, store false
-					BuildEngine4.RegisterTaskObject (key, false, Lifetime, AllowEarlyCollection);
+					BuildEngine4.RegisterTaskObjectAssemblyLocal (key, value: false, Lifetime);
 				}
 			}
 			OutputAssemblies = output.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Android.Tasks
 
 			string key = CompressedAssemblyInfo.GetKey (ProjectFullPath);
 			Log.LogDebugMessage ($"Storing compression assemblies info with key '{key}'");
-			BuildEngine4.RegisterTaskObject (key, assemblies, RegisteredTaskObjectLifetime.Build, false);
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (key, assemblies, RegisteredTaskObjectLifetime.Build);
 			Generate (assemblies);
 
 			void Generate (IDictionary<string, CompressedAssemblyInfo> dict)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -412,7 +412,7 @@ namespace Xamarin.Android.Tasks
 			if (!tmg.Generate (Debug, SkipJniAddNativeMethodRegistrationAttributeScan, types, cache, TypemapOutputDirectory, GenerateNativeAssembly, out ApplicationConfigTaskState appConfState))
 				throw new XamarinAndroidException (4308, Properties.Resources.XA4308);
 			GeneratedBinaryTypeMaps = tmg.GeneratedBinaryTypeMaps.ToArray ();
-			BuildEngine4.RegisterTaskObject (ApplicationConfigTaskState.RegisterTaskObjectKey, appConfState, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (ApplicationConfigTaskState.RegisterTaskObjectKey, appConfState, RegisteredTaskObjectLifetime.Build);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -260,7 +260,7 @@ namespace Xamarin.Android.Tasks
 				throw new InvalidOperationException ($"Unsupported BoundExceptionType value '{BoundExceptionType}'");
 			}
 
-			var appConfState = BuildEngine4.GetRegisteredTaskObject (ApplicationConfigTaskState.RegisterTaskObjectKey, RegisteredTaskObjectLifetime.Build) as ApplicationConfigTaskState;
+			var appConfState = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ApplicationConfigTaskState> (ApplicationConfigTaskState.RegisterTaskObjectKey, RegisteredTaskObjectLifetime.Build);
 			foreach (string abi in SupportedAbis) {
 				NativeAssemblerTargetProvider asmTargetProvider = GetAssemblyTargetProvider (abi);
 				string baseAsmFilePath = Path.Combine (EnvironmentOutputDirectory, $"environment.{abi.ToLowerInvariant ()}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -200,6 +200,8 @@ namespace Xamarin.Android.Tasks
 			var aapt2Tool = Path.Combine (Aapt2ToolPath, Aapt2);
 
 			// Try to use a cached value for Aapt2Version
+			// NOTE: this doesn't need to use GetRegisteredTaskObjectAssemblyLocal()
+			// because the path to aapt2 is in the key and the value is a string.
 			var key = ($"{nameof (ResolveAndroidTooling)}.{nameof (Aapt2Version)}", aapt2Tool);
 			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
 			if (!string.IsNullOrEmpty (cached)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
@@ -43,6 +43,8 @@ namespace Xamarin.Android.Tasks
 
 		string GetJvmPath ()
 		{
+			// NOTE: this doesn't need to use GetRegisteredTaskObjectAssemblyLocal()
+			// because JavaSdkPath is the key and the value is a string.
 			var key = new Tuple<string, string> (nameof (ResolveJdkJvmPath), JavaSdkPath);
 			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
 			if (cached != null) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -91,6 +91,8 @@ namespace Xamarin.Android.Tasks
 
 		protected Version GetVersionFromTool (string javaExe, Regex versionRegex)
 		{
+			// NOTE: this doesn't need to use GetRegisteredTaskObjectAssemblyLocal()
+			// because the path to java/javac is the key and the value is a System.Version.
 			var javaTool = Path.Combine (JavaSdkPath, "bin", javaExe);
 			var key = new Tuple<string, string> (nameof (ValidateJavaVersion), javaTool);
 			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as Version;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks
 				var key = new Tuple<string, string> (nameof (WriteLockFile), path); // Use the full path as part of the key
 
 				// Check if already registered, for sanity
-				var existing = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build) as DeleteFileAfterBuild;
+				var existing = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<DeleteFileAfterBuild> (key, RegisteredTaskObjectLifetime.Build);
 				if (existing == null) {
 					if (File.Exists (path)) {
 						Log.LogCodedWarning ("XA5302", Properties.Resources.XA5302, path);
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks
 						File.WriteAllText (path, "");
 					}
 
-					BuildEngine4.RegisterTaskObject (key, new DeleteFileAfterBuild (path), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+					BuildEngine4.RegisterTaskObjectAssemblyLocal (key, new DeleteFileAfterBuild (path), RegisteredTaskObjectLifetime.Build);
 				} else {
 					Log.LogDebugMessage ("Lock file was created earlier in the build.");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Build.Tests
 				DaemonKeepInDomain = false,
 			};
 			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
-			Aapt2Daemon daemon = (Aapt2Daemon)engine.GetRegisteredTaskObject (typeof(Aapt2Daemon).FullName, RegisteredTaskObjectLifetime.Build);
+			var daemon = engine.GetRegisteredTaskObjectAssemblyLocal<Aapt2Daemon> (Aapt2Daemon.RegisterTaskObjectKey, RegisteredTaskObjectLifetime.Build);
 			Assert.IsNotNull (daemon, "Should have got a Daemon");
 			Assert.AreEqual (expectedMax, daemon.MaxInstances, $"Expected {expectedMax} but was {daemon.MaxInstances}");
 			Assert.AreEqual (expectedInstances, daemon.CurrentInstances, $"Expected {expectedInstances} but was {daemon.CurrentInstances}");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -14,14 +14,18 @@ namespace Xamarin.Android.Tasks
 {
 	internal class Aapt2Daemon : IDisposable
 	{
+		static readonly string TypeFullName = typeof (Aapt2Daemon).FullName;
+
+		internal static object RegisterTaskObjectKey => TypeFullName;
+
 		public static Aapt2Daemon GetInstance (IBuildEngine4 engine, string aapt2, int numberOfInstances, int initalNumberOfDaemons, bool registerInDomain = false)
 		{
 			var area = registerInDomain ? RegisteredTaskObjectLifetime.AppDomain : RegisteredTaskObjectLifetime.Build;
-			Aapt2Daemon daemon = (Aapt2Daemon)engine.GetRegisteredTaskObject (typeof (Aapt2Daemon).FullName, area);
+			var daemon = engine.GetRegisteredTaskObjectAssemblyLocal<Aapt2Daemon> (RegisterTaskObjectKey, area);
 			if (daemon == null)
 			{
 				daemon = new Aapt2Daemon (aapt2, numberOfInstances, initalNumberOfDaemons);
-				engine.RegisterTaskObject (typeof (Aapt2Daemon).FullName, daemon, area, allowEarlyCollection: false);
+				engine.RegisterTaskObjectAssemblyLocal (RegisterTaskObjectKey, daemon, area, allowEarlyCollection: false);
 			}
 			return daemon;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
@@ -251,5 +251,40 @@ namespace Xamarin.Android.Tasks
 				assembly.SetMetadata ("DestinationSubPath", path);
 			}
 		}
+
+		static readonly string AssemblyLocation = typeof (MSBuildExtensions).Assembly.Location;
+
+		/// <summary>
+		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
+			engine.RegisterTaskObject ((AssemblyLocation, key), value, lifetime, allowEarlyCollection);
+
+		/// <summary>
+		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
+			engine.GetRegisteredTaskObject ((AssemblyLocation, key), lifetime);
+
+		/// <summary>
+		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+			where T : class =>
+			engine.GetRegisteredTaskObject ((AssemblyLocation, key), lifetime) as T;
+
+
+		/// <summary>
+		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
+			engine.UnregisterTaskObject ((AssemblyLocation, key), lifetime);
+
+		/// <summary>
+		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+			where T : class =>
+			engine.UnregisterTaskObject ((AssemblyLocation, key), lifetime) as T;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -554,7 +554,7 @@ namespace Xamarin.Android.Tasks
 
 		public static Dictionary<string, HashSet<string>> LoadCustomViewMapFile (IBuildEngine4 engine, string mapFile)
 		{
-			var cachedMap = (Dictionary<string, HashSet<string>>)engine?.GetRegisteredTaskObject (mapFile, RegisteredTaskObjectLifetime.Build);
+			var cachedMap = engine?.GetRegisteredTaskObjectAssemblyLocal<Dictionary<string, HashSet<string>>> (mapFile, RegisteredTaskObjectLifetime.Build);
 			if (cachedMap != null)
 				return cachedMap;
 			var map = new Dictionary<string, HashSet<string>> ();
@@ -574,7 +574,7 @@ namespace Xamarin.Android.Tasks
 
 		public static bool SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)
 		{
-			engine?.RegisterTaskObject (mapFile, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+			engine?.RegisterTaskObjectAssemblyLocal (mapFile, map, RegisteredTaskObjectLifetime.Build);
 			using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				foreach (var i in map.OrderBy (x => x.Key)) {
 					foreach (var v in i.Value.OrderBy (x => x))
@@ -633,11 +633,10 @@ namespace Xamarin.Android.Tasks
 		static readonly string ResourceCaseMapKey = $"{nameof (MonoAndroidHelper)}_ResourceCaseMap";
 
 		public static void SaveResourceCaseMap (IBuildEngine4 engine, Dictionary<string, string> map) =>
-			engine.RegisterTaskObject (ResourceCaseMapKey, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+			engine.RegisterTaskObjectAssemblyLocal (ResourceCaseMapKey, map, RegisteredTaskObjectLifetime.Build);
 
 		public static Dictionary<string, string> LoadResourceCaseMap (IBuildEngine4 engine) =>
-			engine.GetRegisteredTaskObject (ResourceCaseMapKey, RegisteredTaskObjectLifetime.Build)
-				as Dictionary<string, string> ?? new Dictionary<string, string> (0);
+			engine.GetRegisteredTaskObjectAssemblyLocal<Dictionary<string, string>> (ResourceCaseMapKey, RegisteredTaskObjectLifetime.Build) ?? new Dictionary<string, string> (0);
 
 		public static string FixUpAndroidResourcePath (string file, string resourceDirectory, string resourceDirectoryFullPath, Dictionary<string, string> resource_name_case_map)
 		{


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/Xamarin.Legacy.Sdk

When working on an experiment that enables multi-targeting such as:

  <Project Sdk="Xamarin.Legacy.Sdk">
    <PropertyGroup>
      <TargetFrameworks>monoandroid11.0;net6.0-android</TargetFrameworks>
    </PropertyGroup>
  </Project>

I got the build error:

    Xamarin.Android.Aapt2.targets(123,3): error MSB4018: The "Aapt2Compile" task failed unexpectedly.
    System.InvalidCastException: [A]Xamarin.Android.Tasks.Aapt2Daemon cannot be cast to [B]Xamarin.Android.Tasks.Aapt2Daemon. Type A originates from 'Xamarin.Android.Build.Tasks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' in the context 'Default' at location 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll'. Type B originates from 'Xamarin.Android.Build.Tasks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' in the context 'Default' at location 'C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.win-x64\11.0.200-ci.master.22\tools\Xamarin.Android.Build.Tasks.dll'.
      at Xamarin.Android.Tasks.Aapt2Daemon.GetInstance(IBuildEngine4 engine, String aapt2, Int32 numberOfInstances, Int32 initalNumberOfDaemons, Boolean registerInDomain)
      at Xamarin.Android.Tasks.Aapt2.Execute()
      at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
      at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)

This fails because we are doing an explicit cast instead of using the
`as` keyword. An `Aapt2Daemon` instance from the VS location of
`Xamarin.Android.Build.Tasks.dll` cannot be used from the .NET 6
location of the assembly.

I also added some extension methods that include the current
`Assembly.Location` in the key:

* `RegisterTaskObjectAssemblyLocal()`
* `GetRegisteredTaskObjectAssemblyLocal()`
* `UnregisterTaskObjectAssemblyLocal()`

I audited all `GetRegisteredTaskObject()` calls in this repo, and
added comments for the three tasks the usage seemed appropriate.

These all would be able to be shared between assemblies:

* `<ResolveAndroidTooling/>` uses the path to `aapt2` as a key and
  stores `System.Version` in the value.
* `<ResolveJdkJvmPath/>` uses `JavaSdkPath` as the key and stores the
  string `JdkJvmPath` in the value.
* `<ValidateJavaVersion/>` uses the path to java/javac as the key and
  stores a string in the value.