### PR TITLE
[Xamarin.Android.Build.Tasks] run 'mono generator.exe' in some cases

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
@@ -15,16 +15,16 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// If `true`, this task should run `dotnet foo.dll` and `foo.exe` otherwise.
 		/// </summary>
-		protected bool UsingDotnet { get; private set; }
+		protected bool NeedsDotnet { get; private set; }
 
 		/// <summary>
 		/// If `true`, this task should run `mono foo.exe`.
 		/// NOTE: this would only occur when building "legacy" Xamarin.Android projects under `dotnet build`.
 		/// </summary>
-		protected bool UsingMono { get; private set; }
+		protected bool NeedsMono { get; private set; }
 
 		/// <summary>
-		/// The path to the assembly `foo.dll`. Will be `null` when UsingDotnet and UsingMono are `false`.
+		/// The path to the assembly `foo.dll`. Will be `null` when NeedsDotnet and NeedsMono are `false`.
 		/// </summary>
 		protected string AssemblyPath { get; private set; }
 
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Tasks
 
 			var assemblyPath = Path.Combine (ToolPath, $"{BaseToolName}.dll");
 			if (File.Exists (assemblyPath)) {
-				UsingDotnet = true;
+				NeedsDotnet = true;
 				AssemblyPath = assemblyPath;
 				ToolPath = null;
 
@@ -44,12 +44,14 @@ namespace Xamarin.Android.Tasks
 			} else {
 				if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) &&
 						!RuntimeInformation.FrameworkDescription.StartsWith ("Mono", StringComparison.OrdinalIgnoreCase)) {
-					UsingMono = true;
-					AssemblyPath = Path.ChangeExtension (assemblyPath, ".exe");
+					// If not Windows and not running under Mono
+					NeedsMono = true;
+					AssemblyPath = Path.Combine (ToolPath, $"{BaseToolName}.exe");
 					ToolPath = null;
 
 					Log.LogDebugMessage ($"Using: mono {AssemblyPath}");
 				} else {
+					// Otherwise running the .exe directly should work
 					Log.LogDebugMessage ($"Using: {GenerateFullPathToTool ()}");
 				}
 			}
@@ -64,35 +66,62 @@ namespace Xamarin.Android.Tasks
 			get;
 		}
 
-		protected override string ToolName =>
-			UsingDotnet ? "dotnet" : UsingMono ? "mono" : $"{BaseToolName}.exe";
+		protected override string ToolName {
+			get {
+				if (NeedsDotnet)
+					return "dotnet";
+				if (NeedsMono)
+					return "mono";
+				return $"{BaseToolName}.exe";
+			}
+		}
 
-		protected override string GenerateFullPathToTool () =>
-			UsingDotnet ? "dotnet" : UsingMono ? FindMono () : Path.Combine (ToolPath, ToolExe);
+		protected override string GenerateFullPathToTool ()
+		{
+			if (NeedsDotnet)
+				return "dotnet";
+			if (NeedsMono)
+				return FindMono ();
+			return Path.Combine (ToolPath, ToolExe);
+		}
 
 
 		const RegisteredTaskObjectLifetime Lifetime = RegisteredTaskObjectLifetime.Build;
 		const string MonoKey = nameof (AndroidDotnetToolTask) + "_Mono";
+		static readonly string [] KnownMonoPaths = new [] {
+			"/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono",
+			"/usr/bin/mono",
+		};
 
 		string FindMono ()
 		{
 			string mono = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<string> (MonoKey, Lifetime);
-			if (!string.IsNullOrEmpty (mono))
+			if (!string.IsNullOrEmpty (mono)) {
+				Log.LogDebugMessage ($"Found cached mono via {nameof (BuildEngine4.RegisterTaskObject)}");
 				return mono;
+			}
 
 			var env = Environment.GetEnvironmentVariable ("PATH");
 			if (string.IsNullOrEmpty (env)) {
 				foreach (var path in env.Split (Path.PathSeparator)) {
-					mono = Path.Combine (path, "mono");
-					if (File.Exists (mono)) {
+					if (File.Exists (mono = Path.Combine (path, "mono"))) {
+						Log.LogDebugMessage ("Found mono in $PATH");
 						BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono, Lifetime);
 						return mono;
 					}
 				}
 			}
 
-			mono = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono";
-			BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono, Lifetime);
+			foreach (var path in KnownMonoPaths) {
+				if (File.Exists (mono = path)) {
+					Log.LogDebugMessage ($"Found mono in {nameof (KnownMonoPaths)}");
+					BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono, Lifetime);
+					return mono;
+				}
+			}
+
+			// Last resort
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono = "mono", Lifetime);
 			return mono;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidDotnetToolTask.cs
@@ -1,4 +1,7 @@
+using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
@@ -15,7 +18,13 @@ namespace Xamarin.Android.Tasks
 		protected bool UsingDotnet { get; private set; }
 
 		/// <summary>
-		/// The path to the assembly `foo.dll`. Will be `null` when not running on .NET 5+.
+		/// If `true`, this task should run `mono foo.exe`.
+		/// NOTE: this would only occur when building "legacy" Xamarin.Android projects under `dotnet build`.
+		/// </summary>
+		protected bool UsingMono { get; private set; }
+
+		/// <summary>
+		/// The path to the assembly `foo.dll`. Will be `null` when UsingDotnet and UsingMono are `false`.
 		/// </summary>
 		protected string AssemblyPath { get; private set; }
 
@@ -27,12 +36,22 @@ namespace Xamarin.Android.Tasks
 
 			var assemblyPath = Path.Combine (ToolPath, $"{BaseToolName}.dll");
 			if (File.Exists (assemblyPath)) {
-				Log.LogDebugMessage ($"Using: dotnet {assemblyPath}");
 				UsingDotnet = true;
 				AssemblyPath = assemblyPath;
 				ToolPath = null;
+
+				Log.LogDebugMessage ($"Using: dotnet {AssemblyPath}");
 			} else {
-				Log.LogDebugMessage ($"Using: {GenerateFullPathToTool ()}");
+				if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) &&
+						!RuntimeInformation.FrameworkDescription.StartsWith ("Mono", StringComparison.OrdinalIgnoreCase)) {
+					UsingMono = true;
+					AssemblyPath = Path.ChangeExtension (assemblyPath, ".exe");
+					ToolPath = null;
+
+					Log.LogDebugMessage ($"Using: mono {AssemblyPath}");
+				} else {
+					Log.LogDebugMessage ($"Using: {GenerateFullPathToTool ()}");
+				}
 			}
 
 			return base.Execute ();
@@ -46,10 +65,36 @@ namespace Xamarin.Android.Tasks
 		}
 
 		protected override string ToolName =>
-			UsingDotnet ? "dotnet" : $"{BaseToolName}.exe";
+			UsingDotnet ? "dotnet" : UsingMono ? "mono" : $"{BaseToolName}.exe";
 
 		protected override string GenerateFullPathToTool () =>
-			UsingDotnet ? "dotnet" : Path.Combine (ToolPath, ToolExe);
+			UsingDotnet ? "dotnet" : UsingMono ? FindMono () : Path.Combine (ToolPath, ToolExe);
+
+
+		const RegisteredTaskObjectLifetime Lifetime = RegisteredTaskObjectLifetime.Build;
+		const string MonoKey = nameof (AndroidDotnetToolTask) + "_Mono";
+
+		string FindMono ()
+		{
+			string mono = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<string> (MonoKey, Lifetime);
+			if (!string.IsNullOrEmpty (mono))
+				return mono;
+
+			var env = Environment.GetEnvironmentVariable ("PATH");
+			if (string.IsNullOrEmpty (env)) {
+				foreach (var path in env.Split (Path.PathSeparator)) {
+					mono = Path.Combine (path, "mono");
+					if (File.Exists (mono)) {
+						BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono, Lifetime);
+						return mono;
+					}
+				}
+			}
+
+			mono = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono";
+			BuildEngine4.RegisterTaskObjectAssemblyLocal (MonoKey, mono, Lifetime);
+			return mono;
+		}
 
 		protected virtual CommandLineBuilder GetCommandLineBuilder ()
 		{


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Legacy.Sdk

When building this project under `dotnet build`:

    <Project Sdk="Xamarin.Legacy.Sdk">
      <PropertyGroup>
        <TargetFrameworks>monoandroid11.0;net6.0-android</TargetFrameworks>
      </PropertyGroup>
    </Project>

We are in a situation where `AndroidDotnetToolTask` will attempt to
run `generator.exe` for a "legacy" Xamarin.Android binding project.

This works on Windows, because you can just run `generator.exe`.

On Mac, however, we need to run `mono generator.exe`. If the runtime
is Mono, this happens implicitly:

https://github.com/mono/mono/blob/2020-02/mono/metadata/w32process-unix.c#L1745
https://github.com/mono/mono/blob/2020-02/mono/metadata/w32process-unix.c#L1236-L1363

But if the runtime is .NET 6, you get the error:

    /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets(35,5): error MSB6003: The specified task executable "generator.exe" could not be run. System.ComponentModel.Win32Exception (13): Permission denied
    at System.Diagnostics.Process.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
    at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
    at System.Diagnostics.Process.Start()
    at Microsoft.Build.Utilities.ToolTask.ExecuteTool(String pathToTool, String responseFileCommands, String commandLineCommands)
    at Microsoft.Build.Utilities.ToolTask.Execute() [/Users/runner/work/1/s/samples/JavaBinding/JavaBinding.csproj]

`generator.exe` won't have the execute bit set (`chmod`). We need to
detect this situation and run `mono generator.exe` instead.

When:

1. `generator.dll` is not found
2. The OS is not Windows
3. `RuntimeInformation.FrameworkDescription` does not start with `Mono`

Look in `$PATH` for a path to `mono` and use it.

Use `/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono`
as a last resort.