### PR TITLE
[Xamarin.Android.Build.Tasks] fix @(AndroidLibrary) in legacy Xamarin.Android

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -95,8 +95,8 @@ This item group populates the Build Action drop-down in IDEs.
     <!-- Legacy binding projects -->
     <ItemGroup Condition=" '$(_AndroidIsBindingProject)' == 'true' and '$(UsingAndroidNETSdk)' != 'true' ">
       <LibraryProjectZip    Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
-      <EmbeddedJar          Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
-      <EmbeddedReferenceJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
+      <EmbeddedJar          Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
+      <EmbeddedReferenceJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -46,8 +46,15 @@ namespace Xamarin.Android.Build.Tests
 				WebContent = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/svg-android/svg-android.jar"
 			});
 			proj.AndroidClassParser = classParser;
-			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateDllBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var assemblyPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.dll");
+				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
+					var typeName = "Com.Larvalabs.Svgandroid.SVG";
+					var type = assembly.MainModule.GetType (typeName);
+					Assert.IsNotNull (type, $"{assemblyPath} should contain {typeName}");
+				}
 
 				//A list of properties we check exist in binding projects
 				var properties = new [] {


### PR DESCRIPTION
I was testing the new `@(AndroidLibrary)` item group, and noticed some
logic was backwards:

    <EmbeddedJar          Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
    <EmbeddedReferenceJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />

`@(EmbeddedJar)` should be used when `%(Bind)` is `true`! Because it
is using `@(EmbeddedReferenceJar)` instead, we are not currently
generating C# bindings by default.

We had a test for this item group, but it didn't actually check the
output assembly has a C# class from the `@(AndroidLibrary)`.

I updated the test and fixed the logic here.