### PR TITLE
Bump to .NET 6.0.100-preview.1.21081.5

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -76,7 +76,7 @@
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-alpha.1.21064.27</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.1.21081.5</DotNetPreviewVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.10.2</AndroidCmakeVersion>
     <AndroidCmakeVersionPath Condition=" '$(AndroidCmakeVersionPath)' == '' ">$(AndroidCmakeVersion).4988404</AndroidCmakeVersionPath>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -39,8 +39,6 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.AndroidX.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android.Support.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Google.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.GooglePlayServices.')) ) ">
         <TrimMode>link</TrimMode>
       </ResolvedFileToPublish>
-      <!-- Mark our entry assembly as a root assembly. -->
-      <TrimmerRootAssembly Include="$(AssemblyName)" />
     </ItemGroup>
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->


### PR DESCRIPTION
Changes: https://github.com/dotnet/installer/compare/47153b5f...f4682754

After updating, `Release` builds were failing with:

    Fatal error in IL Linker
    Unhandled exception. System.IO.FileNotFoundException: Could not find file 'C:\src\xamarin-android\bin\TestDebug\temp\DotNetBuildandroid.21-armTrue\UnnamedProject'.
    File name: 'C:\src\xamarin-android\bin\TestDebug\temp\DotNetBuildandroid.21-armTrue\UnnamedProject'
        at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
        at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)
        at Mono.Linker.DirectoryAssemblyResolver.GetAssembly(String file, ReaderParameters parameters)
        at Mono.Linker.Steps.RootAssemblyInput.LoadAssemblyFile()
        at Mono.Linker.Steps.RootAssemblyInput.Process()
        at Mono.Linker.Steps.BaseStep.Process(LinkContext context)
        at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
        at Mono.Linker.Pipeline.Process(LinkContext context)
        at Mono.Linker.Driver.Run(ILogger customLogger)
        at Mono.Linker.Driver.Main(String[] args)

Looking at the input to the `<ILLink/>` MSBuild task:

    RootAssemblyNames
        UnnamedProject
        obj\Release\net6.0-android\android.21-arm\UnnamedProject.dll
            CopyToPublishDirectory = PreserveNewest
            PostprocessAssembly = true
            RelativePath = UnnamedProject.dll

We were adding to `@(TrimmerRootAssembly)` ourselves, such as:

    <TrimmerRootAssembly Include="$(AssemblyName)" />

It appears we can remove this now, as it is done automatically. The
same `Release` app builds & runs after removing this.