### PR TITLE
[build] disable analyzers in IDE

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -218,4 +218,5 @@
   <Target Name="CreateManifestResourceNames" />
 
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\Ndk.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RoslynAnalyzers.projitems" Condition=" '$(EnableRoslynAnalyzers)' == 'true' " />
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,13 +22,5 @@
     -->
     <AndroidPackVersion>11.0.200</AndroidPackVersion>
   </PropertyGroup>
-  
-  <!-- Add Roslyn analyzers NuGet to all projects (except NRefactory which has violations but is only used for running tests and XamarinManifestGenerator which uses packages.config ) -->
-  <ItemGroup Condition=" '$(EnableRoslynAnalyzers)' == 'True' And !$(AssemblyName.StartsWith ('ICSharpCode.NRefactory')) And !$(AssemblyName.StartsWith ('XamarinManifestGenerator')) ">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
 </Project>

--- a/build-tools/scripts/RoslynAnalyzers.projitems
+++ b/build-tools/scripts/RoslynAnalyzers.projitems
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Add Roslyn analyzers NuGet to all projects (except NRefactory which has violations but is only used for running tests and XamarinManifestGenerator which uses packages.config ) -->
+  <ItemGroup Condition=" !$(AssemblyName.StartsWith ('ICSharpCode.NRefactory')) and !$(AssemblyName.StartsWith ('XamarinManifestGenerator')) ">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If I open our `.sln` files in VS Windows, I start getting errors about
projects in `external/nrefactory` and `external/debugger-libs`:

    "Xamarin.Android.sln" (default target) (1) ->
    "tests\MSBuildDeviceIntegration\MSBuildDeviceIntegration.csproj" (default target) (53) ->
    "tests\MSBuildDeviceIntegration\MSBuildDeviceIntegration.csproj" (Build target) (53:2) ->
    "external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj" (default target) (54:2) ->
    "external\debugger-libs\Mono.Debugging\Mono.Debugging.csproj" (default target) (56:3) ->
    "external\nrefactory\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj" (default target) (57:3) ->
    (CoreCompile target) ->
        external\nrefactory\ICSharpCode.NRefactory\Documentation\XmlDocumentationProvider.cs(122,38): error CA3075: XmlTextReader instance created with insecure default settings.
        external\nrefactory\ICSharpCode.NRefactory\Documentation\XmlDocumentationProvider.cs(134,52): error CA3075: XmlTextReader instance created with insecure default settings.
        external\nrefactory\ICSharpCode.NRefactory\Documentation\XmlDocumentationProvider.cs(362,39): error CA3075: XmlTextReader instance created with insecure default settings.
        external\nrefactory\ICSharpCode.NRefactory\Documentation\XmlDocumentationProvider.cs(399,30): error CA3075: XmlTextReader instance created with insecure default settings.

To workaround the issue, I could do:

    cd external/nrefactory ; git clean -dxf;
    cd ../debugger-libs ; git clean -dxf;
    msbuild Xamarin.Android.sln -t:Restore

Then build again... It breaks again if I open a `.sln` file in the IDE.

I moved the MSBuild logic from `Directory.Build.props` to a new file
that `Configuration.props` imports. This appears to solve the issue,
as we will only import the analyzers for projects that import
`Configuration.props`.

I looked to see if we could fix NRefactory itself, but the Github repo
is archived!

https://github.com/icsharpcode/NRefactory/tree/0607a4ad96ebdd16817e47dcae85b1cfcb5b5bf5