### PR TITLE
[Xamarin.Android.Build.Tasks] Allow whitespace chars in $(AndroidSigningKeyAlias)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-signedjar ", Path.Combine (SignedApkDirectory, $"{fileName}{FileSuffix}{extension}" ));
 
 			cmd.AppendFileNameIfNotNull (UnsignedApk);
-			cmd.AppendSwitch (KeyAlias);
+			cmd.AppendSwitchIfNotNull (" ", KeyAlias);
 
 			return cmd.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -382,7 +382,6 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-
 			};
 			proj.SetProperty (proj.ReleaseProperties, "AndroidUseApkSigner", useApkSigner);
 			proj.SetProperty (proj.ReleaseProperties, "AndroidKeyStore", "True");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -366,11 +366,12 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			string keyToolPath = Path.Combine (androidSdk.JavaSdkPath, "bin");
 			var engine = new MockBuildEngine (Console.Out);
 			string pass = "Cy(nBW~j.&@B-!R_aq7/syzFR!S$4]7R%i6)R!";
+			string alias = "release store";
 			var task = new AndroidCreateDebugKey {
 				BuildEngine = engine,
 				KeyStore = keyfile,
 				StorePass = pass,
-				KeyAlias = "releasestore",
+				KeyAlias = alias,
 				KeyPass = pass,
 				KeyAlgorithm="RSA",
 				Validity=30,
@@ -381,15 +382,12 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
+
 			};
-			if (useApkSigner) {
-				proj.SetProperty ("AndroidUseApkSigner", "true");
-			} else {
-				proj.RemoveProperty ("AndroidUseApkSigner");
-			}
+			proj.SetProperty (proj.ReleaseProperties, "AndroidUseApkSigner", useApkSigner);
 			proj.SetProperty (proj.ReleaseProperties, "AndroidKeyStore", "True");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyStore", keyfile);
-			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyAlias", "releasestore");
+			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyAlias", alias);
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningKeyPass", Uri.EscapeDataString (pass));
 			proj.SetProperty (proj.ReleaseProperties, "AndroidSigningStorePass", Uri.EscapeDataString (pass));
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, perAbiApk);


### PR DESCRIPTION
Fixes: #5553

Package signing attempts that do not use `apksigner.jar` can fail if the
provided `$(AndroidSigningKeyAlias)` has a space in it:

    _Sign:
      /Users/peter/Library/Developer/Xamarin/jdk/microsoft_dist_openjdk_1.8.0.25/bin/jarsigner -keystore "test file.keystore" -storepass "test pass" -keypass "test pass" -digestalg SHA-256 -sigalg SHA256withRSA -signedjar bin/Release/mono.samples.button-Signed-Unaligned.apk /Users/peter/source/monodroid-samples/Button/obj/Release/android/bin/mono.samples.button.apk test alias
      Only one alias can be specified
      Please type jarsigner -help for usage
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2244,2): error MSB6006: "jarsigner" exited with code 1. [/Users/peter/source/monodroid-samples/Button/DroidButton.csproj]

To fix this, `CommandLineBuilder.AppendSwitchIfNotNull` can be used as
it will automatically quote the parameter if necessary.  The
`CheckSignApk` test has been updated to always set
`$(AndroidUseApkSigner)`, as it was previously not exercising the
`AndroidUseApkSigner=false` code path.