### PR TITLE
[xabuild] fix dependencies from decompress-assemblies

### DIFF
--- a/tools/decompress-assemblies/decompress-assemblies.csproj
+++ b/tools/decompress-assemblies/decompress-assemblies.csproj
@@ -17,6 +17,8 @@
   <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="$(LZ4PackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4445246&view=logs&j=cac0e8d3-0ef5-5d2b-b57e-e8fde7204df3&t=31862389-0152-5a37-13be-1c23abc1cf4f&l=18
Context: https://weblog.west-wind.com/posts/2019/Apr/30/NET-Core-30-SDK-Projects-Controlling-Output-Folders-and-Content

The `Windows Build & Smoke Test` phase is currently failing with:

    bin\Release\bin\xabuild.exe Xamarin.Android-Tests.sln /restore /p:Configuration=Release /bl:C:\a\1\s\bin\TestRelease\msbuild-build-tests.binlog
    ...
    Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.
    C:\a\1\s\bin\Release\bin\bin\Release\bin\xabuild.exe /bl:C:\a\1\s\bin\TestRelease\msbuild-build-tests.binlog /p:Configuration=Release /restore Xamarin.Android-Tests.sln
    Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
    MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
    System.IO.FileLoadException: Could not load file or assembly 'System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
    File name: 'System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
        at Microsoft.Build.Evaluation.Expander`2.Function`1.ExtractPropertyFunction(String expressionFunction, IElementLocation elementLocation, Object propertyValue, UsedUninitializedProperties usedUnInitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertyBody(String propertyBody, Object propertyValue, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveTypedAndEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem)
        at Microsoft.Build.Evaluation.Expander`2.ExpandIntoStringLeaveEscaped(String expression, ExpanderOptions options, IElementLocation elementLocation)
        at Microsoft.Build.Evaluation.ToolsetReader.ExpandPropertyUnescaped(ToolsetPropertyDefinition property, Expander`2 expander)
        at Microsoft.Build.Evaluation.ToolsetReader.EvaluateAndSetProperty(ToolsetPropertyDefinition property, PropertyDictionary`1 properties, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& toolsPath, String& binPath, Expander`2& expander)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadToolset(ToolsetPropertyDefinition toolsVersion, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadEachToolset(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadToolsets(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& msBuildOverrideTasksPath, String& defaultOverrideToolsVersion)
        at Microsoft.Build.Evaluation.ToolsetReader.ReadAllToolsets(Dictionary`2 toolsets, ToolsetRegistryReader registryReader, ToolsetConfigurationReader configurationReader, PropertyDictionary`1 environmentProperties, PropertyDictionary`1 globalProperties, ToolsetDefinitionLocations locations)
        at Microsoft.Build.Evaluation.ProjectCollection.InitializeToolsetCollection(ToolsetRegistryReader registryReader, ToolsetConfigurationReader configReader)
        at Microsoft.Build.Evaluation.ProjectCollection..ctor(IDictionary`2 globalProperties, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, Int32 maxNodeCount, Boolean onlyLogCriticalEvents, Boolean loadProjectsReadOnly)
        at Microsoft.Build.CommandLine.MSBuildApp.BuildProject(String projectFile, String[] targets, String toolsVersion, Dictionary`2 globalProperties, Dictionary`2 restoreProperties, ILogger[] loggers, LoggerVerbosity verbosity, DistributedLoggerRecord[] distributedLoggerRecords, Boolean needToValidateProject, String schemaFile, Int32 cpuCount, Boolean enableNodeReuse, TextWriter preprocessWriter, TextWriter targetsWriter, Boolean detailedSummary, ISet`1 warningsAsErrors, ISet`1 warningsAsMessages, Boolean enableRestore, ProfilerLogger profilerLogger, Boolean enableProfiler, Boolean interactive, Boolean isolateProjects, Boolean graphBuild, Boolean lowPriority, String[] inputResultsCaches, String outputResultsCache)
        at Microsoft.Build.CommandLine.MSBuildApp.Execute(String commandLine)

This broke in 8bde758f, when I migrated `xabuild.csproj` to a
short-form MSBuild project.

What is weird is the PR build *worked*, with the same MSBuild version:

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4441935&view=logs&j=cac0e8d3-0ef5-5d2b-b57e-e8fde7204df3&t=31862389-0152-5a37-13be-1c23abc1cf4f&l=18

    bin\Release\bin\xabuild.exe Xamarin.Android-Tests.sln /restore /p:Configuration=Release /bl:C:\a\1\s\bin\TestRelease\msbuild-build-tests.binlog
    ...
    Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.
    C:\a\1\s\bin\Release\bin\bin\Release\bin\xabuild.exe /bl:C:\a\1\s\bin\TestRelease\msbuild-build-tests.binlog /p:Configuration=Release /restore Xamarin.Android-Tests.sln
    ...
    Build started 2/4/2021 9:22:53 PM.
        172 Warning(s)
        0 Error(s)
    Time Elapsed 00:04:23.01

I tested locally, and I could reproduce the problem simply deleting
the output of `xabuild.csproj` and building it again:

    > rm -r .\bin\Debug\bin
    ...
    > msbuild Xamarin.Android.sln
    ...
    > .\bin\Debug\bin\xabuild .\samples\HelloWorld\HelloWorld.csproj
    MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
    System.IO.FileLoadException: Could not load file or assembly 'System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)

But if I built `xabuild.csproj` by itself (instead of
`Xamarin.Android.sln`), it worked!

Then I noticed the new `decompress-assemblies` tool has its output in
`bin\Debug\bin`. The `Xamarin.LibZipSharp` PackageReference is
bringing in different versions of `System.Memory` (and others).

Adding two `@(PackageReference)` to match `xabuild.csproj` solves the
issue:

    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />

This also explains why PR #5594 worked, because the
`decompress-assemblies` tool wasn't merged yet.