### PR TITLE
[ci] Set demand for macOS Mojave build machines

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -39,6 +39,8 @@ stages:
     displayName: Mac Build
     pool:
       name: $(XA.Build.MacOSSPool)
+      demands:
+      - agent.osversionfamily -equals 10.14
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -124,7 +124,10 @@ stages:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
     displayName: Build
-    pool: $(MacMojaveBuildPool)
+    pool:
+      name: $(MacMojaveBuildPool)
+      demands:
+      - agent.osversionfamily -equals 10.14
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1159,7 +1162,10 @@ stages:
   # Check - "Xamarin.Android (Finalize Installers Notarize and Upload to Storage)"
   - job: notarize_pkg_upload_storage
     displayName: Notarize and Upload to Storage
-    pool: $(MacMojaveBuildPool)
+    pool:
+      name: $(MacMojaveBuildPool)
+      demands:
+      - agent.osversionfamily -equals 10.14
     timeoutInMinutes: 90
     cancelTimeoutInMinutes: 1
     workspace:


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5589

We are working on upgrading our macOS build machines to macOS Catalina,
and in certain cases we'd like to continue to use an existing agent pool
rather than creating and authorizing a new one.  In those cases, the
existing pool will be updated to contain both Mojave and Catalina
machines.  We can make sure to always pick a Mojave machine by setting
a demand for the relevant system [capability][0] that any given
[machine may have][1].

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=browser#capabilities
[1]: https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?agentId=688191&queueId=2206&view=capabilities