### PR TITLE
Remove fallback code in GetJavaToManagedType

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -218,29 +218,9 @@ namespace Java.Interop {
 			if (type != null)
 				return type;
 
-			if (!JNIEnv.IsRunningOnDesktop) {
-				// Miss message is logged in the native runtime
-				if (JNIEnv.LogTypemapMissStackTrace)
-					JNIEnv.LogTypemapTrace (new System.Diagnostics.StackTrace (true));
-				return null;
-			}
+			if (!JNIEnv.IsRunningOnDesktop && JNIEnv.LogTypemapMissStackTrace)
+				JNIEnv.LogTypemapTrace (new System.Diagnostics.StackTrace (true));
 
-			__TypeRegistrations.RegisterPackages ();
-
-			type = null;
-			int ls      = class_name.LastIndexOf ('/');
-			var package = ls >= 0 ? class_name.Substring (0, ls) : "";
-			if (packageLookup.TryGetValue (package, out var mappers)) {
-				foreach (Converter<string, Type?> c in mappers) {
-					type = c (class_name);
-					if (type == null)
-						continue;
-					return type;
-				}
-			}
-			if ((type = Type.GetType (JavaNativeTypeManager.ToCliType (class_name))) != null) {
-				return type;
-			}
 			return null;
 		}
 
@@ -353,36 +333,14 @@ namespace Java.Interop {
 			}
 		}
 
-		static Dictionary<string, List<Converter<string, Type?>>> packageLookup = new Dictionary<string, List<Converter<string, Type?>>> ();
-
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)
 		{
-			lock (packageLookup) {
-				if (!packageLookup.TryGetValue (package, out var lookups))
-					packageLookup.Add (package, lookups = new List<Converter<string, Type?>> ());
-				lookups.Add (lookup);
-			}
+			throw new NotImplementedException ();
 		}
 
 		public static void RegisterPackages (string[] packages, Converter<string, Type?>[] lookups)
 		{
-			if (packages == null)
-				throw new ArgumentNullException ("packages");
-			if (lookups == null)
-				throw new ArgumentNullException ("lookups");
-			if (packages.Length != lookups.Length)
-				throw new ArgumentException ("`packages` and `lookups` arrays must have same number of elements.");
-
-			lock (packageLookup) {
-				for (int i = 0; i < packages.Length; ++i) {
-					string package                  = packages [i];
-					var lookup			= lookups [i];
-
-					if (!packageLookup.TryGetValue (package, out var _lookups))
-						packageLookup.Add (package, _lookups = new List<Converter<string, Type?>> ());
-					_lookups.Add (lookup);
-				}
-			}
+			throw new NotImplementedException ();
 		}
 
 		[Register ("mono/android/TypeManager", DoNotGenerateAcw = true)]

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -120,7 +120,11 @@
   <Import Project="..\..\build-tools\scripts\JavaCallableWrappers.targets" />
   <Import Project="$(IntermediateOutputPath)mcw\Mono.Android.projitems" Condition="Exists('$(IntermediateOutputPath)mcw\Mono.Android.projitems')" />
 
-<ItemGroup>
+  <ItemGroup>
+      <Compile Remove="$(IntermediateOutputPath)mcw\Java.Interop.__TypeRegistrations.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Android\IncludeAndroidResourcesFromAttribute.cs" />
     <Compile Include="Android\LinkerSafeAttribute.cs" />
     <Compile Include="Android\NativeLibraryReferenceAttribute.cs" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -167,7 +167,7 @@
         IgnoreStandardErrorWarningFormat="True"
     />
     <ItemGroup>
-      <Compile Include="$(_FullIntermediateOutputPath)\mcw\**\*.cs" KeepDuplicates="False" />
+      <Compile Include="$(_FullIntermediateOutputPath)\mcw\**\*.cs" KeepDuplicates="False" Exclude="$(_FullIntermediateOutputPath)\mcw\Java.Interop.__TypeRegistrations.cs" />
     </ItemGroup>
     <XmlPeek
         Namespaces="&lt;Namespace Prefix='msbuild' Uri='http://schemas.microsoft.com/developer/msbuild/2003' /&gt;"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5515

All the java to managed type names lookup is now handled by typemap,
so we should not need this fallback anymore.

This results in another nice apk size decrease.

apk size difference in BuildReleaseArm64False/net6 test:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -         198 assemblies/System.Private.CoreLib.dll
      -      21,679 assemblies/Mono.Android.dll
    Summary:
      -      21,877 Assemblies -3.03% (of 721,731)
      -     123,392 Uncompressed assemblies -8.24% (of 1,497,088)