### PR TITLE
Fix LinkAssembliesNoShrink/AndroidAddKeepAlives crash (d16-9)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -103,16 +103,49 @@ namespace MonoDroid.Tuner
 					if (method.Parameters [i].ParameterType.IsValueType || method.Parameters [i].ParameterType.FullName == "System.String")
 						continue;
 
-					changed = true;
-
 					if (methodKeepAlive == null)
-						methodKeepAlive = Context.GetMethod ("mscorlib", "System.GC", "KeepAlive", new string [] { "System.Object" });
+						methodKeepAlive = GetKeepAliveMethod ();
+
+					if (methodKeepAlive == null) {
+						LogMessage ("Unable to add KeepAlive call, did not find System.GC.KeepAlive method.");
+						break;
+					}
 
 					processor.InsertBefore (end, GetLoadArgumentInstruction (method.IsStatic ? i : i + 1, method.Parameters [i]));
 					processor.InsertBefore (end, Instruction.Create (OpCodes.Call, module.ImportReference (methodKeepAlive)));
+					changed = true;
 				}
 			}
 			return changed;
+		}
+
+		protected virtual AssemblyDefinition GetCorlibAssembly ()
+		{
+			return Context.GetAssembly (
+#if NETCOREAPP
+							"System.Private.CoreLib"
+#else
+							"mscorlib"
+#endif
+				);
+		}
+
+		MethodDefinition GetKeepAliveMethod ()
+		{
+			var corlibAssembly = GetCorlibAssembly ();
+			if (corlibAssembly == null)
+				return null;
+
+			var gcType = Extensions.GetType (corlibAssembly, "System.GC");
+			if (gcType == null)
+				return null;
+
+			return Extensions.GetMethod (gcType, "KeepAlive", new string [] { "System.Object" });
+		}
+
+		public virtual void LogMessage (string message)
+		{
+			Context.LogMessage (message);
 		}
 
 		// Adapted from src/Mono.Android.Export/Mono.CodeGeneration/CodeArgumentReference.cs

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 				// Set up the FixAbstractMethodsStep
 				var step1 = new FixAbstractMethodsStep (resolver, new TypeDefinitionCache (), Log);
 				// Set up the AddKeepAlivesStep
-				var step2 = new MonoDroid.Tuner.AddKeepAlivesStep (new TypeDefinitionCache ());
+				var step2 = new AddKeepAlivesStep (resolver, new TypeDefinitionCache (), Log);
 				for (int i = 0; i < SourceFiles.Length; i++) {
 					var source = SourceFiles [i];
 					var destination = DestinationFiles [i];
@@ -110,6 +110,29 @@ namespace Xamarin.Android.Tasks
 			protected override AssemblyDefinition GetMonoAndroidAssembly ()
 			{
 				return resolver.GetAssembly ("Mono.Android.dll");
+			}
+
+			public override void LogMessage (string message)
+			{
+				logger.LogDebugMessage ("{0}", message);
+			}
+		}
+
+		class AddKeepAlivesStep : MonoDroid.Tuner.AddKeepAlivesStep
+		{
+			readonly DirectoryAssemblyResolver resolver;
+			readonly TaskLoggingHelper logger;
+
+			public AddKeepAlivesStep (DirectoryAssemblyResolver resolver, TypeDefinitionCache cache, TaskLoggingHelper logger)
+				: base (cache)
+			{
+				this.resolver = resolver;
+				this.logger = logger;
+			}
+
+			protected override AssemblyDefinition GetCorlibAssembly ()
+			{
+				return resolver.GetAssembly ("mscorlib.dll");
 			}
 
 			public override void LogMessage (string message)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -289,12 +289,16 @@ $@"			var myButton = new AttributedButtonStub (this);
 			}
 		}
 
+		// mode
+		//   0 .. Debug configuration
+		//   1 .. Release configuration
+		//   2 .. Release configuration, AndroidLinkMode=None
 		[Test]
 		[Category ("DotNetIgnore")]
-		public void AndroidAddKeepAlives ()
+		public void AndroidAddKeepAlives ([Values (0, 1, 2)] int mode)
 		{
 			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = true,
+				IsRelease = (mode > 0),
 				OtherBuildItems = {
 					new BuildItem ("Compile", "Method.cs") { TextContent = () => @"
 using System;
@@ -323,6 +327,9 @@ namespace UnnamedProject {
 			};
 
 			proj.SetProperty ("AllowUnsafeBlocks", "True");
+
+			if (mode == 2)
+				proj.SetProperty (proj.ReleaseProperties, "AndroidLinkMode", "None");
 
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5562

Add `AddKeepAlivesStep` class to `LinkAssembliesNoShrink` task. This class overrides linker's `AddKeepAlivesStep` and provides corlib assembly without accessing linker context. It also provides logging for the step.

Test more scenarios with `AndroidAddKeepAlives`. Two of these scenarios led to a crash in the linker step before the fix - `Debug` configuration with `AndroidAddKeepAlives` enabled and `Release` configuration with linker mode set to `None`.