### PR TITLE
[build] Apple Silicon M1 build support

### DIFF
--- a/Documentation/building/unix/dependencies.md
+++ b/Documentation/building/unix/dependencies.md
@@ -2,6 +2,7 @@
 
 Building Xamarin.Android requires:
 
+  * [Homebrew](#homebrew)
   * [Latest Mono](#mono-sdk)
   * [The Java Development Kit (JDK)](#jdk)
   * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
@@ -27,6 +28,18 @@ then the build will fail and an error message will be displayed attempting
 to provide install instructions to obtain the missing dependency, e.g.:
 
     error : Could not find required program '7za'. Please run: brew install 'p7zip'.
+
+<a name="homebrew" />
+
+## Homebrew
+
+[Homebrew](https://brew.sh) must be installed and available via `$PATH` in
+order to provision xamarin-android.
+
+When building on Apple Silicon (arm64) machines, use the **arch**(1) command to
+allow Homebrew to be installed:
+
+	% arch -arch x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 
 <a name="mono-sdk" />

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Android.Prepare
 
 			WriteVariable ("export OS_NAME", context.OS.Type);
 			WriteVariable ("export OS_ARCH", context.OS.Architecture);
+			WriteVariable ("export OS_ARCH_TRANSLATED", context.OS.ProcessIsTranslated ? "true" : "false");
 			WriteVariable ("PRODUCT_VERSION", context.ProductVersion);
 			WriteVariable ("MONO_SOURCE_FULL_PATH", Configurables.Paths.MonoSourceFullPath);
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -133,6 +133,8 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public string HomebrewPrefix { get; set; } = String.Empty;
 
+		public virtual bool ProcessIsTranslated => false;
+
 		/// <summary>
 		///   File extension used for ZIP archives
 		/// </summary>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5518

Context: https://github.com/xamarin/xamarin-android/projects/16

[Apple announced new Mac hardware][0], which use an [M1 CPU][1], which
is an arm64-compatible ABI, *not* intel based.  Legacy software built
for intel CPUs will still run via the [Rosetta][3] translation
environment.

Because of Rosetta, existing Xamarin.Android binaries will work as-is
on Mac hardware with M1 CPUs.

However, what if you want to *build* the xamarin-android repo on an
M1 CPU?

Previously, that would fail:

	% make prepare PREPARE_AUTOPROVISION=true
	…
	  Error: Could not find Homebrew on this system, please install it from https://brew.sh/

Unfortunately, [Homebrew][4] won't install by default:

	% /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

	Password:
	Homebrew is not (yet) supported on ARM processors!
	Rerun the Homebrew installer under Rosetta 2.
	If you really know what you are doing and are prepared for a very broken
	experience you can use another installation option for installing on ARM:
	  https://docs.brew.sh/Installation

However, there *is* a way to install Homebrew!  You "just" need to
"lie" about the processor being used!

	% arch -arch x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
	# works!

This works by using the [**arch**(1)][5] command, which allows
explicitly specifying (overriding) the CPU environment that the child
process runs within.  Within `arch -arch x86_64 command`, `command`
believes it's running on an x86_64 CPU.

Update the Unix `dependencies.md` documentation to document how to
install Homebrew on an M1 CPU.

Update `xaprepare` so that whenever a `brew` command is executed on
an M1 CPU, the command is prefixed with `arch -arch x86_64`.

`xaprepare` uses the [`sysctl.proc_translated` system control][6]
to determine if it's currently running within a Rosetta environment,
so that `arch -arch x86_64` is not used unless required.

Finally, *disable* provisioning of the
[`xamarin/xamarin-android-windeps/mingw-zlib`][7] tap on M1 devices,
as it currently does not build:

	% arch -arch x86_64 /usr/local/bin/brew "install" "xamarin/xamarin-android-windeps/mingw-zlib"
	...
	==> make -f win32/Makefile.gcc PREFIX=i686-w64-mingw32- DESTDIR=/usr/local/Cellar/mingw-zlib/1.2.11 BINARY_PATH=/usr/i686-w64-mingw32/lib INCLUDE_
	Last 15 lines from /Users/jon/Library/Logs/Homebrew/mingw-zlib/02.usr:
	with preprocessed source if appropriate.
	See <https://github.com/Homebrew/homebrew-core/issues> for instructions.
	make: *** [gzlib.o] Error 4
	make: *** Waiting for unfinished jobs....
	make: *** [deflate.o] Error 4
	make: *** [crc32.o] Error 4
	make: *** [compress.o] Error 4
	make: *** [adler32.o] Error 4
	i686-w64-mingw32-gcc: internal compiler error: Abort trap: 6 signal terminated program cc1
	Please submit a full bug report,
	with preprocessed source if appropriate.
	See <https://github.com/Homebrew/homebrew-core/issues> for instructions.
	make: *** [gzclose.o] Error 4
	make: *** [gzread.o] Error 4
	make: *** [gzwrite.o] Error 4

	If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
	  https://github.com/xamarin/homebrew-xamarin-android-windeps/issues

[0]: https://www.apple.com/newsroom/2020/11/introducing-the-next-generation-of-mac/
[1]: https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/
[2]: https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/
[3]: https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment
[4]: https://brew.sh
[5]: https://www.unix.com/man-page/osx/1/arch/
[6]: https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment#3616845
[7]: https://github.com/xamarin/homebrew-xamarin-android-windeps