### PR TITLE
[ci] Migrate macOS test jobs to 10.15 Catalina

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -115,8 +115,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					Log.LogError ($"Emulator failed to start: `{e.Data}`. Please try again?");
 					sawError.Set ();
 				}
+				// The following may not be fatal:
+				// [emulator stderr] eglMakeCurrent failed in binding subwindow!
 				if (e.Data.IndexOf ("ERROR:", StringComparison.Ordinal) >= 0 ||
-						e.Data.IndexOf (" failed ", StringComparison.Ordinal) >= 0) {
+						(e.Data.IndexOf (" failed ", StringComparison.Ordinal) >= 0 && e.Data.IndexOf ("eglMakeCurrent", StringComparison.Ordinal) == -1)) {
 					Log.LogError ($"Emulator failed to start: {e.Data}");
 					sawError.Set ();
 				}

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -54,8 +54,7 @@ variables:
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.201
   DotNet5Version: 5.0.100
-  HostedMacMojave: Hosted Mac Internal Mojave
-  HostedMac: Hosted Mac Internal
+  HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: Xamarin-Android-Win2019-1120
   # Run all tests if:
@@ -394,7 +393,8 @@ stages:
   # Check - "Xamarin.Android (Smoke Tests APK Instrumentation - macOS)"
   - job: mac_apk_tests
     displayName: APK Instrumentation - macOS
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -688,7 +688,8 @@ stages:
   # Check - "Xamarin.Android (Smoke Tests MSBuild Emulator - macOS)"
   - job: mac_msbuilddevice_tests
     displayName: MSBuild Emulator - macOS
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 90
     cancelTimeoutInMinutes: 5
     workspace:
@@ -867,7 +868,8 @@ stages:
  # Check - "Xamarin.Android (Designer Tests macOS)"
   - job: designer_integration_mac
     displayName: macOS
-    pool: $(HostedMacMojave)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1041,7 +1043,8 @@ stages:
   # Check - "Xamarin.Android (BCL Emulator Tests macOS)"
   - job: mac_bcl_tests
     displayName: macOS
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 180
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -9,7 +9,8 @@ parameters:
 jobs:
   - job: ${{ parameters.job_name }}
     displayName: MSBuild With Emulator - macOS - ${{ parameters.job_suffix }}
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 150
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -11,7 +11,8 @@ parameters:
 jobs:
   - job: ${{ parameters.job_name }}
     displayName: MSBuild ${{ parameters.job_suffix }} - macOS-${{ parameters.node_id }}
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -6,7 +6,8 @@ parameters:
 jobs:
   - job: mac_timezoneinfo_tests_${{ parameters.node_id }}
     displayName: macOS-${{ parameters.node_id }}
-    pool: $(HostedMac)
+    pool:
+      vmImage: $(HostedMacImage)
     timeoutInMinutes: 90
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -7,7 +7,7 @@ parameters:
 
 steps:
 
-  - powershell: |
+  - pwsh: |
       $ErrorActionPreference = 'Stop'
       $ProgressPreference = 'SilentlyContinue'
       $DotNetRoot = "$env:ProgramFiles\dotnet\"

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -14,7 +14,7 @@ steps:
       if ("${{ parameters.remove_dotnet }}" -eq $true) {
         Remove-Item -Recurse $DotNetRoot -Verbose
       }
-      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1 -MaximumRetryCount 5 -RetryIntervalSec 30
       & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
       & dotnet --list-sdks
     displayName: install .NET Core ${{ parameters.version }}
@@ -23,7 +23,7 @@ steps:
   - bash: >
       DOTNET_ROOT=~/.dotnet/ &&
       (if [[ "${{ parameters.remove_dotnet }}" == "true" ]] ; then rm -rfv $DOTNET_ROOT; fi) &&
-      curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
+      curl -L https://dot.net/v1/dotnet-install.sh --retry 5 --retry-max-time 300 > dotnet-install.sh &&
       chmod +x dotnet-install.sh &&
       ./dotnet-install.sh --version ${{ parameters.version }} --install-dir $DOTNET_ROOT --verbose &&
       PATH="$DOTNET_ROOT:$PATH" &&

--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -12,9 +12,31 @@ steps:
       $ProgressPreference = 'SilentlyContinue'
       $DotNetRoot = "$env:ProgramFiles\dotnet\"
       if ("${{ parameters.remove_dotnet }}" -eq $true) {
-        Remove-Item -Recurse $DotNetRoot -Verbose
+          Remove-Item -Recurse $DotNetRoot -Verbose
       }
-      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1 -MaximumRetryCount 5 -RetryIntervalSec 30
+      $currentAttempt = 1
+      $totalAttempts = 5
+      $sleepTime = 5
+      $completed = $false
+      while (-not $completed -and $currentAttempt -le $totalAttempts) {
+          try {
+              $response = Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1 -PassThru
+              if ($response.StatusCode -ne 200) {
+                  throw
+              }
+              $completed = $true
+          } catch {
+              if ($currentAttempt -eq $totalAttempts) {
+                  Write-Host "Unable to download 'dotnet-install.ps1' after $currentAttempt attempts."
+                  throw
+              }
+              Write-Host $_.Exception
+              Write-Host "Retrying after $sleepTime seconds..."
+              Start-Sleep $sleepTime
+              $currentAttempt++
+              $sleepTime = $sleepTime * 2
+          }
+      }
       & .\dotnet-install.ps1 -Version ${{ parameters.version }} -InstallDir $DotNetRoot -Verbose
       & dotnet --list-sdks
     displayName: install .NET Core ${{ parameters.version }}


### PR DESCRIPTION
All test jobs that were running on a macOS [Microsoft-hosted agent][1]
have been updated to use the 10.15 Catalina VM Image.  The majority of
these jobs were still running on High Sierra, and we have hit a number
of issues there recently when trying to install various brew tools.

Retry attempts have also been added to the `use-dot-net.yaml` template
to try to make dotnet SDK installation attempts more robust.

An initial attempt to use this image saw a few emulator jobs fail with:

    /Users/runner/work/1/s/build-tools/scripts/TestApks.targets(57,5): Emulator failed to start: eglMakeCurrent failed in binding subwindow! [/Users/runner/work/1/s/tests/Mono.Android-Tests/Mono.Android-Tests.csproj]

The `StartAndroidEmulator` task has been updated to ignore this
output as it doesn't appear to be fatal.

[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml