### PR TITLE
[ci] Move TimeZoneInfo tests to Nightly pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -43,6 +43,7 @@ variables:
   HostedMacImage: macOS-10.15
   VSEngWinVS2019: Xamarin-Android-Win2019-1120
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
+  NUnit.NumberOfTestWorkers: 4
 
 stages:
 - stage: mac_build

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -71,6 +71,9 @@ stages:
 - stage: test
   displayName: Test
   dependsOn: mac_build
+  variables:
+    - group: Xamarin-Secrets
+    - group: xamops-azdev-secrets
   jobs:
   - job: emulator_tests
     displayName: Emulator
@@ -97,9 +100,6 @@ stages:
       vmImage: $(HostedMacImage)
     workspace:
       clean: all
-    variables:
-      - group: Xamarin-Secrets
-      - group: xamops-azdev-secrets
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -149,3 +149,20 @@ stages:
         artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi) - macOS
 
     - template: yaml-templates/fail-on-issue.yaml
+
+  # TimeZoneInfo test jobs
+  - template: yaml-templates/run-timezoneinfo-tests.yaml
+    parameters:
+      node_id: 1
+
+  - template: yaml-templates/run-timezoneinfo-tests.yaml
+    parameters:
+      node_id: 2
+
+  - template: yaml-templates/run-timezoneinfo-tests.yaml
+    parameters:
+      node_id: 3
+
+  - template: yaml-templates/run-timezoneinfo-tests.yaml
+    parameters:
+      node_id: 4

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -900,28 +900,6 @@ stages:
         artifactName: Test Results - Designer - Windows
         targetPath: $(Build.ArtifactStagingDirectory)\designer-binlogs
 
-- stage: tz_tests
-  displayName: TimeZoneInfo Emulator Tests
-  dependsOn: mac_build
-  condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'TimeZone')))
-  jobs:
-  # TimeZoneInfo tests
-  - template: yaml-templates\run-timezoneinfo-tests.yaml
-    parameters:
-      node_id: 1
-
-  - template: yaml-templates\run-timezoneinfo-tests.yaml
-    parameters:
-      node_id: 2
-
-  - template: yaml-templates\run-timezoneinfo-tests.yaml
-    parameters:
-      node_id: 3
-
-  - template: yaml-templates\run-timezoneinfo-tests.yaml
-    parameters:
-      node_id: 4
-
 - stage: bcl_tests
   displayName: BCL Emulator Tests
   dependsOn: mac_build

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
   - job: mac_timezoneinfo_tests_${{ parameters.node_id }}
-    displayName: macOS-${{ parameters.node_id }}
+    displayName: TimeZoneInfo Emulator Tests ${{ parameters.node_id }}
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 120

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -46,13 +46,11 @@ namespace Xamarin.Android.Prepare
 				// MSBuild: Runs all legacy and One .NET Xamarin.Android.Build.Task tests
 				// MSBuildDevice: Runs all MSBuildDeviceIntegration tests
 				// BCL: Runs BCL tests on emulator
-				// TimeZone: Runs timezone unit tests on emulator
 				// Designer: Runs designer integration tests
 				if (file == ".external" || file == "Configuration.props" || IsRelevantBuildToolsFile (file)) {
 					testAreas.Add ("MSBuild");
 					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("BCL");
-					testAreas.Add ("TimeZone");
 					testAreas.Add ("Designer");
 				}
 
@@ -146,7 +144,6 @@ namespace Xamarin.Android.Prepare
 
 				if (file.Contains ("tests/MSBuildDeviceIntegration")) {
 					testAreas.Add ("MSBuildDevice");
-					testAreas.Add ("TimeZone");
 				}
 
 				if (file.Contains ("tests/msbuild-times-reference")) {


### PR DESCRIPTION
The broad set of TimeZoneInfo deployment tests don't need to be running
against every commit and PR build.  They should be moved to the Nightly
build and test pipeline that was introduced in commit 916d24b.  This 
will reduce PR build execution times and the overall machine time cost
of PR/CI builds.