### PR TITLE
[illink] fix for .NET 6 & AndroidLinkMode=Full

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -39,6 +39,8 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.AndroidX.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android.Support.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Google.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.GooglePlayServices.')) ) ">
         <TrimMode>link</TrimMode>
       </ResolvedFileToPublish>
+      <!-- Mark our entry assembly as a root assembly. -->
+      <TrimmerRootAssembly Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Filename)' == '$(AssemblyName)' and '%(ResolvedFileToPublish.Extension)' == '.dll' " />
     </ItemGroup>
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/pull/10552

After bumping .NET 6 in 240a3e1c, I found the
`CustomLinkDescriptionPreserve(Full)` test fails:

    Linker test app did not run successfully.
    Expected: True
    But was:  False

This fails because we are producing an `.apk` file where the
`MainActivity` is completely linked away.

It seems that removing `@(TrimmerRootAssembly)` completely in 240a3e1c
only worked if `AndroidLinkMode` was `SdkOnly` and not `Full`.

I brought over the change that worked for Xamarin.iOS to fix this
issue.