### PR TITLE
[monodroid] fix for Fast Dev & extractNativeLibs="false"

### DIFF
--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -29,7 +29,7 @@ void log_fatal (LogCategories category, const char *format, ...);
 
 static void copy_file_to_internal_location (char *to_dir, char *from_dir, char *file);
 static void copy_native_libraries_to_internal_location ();
-static char* get_libmonosgen_path ();
+static const char* get_libmonosgen_path ();
 
 bool maybe_load_library (const char *path);
 
@@ -87,7 +87,7 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, [[maybe_unused]] jclass klass,
 		log_warn (LOG_DEFAULT, "Using runtime path: %s", androidSystem.get_runtime_libdir ());
 	}
 
-	char *monosgen_path = get_libmonosgen_path ();
+	const char *monosgen_path = get_libmonosgen_path ();
 	void *monosgen = dlopen (monosgen_path, RTLD_LAZY | RTLD_GLOBAL);
 	if (monosgen == nullptr) {
 		log_fatal (LOG_DEFAULT, "Failed to dlopen Mono runtime from %s: %s", monosgen_path, dlerror ());
@@ -196,7 +196,7 @@ runtime_exists (const char *dir, char*& libmonoso)
 	return false;
 }
 
-static char*
+static const char*
 get_libmonosgen_path ()
 {
 	char *libmonoso;
@@ -207,7 +207,7 @@ get_libmonosgen_path ()
 	copy_native_libraries_to_internal_location ();
 
 	if (androidSystem.is_embedded_dso_mode_enabled ()) {
-		return (char*) SharedConstants::MONO_SGEN_SO;
+		return SharedConstants::MONO_SGEN_SO;
 	}
 
 	for (size_t i = 0; i < BasicAndroidSystem::MAX_OVERRIDES; ++i) {

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -200,26 +200,25 @@ static char*
 get_libmonosgen_path ()
 {
 	char *libmonoso;
-	bool embedded_dso_mode_enabled = androidSystem.is_embedded_dso_mode_enabled ();
 
 	// Android 5 includes some restrictions on loading dynamic libraries via dlopen() from
 	// external storage locations so we need to file copy the shared object to an internal
 	// storage location before loading it.
 	copy_native_libraries_to_internal_location ();
 
-	if (!embedded_dso_mode_enabled) {
-		for (size_t i = 0; i < BasicAndroidSystem::MAX_OVERRIDES; ++i) {
-			if (runtime_exists (BasicAndroidSystem::override_dirs [i], libmonoso)) {
-				return libmonoso;
-			}
+	if (androidSystem.is_embedded_dso_mode_enabled ()) {
+		return (char*) SharedConstants::MONO_SGEN_SO;
+	}
+
+	for (size_t i = 0; i < BasicAndroidSystem::MAX_OVERRIDES; ++i) {
+		if (runtime_exists (BasicAndroidSystem::override_dirs [i], libmonoso)) {
+			return libmonoso;
 		}
 	}
 
-	if (!embedded_dso_mode_enabled) {
-		for (size_t i = 0; i < BasicAndroidSystem::app_lib_directories_size; i++) {
-			if (runtime_exists (BasicAndroidSystem::app_lib_directories [i], libmonoso)) {
-				return libmonoso;
-			}
+	for (size_t i = 0; i < BasicAndroidSystem::app_lib_directories_size; i++) {
+		if (runtime_exists (BasicAndroidSystem::app_lib_directories [i], libmonoso)) {
+			return libmonoso;
 		}
 	}
 
@@ -265,12 +264,10 @@ get_libmonosgen_path ()
 		return libmonoso;
 	log_fatal (LOG_DEFAULT, "Cannot find '%s'. Looked in the following locations:", SharedConstants::MONO_SGEN_SO);
 
-	if (!embedded_dso_mode_enabled) {
-		for (size_t i = 0; i < BasicAndroidSystem::MAX_OVERRIDES; ++i) {
-			if (BasicAndroidSystem::override_dirs [i] == nullptr)
-				continue;
-			log_fatal (LOG_DEFAULT, "  %s", BasicAndroidSystem::override_dirs [i]);
-		}
+	for (size_t i = 0; i < BasicAndroidSystem::MAX_OVERRIDES; ++i) {
+		if (BasicAndroidSystem::override_dirs [i] == nullptr)
+			continue;
+		log_fatal (LOG_DEFAULT, "  %s", BasicAndroidSystem::override_dirs [i]);
 	}
 
 	for (size_t i = 0; i < BasicAndroidSystem::app_lib_directories_size; i++) {


### PR DESCRIPTION
When using `$(EmbedAssembliesIntoApk)=false` and
`/application/@extractNativeLibs="false"`, apps crash on startup with:

    D debug-app-helper: Checking if libmonodroid was unpacked to /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/lib/arm64/libmonodroid.so
    D debug-app-helper: /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/lib/arm64/libmonodroid.so not found, assuming application/android:extractNativeLibs == false
    I debug-app-helper: Setting up for DSO lookup directly in the APK
    D debug-app-helper: Added APK DSO lookup location: /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/base.apk!/lib/arm64-v8a
    W debug-app-helper: Using runtime path: /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/lib/arm64
    W debug-app-helper: checking directory: `/data/user/0/UnnamedProject.UnnamedProject/files/.__override__/lib`
    W debug-app-helper: directory does not exist: `/data/user/0/UnnamedProject.UnnamedProject/files/.__override__/lib`
    W debug-app-helper: Trying to load sgen from: /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/lib/arm64/libmonosgen-64bit-2.0.so
    W debug-app-helper: Checking whether Mono runtime exists at: /system/lib64/libmonosgen-2.0.so
    F debug-app-helper: Cannot find 'libmonosgen-2.0.so'. Looked in the following locations:
    F debug-app-helper:   /data/app/~~5pGpNKwo58itttVZIz8-GA==/UnnamedProject.UnnamedProject-Lh_MOHcs1J3EajxFou0uBg==/base.apk!/lib/arm64-v8a
    F debug-app-helper: Do you have a shared runtime build of your app with AndroidManifest.xml android:minSdkVersion < 10 while running on a 64-bit Android 5.0 target? This combination is not supported.
    F debug-app-helper: Please either set android:minSdkVersion >= 10 or use a build without the shared runtime (like default Release configuration).

This is only occurring on `master`, not `d16-9`.

It appears `get_libmonosgen_path()` needs to check
`androidSystem.is_embedded_dso_mode_enabled()` and return early for
`Debug` builds using Fast Deployment:

    if (androidSystem.is_embedded_dso_mode_enabled ()) {
        return SharedConstants::MONO_SGEN_SO;
    }

This was working for `Release` builds.

I think a combination of changes surfaced this bug:

* Fast Dev vNext was introduced, removing the Mono Shared runtime.
  Previously, the `libmonosgen-2.0.so` would be located from the
  shared runtime.
* We accidentally lost usage of `java_runtime_fastdev.jar`.
  Fixed in: https://github.com/xamarin/monodroid/commit/aae6670c
* `BuildConfig.java` now reports the appropriate value for
  `mono.android.BuildConfig.Debug`.