### PR TITLE
[ci] Add nightly build and test pipeline

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/WaitForAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/WaitForAndroidEmulator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class WaitForAndroidEmulator : Adb
+	{
+		int bootCompleted = -1;
+
+		public override bool Execute ()
+		{
+			var endTime = DateTime.UtcNow.AddMilliseconds (Timeout);
+			while (DateTime.UtcNow < endTime && bootCompleted != 1) {
+				base.Execute ();
+				Thread.Sleep (3000);
+			}
+
+			if (bootCompleted != 1) {
+				Log.LogError ($"Emulator '{AdbTarget}' did not finish launching in {Timeout} ms.");
+				return false;
+			} else {
+				return true;
+			}
+		}
+
+		protected override List <CommandInfo> GenerateCommandArguments ()
+		{
+			return new List <CommandInfo> {
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} shell getprop sys.boot_completed",
+				},
+			};
+		}
+
+		protected override void ProcessStdout (string line)
+		{
+			if (string.IsNullOrEmpty (line))
+				return;
+
+			if (!int.TryParse (line, out int bootCompletedPropValue))
+				return;
+
+			bootCompleted = bootCompletedPropValue;
+		}
+	}
+}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/WaitForAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/WaitForAndroidEmulator.cs
@@ -18,10 +18,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 			if (bootCompleted != 1) {
 				Log.LogError ($"Emulator '{AdbTarget}' did not finish launching in {Timeout} ms.");
-				return false;
-			} else {
-				return true;
 			}
+
+			return !Log.HasLoggedErrors;
 		}
 
 		protected override List <CommandInfo> GenerateCommandArguments ()

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -9,12 +9,13 @@ pr:
   - none
 
 schedules:
-- cron: "0 3 * * *"
+- cron: "*/5 * * * *"
   displayName: Run daily at 3:00 UTC
   branches:
     include:
     - master
     - d16-9
+    - scheduled-build-test
 
 # External sources, scripts, tests, and yaml template files.
 resources:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -9,13 +9,12 @@ pr:
   - none
 
 schedules:
-- cron: "*/5 * * * *"
+- cron: "0 3 * * *"
   displayName: Run daily at 3:00 UTC
   branches:
     include:
     - master
     - d16-9
-    - scheduled-build-test
 
 # External sources, scripts, tests, and yaml template files.
 resources:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -1,0 +1,228 @@
+# Xamarin.Android Nightly Pipeline
+
+name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+
+trigger:
+- none
+
+pr:
+- none
+
+schedules:
+- cron: "0 3 * * Sun"
+  displayName: Run daily at 3:00 UTC
+  branches:
+    include:
+    - master
+    - d16-9
+
+# External sources, scripts, tests, and yaml template files.
+resources:
+  repositories:
+  - repository: yaml
+    type: github
+    name: xamarin/yaml-templates
+    ref: refs/heads/main
+    endpoint: xamarin
+  - repository: monodroid
+    type: github
+    name: xamarin/monodroid
+    endpoint: xamarin
+
+# Global variables
+variables:
+  RunningOnCI: true
+  XA.Build.Configuration: Release
+  XA.Jdk8.Folder: jdk-1.8
+  XA.Jdk11.Folder: jdk-11
+  NuGetArtifactName: nupkgs
+  InstallerArtifactName: installers
+  TestAssembliesArtifactName: test-assemblies
+  DotNetCoreVersion: 3.1.201
+  DotNet5Version: 5.0.100
+  MacMojaveBuildPool:
+  HostedMacImage: macOS-10.15
+  VSEngWinVS2019: Xamarin-Android-Win2019-1120
+  XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMac-Android-Untrusted
+
+stages:
+- stage: mac_build
+  displayName: Mac
+  dependsOn: []
+  jobs:
+  - job: mac_build_create_installers
+    displayName: Build
+    pool: $(MacMojaveBuildPool)
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      submodules: recursive
+
+    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
+      displayName: set JI_JAVA_HOME
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNet5Version)
+        remove_dotnet: true
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNetCoreVersion)
+
+    - task: provisionator@2
+      displayName: Install Xcode
+      inputs:
+        github_token: $(GitHub.Token)
+        provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
+        provisioning_extra_args: '-v -v -v -v'
+
+    # Prepare and build everything
+    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make prepare-update-mono
+
+    # Clone monodroid wth submodules, but disregard the unused xamarin-android submodule.
+    - checkout: monodroid
+      clean: true
+      submodules: recursive
+      path: s/xamarin-android/external/monodroid
+      persistCredentials: true
+
+    - script: rm -rf external/monodroid/external/xamarin-android
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: delete legacy xamarin-android submodule
+
+    - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make prepare-external-git-dependencies
+
+    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make jenkins
+
+    # Build and package test assemblies
+    - script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make all-tests
+
+    - script: >
+        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
+        cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: copy bcl-tests assemblies
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload test assemblies
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: pack all nupkgs
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+
+    # Create installers
+    - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make create-installers
+
+    - script: >
+        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: copy unsigned installers
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload installers
+      inputs:
+        artifactName: $(InstallerArtifactName)
+        targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload nupkgs
+      inputs:
+        artifactName: $(NuGetArtifactName)
+        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        artifactName: Build Results - macOS
+
+- stage: test
+  displayName: Test
+  dependsOn: mac_build
+  jobs:
+  - job: emulator_tests
+    displayName: Emulator
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 2
+    strategy:
+      matrix:
+        Android21:
+          apiLevel: 21
+        Android23:
+          apiLevel: 23
+        Android24:
+          apiLevel: 24
+        Android26:
+          apiLevel: 26
+        Android28:
+          apiLevel: 28
+    pool:
+      vmImage: $(HostedMacImage)
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+
+    - script: >
+        mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe
+        --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+      displayName: install required brew tools and prepare java.interop
+
+    - script:>
+        mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe
+        --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:InstallAvdImage;AcquireAndroidTarget /p:TestAvdApiLevel=$(apiLevel) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-$(apiLevel).binlog
+      
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        testName: Mono.Android_Tests
+        project: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android_Tests-$(XA.Build.Configuration).xml
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: Default
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:AcquireAndroidTarget,ReleaseAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        artifactName: Test Results - Emulator API $(apiLevel) - macOS
+
+    - template: yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -3,13 +3,13 @@
 name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
 trigger:
-- none
+  - none
 
 pr:
-- none
+  - none
 
 schedules:
-- cron: "0 3 * * Sun"
+- cron: "0 3 * * *"
   displayName: Run daily at 3:00 UTC
   branches:
     include:
@@ -34,128 +34,39 @@ variables:
   RunningOnCI: true
   XA.Build.Configuration: Release
   XA.Jdk8.Folder: jdk-1.8
-  XA.Jdk11.Folder: jdk-11
   NuGetArtifactName: nupkgs
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   DotNetCoreVersion: 3.1.201
   DotNet5Version: 5.0.100
-  MacMojaveBuildPool:
+  MacMojaveBuildPool: VSEng-Xamarin-RedmondMac-Android-Untrusted
   HostedMacImage: macOS-10.15
   VSEngWinVS2019: Xamarin-Android-Win2019-1120
-  XA.Build.MacOSSPool: VSEng-Xamarin-RedmondMac-Android-Untrusted
+  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 
 stages:
 - stage: mac_build
-  displayName: Mac
+  displayName: Build
   dependsOn: []
   jobs:
   - job: mac_build_create_installers
-    displayName: Build
+    displayName: macOS
     pool: $(MacMojaveBuildPool)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
+    variables:
+      - group: Xamarin-Secrets
+      - group: Xamarin Signing
+      - group: xamops-azdev-secrets
     steps:
     - checkout: self
       submodules: recursive
 
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
-      displayName: set JI_JAVA_HOME
-
-    - template: yaml-templates/use-dot-net.yaml
+    - template: yaml-templates/commercial-build.yaml
       parameters:
-        version: $(DotNet5Version)
-        remove_dotnet: true
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNetCoreVersion)
-
-    - task: provisionator@2
-      displayName: Install Xcode
-      inputs:
-        github_token: $(GitHub.Token)
-        provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
-        provisioning_extra_args: '-v -v -v -v'
-
-    # Prepare and build everything
-    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make prepare-update-mono
-
-    # Clone monodroid wth submodules, but disregard the unused xamarin-android submodule.
-    - checkout: monodroid
-      clean: true
-      submodules: recursive
-      path: s/xamarin-android/external/monodroid
-      persistCredentials: true
-
-    - script: rm -rf external/monodroid/external/xamarin-android
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: delete legacy xamarin-android submodule
-
-    - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make prepare-external-git-dependencies
-
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make jenkins
-
-    # Build and package test assemblies
-    - script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make all-tests
-
-    - script: >
-        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
-        cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: copy bcl-tests assemblies
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload test assemblies
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: pack all nupkgs
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
-
-    # Create installers
-    - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make create-installers
-
-    - script: >
-        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
-        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
-        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: copy unsigned installers
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload installers
-      inputs:
-        artifactName: $(InstallerArtifactName)
-        targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload nupkgs
-      inputs:
-        artifactName: $(NuGetArtifactName)
-        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
-
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-        artifactName: Build Results - macOS
+        makeMSBuildArgs: /p:EnableRoslynAnalyzers=true
 
 - stage: test
   displayName: Test
@@ -163,24 +74,32 @@ stages:
   jobs:
   - job: emulator_tests
     displayName: Emulator
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
     strategy:
       matrix:
-        Android21:
-          apiLevel: 21
-        Android23:
-          apiLevel: 23
-        Android24:
-          apiLevel: 24
-        Android26:
-          apiLevel: 26
-        Android28:
-          apiLevel: 28
+        Android21-x86:
+          avdApiLevel: 21
+          avdAbi: x86
+        Android23-x86:
+          avdApiLevel: 23
+          avdAbi: x86
+        Android24-x86:
+          avdApiLevel: 24
+          avdAbi: x86
+        Android26-x86_64:
+          avdApiLevel: 26
+          avdAbi: x86_64
+        Android28-x86_64:
+          avdApiLevel: 28
+          avdAbi: x86_64
     pool:
       vmImage: $(HostedMacImage)
     workspace:
       clean: all
+    variables:
+      - group: Xamarin-Secrets
+      - group: xamops-azdev-secrets
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -191,24 +110,28 @@ stages:
         --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
       displayName: install required brew tools and prepare java.interop
 
-    - script:>
+    - script: >
         mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe
         --s=EmulatorTestDependencies --no-emoji --run-mode=CI
       displayName: install emulator
 
+    - script: echo "##vso[task.setvariable variable=Java8SdkDirectory]$HOME/Library/Android/$(XA.Jdk8.Folder)"
+      displayName: set Java8SdkDirectory
+
     - task: MSBuild@1
-      displayName: shut down emulator
+      displayName: install and launch emulator
       inputs:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:InstallAvdImage;AcquireAndroidTarget /p:TestAvdApiLevel=$(apiLevel) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-$(apiLevel).binlog
-      
+        msbuildArguments: /t:InstallAvdImage;AcquireAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-$(avdApiLevel).binlog
+
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
-        testName: Mono.Android_Tests
+        testName: Mono.Android_Tests-$(avdApiLevel)-$(avdAbi)
         project: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(XA.Build.Configuration).xml
+        extraBuildArgs: /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi)
         artifactName: Mono.Android_Tests-Signed.apk
         artifactFolder: Default
 
@@ -217,12 +140,12 @@ stages:
       inputs:
         solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:AcquireAndroidTarget,ReleaseAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+        msbuildArguments: /t:AcquireAndroidTarget,ReleaseAndroidTarget /p:TestAvdApiLevel=$(avdApiLevel) /p:TestAvdAbi=$(avdAbi) /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       condition: always()
 
     - template: yaml-templates/upload-results.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
-        artifactName: Test Results - Emulator API $(apiLevel) - macOS
+        artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi) - macOS
 
     - template: yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -61,7 +61,7 @@ variables:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
-  IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
+  IsMonoBranch: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
   DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger'
   NUnit.NumberOfTestWorkers: 4
@@ -131,7 +131,7 @@ stages:
   - job: mac_build_create_installers
     displayName: Build
     pool: $(MacMojaveBuildPool)
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
@@ -139,126 +139,12 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
-      displayName: set JI_JAVA_HOME
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNet5Version)
-        remove_dotnet: true
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNetCoreVersion)
-
-    - template: install-certificates.yml@yaml
-      parameters:
-        DeveloperIdApplication: $(developer-id-application)
-        DeveloperIdInstaller: $(developer-id-installer)
-        IphoneDeveloper: $(iphone-developer)
-        MacDeveloper: $(mac-developer)
-        HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
-
-    - task: provisionator@2
-      displayName: Install Xcode
-      inputs:
-        github_token: $(GitHub.Token)
-        provisioning_script: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/provisioning/xcode.csx
-        provisioning_extra_args: '-v -v -v -v'
-
-    # Prepare and build everything
-    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make prepare-update-mono
+    - template: yaml-templates/commercial-build.yaml
 
     - script: mono $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=DetermineApplicableTests --no-emoji --run-mode=CI
+      displayName: determine which test stages to run
       name: TestConditions
       condition: and(succeeded(), eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR'))
-
-    # Clone monodroid wth submodules, but disregard the unused xamarin-android submodule.
-    - checkout: monodroid
-      clean: true
-      submodules: recursive
-      path: s/xamarin-android/external/monodroid
-      persistCredentials: true
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-
-    - script: rm -rf external/monodroid/external/xamarin-android
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: delete legacy xamarin-android submodule
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-
-    - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make prepare-external-git-dependencies
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make jenkins
-
-    # Build and package test assemblies
-    - script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make all-tests
-
-    - script: >
-        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
-        cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: copy bcl-tests assemblies
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload test assemblies
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: pack all nupkgs
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
-
-    # Create installers
-    - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make create-installers
-
-    - script: >
-        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
-        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
-        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: copy unsigned installers
-
-    - script: >
-        VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct` &&
-        echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: create updateinfo file
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload installers
-      inputs:
-        artifactName: $(InstallerArtifactName)
-        targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload nupkgs
-      inputs:
-        artifactName: $(NuGetArtifactName)
-        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
-
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-        artifactName: Build Results - macOS
-
-    - template: uninstall-certificates/v1.yml@yaml
-      parameters:
-        HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 # Check - "Xamarin.Android (Windows Build and Test)"
@@ -483,7 +369,6 @@ stages:
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
-        condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
         configuration: $(ApkTestConfiguration)
         testName: Xamarin.Android.JcwGen_Tests_FastDev
         project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
@@ -1269,7 +1154,7 @@ stages:
 - stage: finalize_installers
   displayName: Finalize Installers
   dependsOn: mac_build
-  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android'))
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android'))
   jobs:
   # Check - "Xamarin.Android (Finalize Installers Notarize and Upload to Storage)"
   - job: notarize_pkg_upload_storage

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -19,7 +19,7 @@ steps:
     msbuildArguments: >-
       /restore
       /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
-      /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run${{ parameters.testName }}.binlog
+      /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
       ${{ parameters.extraBuildArgs }}
   condition: ${{ parameters.condition }}
   continueOnError: true

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -1,0 +1,119 @@
+parameters:
+  xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
+  makeMSBuildArgs: ''
+
+steps:
+- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
+  displayName: set JI_JAVA_HOME
+
+- template: use-dot-net.yaml
+  parameters:
+    version: $(DotNet5Version)
+    remove_dotnet: true
+
+- template: use-dot-net.yaml
+  parameters:
+    version: $(DotNetCoreVersion)
+
+- template: install-certificates.yml@yaml
+  parameters:
+    DeveloperIdApplication: $(developer-id-application)
+    DeveloperIdInstaller: $(developer-id-installer)
+    IphoneDeveloper: $(iphone-developer)
+    MacDeveloper: $(mac-developer)
+    HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
+
+- task: provisionator@2
+  displayName: Install Xcode
+  inputs:
+    github_token: $(GitHub.Token)
+    provisioning_script: ${{ parameters.xaSourcePath }}/build-tools/provisioning/xcode.csx
+    provisioning_extra_args: '-v -v -v -v'
+
+- script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make prepare-update-mono
+
+# Clone and prepare monodroid with submodules, but disregard the unused xamarin-android submodule.
+- checkout: monodroid
+  clean: true
+  submodules: recursive
+  path: s/xamarin-android/external/monodroid
+  persistCredentials: true
+
+- script: rm -rf external/monodroid/external/xamarin-android
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: delete legacy xamarin-android submodule
+
+- script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make prepare-external-git-dependencies
+
+# Prepare and Build everything
+- script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make jenkins
+
+# Build and package test assemblies
+- script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make all-tests
+
+- script: >
+    cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
+    cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: copy bcl-tests assemblies
+
+- task: PublishPipelineArtifact@1
+  displayName: upload test assemblies
+  inputs:
+    artifactName: $(TestAssembliesArtifactName)
+    targetPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
+
+# Create and upload .nupkgs
+- task: MSBuild@1
+  displayName: pack all nupkgs
+  inputs:
+    solution: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
+    configuration: $(XA.Build.Configuration)
+    msbuildArguments: /t:CreateAllPacks /restore /p:NuGetLicense=${{ parameters.xaSourcePath }}/external/monodroid/tools/scripts/License.txt /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+
+- task: PublishPipelineArtifact@1
+  displayName: upload nupkgs
+  inputs:
+    artifactName: $(NuGetArtifactName)
+    targetPath:  ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+
+# Create and upload legacy installers
+- script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make create-installers
+
+- script: >
+    mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+    cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
+    cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: copy unsigned installers
+
+- script: >
+    VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct` &&
+    echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: create updateinfo file
+
+- task: PublishPipelineArtifact@1
+  displayName: upload installers
+  inputs:
+    artifactName: $(InstallerArtifactName)
+    targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+
+- template: uninstall-certificates/v1.yml@yaml
+  parameters:
+    HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
+
+- template: upload-results.yaml
+  parameters:
+    solution: ${{ parameters.xaSourcePath }}/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+    artifactName: Build Results - macOS

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -36,17 +36,6 @@ steps:
   parameters:
     version: $(DotNetCoreVersion)
 
-- script: |
-    dotnet tool install --global boots
-  displayName: install boots
-  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
-
-- script: |
-    export PATH="$PATH:/Users/runner/.dotnet/tools"
-    boots https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.105.macos10.xamarin.universal.pkg
-  displayName: update Mono to version 6.x
-  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
-
 - task: MSBuild@1
   displayName: build xaprepare
   inputs:

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -11,14 +11,22 @@
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunUITests" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.KillProcess" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.WaitForAndroidEmulator" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.Sleep" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessLogcatTiming" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessApkSizes" />
 
+  <!-- Scheduled tests run on Android 5.0 (21), 6.0 (23), 7.0 (24), 8.0 (26), 9 (28), 10 (29) -->
   <PropertyGroup>
-    <_TestImageName>XamarinAndroidTestRunner64</_TestImageName>
+    <TestAvdApiLevel Condition=" '$(TestAvdApiLevel)' == '' ">29</TestAvdApiLevel>
+    <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' ">x86_64</TestAvdAbi>
+    <SdkManagerImageName Condition=" '$(SdkManagerImageName)' == '' ">system-images;android-$(TestAvdApiLevel);default;$(TestAvdAbi)</SdkManagerImageName>
+    <TestAvdName>XamarinAndroidTestRunner$(TestAvdApiLevel)-$(TestAvdAbi)</TestAvdName>
     <_AdbEmulatorPort>5570</_AdbEmulatorPort>
     <_ApkSizesReferenceDirectory>$(MSBuildThisFileDirectory)..\..\tests\apk-sizes-reference</_ApkSizesReferenceDirectory>
+    <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">5</AvdLaunchTimeoutMinutes>
+    <AvdLaunchTimeoutSeconds>$([MSBuild]::Multiply($(AvdLaunchTimeoutMinutes), 60))</AvdLaunchTimeoutSeconds>
+    <AvdLaunchTimeoutMS>$([MSBuild]::Multiply($(AvdLaunchTimeoutSeconds), 1000))</AvdLaunchTimeoutMS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,11 +52,12 @@
     </Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget>
     <CreateAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "
-        AndroidAbi="x86_64"
+        AndroidAbi="$(TestAvdAbi)"
         AndroidSdkHome="$(AndroidSdkDirectory)"
         JavaSdkHome="$(JavaSdkDirectory)"
-        SdkVersion="29"
-        ImageName="$(_TestImageName)"
+        SdkVersion="$(TestAvdApiLevel)"
+        TargetId="$(SdkManagerImageName)"
+        ImageName="$(TestAvdName)"
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(CommandLineToolsBinPath)"
         RamSizeMB="3072"
@@ -57,7 +66,7 @@
     <StartAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         AndroidSdkHome="$(AndroidSdkDirectory)"
-        ImageName="$(_TestImageName)"
+        ImageName="$(TestAvdName)"
         Port="$(_AdbEmulatorPort)"
         ToolExe="$(EmulatorToolExe)"
         ToolPath="$(EmulatorToolPath)">
@@ -74,14 +83,13 @@
         Timeout="120000"
         WriteOutputAsMessage="True"
     />
-    <Xamarin.Android.Tools.BootstrapTasks.Adb
+    <WaitForAndroidEmulator
         EnvironmentVariables="ADB_TRACE=all"
         Condition=" '$(_ValidAdbTarget)' != 'True' "
-        ContinueOnError="ErrorAndContinue"
-        Arguments="$(_EmuTarget) shell 'counter=0; while [ $counter -lt 60 ] &amp;&amp; [ &quot;`getprop sys.boot_completed`&quot; != &quot;1&quot; ]; do echo Waiting for device to fully boot; sleep 1; let &quot;counter++&quot;; done'"
+        AdbTarget="$(_EmuTarget)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
-        Timeout="120000"
+        Timeout="$(AvdLaunchTimeoutMS)"
         WriteOutputAsMessage="True"
     />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
@@ -336,8 +344,48 @@
   <Target Name="CheckBootTimes"
       DependsOnTargets="AcquireAndroidTarget;ReleaseAndroidTarget">
     <RunAndroidEmulatorCheckBootTimes
-		DeviceName="$(_TestImageName)"
+        DeviceName="$(TestAvdName)"
         CheckBootTimesPath="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\check-boot-times.exe"
     />
   </Target>
+
+  <Target Name="InstallAvdImage" >
+    <PropertyGroup>
+
+    </PropertyGroup>
+    <!-- SDK component installation can be frail, try a few times. -->
+    <Exec
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
+        ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
+    </Exec>
+    <Sleep
+        Milliseconds="5000"
+        Condition=" '$(_SdkManagerExitCode)' != '0' "
+    />
+    <Exec
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
+        ContinueOnError="true"
+        Condition=" '$(_SdkManagerExitCode)' != '0' ">
+      <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
+    </Exec>
+    <Sleep
+        Milliseconds="10000"
+        Condition=" '$(_SdkManagerExitCode)' != '0' "
+    />
+    <Exec
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
+        ContinueOnError="true"
+        Condition=" '$(_SdkManagerExitCode)' != '0' ">
+      <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
+    </Exec>
+    <Error
+        Text="Attempt to install $(AvdImageName) failed after three attempts."
+        Condition=" '$(_SdkManagerExitCode)' != '0' "
+    />
+  </Target>
+
 </Project>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -16,7 +16,6 @@
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessLogcatTiming" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessApkSizes" />
 
-  <!-- Scheduled tests run on Android 5.0 (21), 6.0 (23), 7.0 (24), 8.0 (26), 9 (28), 10 (29) -->
   <PropertyGroup>
     <TestAvdApiLevel Condition=" '$(TestAvdApiLevel)' == '' ">29</TestAvdApiLevel>
     <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' ">x86_64</TestAvdAbi>
@@ -350,12 +349,9 @@
   </Target>
 
   <Target Name="InstallAvdImage" >
-    <PropertyGroup>
-
-    </PropertyGroup>
     <!-- SDK component installation can be frail, try a few times. -->
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
@@ -365,7 +361,7 @@
         Condition=" '$(_SdkManagerExitCode)' != '0' "
     />
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
@@ -376,7 +372,7 @@
         Condition=" '$(_SdkManagerExitCode)' != '0' "
     />
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; $(SdkManagerImageName)"
+        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Prepare
 				// BCL: Runs BCL tests on emulator
 				// TimeZone: Runs timezone unit tests on emulator
 				// Designer: Runs designer integration tests
-				if (file == ".external" || file == "Configuration.props" || file.Contains ("build-tools/")) {
+				if (file == ".external" || file == "Configuration.props" || IsRelevantBuildToolsFile (file)) {
 					testAreas.Add ("MSBuild");
 					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("BCL");
@@ -156,6 +156,17 @@ namespace Xamarin.Android.Prepare
 			}
 
 			Log.MessageLine ($"##vso[task.setvariable variable=TestAreas;isOutput=true]{string.Join (",", testAreas)}");
+			return true;
+		}
+
+		bool IsRelevantBuildToolsFile (string fileName)
+		{
+			if (!fileName.Contains ("build-tools/"))
+				return false;
+
+			if (fileName.Contains ("-nightly") || fileName.Contains ("-oss"))
+				return false;
+
 			return true;
 		}
 

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -215,16 +215,11 @@ namespace Xamarin.Android.UnitTests
 			LogPaddedInfo ("Manufacturer", Build.Manufacturer, alignColumn);
 			LogPaddedInfo ("Model", Build.Model, alignColumn);
 			LogPaddedInfo ("Product", Build.Product, alignColumn);
-#if __ANDROID_9__
+#if __ANDROID_9__ && !__ANDROID_26__
 			if (sdkInt >= 8) {
-#if __ANDROID_26__
-				// .Serial was deprecated in API26, .GetSerial () is the recommended replacement
-				// GetSerial is now restricted on API 29+ - https://developer.android.com/reference/android/os/Build.html#getSerial()
-				if (sdkInt >= 26 && sdkInt < 29)
-					LogPaddedInfo ("Serial", Build.GetSerial (), alignColumn);
-				else if (sdkInt < 26)
-#endif
-					LogPaddedInfo ("Serial", Build.Serial, alignColumn);
+				// .Serial was deprecated in API26, however the recommended replacement .GetSerial () requires the READ_PHONE_STATE permission.
+				// .GetSerial () will also always throw when compiling against API 29+ - https://developer.android.com/reference/android/os/Build.html#getSerial()
+				LogPaddedInfo ("Serial", Build.Serial, alignColumn);
 			}
 #endif
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5098

A new `azure-pipelines-nightly.yaml` build pipeline file has been added
to run our longer running build and test tasks that we don't want to run
against every commit or PR build.  This new pipeline is scheduled to run
every day at 3:00am UTC.  The pipeline will only run if there have been
source code changes since the last successful scheduled run.  For more
information see the [scheduled triggers documentation][1].

This new nightly pipeline starts with a commercial build on macOS, which
provides an opportunity to run time consuming Roslyn analyzers.  Other
code analysis steps can be added to this nightly build in the future.

After the build completes, the artifacts that are produced will be used
by new supplemental test jobs.  Five new emulator test environments
have been added to this nightly pipeline which will allow us to run
tests on a broader set of Android versions.  The following emulators are
now available for testing:

    Android 5.0 (API 21) - x86
    Android 6.0 (API 23) - x86
    Android 7.0 (API 24) - x86
    Android 8.0 (API 26) - x86_64
    Android 9.0 (API 28) - x86_64

These new test jobs currently only run the default configuration of the
Mono.Android-Tests suite against our legacy installers.  It should be
easy to extend these jobs to run additional tests as needed.

Some clean up has also been applied to the main `azure-pipelines.yaml`
file.  Usage of `XA.Commercial.Build` has been removed, as any builds
using this file will always be "commercial".  Additionally, the test
environment update from commit 75317db5 allows us to remove a
supplemental mono installation step as a newer mono is available on
these machines.

[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml