### PR TITLE
[remap-assembly-ref] use Mono.Cecil from NuGet

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -198,7 +198,7 @@
     <AndroidSupportedTargetAotAbisSplit>$(AndroidSupportedTargetAotAbis.Split(':'))</AndroidSupportedTargetAotAbisSplit>
   </PropertyGroup>
   <PropertyGroup>
-    <RemapAssemblyRefToolExecutable>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\remap-assembly-ref.exe</RemapAssemblyRefToolExecutable>
+    <RemapAssemblyRefToolExecutable>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\remap-assembly-ref\remap-assembly-ref.exe</RemapAssemblyRefToolExecutable>
     <RemapAssemblyRefTool>$(ManagedRuntime) $(ManagedRuntimeArgs) &quot;$(RemapAssemblyRefToolExecutable)&quot;</RemapAssemblyRefTool>
   </PropertyGroup>
 

--- a/Configuration.props
+++ b/Configuration.props
@@ -126,6 +126,7 @@
     <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
     <LibZipSharpVersion>1.0.20</LibZipSharpVersion>
+    <MonoCecilVersion>0.11.2</MonoCecilVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>remapassemblyref</RootNamespace>
     <AssemblyName>remap-assembly-ref</AssemblyName>
-    <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
+    <OutputPath>..\..\bin\Build$(Configuration)\remap-assembly-ref</OutputPath>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
@@ -12,9 +12,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
-    <Reference Include="Mono.Cecil">
-      <HintPath>$(XamarinAndroidSourcePath)external\mono\sdks\out\android-bcl\monodroid_tools\Mono.Cecil.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
   </ItemGroup>
 
 </Project>

--- a/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
+    <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
   </ItemGroup>
 
 </Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -48,17 +48,11 @@ namespace Xamarin.Android.Prepare
 				// BCL: Runs BCL tests on emulator
 				// TimeZone: Runs timezone unit tests on emulator
 				// Designer: Runs designer integration tests
-				if (file == ".external" || file == "Configuration.props") {
+				if (file == ".external" || file == "Configuration.props" || file.Contains ("build-tools/")) {
 					testAreas.Add ("MSBuild");
 					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("BCL");
 					testAreas.Add ("TimeZone");
-					testAreas.Add ("Designer");
-				}
-
-				if (file.Contains ("build-tools/installers")) {
-					testAreas.Add ("MSBuild");
-					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("Designer");
 				}
 


### PR DESCRIPTION
BCL Test phases are failing with:

    remap-assembly-ref.cs(3,12): error CS0234: The type or namespace name 'Cecil' does not exist in the namespace 'Mono' (are you missing an assembly reference?)

The problem being `Mono.Cecil.dll` does not actually exist:

    warning MSB3245: Could not resolve this reference. Could not locate the assembly "Mono.Cecil". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.

This appears to have started failing since 49e570d8.

19c3b731 fixed the issue with needing `/restore`, but this is the next
issue...

Reviewing a build log from before 49e570d8, it *only* worked because
the build was pulling `Mono.Cecil.dll` from Mono's GAC:

    Task ResolveAssemblyReference
        Reference found at search path location "{GAC}".
        ...
        Considered "/Users/runner/work/1/s/external/mono/sdks/out/android-bcl/monodroid_tools/Mono.Cecil.dll", but it didn't exist.
        ...
    OutputItems
        ReferencePath
            /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/gac/Mono.Cecil/0.11.1.0__0738eb9f132ed756/Mono.Cecil.dll

Switching to `Microsoft.NET.Sdk` prevented the probing of the GAC,
because `$(AssemblySearchPaths)` does not contain `{GAC}` in the
dotnet/sdk:

https://github.com/dotnet/sdk/blob/ee455863aa6ddf13108bb54b37a5a47fb12fe39e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L90-L91

To fix the problem, I think we should just use a `<PackageReference/>`
for Mono.Cecil in this tool.

I also updated `Step_DetermineAzurePipelinesTestJobs`, so changes to
`build-tools` will run all tests.