### PR TITLE
Fix LinkAssembliesNoShrink/AndroidAddKeepAlives crash

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 				// Set up the FixAbstractMethodsStep
 				var step1 = new FixAbstractMethodsStep (resolver, new TypeDefinitionCache (), Log);
 				// Set up the AddKeepAlivesStep
-				var step2 = new MonoDroid.Tuner.AddKeepAlivesStep (new TypeDefinitionCache ());
+				var step2 = new AddKeepAlivesStep (resolver, new TypeDefinitionCache (), Log);
 				for (int i = 0; i < SourceFiles.Length; i++) {
 					var source = SourceFiles [i];
 					var destination = DestinationFiles [i];
@@ -110,6 +110,29 @@ namespace Xamarin.Android.Tasks
 			protected override AssemblyDefinition GetMonoAndroidAssembly ()
 			{
 				return resolver.GetAssembly ("Mono.Android.dll");
+			}
+
+			public override void LogMessage (string message)
+			{
+				logger.LogDebugMessage ("{0}", message);
+			}
+		}
+
+		class AddKeepAlivesStep : MonoDroid.Tuner.AddKeepAlivesStep
+		{
+			readonly DirectoryAssemblyResolver resolver;
+			readonly TaskLoggingHelper logger;
+
+			public AddKeepAlivesStep (DirectoryAssemblyResolver resolver, TypeDefinitionCache cache, TaskLoggingHelper logger)
+				: base (cache)
+			{
+				this.resolver = resolver;
+				this.logger = logger;
+			}
+
+			protected override AssemblyDefinition GetCorlibAssembly ()
+			{
+				return resolver.GetAssembly ("mscorlib.dll");
 			}
 
 			public override void LogMessage (string message)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -44,10 +44,14 @@ namespace Xamarin.Android.Tasks
 				DeterministicMvid = Deterministic,
 			};
 
+			var hasSystemPrivateCorelib = false;
 			using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: true, loadReaderParameters: readerParameters)) {
 				// Add SearchDirectories with ResolvedAssemblies
 				foreach (var assembly in ResolvedAssemblies) {
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
+					if (Path.GetFileName (assembly.ItemSpec) == "System.Private.CoreLib.dll")
+						hasSystemPrivateCorelib = true;
+
 					if (!resolver.SearchDirectories.Contains (path))
 						resolver.SearchDirectories.Add (path);
 				}
@@ -55,7 +59,7 @@ namespace Xamarin.Android.Tasks
 				// Set up the FixAbstractMethodsStep
 				var step1 = new FixAbstractMethodsStep (resolver, new TypeDefinitionCache (), Log);
 				// Set up the AddKeepAlivesStep
-				var step2 = new AddKeepAlivesStep (resolver, new TypeDefinitionCache (), Log);
+				var step2 = new AddKeepAlivesStep (resolver, new TypeDefinitionCache (), Log, hasSystemPrivateCorelib);
 				for (int i = 0; i < SourceFiles.Length; i++) {
 					var source = SourceFiles [i];
 					var destination = DestinationFiles [i];
@@ -122,17 +126,19 @@ namespace Xamarin.Android.Tasks
 		{
 			readonly DirectoryAssemblyResolver resolver;
 			readonly TaskLoggingHelper logger;
+			readonly bool hasSystemPrivateCoreLib;
 
-			public AddKeepAlivesStep (DirectoryAssemblyResolver resolver, TypeDefinitionCache cache, TaskLoggingHelper logger)
+			public AddKeepAlivesStep (DirectoryAssemblyResolver resolver, TypeDefinitionCache cache, TaskLoggingHelper logger, bool hasSystemPrivateCoreLib)
 				: base (cache)
 			{
 				this.resolver = resolver;
 				this.logger = logger;
+				this.hasSystemPrivateCoreLib = hasSystemPrivateCoreLib;
 			}
 
 			protected override AssemblyDefinition GetCorlibAssembly ()
 			{
-				return resolver.GetAssembly ("mscorlib.dll");
+				return resolver.GetAssembly (hasSystemPrivateCoreLib ? "System.Private.CoreLib.dll" : "mscorlib.dll");
 			}
 
 			public override void LogMessage (string message)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Android.Tasks
 				// Add SearchDirectories with ResolvedAssemblies
 				foreach (var assembly in ResolvedAssemblies) {
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
-					if (Path.GetFileName (assembly.ItemSpec) == "System.Private.CoreLib.dll")
+					if (Path.GetFileName (assembly.ItemSpec).Equals ("System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
 						hasSystemPrivateCorelib = true;
 
 					if (!resolver.SearchDirectories.Contains (path))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -364,7 +364,8 @@ namespace UnnamedProject {
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");
 
-				var assemblyPath = BuildTest.GetLinkedPath (b,  true, "UnnamedProject.dll");
+				var assemblyFile = "UnnamedProject.dll";
+				var assemblyPath = (Builder.UseDotNet && (!isRelease || setLinkModeNone)) ? b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", assemblyFile)) : BuildTest.GetLinkedPath (b,  true, assemblyFile);
 				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
 					Assert.IsTrue (assembly != null);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -291,13 +291,14 @@ $@"			var myButton = new AttributedButtonStub (this);
 
 		// mode
 		//   0 .. Debug configuration
-		//   1 .. Release configuration
-		//   2 .. Release configuration, AndroidLinkMode=None
+		//   1 .. Debug configuration, AndroidAddKeepAlives=true
+		//   2 .. Release configuration
+		//   3 .. Release configuration, AndroidLinkMode=None
 		[Test]
-		public void AndroidAddKeepAlives ([Values (0, 1, 2)] int mode)
+		public void AndroidAddKeepAlives ([Values (0, 1, 2, 3)] int mode)
 		{
 			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = (mode > 0),
+				IsRelease = (mode > 1),
 				OtherBuildItems = {
 					new BuildItem ("Compile", "Method.cs") { TextContent = () => @"
 using System;
@@ -327,8 +328,14 @@ namespace UnnamedProject {
 
 			proj.SetProperty ("AllowUnsafeBlocks", "True");
 
-			if (mode == 2)
-				proj.SetProperty (proj.ReleaseProperties, "AndroidLinkMode", "None");
+			switch (mode) {
+				case 1:
+					proj.SetProperty ("AndroidAddKeepAlives", "True");
+					break;
+				case 3:
+					proj.SetProperty (proj.ReleaseProperties, "AndroidLinkMode", "None");
+					break;
+			}
 
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");
@@ -358,7 +365,10 @@ namespace UnnamedProject {
 						break;
 					}
 
-					Assert.IsTrue (hasKeepAliveCall);
+					if (mode == 0)
+						Assert.IsFalse (hasKeepAliveCall);
+					else
+						Assert.IsTrue (hasKeepAliveCall);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -289,11 +289,15 @@ $@"			var myButton = new AttributedButtonStub (this);
 			}
 		}
 
+		// mode
+		//   0 .. Debug configuration
+		//   1 .. Release configuration
+		//   2 .. Release configuration, AndroidLinkMode=None
 		[Test]
-		public void AndroidAddKeepAlives ()
+		public void AndroidAddKeepAlives ([Values (0, 1, 2)] int mode)
 		{
 			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = true,
+				IsRelease = (mode > 0),
 				OtherBuildItems = {
 					new BuildItem ("Compile", "Method.cs") { TextContent = () => @"
 using System;
@@ -322,6 +326,9 @@ namespace UnnamedProject {
 			};
 
 			proj.SetProperty ("AllowUnsafeBlocks", "True");
+
+			if (mode == 2)
+				proj.SetProperty (proj.ReleaseProperties, "AndroidLinkMode", "None");
 
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5562

Add `AddKeepAlivesStep` class to `LinkAssembliesNoShrink` task. This class overrides linker's `AddKeepAlivesStep` and provides corlib assembly without accessing linker context. It also provides logging for the step.

Test more scenarios with `AndroidAddKeepAlives`. Two of these scenarios led to a crash in the linker step before the fix - `Debug` configuration with `AndroidAddKeepAlives` enabled and `Release` configuration with linker mode set to `None`.