### PR TITLE
[xaprepare] Increase initial network download timeout to 30s

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 {
 	static partial class Utilities
 	{
-		static readonly TimeSpan ExceptionRetryInitialDelay = TimeSpan.FromMilliseconds (250);
+		static readonly TimeSpan ExceptionRetryInitialDelay = TimeSpan.FromSeconds (30);
 		static readonly TimeSpan WebRequestTimeout = TimeSpan.FromMinutes (60);
 		static readonly int ExceptionRetries = 5;
 


### PR DESCRIPTION
Try to prevent download failures in CI downloads by increasing the
initial download timeout time from the current 250ms to 30s.  `xaprepare`
attempts the download up to 5 times, each time increasing timeout twofold.
Starting with 30s will, hopefully, decrease the number of timed out
downloads.