### PR TITLE
[Xamarin.Android.Build.Tasks] warn for "alias already exists"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -26,6 +26,17 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-storetype ", StoreType);
 			return cmd;
 		}
+
+		protected override void LogFromStandardError (string text)
+		{
+			// Downgrade error message to warning:
+			// error: java.lang.Exception: Key pair not generated, alias <androiddebugkey> already exists
+			if (text.Contains ($"alias <{KeyAlias}> already exists")) {
+				text = text.Replace ("error:", "warning:");
+			}
+
+			base.LogFromStandardError (text);
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
@@ -53,11 +53,13 @@ namespace Xamarin.Android.Tasks
 				if (previousLine != null && previousLine.EndsWith (":", StringComparison.Ordinal)) {
 					text = previousLine + " " + text;
 				}
-				Log.LogFromStandardError (DefaultErrorCode, text);
+				LogFromStandardError (text);
 			}
 
 			previousLine = text;
 		}
+
+		protected virtual void LogFromStandardError (string text) => Log.LogFromStandardError (DefaultErrorCode, text);
 
 		protected virtual CommandLineBuilder CreateCommandLine()
 		{


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4418226&view=ms.vss-test-web.build-test-results-tab&runId=18501656&resultId=100103&paneView=debug

Our .NET 6 MSBuild tests have a common failure on Windows & Mac:

    Task "AndroidCreateDebugKey" (TaskId:407)
        Task Parameter:StorePass=android (TaskId:407)
        Task Parameter:ToolPath=C:\Users\AzDevOps\android-toolchain\jdk-11\bin (TaskId:407)
        Task Parameter:KeyAlias=androiddebugkey (TaskId:407)
        Task Parameter:Validity=10950 (TaskId:407)
        Task Parameter:KeyAlgorithm=RSA (TaskId:407)
        Task Parameter:StoreType=pkcs12 (TaskId:407)
        Task Parameter:KeyPass=android (TaskId:407)
        Task Parameter:Command=-genkeypair (TaskId:407)
        Task Parameter:KeyStore=C:\Users\AzDevOps\AppData\Local\Xamarin\Mono for Android\debug.keystore (TaskId:407)
        KeyTool : -genkeypair (TaskId:407)
                    C:\Users\AzDevOps\AppData\Local\Xamarin\Mono for Android\debug.keystore (TaskId:407)
        C:\Users\AzDevOps\android-toolchain\jdk-11\bin\keytool.exe -genkeypair -alias androiddebugkey -storepass android -keypass android -keystore "C:\Users\AzDevOps\AppData\Local\Xamarin\Mono for Android\debug.keystore" -dname "CN=Android Debug,O=Android,C=US" -keyalg RSA -validity 10950 -storetype pkcs12  (TaskId:407)
        Xamarin.Android.Common.targets(2169,2): error ANDKT0000: keytool error: java.lang.Exception: Key pair not generated, alias <androiddebugkey> already exists

I think this is happening because `AidlTest` is running *first* in the
test run and declares `[Parallelizable (ParallelScope.Children)]`.

I don't think this would commonly hit Xamarin users, as it would be
building *two* Xamarin.Android application projects at the same time
on a fresh machine. Two builds at once would be generating
`%localappdata%\Xamarin\Mono for Android\debug.keystore`.

To solve this issue, let's downgrade this particular error message to
a *warning*. This should hopefully improve the reliability of these
tests. It would also be reasonable if someone hit this in the wild, I
think the project would successfully build with a warning.