### PR TITLE
[check-build-times] Always close all running emulators

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return !Log.HasLoggedErrors;
 			}
 
-			var timeoutInMS = (int) TimeSpan.FromMinutes (12).TotalMilliseconds;
+			var timeoutInMS = (int) TimeSpan.FromMinutes (15).TotalMilliseconds;
 			bool finishAsExpected = false;
 			bool processTimedOut = false;
 			var success = RunProcess (

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			bool processTimedOut = false;
 			var success = RunProcess (
 				fileInfo.FullName,
-				$"--devicename {DeviceName}",
+				$"--devicename {DeviceName} --verbose",
 				timeoutInMS,
 				(string data, ManualResetEvent mre) => {
 					Log.LogMessage (MessageImportance.High, $"CheckBootTimes ({DateTime.UtcNow}): {data}");

--- a/build-tools/check-boot-times/check-boot-times.csproj
+++ b/build-tools/check-boot-times/check-boot-times.csproj
@@ -11,8 +11,7 @@
 
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20079.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4396987&view=logs&jobId=4ae5d5b0-7ab6-5bea-80fd-0525fc475851&j=4ae5d5b0-7ab6-5bea-80fd-0525fc475851&t=8f6971e6-2797-5530-8020-c2758d44f276

The `check-boot-times` tool has been failing intermittently across a
handful of CI runs.  I noticed that the tool will hang and eventually
fail with a process timeout when attempting to boot an emulator that is
already running.  In order to prevent this, the tool will now attempt to
close all emulators that are running before all "cold" or "hot" boot
attempts.  Additional output verbosity has also been enabled to help
with any future troubleshooting.