### PR TITLE
[ci] Add more Mono.Android-Tests data to App Insights

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -516,8 +516,6 @@ stages:
     # Process Plot CSV files and send results to AppInsights
     # XamarinAndroidMetrics: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/64e11c84-c922-4ffd-bea9-67ab39354edd/resourceGroups/XamarinMetrics/providers/microsoft.insights/components/XamarinAndroidMetrics/overview
     # UNDONE: Need plot definitions for the following files:
-    #  TestResult-Mono.Android_TestsAppBundle-times.csv
-    #  TestResult-Mono.Android_TestsMultiDex-times.csv
     #  TestResult-Xamarin.Android.EmbeddedDSO_Test-times.csv
 
     - template: yaml-templates/plots-to-appinsights.yaml
@@ -527,6 +525,30 @@ stages:
         plotGroup: Test times
         plotTitle: Runtime merged
         plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_Tests-times.csv
+
+    - template: yaml-templates/plots-to-appinsights.yaml
+      parameters:
+        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
+        configuration: $(ApkTestConfiguration)
+        plotGroup: Test times
+        plotTitle: Runtime merged
+        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_TestsAppBundle-times.csv
+
+    - template: yaml-templates/plots-to-appinsights.yaml
+      parameters:
+        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
+        configuration: $(ApkTestConfiguration)
+        plotGroup: Test times
+        plotTitle: Runtime merged
+        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_TestsMultiDex-times.csv
+
+    - template: yaml-templates/plots-to-appinsights.yaml
+      parameters:
+        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
+        configuration: $(ApkTestConfiguration)
+        plotGroup: Test times
+        plotTitle: Runtime merged
+        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android.NET_Tests-times.csv
 
     - template: yaml-templates/plots-to-appinsights.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -531,30 +531,6 @@ stages:
         condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
         configuration: $(ApkTestConfiguration)
         plotGroup: Test times
-        plotTitle: Runtime merged
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_TestsAppBundle-times.csv
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(ApkTestConfiguration)
-        plotGroup: Test times
-        plotTitle: Runtime merged
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android_TestsMultiDex-times.csv
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(ApkTestConfiguration)
-        plotGroup: Test times
-        plotTitle: Runtime merged
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android.NET_Tests-times.csv
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(ApkTestConfiguration)
-        plotGroup: Test times
         plotTitle: Jcw
         plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Xamarin.Android.JcwGen_Tests-times.csv
 

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -243,6 +243,7 @@
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
       <_LogcatFilenameBase>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
+      <PlotDataLabelSuffix Condition=" '$(PlotDataLabelSuffix)' == '' ">$(TestsFlavor)</PlotDataLabelSuffix>
     </PropertyGroup>
     <RunInstrumentationTests
         Condition=" '%(TestApkInstrumentation.Identity)' != ''"
@@ -280,7 +281,7 @@
         ResultsFilename="%(_AllArchives.TimingResultsFilename)"
         DefinitionsFilename="%(_AllArchives.TimingDefinitionsFilename)"
         AddResults="true"
-        LabelSuffix="-$(Configuration)$(TestsFlavor)"
+        LabelSuffix="-$(Configuration)$(PlotDataLabelSuffix)"
         Activity="%(_AllArchives.Activity)" />
   </Target>
   <Target Name="RenameTestCases">

--- a/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
+++ b/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
@@ -80,7 +80,8 @@
       <InstrumentationType>xamarin.android.runtimetests.NUnitInstrumentation</InstrumentationType>
       <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-$(_MonoAndroidTestPackage).xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
-      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-$(_MonoAndroidTestPackage)-times.csv</TimingResultsFilename>
+      <!-- Use default package name to write all Mono.Android-Tests* timing data to the same .csv -->
+      <TimingResultsFilename>$(XamarinAndroidSourcePath)TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
     </TestAab>
   </ItemGroup>
 

--- a/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
+++ b/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
@@ -24,6 +24,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <_SkipJniAddNativeMethodRegistrationAttributeScan>True</_SkipJniAddNativeMethodRegistrationAttributeScan>
     <_MonoAndroidTestPackage>Mono.Android_TestsAppBundle</_MonoAndroidTestPackage>
+    <PlotDataLabelSuffix>-AppBundle</PlotDataLabelSuffix>
   </PropertyGroup>
   <Import Project="..\Mono.Android-Test.Shared.projitems" Label="Shared" Condition="Exists('..\Mono.Android-Test.Shared.projitems')" />
   <Import Project="..\..\..\Configuration.props" />

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -40,7 +40,8 @@
       <InstrumentationType>xamarin.android.runtimetests.NUnitInstrumentation</InstrumentationType>
       <ResultsPath>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage).xml</ResultsPath>
       <TimingDefinitionsFilename>$(XamarinAndroidSourcePath)build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
-      <TimingResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-times.csv</TimingResultsFilename>
+      <!-- Use default package name to write all Mono.Android-Tests* timing data to the same .csv -->
+      <TimingResultsFilename>$(XamarinAndroidSourcePath)TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
       <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(XamarinAndroidSourcePath)build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -18,6 +18,7 @@
     <EnableDefaultAndroidResourceItems>false</EnableDefaultAndroidResourceItems>
     <EnableDefaultAndroidAssetItems>false</EnableDefaultAndroidAssetItems>
     <_MonoAndroidTestPackage>Mono.Android.NET_Tests</_MonoAndroidTestPackage>
+    <PlotDataLabelSuffix>-NET6</PlotDataLabelSuffix>
     <!-- TODO: Fix excluded tests -->
     <ExcludeCategories>DotNetIgnore:InetAccess</ExcludeCategories>
   </PropertyGroup>

--- a/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
+++ b/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
@@ -24,6 +24,7 @@
     <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <_SkipJniAddNativeMethodRegistrationAttributeScan>True</_SkipJniAddNativeMethodRegistrationAttributeScan>
     <_MonoAndroidTestPackage>Mono.Android_TestsMultiDex</_MonoAndroidTestPackage>
+    <PlotDataLabelSuffix>-MultiDex</PlotDataLabelSuffix>
   </PropertyGroup>
   <Import Project="..\Mono.Android-Test.Shared.projitems" Label="Shared" Condition="Exists('..\Mono.Android-Test.Shared.projitems')" />
   <Import Project="..\..\..\Configuration.props" />

--- a/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
+++ b/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
@@ -80,7 +80,8 @@
       <InstrumentationType>xamarin.android.runtimetests.NUnitInstrumentation</InstrumentationType>
       <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-$(_MonoAndroidTestPackage).xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
-      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-$(_MonoAndroidTestPackage)-times.csv</TimingResultsFilename>
+      <!-- Use default package name to write all Mono.Android-Tests* timing data to the same .csv -->
+      <TimingResultsFilename>$(XamarinAndroidSourcePath)TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
       <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>


### PR DESCRIPTION
The AppBundle, MultiDex, and .NET 6 variants of Mono.Android-Tests will
now write their timing data to the same .csv file that is used for all
other Mono.Android-Tests variants.  This will allow us to compare
timing data from any Mono.Android-Tests run in the same chart.

See the [App Insights wiki][0] for more information on how we visualize
the startup timing that is being sent to App Insights.

[0]: https://github.com/xamarin/monodroid/wiki/Azure-Pipelines-and-DevOps#startup-timing-visualizations-using-app-insights