### PR TITLE
[xaprepare] remove dependency on the windep homebrew recipe on mac

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Android.Prepare
 
 			new HomebrewProgram ("ninja"),
 			new HomebrewProgram ("p7zip", "7za"),
-			new HomebrewProgram ("xamarin/xamarin-android-windeps/mingw-zlib", "xamarin/xamarin-android-windeps", null),
 
 			new MonoPkgProgram ("Mono", "com.xamarin.mono-MDK.pkg", new Uri (Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoDarwinPackageUrl))) {
 				MinimumVersion = Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoRequiredMinimumVersion),


### PR DESCRIPTION
We've been seeing the attempts to install the recipe time out on our CI
servers:

    Error: Process '/usr/local/bin/brew "install" "xamarin/xamarin-android-windeps/mingw-zlib"' timed out after 00:30:00
    Error: Installation of xamarin/xamarin-android-windeps/mingw-zlib failed

Since the recipe existed only for the benefit of cross-building Mono for
Windows on macOS using mingw and we no longer do that, we can remove the
recipe.