### PR TITLE
[Xamarin.ProjectTools] fix toggling XamarinProject.IsRelease

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -40,13 +40,23 @@ namespace Xamarin.ProjectTools
 		public virtual bool ShouldPopulate => true;
 		public IList<Import> Imports { get; private set; }
 		PropertyGroup common, debug, release;
+		bool isRelease;
 
 		/// <summary>
 		/// Configures projects with Configuration=Debug or Release
 		/// * Directly in the `.csproj` file for legacy projects
 		/// * Uses `Directory.Build.props` for .NET 5+ projects
 		/// </summary>
-		public bool IsRelease { get; set; }
+		public bool IsRelease {
+			get => isRelease;
+			set {
+				isRelease = value;
+
+				if (Builder.UseDotNet) {
+					Touch ("Directory.Build.props");
+				}
+			}
+		}
 
 		public string Configuration => IsRelease ? releaseConfigurationName : debugConfigurationName;
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4422361&view=ms.vss-test-web.build-test-results-tab&runId=18547936&resultId=100086&paneView=debug

We had an MSBuild test failing under .NET 6:

    MSBuildDeviceIntegration On Device - macOS - One .NET > SwitchConfigurationsShouldRedeploy
    fastdev directory should NOT exist for Release builds.
    Expected string length 0 but was 4970. Strings differ at index 0.
    Expected: <string.Empty>
    But was:  "Java.Interop.dll\nMicrosoft.CSharp.dll\nMicrosoft.VisualBasic.C..."

This was because a supposed `Release` build was skipping the `_Upload`
target completely:

    Skipping target "_Upload" because all output files are up-to-date with respect to the input files.
    Input files: bin\Debug\UnnamedProject.UnnamedProject-Signed.apk...

It appears that toggling `XamarinProject.IsRelease` is not triggering
the correct files to save when the tests run under .NET 6.

Under "legacy" Xamarin.Android, the tests simply put this at the top
of the `.csproj`:

      <Configuration>Debug</Configuration>
    ...
    <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

This won't work in short-form MSBuild projects, because the `.csproj`
is effectively:

    <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
    ...
      <Configuration>Debug</Configuration>
    ...
    <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

For things to work properly, we need `$(Configuration)` to be set
*before* `Microsoft.NET.Sdk/Sdk.props`.

So we put `$(Configuration)` in a `Directory.Build.props` to solve
this ordering problem. Unfortunately, we were not calling `Touch()` on
this file when `XamarinProject.IsRelease` changes.

After making this change, `SwitchConfigurationsShouldRedeploy` passes.