### PR TITLE
[build] Attempt to fix broken dotnet preview installations

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -38,6 +38,13 @@ namespace Xamarin.Android.Prepare
 				}
 			}
 
+			if (Directory.Exists (dotnetPath)) {
+				if (!TestDotNetSdk (dotnetPath)) {
+					Log.WarningLine ($"Attempt to run `dotnet --version` failed, reinstalling the SDK.");
+					Utilities.DeleteDirectory (dotnetPath);
+				}
+			}
+
 			if (!await InstallDotNetAsync (context, dotnetPath, dotnetPreviewVersion)) {
 				Log.ErrorLine ($"Installation of dotnet SDK {dotnetPreviewVersion} failed.");
 				return false;
@@ -92,7 +99,8 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			Log.StatusLine ($"Installing dotnet SDK/runtime '{version}'...");
+			var type = runtimeOnly ? "runtime" : "SDK";
+			Log.StatusLine ($"Installing dotnet {type} '{version}'...");
 
 			if (Context.IsWindows) {
 				var args = new List<string> {
@@ -112,6 +120,11 @@ namespace Xamarin.Android.Prepare
 
 				return Utilities.RunCommand ("bash", args.ToArray ());
 			}
+		}
+
+		bool TestDotNetSdk (string dotnetPath)
+		{
+			return Utilities.RunCommand (Path.Combine (dotnetPath, "dotnet"), new string [] { "--version" });
 		}
 
 	}


### PR DESCRIPTION
We've been running into an issue when attempting to pack our .nupkg
files:

    CreateAllPacks:
        Directory "/Users/builder/azdo/_work/1/s/xamarin-android/bin/BuildRelease/nupkgs" doesn't exist. Skipping.
        /Users/builder/Library/Android/dotnet/dotnet pack -p:Configuration=Release -p:NuGetLicense=/Users/builder/azdo/_work/1/s/xamarin-android/external/monodroid/tools/scripts/License.txt -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a "/Users/builder/azdo/_work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj"
        Found .NET SDK, but did not find dotnet.dll at [/Users/builder/Library/Android/dotnet/sdk/6.0.100-alpha.1.21064.27/dotnet.dll]

We should try to test the `dotnet` tool in this preview installation
location before using it, and reinstall the entire SDK if it does not
work.