### PR TITLE
[One .NET] AOT support

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -164,6 +164,18 @@ It is recommended to migrate to the new linker settings, as
 [linker]: https://docs.microsoft.com/dotnet/core/deploying/trimming-options
 [linker-full]: https://docs.microsoft.com/dotnet/core/deploying/trimming-options#trimmed-assemblies
 
+## AOT
+
+`$(RunAOTCompilation)` will be the new MSBuild property for enabling
+AOT. This is the same property used for [Blazor WASM][blazor].
+`$(AotAssemblies)` will also enable AOT, in order to help with
+migration from "legacy" Xamarin.Android to .NET 6.
+
+It is recommended to migrate to the new `$(RunAOTCompilation)`
+property, as `$(AotAssemblies)` will eventually be deprecated.
+
+[blazor]: https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-4/#blazor-webassembly-ahead-of-time-aot-compilation
+
 ## dotnet cli
 
 There are currently a few "verbs" we are aiming to get working in

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
@@ -64,6 +64,10 @@ Specifies the supported Android platform versions for this SDK.
 				writer.WriteAttributeString ("Condition", " '$(TargetPlatformVersion)' == '' ");
 				writer.WriteString (versions.MaxStableVersion.ApiLevel.ToString ("0.0", CultureInfo.InvariantCulture));
 				writer.WriteEndElement (); // </TargetPlatformVersion>
+				writer.WriteStartElement ("AndroidMinimumSupportedApiLevel");
+				writer.WriteAttributeString ("Condition", " '$(AndroidMinimumSupportedApiLevel)' == '' ");
+				writer.WriteString (MinimumApiLevel.ToString ());
+				writer.WriteEndElement (); // </AndroidMinimumSupportedApiLevel>
 				writer.WriteEndElement (); // </PropertyGroup>
 
 				writer.WriteStartElement ("ItemGroup");

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -803,9 +803,8 @@ stages:
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-Aot
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
-        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)-Aot.xml
-        # InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
-        extraBuildArgs: /p:RunAOTCompilation=true /p:ExcludeCategories=InetAccess
+        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Aot.xml
+        extraBuildArgs: /p:TestsFlavor=Aot /p:RunAOTCompilation=true
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-aot
         useDotNet: true

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -49,7 +49,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != LLVM & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
   NUnit.NumberOfTestWorkers: 4
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
   CONVERT_JAVADOC_TO_XMLDOC: $[ne(variables['Build.DefinitionName'], 'Xamarin.Android-PR')]
@@ -796,6 +796,18 @@ stages:
         extraBuildArgs: /p:TestsFlavor=Interpreter /p:UseInterpreter=True
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-Interpreter
+        useDotNet: true
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        testName: Mono.Android.NET_Tests-Aot
+        project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)-Aot.xml
+        # InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
+        extraBuildArgs: /p:RunAOTCompilation=true /p:ExcludeCategories=InetAccess
+        artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
+        artifactFolder: net6-aot
         useDotNet: true
 
     - task: MSBuild@1

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -18,6 +18,7 @@ This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
   <Import Project="..\tools\Xamarin.Android.Bindings.Core.targets" />
   <Import Project="..\tools\Xamarin.Android.Bindings.ClassParse.targets" />
   <Import Project="Microsoft.Android.Sdk.AndroidLibraries.targets" />
+  <Import Project="Microsoft.Android.Sdk.Aot.targets"         Condition=" '$(AndroidApplication)' == 'true' " />
   <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
   <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
   <Import Project="Microsoft.Android.Sdk.ILLink.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -1,0 +1,87 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.Aot.targets
+
+.NET 6 AOT support. You can find "legacy" Xamarin.Android AOT support
+in Xamarin.Android.Legacy.targets.
+
+For <MonoAOTCompiler/> usage, see:
+* https://github.com/dotnet/runtime/blob/15dec9a2aa5a4236d6ba70de2e9c146867b9d2e0/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+* https://github.com/dotnet/runtime/blob/15dec9a2aa5a4236d6ba70de2e9c146867b9d2e0/src/mono/netcore/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
+
+These targets are running within the _ComputeFilesToPublishForRuntimeIdentifiers target.
+They run in a context of an inner build with a single $(RuntimeIdentifier).
+
+***********************************************************************************************
+-->
+<Project>
+
+  <!--
+    NOTE: currently, the only way to allow $(AotAssemblies) in
+    .csproj files is to import these in the Android workload
+    when $(MonoAOTCompilerTasksAssemblyPath) is blank:
+    https://github.com/dotnet/runtime/blob/69711860262e44458bbe276393ea3eb9f7a2192a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in#L20-L25
+  -->
+  <ImportGroup Condition=" '$(MonoAOTCompilerTasksAssemblyPath)' == '' and '$(AotAssemblies)' == 'true' ">
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64" />
+  </ImportGroup>
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.GetAotArguments" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
+  <Target Name="_AndroidAotInputs">
+    <ItemGroup>
+      <_AndroidAotInputs Include="@(ResolvedFileToPublish)" Condition=" '%(Extension)' == '.dll' " />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AndroidAot"
+      Condition=" '$(AotAssemblies)' == 'true' and '$(RuntimeIdentifier)' != '' "
+      DependsOnTargets="_AndroidAotInputs"
+      Inputs="@(_AndroidAotInputs)"
+      Outputs="$(_AndroidStampDirectory)_AndroidAot.stamp">
+    <GetAotArguments
+        AndroidAotMode="$(AndroidAotMode)"
+        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+        AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
+        AndroidApiLevel="$(_AndroidApiLevel)"
+        MinimumSupportedApiLevel="$(AndroidMinimumSupportedApiLevel)"
+        AndroidSequencePointsMode="$(_SequencePointsMode)"
+        AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
+        AotOutputDirectory="$(_AndroidAotBinDirectory)"
+        RuntimeIdentifier="$(RuntimeIdentifier)"
+        EnableLLVM="$(EnableLLVM)"
+        Profiles="@(_AotProfiles)">
+      <Output PropertyName="_AotArguments" TaskParameter="Arguments" />
+      <Output PropertyName="_LLVMPath" TaskParameter="LLVMPath" />
+    </GetAotArguments>
+    <ItemGroup>
+      <_MonoAOTAssemblies Include="@(_AndroidAotInputs->'%(FullPath)')" AotArguments="$(_AotArguments)" />
+    </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)aot\" />
+    <MonoAOTCompiler
+        Assemblies="@(_MonoAOTAssemblies)"
+        CompilerBinaryPath="@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', '$(RuntimeIdentifier)'))"
+        DisableParallelAot="$(_DisableParallelAot)"
+        LibraryFormat="So"
+        Mode="$(AndroidAotMode)"
+        OutputDir="$(IntermediateOutputPath)aot\"
+        OutputType="Library"
+        UseAotDataFile="false"
+        UseLLVM="$(EnableLLVM)"
+        LLVMPath="$(_LLVMPath)">
+      <Output TaskParameter="CompiledAssemblies" ItemName="_AotCompiledAssemblies" />
+      <Output TaskParameter="FileWrites"         ItemName="FileWrites" />
+    </MonoAOTCompiler>
+    <Touch Files="$(_AndroidStampDirectory)_AndroidAot.stamp" AlwaysCreate="true" />
+    <ItemGroup>
+      <ResolvedFileToPublish
+          Include="@(_AotCompiledAssemblies->'%(LibraryFile)')"
+          ArchiveFileName="libaot-$([System.IO.Path]::GetFileNameWithoutExtension('%(_AotCompiledAssemblies.LibraryFile)')).so"
+      />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -31,7 +31,7 @@ _ResolveAssemblies MSBuild target.
   </PropertyGroup>
 
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
-      DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish"
+      DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish;_AndroidAot"
       Returns="@(ResolvedFileToPublish)">
       <ItemGroup>
         <ResolvedFileToPublish

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -68,6 +68,9 @@
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">AndroidManifest.xml</AndroidManifest>
     <GenerateApplicationManifest Condition=" '$(GenerateApplicationManifest)' == '' ">true</GenerateApplicationManifest>
+    <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == 'true' ">true</RunAOTCompilation>
+    <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' ">false</RunAOTCompilation>
+    <AotAssemblies>$(RunAOTCompilation)</AotAssemblies>
 
     <!--
       Runtime libraries feature switches defaults

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -696,7 +696,11 @@ namespace Xamarin.Android.Tasks
 				return;
 
 			var libs = AdditionalNativeLibraryReferences
-				.Select (l => new LibInfo { Path = l.ItemSpec, Abi = AndroidRidAbiHelper.GetNativeLibraryAbi (l) });
+				.Select (l => new LibInfo {
+					Path = l.ItemSpec,
+					Abi = AndroidRidAbiHelper.GetNativeLibraryAbi (l),
+					ArchiveFileName = l.GetMetadata ("ArchiveFileName"),
+				});
 
 			AddNativeLibraries (files, supportedAbis, libs);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
 		[Required]
-		public ITaskItem ApkOutputPath { get; set; }
+		public string StampFile { get; set; }
 
 		public CilStrip ()
 		{
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (nonstripDir))
 				Directory.CreateDirectory (nonstripDir);
 
-			var timestampFileDate = File.GetLastWriteTimeUtc (ApkOutputPath.ItemSpec);
+			var timestampFileDate = File.GetLastWriteTimeUtc (StampFile);
 
 			foreach (var assembly in ResolvedAssemblies) {
 				string assemblyPath = Path.GetFullPath (assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// The <Aot/> task subclasses this in "legacy" Xamarin.Android.
+	/// Called directly in .NET 5 to populate %(AotArguments) metadata.
+	/// </summary>
+	public class GetAotArguments : AndroidAsyncTask
+	{
+		public override string TaskPrefix => "GAOT";
+
+		[Required]
+		public string AndroidApiLevel { get; set; }
+
+		[Required]
+		public string AndroidAotMode { get; set; }
+
+		[Required]
+		public string AotOutputDirectory { get; set; }
+
+		[Required]
+		public string AndroidBinUtilsDirectory { get; set; }
+
+		/// <summary>
+		/// Will be blank in .NET 6+
+		/// </summary>
+		public string ManifestFile { get; set; }
+
+		/// <summary>
+		/// $(AndroidMinimumSupportedApiLevel) in .NET 6+
+		/// </summary>
+		public string MinimumSupportedApiLevel { get; set; }
+
+		public string RuntimeIdentifier { get; set; }
+
+		public string AndroidNdkDirectory { get; set; }
+
+		public bool EnableLLVM { get; set; }
+
+		public string AndroidSequencePointsMode { get; set; }
+
+		public ITaskItem [] Profiles { get; set; }
+
+		public string AotAdditionalArguments { get; set; }
+
+		[Output]
+		public string Arguments { get; set; }
+
+		[Output]
+		public string LLVMPath { get; set; }
+
+		protected AotMode AotMode;
+		protected SequencePointsMode SequencePointsMode;
+		protected string SdkBinDirectory;
+
+		public static bool GetAndroidAotMode(string androidAotMode, out AotMode aotMode)
+		{
+			aotMode = AotMode.Normal;
+
+			switch ((androidAotMode ?? string.Empty).ToLowerInvariant().Trim())
+			{
+			case "":
+			case "none":
+				aotMode = AotMode.None;
+				return true;
+			case "normal":
+				aotMode = AotMode.Normal;
+				return true;
+			case "hybrid":
+				aotMode = AotMode.Hybrid;
+				return true;
+			case "full":
+				aotMode = AotMode.Full;
+				return true;
+			case "interpreter":
+				// We don't do anything here for this mode, this is just to set the flag for the XA
+				// runtime to initialize Mono in the interpreter "AOT" mode.
+				aotMode = AotMode.Interp;
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool TryGetSequencePointsMode (string value, out SequencePointsMode mode)
+		{
+			mode = SequencePointsMode.None;
+			switch ((value ?? string.Empty).ToLowerInvariant ().Trim ()) {
+			case "none":
+				mode = SequencePointsMode.None;
+				return true;
+			case "normal":
+				mode = SequencePointsMode.Normal;
+				return true;
+			case "offline":
+				mode = SequencePointsMode.Offline;
+				return true;
+			}
+			return false;
+		}
+
+		public override Task RunTaskAsync ()
+		{
+			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
+			if (ndk == null) {
+				return Task.CompletedTask; // NdkTools.Create will log appropriate error
+			}
+
+			bool hasValidAotMode = GetAndroidAotMode (AndroidAotMode, out AotMode);
+			if (!hasValidAotMode) {
+				LogCodedError ("XA3002", Properties.Resources.XA3002, AndroidAotMode);
+				return Task.CompletedTask;
+			}
+
+			if (AotMode == AotMode.Interp) {
+				LogDebugMessage ("Interpreter AOT mode enabled");
+				return Task.CompletedTask;
+			}
+
+			TryGetSequencePointsMode (AndroidSequencePointsMode, out SequencePointsMode);
+
+			SdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
+
+			var abi = AndroidRidAbiHelper.RuntimeIdentifierToAbi (RuntimeIdentifier);
+			if (string.IsNullOrEmpty (abi)) {
+				Log.LogCodedError ("XA0035", Properties.Resources.XA0035, RuntimeIdentifier);
+				return Task.CompletedTask;
+			}
+
+			(_, string outdir, string mtriple, AndroidTargetArch arch) = GetAbiSettings (abi);
+			string toolPrefix = GetToolPrefix (ndk, arch, out _);
+
+			Arguments = string.Join (",", GetAotOptions (outdir, mtriple, toolPrefix));
+			if (EnableLLVM)
+				LLVMPath = Path.GetDirectoryName (toolPrefix);
+			return Task.CompletedTask;
+		}
+
+		protected string GetToolPrefix (NdkTools ndk, AndroidTargetArch arch, out int level)
+		{
+			level = 0;
+			return EnableLLVM
+				? ndk.GetNdkToolPrefixForAOT (arch, level = GetNdkApiLevel (ndk, arch))
+				: Path.Combine (AndroidBinUtilsDirectory, $"{ndk.GetArchDirName (arch)}-");
+		}
+
+		int GetNdkApiLevel (NdkTools ndk, AndroidTargetArch arch)
+		{
+			AndroidAppManifest manifest = null;
+			if (!string.IsNullOrEmpty (ManifestFile)) {
+				manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);
+			}
+
+			int level;
+			if (manifest?.MinSdkVersion != null) {
+				level       = manifest.MinSdkVersion.Value;
+			} else if (int.TryParse (MinimumSupportedApiLevel, out level)) {
+				// level already set
+			} else if (int.TryParse (AndroidApiLevel, out level)) {
+				// level already set
+			} else {
+				// Probably not ideal!
+				level       = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+			}
+
+			// Some Android API levels do not exist on the NDK level. Workaround this my mapping them to the
+			// most appropriate API level that does exist.
+			if (level == 6 || level == 7) level = 5;
+			else if (level == 10) level = 9;
+			else if (level == 11) level = 12;
+			else if (level == 20) level = 19;
+			else if (level == 22) level = 21;
+			else if (level == 23) level = 21;
+
+			// API levels below level 21 do not provide support for 64-bit architectures.
+			if (ndk.IsNdk64BitArch (arch) && level < 21) {
+				level = 21;
+			}
+
+			// We perform a downwards API level lookup search since we might not have hardcoded the correct API
+			// mapping above and we do not want to crash needlessly.
+			for (; level >= 5; level--) {
+				try {
+					ndk.GetDirectoryPath (NdkToolchainDir.PlatformLib, arch, level);
+					break;
+				} catch (InvalidOperationException ex) {
+					// Path not found, continue searching...
+					continue;
+				}
+			}
+
+			return level;
+		}
+
+		protected (string aotCompiler, string outdir, string mtriple, AndroidTargetArch arch) GetAbiSettings (string abi)
+		{
+			switch (abi) {
+				case "armeabi-v7a":
+					return (
+						Path.Combine (SdkBinDirectory, "cross-arm"),
+						Path.Combine (AotOutputDirectory, "armeabi-v7a"),
+						"armv7-linux-gnueabi",
+						AndroidTargetArch.Arm
+					);
+
+				case "arm64":
+				case "arm64-v8a":
+				case "aarch64":
+					return (
+						Path.Combine (SdkBinDirectory, "cross-arm64"),
+						Path.Combine (AotOutputDirectory, "arm64-v8a"),
+						"aarch64-linux-android",
+						AndroidTargetArch.Arm64
+					);
+
+				case "x86":
+					return (
+						Path.Combine (SdkBinDirectory, "cross-x86"),
+						Path.Combine (AotOutputDirectory, "x86"),
+						"i686-linux-android",
+						AndroidTargetArch.X86
+					);
+
+				case "x86_64":
+					return (
+						Path.Combine (SdkBinDirectory, "cross-x86_64"),
+						Path.Combine (AotOutputDirectory, "x86_64"),
+						"x86_64-linux-android",
+						AndroidTargetArch.X86_64
+					);
+
+				// case "mips":
+				default:
+					throw new Exception ("Unsupported Android target architecture ABI: " + abi);
+			}
+		}
+
+		/// <summary>
+		/// Returns a list of parameters to pass to the --aot switch
+		/// </summary>
+		protected List<string> GetAotOptions (string outdir, string mtriple, string toolPrefix)
+		{
+			List<string> aotOptions = new List<string> ();
+
+			if (Profiles != null && Profiles.Length > 0) {
+				aotOptions.Add ("profile-only");
+				foreach (var p in Profiles) {
+					var fp = Path.GetFullPath (p.ItemSpec);
+					aotOptions.Add ($"profile={fp}");
+				}
+			}
+			if (!string.IsNullOrEmpty (AotAdditionalArguments))
+				aotOptions.Add (AotAdditionalArguments);
+			if (SequencePointsMode == SequencePointsMode.Offline)
+				aotOptions.Add ($"msym-dir={outdir}");
+			if (AotMode != AotMode.Normal)
+				aotOptions.Add (AotMode.ToString ().ToLowerInvariant ());
+
+			aotOptions.Add ("asmwriter");
+			aotOptions.Add ($"mtriple={mtriple}");
+			aotOptions.Add ($"tool-prefix={toolPrefix}");
+			return aotOptions;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Android.Build.Tests
 			Directory.Delete (SdkWithSpacesPath, recursive: true);
 		}
 
-		[Test, Category ("SmokeTests")]
+		[Test, Category ("SmokeTests"), Category ("ProfiledAOT")]
 		public void BuildBasicApplicationReleaseProfiledAot ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		[Test, Category ("SmokeTests")]
+		[Test, Category ("SmokeTests"), Category ("ProfiledAOT")]
 		public void BuildBasicApplicationReleaseWithCustomAotProfile ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		[Test]
+		[Test, Category ("ProfiledAOT")]
 		public void BuildBasicApplicationReleaseProfiledAotWithoutDefaultProfile ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -147,8 +147,11 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (AotChecks))]
+		[Category ("DotNetIgnore")] // Not currently working, see: https://github.com/dotnet/runtime/issues/56163
 		public void BuildAotApplicationAndÜmläüts (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
+			AssertLLVMSupported (enableLLVM);
+
 			var path = Path.Combine ("temp", string.Format ("BuildAotApplication AndÜmläüts_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -224,8 +227,11 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[TestCaseSource (nameof (AotChecks))]
 		[Category ("Minor"), Category ("MkBundle")]
+		[Category ("DotNetIgnore")] // Not currently working, see: https://github.com/dotnet/runtime/issues/56163
 		public void BuildAotApplicationAndBundleAndÜmläüts (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
+			AssertLLVMSupported (enableLLVM);
+
 			var path = Path.Combine ("temp", string.Format ("BuildAotApplicationAndBundle AndÜmläüts_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -368,6 +374,7 @@ namespace "+ libName + @" {
 		}
 
 		[Test]
+		[Category ("HybridAOT")]
 		public void HybridAOT ([Values ("armeabi-v7a;arm64-v8a", "armeabi-v7a", "arm64-v8a")] string abis)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -418,8 +425,11 @@ namespace "+ libName + @" {
 		}
 
 		[Test]
-		public void NoSymbolsArgShouldReduceAppSize ([Values (true, false)] bool enableHybridAot)
+		[Category ("LLVM")]
+		public void NoSymbolsArgShouldReduceAppSize ([Values ("", "Hybrid")] string androidAotMode)
 		{
+			AssertAotModeSupported (androidAotMode);
+
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				AotAssemblies = true,
@@ -427,8 +437,8 @@ namespace "+ libName + @" {
 			var supportedAbi = "arm64-v8a";
 			proj.SetAndroidSupportedAbis (supportedAbi);
 			proj.SetProperty ("EnableLLVM", true.ToString ());
-			if (enableHybridAot)
-				proj.SetProperty ("AndroidAotMode", "Hybrid");
+			if (!string.IsNullOrEmpty (androidAotMode))
+				proj.SetProperty ("AndroidAotMode", androidAotMode);
 
 			var xaAssemblySize = 0;
 			var xaAssemblySizeNoSymbol = 0;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1053,6 +1053,8 @@ namespace Lib2
 		[TestCaseSource (nameof (AotChecks))]
 		public void BuildIncrementalAot (string supportedAbis, string androidAotMode, bool aotAssemblies, bool expectedResult)
 		{
+			AssertAotModeSupported (androidAotMode);
+
 			var targets = new string [] {
 				"_RemoveRegisterAttribute",
 				"_BuildApkEmbed",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -197,6 +197,21 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		protected static void AssertAotModeSupported (string aotMode)
+		{
+			if (Builder.UseDotNet && !string.IsNullOrEmpty (aotMode) &&
+					!string.Equals (aotMode, "Normal", StringComparison.OrdinalIgnoreCase)) {
+				Assert.Ignore ($"AotMode={aotMode} is not yet supported in .NET 6+");
+			}
+		}
+
+		protected static void AssertLLVMSupported (bool llvm)
+		{
+			if (Builder.UseDotNet && llvm) {
+				Assert.Ignore ($"EnableLLVM={llvm} is not yet supported in .NET 6+");
+			}
+		}
+
 		protected static void WaitFor(int milliseconds)
 		{
 			var pause = new ManualResetEvent(false);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -325,41 +325,64 @@ namespace Xamarin.Android.Build.Tests
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          false,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm64",
 				/* isRelease */          false,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-x86",
 				/* isRelease */          false,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-x64",
 				/* isRelease */          false,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
+				/* aot */                false,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm",
+				/* isRelease */          true,
+				/* aot */                true,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm64",
+				/* isRelease */          true,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          false,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86",
 				/* isRelease */          true,
+				/* aot */                false,
 			},
 			new object [] {
 				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          true,
+				/* aot */                false,
+			},
+			new object [] {
+				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
+				/* isRelease */          true,
+				/* aot */                true,
 			},
 		};
 
 		[Test]
 		[Category ("SmokeTests")]
 		[TestCaseSource (nameof (DotNetBuildSource))]
-		public void DotNetBuild (string runtimeIdentifiers, bool isRelease)
+		public void DotNetBuild (string runtimeIdentifiers, bool isRelease, bool aot)
 		{
 			var proj = new XASdkProject {
 				IsRelease = isRelease,
@@ -392,6 +415,9 @@ namespace Xamarin.Android.Build.Tests
 				}
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": AndroidX.AppCompat.App.AppCompatActivity");
+			if (aot) {
+				proj.SetProperty ("RunAOTCompilation", "true");
+			}
 			proj.OtherBuildItems.Add (new AndroidItem.InputJar ("javaclasses.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestJar,
 			});

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1972,68 +1972,6 @@ because xbuild doesn't support framework reference assemblies.
   Inputs="$(_BuildApkEmbedInputs)"
   Outputs="$(_BuildApkEmbedOutputs)"
   Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
-
-  <PropertyGroup>
-    <_StartupAotProfile Condition="'%(ResolvedAssemblies.Filename)' == 'Xamarin.Forms.Platform.Android'">startup-xf.aotprofile</_StartupAotProfile>
-    <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
-    <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
-  </ItemGroup>
-  <SplitProperty Value="$(AndroidAotProfiles)" Condition="'$(AndroidAotProfiles)' != ''">
-    <Output TaskParameter="Output" ItemName="_AotProfiles" />
-  </SplitProperty>
-  <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
-    <_AotProfiles Include="@(AndroidAotProfile)" />
-  </ItemGroup>
-  <Aot
-	Condition="'$(AotAssemblies)' == 'True'"
-	AndroidAotMode="$(AndroidAotMode)"
-	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-	AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
-	AndroidApiLevel="$(_AndroidApiLevel)"
-	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
-	SupportedAbis="@(_BuildTargetAbis)"
-	AndroidSequencePointsMode="$(_SequencePointsMode)"
-	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
-	ExtraAotOptions="$(AndroidExtraAotOptions)"
-	ResolvedAssemblies="@(_ShrunkAssemblies)"
-	AotOutputDirectory="$(_AndroidAotBinDirectory)"
-	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
-	LinkMode="$(AndroidLinkMode)"
-	AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
-	YieldDuringToolExecution="$(YieldDuringToolExecution)"
-	EnableLLVM="$(EnableLLVM)"
-	Profiles="@(_AotProfiles)">
-	   <Output TaskParameter="NativeLibrariesReferences" ItemName="_AdditionalNativeLibraryReferences" />
-  </Aot>
-
-  <ItemGroup Condition=" '$(AndroidAotMode)' == 'Hybrid' And '$(AotAssemblies)' == 'True' ">
-    <_CilStripAssemblies Include="@(_ShrunkAssemblies)" Condition=" '%(FileName)' != 'Mono.Android' " />
-  </ItemGroup>
-
-  <!-- Strip the IL code of the resolved managed assemblies -->
-   <CilStrip
-	Condition=" '$(AndroidAotMode)' == 'Hybrid' And '$(AotAssemblies)' == 'True' "
-	AndroidAotMode="$(AndroidAotMode)"
-	ToolPath="$(_MonoAndroidToolsDirectory)"
-	ApkOutputPath="$(_BuildApkEmbedOutputs)"
-	ResolvedAssemblies="@(_CilStripAssemblies)">
-  </CilStrip>
-
-  <!-- Bundle the assemblies into native libraries in the apk -->
-  <MakeBundleNativeCodeExternal
-		Condition="'$(BundleAssemblies)' == 'True'"
-		KeepTemp="$(AndroidMakeBundleKeepTemporaryFiles)"
-		AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-		Assemblies="@(_ShrunkAssemblies);@(_AndroidResolvedSatellitePaths)"
-		IncludePath="$(MonoAndroidIncludeDirectory)"
-		SupportedAbis="@(_BuildTargetAbis)"
-		TempOutputPath="$(IntermediateOutputPath)"
-		ToolPath="$(_MonoAndroidToolsDirectory)"
-		BundleApiPath="$(MSBuildThisFileDirectory)\mkbundle-api.h">
- 	<Output TaskParameter="OutputNativeLibraries" PropertyName="_BundleResultNativeLibraries" />
-  </MakeBundleNativeCodeExternal>
   <!-- Put the assemblies and native libraries in the apk -->
   <BuildApk
     Condition=" '$(AndroidPackageFormat)' != 'aab' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -149,6 +149,7 @@ projects. .NET 5 projects will not import this file.
       _LintChecks;
       _IncludeNativeSystemLibraries;
       _CheckGoogleSdkRequirements;
+      _AndroidAot;
     </_PrepareBuildApkDependsOnTargets>
     <_UpdateAndroidResourcesDependsOn>
       $(CoreResolveReferencesDependsOn);
@@ -656,6 +657,76 @@ projects. .NET 5 projects will not import this file.
       <FileWrites Include="$(_AndroidLinkFlag)" />
       <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
     </ItemGroup>
+  </Target>
+
+  <!-- Legacy AOT support that runs before _BuildApkEmbed -->
+  <Target Name="_AndroidAot"
+      Condition=" '$(AotAssemblies)' == 'true' or '$(BundleAssemblies)' == 'true' "
+      Inputs="$(_BuildApkEmbedInputs)"
+      Outputs="$(_AndroidStampDirectory)_AndroidAot.stamp">
+    <PropertyGroup>
+      <_StartupAotProfile Condition="'%(ResolvedAssemblies.Filename)' == 'Xamarin.Forms.Platform.Android'">startup-xf.aotprofile</_StartupAotProfile>
+      <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
+    </PropertyGroup>
+    <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
+      <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
+    </ItemGroup>
+    <SplitProperty Value="$(AndroidAotProfiles)" Condition="'$(AndroidAotProfiles)' != ''">
+      <Output TaskParameter="Output" ItemName="_AotProfiles" />
+    </SplitProperty>
+    <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
+      <_AotProfiles Include="@(AndroidAotProfile)" />
+    </ItemGroup>
+    <Aot
+        Condition="'$(AotAssemblies)' == 'True'"
+        AndroidAotMode="$(AndroidAotMode)"
+        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+        AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
+        AndroidApiLevel="$(_AndroidApiLevel)"
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+        SupportedAbis="@(_BuildTargetAbis)"
+        AndroidSequencePointsMode="$(_SequencePointsMode)"
+        AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
+        ExtraAotOptions="$(AndroidExtraAotOptions)"
+        ResolvedAssemblies="@(_ShrunkAssemblies)"
+        AotOutputDirectory="$(_AndroidAotBinDirectory)"
+        IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
+        LinkMode="$(AndroidLinkMode)"
+        AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
+        YieldDuringToolExecution="$(YieldDuringToolExecution)"
+        EnableLLVM="$(EnableLLVM)"
+        Profiles="@(_AotProfiles)">
+      <Output TaskParameter="NativeLibrariesReferences" ItemName="_AdditionalNativeLibraryReferences" />
+    </Aot>
+
+    <ItemGroup Condition=" '$(AndroidAotMode)' == 'Hybrid' And '$(AotAssemblies)' == 'True' ">
+      <_CilStripAssemblies Include="@(_ShrunkAssemblies)" Condition=" '%(FileName)' != 'Mono.Android' " />
+    </ItemGroup>
+
+    <!-- Strip the IL code of the resolved managed assemblies -->
+    <CilStrip
+        Condition=" '$(AndroidAotMode)' == 'Hybrid' And '$(AotAssemblies)' == 'True' "
+        AndroidAotMode="$(AndroidAotMode)"
+        ToolPath="$(_MonoAndroidToolsDirectory)"
+        StampFile="$(_AndroidStampDirectory)_AndroidAot.stamp"
+        ResolvedAssemblies="@(_CilStripAssemblies)"
+    />
+
+    <!-- Bundle the assemblies into native libraries in the apk -->
+    <MakeBundleNativeCodeExternal
+        Condition="'$(BundleAssemblies)' == 'True'"
+        KeepTemp="$(AndroidMakeBundleKeepTemporaryFiles)"
+        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+        Assemblies="@(_ShrunkAssemblies);@(_AndroidResolvedSatellitePaths)"
+        IncludePath="$(MonoAndroidIncludeDirectory)"
+        SupportedAbis="@(_BuildTargetAbis)"
+        TempOutputPath="$(IntermediateOutputPath)"
+        ToolPath="$(_MonoAndroidToolsDirectory)"
+        BundleApiPath="$(MSBuildThisFileDirectory)\mkbundle-api.h">
+      <Output TaskParameter="OutputNativeLibraries" PropertyName="_BundleResultNativeLibraries" />
+    </MakeBundleNativeCodeExternal>
+
+    <Touch Files="$(_AndroidStampDirectory)_AndroidAot.stamp" AlwaysCreate="true" />
   </Target>
 
 </Project>

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -5,7 +5,7 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Category ("UsesDevice"), Category ("AOT")]
+	[Category ("UsesDevice"), Category ("AOT"), Category ("ProfiledAOT")]
 	public class AotProfileTests : DeviceTest
 	{
 

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -19,8 +19,12 @@
     <EnableDefaultAndroidAssetItems>false</EnableDefaultAndroidAssetItems>
     <_MonoAndroidTestPackage>Mono.Android.NET_Tests</_MonoAndroidTestPackage>
     <PlotDataLabelSuffix>-$(TestsFlavor)NET6</PlotDataLabelSuffix>
-    <!-- TODO: Fix excluded tests -->
+    <!--
+      TODO: Fix excluded tests
+      For AOT, InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
+    -->
     <ExcludeCategories>DotNetIgnore</ExcludeCategories>
+    <ExcludeCategories Condition=" '$(RunAOTCompilation)' == 'true' ">$(ExcludeCategories):InetAccess</ExcludeCategories>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6052

Helpful reading:

* https://github.com/dotnet/runtime/blob/15dec9a2aa5a4236d6ba70de2e9c146867b9d2e0/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
* https://github.com/dotnet/runtime/blob/15dec9a2aa5a4236d6ba70de2e9c146867b9d2e0/src/mono/netcore/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md

To make this work, I moved the existing `<Aot/>` MSBuild task calls to
a new `_AndroidAot` MSBuild target in `Xamarin.Android.Legacy.targets`.

In the .NET 6 targets, there is a *different* `_AndroidAot` MSBuild
target that runs the new `<MonoAOTCompiler/>` MSBuild task. The
`_AndroidAot` target runs per `$(RuntimeIdentifier)` after the linker
completes. Native libraries are added to the
`@(ResolvedFileToPublish)` item group to be included in the final
`.apk`.

To follow convention with Blazor WASM:

https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-4/#blazor-webassembly-ahead-of-time-aot-compilation

The `$(RunAOTCompilation)` MSBuild property enables AOT. To help with
backwards compatibility with "legacy" Xamarin.Android, I kept the
`$(AotAssemblies)` MSBuild property intact.

Unfortunately, we have to manually import things to support
`$(AotAssemblies)`:

    <ImportGroup Condition=" '$(MonoAOTCompilerTasksAssemblyPath)' == '' and '$(AotAssemblies)' == 'true' ">
      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
      <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86" />
      <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64" />
      <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm" />
      <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64" />
    </ImportGroup>

Since, the default Mono workload does not support `$(AotAssemblies)`:

https://github.com/dotnet/runtime/blob/69711860262e44458bbe276393ea3eb9f7a2192a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in#L20-L25

I think this is reasonable for now.

## Limitations ##

* Profiled AOT is not implemented yet:

https://github.com/xamarin/xamarin-android/issues/6053

* `$(EnableLLVM)` fails when locating `opt`:

https://github.com/dotnet/runtime/issues/56386

* `AndroidClientHandler` usage causes runtime crash:

https://github.com/dotnet/runtime/issues/56315

* Use of folder names like `Build AndÜmläüts` fails:

https://github.com/dotnet/runtime/issues/56163

## Results ##

All tests were running on a Pixel 5.

Using the HelloAndroid app:

https://github.com/dotnet/maui-samples/tree/main/HelloAndroid

Defaults to two architectures: arm64 and x86

Average of 10 runs with `-c Release` and no AOT:

    Activity: Displayed     00:00:00.308

Apk size: 8367969

Average of 10 runs with `-c Release -p:RunAOTCompilation=true`:

    Activity: Displayed     00:00:00.209

Apk size: 12082123

Using the HelloMaui app:

https://github.com/dotnet/maui-samples/tree/main/HelloMaui

Defaults to two architectures: arm64 and x86

Average of 10 runs with `-c Release` and no AOT:

    Activity: Displayed     00:00:01.117

Apk size: 16272964

Average of 10 runs with `-c Release -p:RunAOTCompilation=true`:

    Activity: Displayed     00:00:00.568

Apk size: 42869016