### PR TITLE
[build-tools/scripts] fixes for nunit3-console.cmd

### DIFF
--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -25,7 +25,7 @@ steps:
            & $env:USERPROFILE\android-toolchain\dotnet\dotnet.exe test ${{ parameters.testAssembly }} --results-directory . --logger "trx;LogFileName=${{ parameters.testResultsFile }}" ${{ parameters.dotNetTestExtraArgs }} -- NUnit.NumberOfTestWorkers=${{ parameters.workers }}
         } else {
            Write-Host '##vso[task.setvariable variable=TestResultsFormat]NUnit'
-           & cmd '${{ parameters.nunitConsole }}.cmd' ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
+           & cmd /c '${{ parameters.nunitConsole }}.cmd' ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
         }
     }
     if ($LASTEXITCODE -ne 0) {

--- a/build-tools/scripts/nunit3-console.cmd
+++ b/build-tools/scripts/nunit3-console.cmd
@@ -10,9 +10,7 @@ if defined NUGET_PACKAGES (
  
 set NUGET_PATH=%MYDIR%..\..\.nuget\NuGet.exe
 if exist "%NUGET_PATH%" (
-  for /f "tokens=1,2,3 delims=:" %%a in ('"%NUGET_PATH%" locals -list global-packages') do set drive=%%b&set dir=%%c
-  rem %drive% will contain a leading space, get rid of it
-  set PACKAGES_PATH=%drive: =%:%dir%
+  for /f "tokens=1,2" %%a in ('"%NUGET_PATH%" locals -list global-packages') do set PACKAGES_PATH=%%b
   goto got_location
 )
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4414611&view=logs&j=674b6335-1d71-5535-2f20-11f5708a0b9d&t=358dacbe-f0d4-5f52-9155-e5dfefeddb0c&l=67

Our Windows NUnit tests do not appear to be running at all:

    Microsoft Windows [Version 10.0.17763.1282]
    (c) 2018 Microsoft Corporation. All rights reserved.

    C:\a\2\s>

It just seems to launch a `cmd` prompt and continue on?

I could reproduce this locally, which I could fix by using `cmd /c`:

https://docs.microsoft.com/windows-server/administration/windows-commands/cmd

Then I hit the next problem:

    > & cmd /c 'C:\src\xamarin-android\build-tools/scripts/nunit3-console.cmd' bin\TestDebug\net472\Xamarin.Android.Build.Tests.dll --test foo
    The system cannot find the path specified.

Reviewing `nunit3-console.cmd`, it seems to parse this output:

    > nuget locals -list global-packages
    global-packages: C:\Users\jopepper\.nuget\packages\

It splits on the `:`, but unfortunately `C:\` contains `:`. The second
item also has a leading space. This logic didn't work for me locally.

I could update the script to split on the space instead and things
work properly now.