### PR TITLE
Make TimeZone tests more reliable.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -161,8 +161,8 @@
     <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">1.0</CommandLineToolsFolder>
     <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">6200805_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
-    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">6466327</EmulatorVersion>
-    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.0.12</EmulatorPkgRevision>
+    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">7033400</EmulatorVersion>
+    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.3.5</EmulatorPkgRevision>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"-verbose -avd {ImageName}{port} -cache-size 512";
+			var arguments = $"-verbose -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -916,6 +916,10 @@ stages:
     parameters:
       node_id: 3
 
+  - template: yaml-templates\run-timezoneinfo-tests.yaml
+    parameters:
+      node_id: 4
+
 - stage: bcl_tests
   displayName: BCL Emulator Tests
   dependsOn: mac_build

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     displayName: macOS-${{ parameters.node_id }}
     pool:
       vmImage: $(HostedMacImage)
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -125,8 +125,8 @@ namespace Xamarin.Android.Build.Tests
 					proc.BeginOutputReadLine ();
 					TimeSpan time = TimeSpan.FromSeconds (timeout);
 					while (!stdout_done.IsSet && !didActionSucceed && time.TotalMilliseconds > 0) {
-						proc.WaitForExit (100);
-						time -= TimeSpan.FromMilliseconds (100);
+						proc.WaitForExit (10);
+						time -= TimeSpan.FromMilliseconds (10);
 					}
 					proc.Kill ();
 					proc.WaitForExit ();

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -35,12 +35,18 @@ namespace Xamarin.Android.Build.Tests
 			if (debuggable != "1") {
 				Assert.Ignore ("TimeZone tests need to use `su root` and this device does not support that feature. Try using an emulator.");
 			}
+			// Disable auto timezone
+			RunAdbCommand ("shell settings put global auto_time_zone 0");
 
 			proj = new XamarinFormsAndroidApplicationProject ();
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			var mainPage = proj.Sources.First (x => x.Include () == "MainPage.xaml.cs");
 			var source = mainPage.TextContent ().Replace ("InitializeComponent ();", @"InitializeComponent ();
+			Console.WriteLine ($""TimeZoneInfoNative={Java.Util.TimeZone.Default.ID}"");
 			Console.WriteLine ($""TimeZoneInfo={TimeZoneInfo.Local.DisplayName}"");
+");
+			source = source.Replace ("Console.WriteLine (\"Button was Clicked!\");", @"Console.WriteLine (""Button was Clicked!"");
+			Console.WriteLine ($""TimeZoneInfoClick={TimeZoneInfo.Local.DisplayName}"");
 ");
 			mainPage.TextContent = () => source;
 			builder = CreateApkBuilder (Path.Combine ("temp", "DeploymentTests"));
@@ -183,7 +189,7 @@ namespace Xamarin.Android.Build.Tests
 			}, Path.Combine (Root, builder.ProjectDirectory, "button-logcat.log")), "Button Should have been Clicked.");
 		}
 
-		private const int NODE_COUNT = 3;
+		private const int NODE_COUNT = 4;
 
 		static object [] GetTimeZoneTestCases (int node)
 		{
@@ -203,38 +209,72 @@ namespace Xamarin.Android.Build.Tests
 			return tests.Where (p => tests.IndexOf (p) % NODE_COUNT == node).ToArray ();
 		}
 
-		[Test]
+		[Test, NonParallelizable]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 0 })]
 		[Category ("TimeZoneInfo")]
+		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode1 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
-		[Test]
+		[Test, NonParallelizable]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 1 })]
 		[Category ("TimeZoneInfo")]
+		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode2 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
-		[Test]
+		[Test, NonParallelizable]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 2 })]
 		[Category ("TimeZoneInfo")]
+		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode3 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
+
+		[Test, NonParallelizable]
+		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 3 })]
+		[Category ("TimeZoneInfo")]
+		[Retry (2)]
+		public void CheckTimeZoneInfoIsCorrectNode4 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
 		public void CheckTimeZoneInfoIsCorrect (string timeZone)
 		{
 			AssertHasDevices ();
 
 			string currentTimeZone = RunAdbCommand ("shell getprop persist.sys.timezone")?.Trim ();
+			string deviceTz = string.Empty;
+			string logFile = Path.Combine (Root, builder.ProjectDirectory, $"startup-logcat-{timeZone.Replace ("/", "-")}.log");
 			try {
-				RunAdbCommand ($"shell su root setprop persist.sys.timezone \"{timeZone}\"");
+				for (int attempt = 0; attempt < 5; attempt++) {
+					RunAdbCommand ($"shell su root setprop persist.sys.timezone \"{timeZone}\"");
+					deviceTz = RunAdbCommand ("shell getprop persist.sys.timezone")?.Trim ();
+					if (deviceTz == timeZone) {
+						break;
+					}
+				}
+				Assert.AreEqual (timeZone, deviceTz, $"The command to set the device timezone to {timeZone} failed. Current device timezone is {deviceTz}");
+				ClearAdbLogcat ();
+				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
+				RunAdbCommand ($"shell am kill --user all {proj.PackageName}");
+				WaitFor ((int)TimeSpan.FromSeconds (2).TotalMilliseconds);
 				ClearAdbLogcat ();
 				AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
-				Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
-					Path.Combine (Root, builder.ProjectDirectory, $"startup-logcat-{timeZone.Replace ("/", "-")}.log")), "Activity should have started");
+				Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity", logFile), "Activity should have started");
+				string line = "";
+				string logCatFile = Path.Combine (Root, builder.ProjectDirectory, $"timezone-logcat-{timeZone.Replace ("/", "-")}.log");
+				ClickButton (proj.PackageName, "myXFButton", "CLICK ME");
 				Assert.IsTrue (MonitorAdbLogcat ((l) => {
-					return l.Contains ($"TimeZoneInfo={timeZone}");
-				}, Path.Combine (Root, builder.ProjectDirectory, $"timezone-logcat-{timeZone.Replace ("/", "-")}.log")), $"TimeZone should have been {timeZone}");
+					if (l.Contains ("TimeZoneInfoClick=")) {
+						line = l;
+						return l.Contains ($"{timeZone}");
+					}
+					return false;
+				}, logCatFile, timeout:30), $"TimeZone should have been {timeZone}. We found : {line}");
 			} finally {
-				if (!string.IsNullOrEmpty (currentTimeZone))
+				RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
+				RunAdbCommand ($"shell am kill --user all {proj.PackageName}");
+				if (!string.IsNullOrEmpty (currentTimeZone)) {
 					RunAdbCommand ($"shell su root setprop persist.sys.timezone \"{currentTimeZone}\"");
+				}
+				if (File.Exists (logFile)) {
+					TestContext.AddTestAttachment (logFile);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The Timezone tests have been very unreliable recently. We speculate that this is down to the emulator not
running as fast as it used to on the CI system.

This PR attempts to make these tests more reliable. 
Firstly we will make use of the `NonParallelizable` attribute to ensure that the tests run in sequence. This 
is to stop them tripping over each other when setting the timezone. Next up we will add a `Retry` attribute
to at least re run a test once if it fails. This might help if the emulator is running slowly. 

Next we introduce the following code both before and after the test.

```
RunAdbCommand ($"shell am force-stop --user all {proj.PackageName}");
RunAdbCommand ($"shell am kill --user all {proj.PackageName}");
```

These commands will force the application to stop, and face any background tasks the application has
to stop as well. This is the best way we could fine to completely kill the application. While we were 
expecting the `TimeZoneChanged` notification to fire if the app was already running, it turns out that
when setting the date time via `adb` that broadcast does NOT get fired. It only fires when the timezone
is changed via the Settings screen. So killing the application completely and forcing a restart is the best
option. We should investigate to see if we can script the timezone change via the UI so we can test the 
broadcast, but that should be done in a separate PR. 
