### PR TITLE
Bump to xamarin/monodroid@ad19471

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@daa2fb6ca52ecfd0884177da5b57501bb4dda3c6
+xamarin/monodroid:master@ad19471b8478f9f8028c9a3517ad3ca7bca5fb4a
 mono/mono:2020-02@5e9cb6d1c1de430965312927d5aed7fcb27bfa73

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@27736a7ffc48d606ab45598f761e873f8572f46a
+xamarin/monodroid:master@daa2fb6ca52ecfd0884177da5b57501bb4dda3c6
 mono/mono:2020-02@5e9cb6d1c1de430965312927d5aed7fcb27bfa73


### PR DESCRIPTION
Changes: http://github.com/xamarin/monodroid/compare/27736a7ffc48d606ab45598f761e873f8572f46a...ad19471b8478f9f8028c9a3517ad3ca7bca5fb4a

 * [tools/msbuild] remove MSBuild targets related to the Xamarin Inspector
 * [tools/msbuild] improve XA0010 error message
 * [tools/msbuild] <FastDeploy/> Length cannot be less than zero
 * Bump to xamarin/xamarin-analysis@9524531
 * [tools/msbuild] FastDeploy is not ignoring warnings in output 