### PR TITLE
[ci] Don't warn on analysis

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -72,6 +72,7 @@ variables:
   ${{ if or(ne(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     MicroBuildSignType: Test
   TeamName: XamarinAndroid
+  NugetSecurityAnalysisWarningLevel: none
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:


### PR DESCRIPTION
A recent check has been added that is breaking our Windows build and
test jobs. These jobs are configured to fail when any issue occurs to
help surface test failures.  We can fix this temporarily by disabling
the warning reporting.