### PR TITLE
[Xamarin.Android.Build.Tasks] _AddMultiDexDependencyJars only runs for apps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1021,7 +1021,8 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
-<Target Name="_AddMultiDexDependencyJars">
+<Target Name="_AddMultiDexDependencyJars"
+    Condition=" '$(AndroidApplication)' == 'true' ">
   <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != '' ">
     <AndroidJavaLibrary Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/247

When porting AndroidX to .NET 6, I noticed something odd... I was
getting `.aar` files in the build output that appeared to contain the
contents of `android-support-multidex.jar`.

Then I noticed:

https://github.com/xamarin/AndroidX/blob/16b02ae51980f7bab7be395d44f9998eea9bf32f/source/AndroidXProject.cshtml#L18

The AndroidX binding projects are setting `$(AndroidEnableMultiDex)`?

This is surely not intentional to be set in a class library, but this
causes `_AddMultiDexDependencyJars` to run:

    <Target Name="_AddMultiDexDependencyJars">
      <!-- ... -->
      <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == '' ">
        <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
      </ItemGroup>
    </Target>

If this was added to `@(AndroidJavaLibrary)`, then the `<CreateAar/>`
MSBuild task would happily package it in a .NET 6 class library!

I think the solution here is that the `_AddMultiDexDependencyJars`
MSBuild target shouldn't actually run unless `$(AndroidApplication)`
is `true`.

I updated an existing test for this scenario.