### PR TITLE
Bump to xamarin/monodroid/main@aae6670c

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@bafd13939f963c1f558dc221e96914f65cf0c185
+xamarin/monodroid:main@aae6670c6ff4b68d36fb976fd6dec67a2a6d43d7
 mono/mono:2020-02@5e9cb6d1c1de430965312927d5aed7fcb27bfa73


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/bafd1393...aae6670c

* [ci] Bump relevant branches to use `main`, not `master`
* [tools/msbuild] fix when java_runtime_fastdev.jar is used