### PR TITLE
[build] MonoAndroidFramework.props/targets for short-form MSBuild projects

### DIFF
--- a/build-tools/scripts/MonoAndroidFramework.props
+++ b/build-tools/scripts/MonoAndroidFramework.props
@@ -1,9 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Note: ..\..\Configuration.props *must* be included FIRST -->
+<!--
+    Import this file at the top, when you need to build a MonoAndroid
+    assembly in the local build tree.
+-->
+<Project>
+  <!-- Common properties -->
+  <PropertyGroup>
+    <NoStdLib>true</NoStdLib>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\product.snk</AssemblyOriginatorKeyFile>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidApplication>false</AndroidApplication>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Project="..\..\Configuration.props" />
+
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
     <FrameworkPathOverride>$(TargetFrameworkRootPath)\MonoAndroid\v1.0</FrameworkPathOverride>
+    <TargetFramework>monoandroid$(AndroidLatestStableFrameworkVersion.TrimStart('v'))</TargetFramework>
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(AndroidLatestStableFrameworkVersion)</TargetFrameworkVersion>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</OutputPath>
   </PropertyGroup>
+
 </Project>

--- a/build-tools/scripts/MonoAndroidFramework.targets
+++ b/build-tools/scripts/MonoAndroidFramework.targets
@@ -1,0 +1,48 @@
+<!--
+    Import this file at the bottom, when you need to build a
+    MonoAndroid assembly in the local build tree.
+-->
+<Project>
+  <PropertyGroup>
+    <LanguageTargets Condition="Exists('$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets')">$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets</LanguageTargets>
+  </PropertyGroup>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <!-- References -->
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Xml">
+      <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Java.Interop">
+      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!-- 
+    NOTE: This prevents transitive project references or other projects in the .sln from copying files to $(OutputPath).
+    Without this Xamarin.Android.Build.Tasks.csproj was copying files to xbuild-frameworks\MonoAndroid\v11.0\
+  -->
+  <Target Name="_DoNotCopyProjectReferences"
+      AfterTargets="AssignProjectConfiguration">
+    <ItemGroup>
+      <ProjectReferenceWithConfiguration Update="@(ProjectReferenceWithConfiguration)" Private="false" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -1,70 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{5EB9E888-E357-417E-9F39-DDEC195CE47F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>OpenTK</RootNamespace>
-    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-    <AndroidResgenClass>Resource</AndroidResgenClass>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <AssemblyName>OpenTK-1.0</AssemblyName>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>MONODROID;MINIMAL;MOBILE;OPENTK_1;OPENTK_1_0</DefineConstants>
-    <NoWarn>3001,3002,3003,3005,3006,3021,3014,0618,1591,0414,0169,0419,1570,1572,1573,1635</NoWarn>
-    <NoStdLib>true</NoStdLib>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AndroidApplication>false</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <AppendTargetFrameworkToIntermediateOutputPath>False</AppendTargetFrameworkToIntermediateOutputPath>
-  </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
+<Project>
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
-    <AndroidLinkMode>None</AndroidLinkMode>
-    <ConsolePause>false</ConsolePause>
+  <PropertyGroup>
+    <AssemblyName>OpenTK-1.0</AssemblyName>
+    <NoWarn>3001,3002,3003,3005,3006,3021,3014,0618,1591,0414,0169,0419,1570,1572,1573,1635</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>true</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
-    <ConsolePause>false</ConsolePause>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System">
-      <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml">
-      <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Java.Interop">
-      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
         <Compile Include="GlobalAssemblyInfo.cs" />
         <Compile Include="$(OpenTKSourceDirectory)\Source\OpenTK\Audio\AudioCapture.cs">
@@ -593,26 +537,13 @@
             <Link>WindowState.cs</Link>
         </Compile>
    </ItemGroup>
-  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" Condition="Exists('$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets')" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.targets" />
   <PropertyGroup>
+    <DefineConstants>MONODROID;MINIMAL;MOBILE;OPENTK_1;OPENTK_1_0</DefineConstants>
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' And '$(AndroidApiLevel)' != '' And $(AndroidApiLevel) &gt; 23 ">1.8</JavacSourceVersion>
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.6</JavacSourceVersion>
     <JavaCallableWrapperAbsAssembly>$(JavaCallableWrapperOutputPathAbs)$(AssemblyName).dll</JavaCallableWrapperAbsAssembly>
     <JavaCallableWrapperAbsAssembly Condition="!Exists('$(JavaCallableWrapperAbsAssembly)')">$(MSBuildProjectDirectory)\$(IntermediateOutputPath)\$(AssemblyName).dll</JavaCallableWrapperAbsAssembly>
   </PropertyGroup>
   <Import Project="..\..\build-tools\scripts\JavaCallableWrappers.targets" />
-  <ItemGroup>
-    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
-      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
-      <Name>Mono.Android</Name>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
-      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
-      <Name>Xamarin.Android.Build.Tasks</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
-  </ItemGroup>
 </Project>

--- a/src/System.EnterpriseServices/System.EnterpriseServices.csproj
+++ b/src/System.EnterpriseServices/System.EnterpriseServices.csproj
@@ -1,54 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{2868FC32-A4E7-4008-87C8-2C7879CACB58}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>System.EnterpriseServices</RootNamespace>
-    <AssemblyName>System.EnterpriseServices</AssemblyName>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <NoStdLib>true</NoStdLib>
-    <AndroidApplication>false</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-  </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
+<Project>
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <NoStdLib>true</NoStdLib>
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <NoStdLib>true</NoStdLib>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib">
-    <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" Condition="Exists('$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets')" />
-  <ItemGroup>
-    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
-      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
-      <Name>Mono.Android</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.targets" />
 </Project>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.NET.csproj
@@ -17,8 +17,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
-  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
-  
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -1,96 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4D603AA3-3BFD-43C8-8050-0CD6C2601126}</ProjectGuid>
-    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Xamarin.Android.NUnitLite</RootNamespace>
-    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-    <AssemblyName>Xamarin.Android.NUnitLite</AssemblyName>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <AndroidApplication>false</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <NoStdLib>true</NoStdLib>
     <!-- Disable XML doc warnings:
          CS1570: XML comment has badly formed XML - 'Whitespace is not allowed at this location.'
          CS1572: XML comment has a param tag for 'Bar', but there is no parameter by that name
          CS1591: Missing XML comment for publicly visible type or member 'Foo'
     -->
     <NoWarn>1570;1572;1591</NoWarn>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentation>true</GenerateDocumentation>
+    <AndroidUseIntermediateDesignerFile>true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
-  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
-    <DefineConstants>DEBUG;NUNITLITE;CLR_4_0;NET_4_5;__MOBILE__;MONOTOUCH</DefineConstants>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);NUNITLITE;CLR_4_0;NET_4_5;__MOBILE__;MONOTOUCH</DefineConstants>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <GenerateDocumentation>True</GenerateDocumentation>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
-    <DefineConstants>NUNITLITE;CLR_4_0;NET_4_5;__MOBILE__;MONOTOUCH</DefineConstants>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <GenerateDocumentation>True</GenerateDocumentation>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System">
-      <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml">
-      <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Java.Interop">
-      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Resources\Resource.designer.cs" />
-    <Compile Include="Gui\AndroidRunner.cs" />
-    <Compile Include="Gui\Activities\TestSuiteActivity.cs" />
-    <Compile Include="Gui\Instrumentations\TestSuiteInstrumentation.cs" />
-    <Compile Include="Gui\Activities\TestResultActivity.cs" />
-    <Compile Include="Gui\Activities\OptionsActivity.cs" />
-    <Compile Include="Gui\Options.cs" />
-    <Compile Include="Gui\TcpTextWriter.cs" />
     <Compile Include="..\..\src-ThirdParty\NUnitLite\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidResource Include="Resources\layout\options.axml" />
-    <AndroidResource Include="Resources\layout\results.axml" />
-    <AndroidResource Include="Resources\layout\test_result.axml" />
-    <AndroidResource Include="Resources\layout\test_suite.axml" />
+    <AndroidResource Include="Resources\layout\*.axml" />
   </ItemGroup>
-  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" Condition="Exists('$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets')"/>
-  <ItemGroup>
-    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
-      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
-      <Name>Mono.Android</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.targets" />
 </Project>


### PR DESCRIPTION
In order to build the following projects:

* OpenTK.csproj
* System.EnterpriseServices.csproj
* Xamarin.Android.NUnitLite.csproj

These need to be `MonoAndroid` assemblies that import
`Xamarin.Android.CSharp.targets`. They are *not* built by `xabuild`.

At first you would think you could just do:

    <Project Sdk="Microsoft.NET.Sdk">
      <!-- Everything else here -->
      <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
    </Project>

This yields a warning such as:

    Xamarin.Android.CSharp.targets(50,5): warning MSB4011: "Microsoft.CSharp.targets" cannot be imported again.
    It was already imported at "C:\Program Files\dotnet\sdk\5.0.102\Sdks\Microsoft.NET.Sdk\Sdk\Sdk.targets (37,3)".
    This is most likely a build authoring error. This subsequent import will be ignored.

We can change this to:

    <PropertyGroup>
      <LanguageTargets Condition="Exists('$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets')">$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets</LanguageTargets>
    </PropertyGroup>
    <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

This makes `Xamarin.Android.CSharp.targets` get imported as if it were
the C# targets. No warnings!

This is the same trick used by MSBuild.Sdk.Extras:

https://github.com/novotnyllc/MSBuildSdkExtras/blob/7bf8b6484b9fc4df3c10ba96b6722423b0898026/Source/MSBuild.Sdk.Extras/Build/Platforms.targets#L16-L18

For extra usability, let's setup things so all three projects can
simply do:

    <Project>
      <Import Project="..\..\build-tools\MonoAndroidFramework.props" />
      <!-- Everything else here -->
      <Import Project="..\..\build-tools\MonoAndroidFramework.targets" />
    </Project>

In a future PR, we can consolidate remaining projects that need to
import `Xamarin.Android.CSharp.targets`.

## Fix for transitive @(ProjectReference) ##

Originally these changes were failing with:

    mono --debug /Users/builder/azdo/_work/1/s/xamarin-android/bin/Release/lib/mandroid-internal/typenamemap-gen.exe -o typemap ...
    Failed to read '/Users/builder/azdo/_work/1/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v11.0/libzip.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
        at Mono.Cecil.PE.ImageReader.ReadOptionalHeaders (System.UInt16& subsystem, System.UInt16& dll_characteristics) [0x000c8] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil.PE/ImageReader.cs:200
        at Mono.Cecil.PE.ImageReader.ReadImage () [0x0008b] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil.PE/ImageReader.cs:85
        at Mono.Cecil.PE.ImageReader.ReadImage (Mono.Disposable`1[T] stream, System.String file_name) [0x00007] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil.PE/ImageReader.cs:763
        at Mono.Cecil.ModuleDefinition.ReadModule (Mono.Disposable`1[T] stream, System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x00006] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil/ModuleDefinition.cs:1146
        at Mono.Cecil.ModuleDefinition.ReadModule (System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x0006c] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil/ModuleDefinition.cs:1118
        at Mono.Cecil.AssemblyDefinition.ReadAssembly (System.String fileName, Mono.Cecil.ReaderParameters parameters) [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/cecil/Mono.Cecil/AssemblyDefinition.cs:131
        at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.ReadAssembly (System.String file) [0x000de] in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs:163
    typenamemap-gen: Error processing assemblies: error XA0009: Error while loading assembly: '/Users/builder/azdo/_work/1/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v11.0/libzip.dll'.

`libzip.dll` is a Windows native library, but why is it even in the
`xbuild-frameworks/MonoAndroid/v11.0` folder at all?

Another difference with the dotnet/sdk, it appears that in some cases
transitive project dependencies projects in `.sln` files will get
their build output included in a projects' `$(OutputPath)`.

I found a helpful blog post on this:

https://cezarypiatek.github.io/post/managing-output-in-sdk-projects/

I added a new `_DoNotCopyProjectReferences` target that sets
`%(Private)` to `false` for every item in `@(ProjectReferenceWithConfiguration)`.

We might eventually want to migrate this behavior repo-wide, as it
will improve our build performance and fix many of the "double writes"
that occur during our build.