### PR TITLE
[ci] Don't test sign PR builds

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1109,7 +1109,8 @@ stages:
   # Check - "Xamarin.Android (.NET 6 Preview Installers Create .pkg)"
   - job: dotnet_create_pkg
     displayName: Create .pkg
-    dependsOn: signing
+    ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+      dependsOn: signing
     pool: $(MacMojaveBuildPool)
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1104,6 +1104,7 @@ stages:
       artifactName: nupkgs
       signType: $(MicroBuildSignType)
       usePipelineArtifactTasks: true
+      condition: eq(variables['MicroBuildSignType'], 'Real')
 
   # Check - "Xamarin.Android (.NET 6 Preview Installers Create .pkg)"
   - job: dotnet_create_pkg
@@ -1126,7 +1127,10 @@ stages:
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifactName: nuget-signed
+        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: nuget-signed
+        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: $(NuGetArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - task: NuGetCommand@2
@@ -1217,7 +1221,10 @@ stages:
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifactName: nuget-signed
+        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: nuget-signed
+        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: $(NuGetArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\$(NuGetArtifactName)
 
     - task: DownloadPipelineArtifact@2
@@ -1227,6 +1234,8 @@ stages:
         patterns: Microsoft.*.pkg
 
     - template: yaml-templates\install-microbuild-tooling.yaml
+      parameters:
+        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android.BootstrapTasks
@@ -1260,6 +1269,8 @@ stages:
         GitHub.Context: .NET 6 Preview Installers
 
     - template: yaml-templates\remove-microbuild-tooling.yaml
+      parameters:
+        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1270,7 +1270,7 @@ stages:
 
     - template: yaml-templates\remove-microbuild-tooling.yaml
       parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - template: yaml-templates/upload-results.yaml
       parameters:


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4410378&view=logs&j=57fca568-3a80-5708-ac58-2fae4dd254ef&t=3f8f3a6c-0017-59f5-c4e0-9209d885e02d&l=134

We're running into issues installing the Microbuild Signing tools when
running PR builds from a fork.  To fix this, we'll only attempt to
install and use the signing tooling when attempting to "Real" sign.