### PR TITLE
[CI] Do not install mingw for APK instrumentation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -288,7 +288,7 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
-    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --no-mingw-w64 --run-mode=CI
       displayName: install required brew tools and prepare java.interop
 
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -358,6 +358,11 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
+		/// <summary>
+		///   Do not install mingw-w64 with brew on MacOS, default false
+		/// </summary>
+		public bool NoMingwW64 { get; set; } = false;
+
 		static Context ()
 		{
 			Instance = new Context ();

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -16,12 +16,6 @@ namespace Xamarin.Android.Prepare
 
 			new HomebrewProgram ("make"),
 
-			new HomebrewProgram ("mingw-w64") {
-				MinimumVersion = "7.0.0_2",
-				MaximumVersion = "7.0.0_3",
-				Pin = true,
-			},
-
 			new HomebrewProgram ("ninja"),
 			new HomebrewProgram ("p7zip", "7za"),
 
@@ -31,9 +25,17 @@ namespace Xamarin.Android.Prepare
 			},
 		};
 
+		static readonly HomebrewProgram mingw = new HomebrewProgram ("mingw-w64") {
+			MinimumVersion = "7.0.0_2",
+			MaximumVersion = "7.0.0_3",
+			Pin = true,
+		}};
+
 		protected override void InitializeDependencies ()
 		{
 			Dependencies.AddRange (programs);
+			if (!Context.Instance.NoMingwW64)
+				Dependencies.Add (mingw);
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Prepare
 			MinimumVersion = "7.0.0_2",
 			MaximumVersion = "7.0.0_3",
 			Pin = true,
-		}};
+		};
 
 		protected override void InitializeDependencies ()
 		{

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Prepare
 			public bool ShowHelp               { get; set; } = false;
 			public bool DumpProps              { get; set; } = false;
 			public bool NoEmoji                { get; set; } = !Configurables.Defaults.UseEmoji;
+			public bool NoMingwW64             { get; set; } = false;
 			public bool ForceRuntimesBuild     { get; set; } = false;
 			public string? HashAlgorithm       { get; set; }
 			public uint MakeConcurrency        { get; set; } = 0;
@@ -89,6 +90,7 @@ namespace Xamarin.Android.Prepare
 				{"d|dump-properties", "Dump values of all the defined properties to the screen", v => parsedOptions.DumpProps = true },
 				{"j|make-concurrency=", "Number of concurrent jobs for make to run. A positive integer or 0 for the default. Defaults to the number of CPUs/cores", v => parsedOptions.MakeConcurrency = EnsureUInt (v, "Invalid Make concurrency value") },
 				{"no-emoji", "Do not use any emoji characters in the output", v => parsedOptions.NoEmoji = true },
+				{"no-mingw-w64", "Do not install mingw-w64 compiler", v => parsedOptions.NoMingwW64 = true },
 				{"r|run-mode=", $"Specify the execution mode: {GetExecutionModes()}. See documentation for mode descriptions. Default: {Configurables.Defaults.ExecutionMode}", v => parsedOptions.ExecutionMode = ParseExecutionMode (v)},
 				{"f|build-runtimes", $"Build runtimes even if the bundle/archives are available.", v => parsedOptions.ForceRuntimesBuild = true },
 				{"H|hash-algorithm=", "Use the specified hash algorithm instead of the default {Configurables.Defaults.HashAlgorithm}", v => parsedOptions.HashAlgorithm = v?.Trim () },
@@ -130,6 +132,7 @@ namespace Xamarin.Android.Prepare
 
 			Context.Instance.MakeConcurrency       = parsedOptions.MakeConcurrency;
 			Context.Instance.NoEmoji               = parsedOptions.NoEmoji;
+			Context.Instance.NoMingwW64            = parsedOptions.NoMingwW64;
 			Context.Instance.ExecutionMode         = parsedOptions.ExecutionMode;
 			Context.Instance.ForceRuntimesBuild    = parsedOptions.ForceRuntimesBuild;
 			Context.Instance.LoggingVerbosity      = parsedOptions.Verbosity;


### PR DESCRIPTION
On CI the `APK instrumentation - MacOS` job is often failing with:

    Error: Installation of mingw-w64 failed

The `mingw-w64` should not be needed for that job, so add a new option
for `xaprepare` to disable that installation.