### PR TITLE
[Mono.Android] Implement JniValueManager.ActivatePeer

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -625,6 +625,11 @@ namespace Android.Runtime {
 			return null;
 		}
 
+		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, Type peerType, Type [] constructorArguments, object? []? argumentValues)
+		{
+			Java.Interop.TypeManager.Activate (self, reference.Handle, peerType, constructorArguments, argumentValues);
+		}
+
 		protected override bool TryUnboxPeerObject (IJavaPeerable value, [NotNullWhen (true)]out object? result)
 		{
 			var proxy = value as JavaProxyThrowable;

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -625,9 +625,9 @@ namespace Android.Runtime {
 			return null;
 		}
 
-		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, Type peerType, Type [] constructorArguments, object? []? argumentValues)
+		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object? []? argumentValues)
 		{
-			Java.Interop.TypeManager.Activate (self, reference.Handle, peerType, constructorArguments, argumentValues);
+			Java.Interop.TypeManager.Activate (self, reference.Handle, cinfo, argumentValues);
 		}
 
 		protected override bool TryUnboxPeerObject (IJavaPeerable value, [NotNullWhen (true)]out object? result)

--- a/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
+++ b/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
@@ -18,7 +18,8 @@ namespace Android.Runtime {
 		static FieldInfo Throwable_handle = typeof (Java.Lang.Throwable).GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
 
-		internal static Action <IntPtr, object? []?> CreateDelegate (Type type, ConstructorInfo cinfo, Type [] parameter_types) {
+		internal static Action <IntPtr, object? []?> CreateDelegate (ConstructorInfo cinfo) {
+			var type = cinfo.DeclaringType;
 			var handle = handlefld;
 			if (typeof (Java.Lang.Throwable).IsAssignableFrom (type)) {
 				handle = Throwable_handle;
@@ -38,7 +39,9 @@ namespace Android.Runtime {
 			il.Emit (OpCodes.Stfld, handle);
 
 			il.Emit (OpCodes.Ldloc_0);
-			for (int i = 0; i < parameter_types.Length; i++) {
+
+			var len = cinfo.GetParameters ().Length;
+			for (int i = 0; i < len; i++) {
 				il.Emit (OpCodes.Ldarg, 1);
 				il.Emit (OpCodes.Ldc_I4, i);
 				il.Emit (OpCodes.Ldelem_Ref);

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -158,6 +158,11 @@ namespace Java.Interop {
 			}
 			Type[] ptypes = GetParameterTypes (JNIEnv.GetString (signature_ptr, JniHandleOwnership.DoNotTransfer));
 			var parms = JNIEnv.GetObjectArray (parameters_ptr, ptypes);
+			Activate (o, jobject, type, ptypes, parms);
+		}
+
+		internal static void Activate (IJavaPeerable? o, IntPtr jobject, Type type, Type[] ptypes, object? []? parms)
+		{
 			var cinfo = type.GetConstructor (ptypes);
 			if (cinfo == null) {
 				throw CreateMissingConstructorException (type, ptypes);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -87,11 +87,8 @@ namespace Xamarin.Android.Build.Tests
 					"Java.Interop.dll",
 					"Mono.Android.dll",
 					"System.Console.dll",
-					"System.Linq.Expressions.dll",
-					"System.ObjectModel.dll",
 					"System.Private.CoreLib.dll",
 					"System.Collections.Concurrent.dll",
-					"System.Collections.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",
 				} :


### PR DESCRIPTION
Implement `JniValueManager.ActivatePeer` method
in `AndroidValueManager`.

Context: https://github.com/xamarin/xamarin-android/pull/5400

This allows us to remove SLE dependency and save cca 15% of assembly
size for XA simple Hello world app.

Size difference of `BuildReleaseArm64False` on net6:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      +          96 assemblies/Mono.Android.dll
      -         331 assemblies/System.Collections.Concurrent.dll
      -         907 assemblies/Java.Interop.dll
      -       1,003 assemblies/System.Linq.dll
      -       3,856 assemblies/System.ObjectModel.dll *1
      -       4,496 assemblies/System.Collections.dll *1
      -       7,824 assemblies/System.Private.CoreLib.dll
      -     115,284 assemblies/System.Linq.Expressions.dll *1
    Summary:
      -     133,605 Assemblies -15.33% (of 871,776)