### PR TITLE
[tests] Add /restore to build remap-assembly-ref

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1061,7 +1061,7 @@ stages:
       inputs:
         solution: build-tools/remap-assembly-ref/remap-assembly-ref.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/remap-assembly-ref.binlog
+        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/remap-assembly-ref.binlog
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:


### PR DESCRIPTION
Should fix this error during CI build:

    "/Users/runner/work/1/s/build-tools/remap-assembly-ref/remap-assembly-ref.csproj" (default target) (1) ->
    (ResolvePackageAssets target) ->
      /Users/runner/.dotnet/sdk/3.1.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(234,5): error NETSDK1004: Assets file '/Users/runner/work/1/s/build-tools/remap-assembly-ref/obj/project.assets.json' not found. Run a NuGet package restore to generate this file. [/Users/runner/work/1/s/build-tools/remap-assembly-ref/remap-assembly-ref.csproj]