### PR TITLE
[One .NET] no longer produce .apk for IDE builds

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -264,6 +264,11 @@ Play, ad-hoc distribution, etc. It could be able to sign the `.apk` or
 `.aab` with different keys. As a starting point, this will currently
 copy the output to a `publish` directory on disk.
 
+_NOTE: Behavior inside IDEs will differ. The `Build` target will not
+produce an `.apk` file if `$(BuildingInsideVisualStudio)` is `true`.
+IDEs will call the `Install` target for deployment, which will produce
+the `.apk` file. This behavior matches "legacy" Xamarin.Android._
+
 [illink]: https://github.com/mono/linker/blob/master/src/linker/README.md
 
 ### dotnet run

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -27,6 +27,13 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       $(BuildDependsOn);
       _CompileDex;
       $(_AfterCompileDex);
+    </BuildDependsOn>
+    <!--
+      Outside IDEs: we need to produce an .apk/.aab and sign
+      Inside IDEs: the Install target produces .apk/.aab files & signs
+    -->
+    <BuildDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+      $(BuildDependsOn);
       _CopyPackage;
       _Sign;
     </BuildDependsOn>


### PR DESCRIPTION
Related: https://github.com/xamarin/xamarin-android/issues/5436

In "legacy" Xamarin.Android, we have the following behavior:

1. The `Build` target does not produce an `.apk` or sign it.
2. Only `SignAndroidPackage` (or `Install`) would do this.

So if you hit F6, Ctrl+B, Command+B, etc. in Visual Studio, you don't
have to wait on a valid `.apk` file to be produced to get build
results. This is useful for incremental build performance -- and
developers' habit of hitting build all the time.

`dotnet build` has different behavior, because it should inherently
produce something that is runnable. `dotnet build` currently produces
an `.apk` file and signs it.

To match "legacy" Xamarin.Android's behavior in IDEs we could do
something different while in Visual Studio when
`$(BuildingInsideVisualStudio)` is set. This way we get the desired
behavior:

* `dotnet build` at the command-line produces a signed `.apk` file.
* IDEs will not produce an `.apk` on `Build`. However, when "deploy"
  occurs, the `Install` target will handle producing an `.apk` file as
  needed.

This allowed me to update the `PerformanceTest` that was adding
additional time under .NET 6 for producing `.apk` files. Our MSBuild
tests always set `$(BuildingInsideVisualStudio)` for testing.

I also updated the `[Retry]` attributes so the value was in one place.