### PR TITLE
Bump JI

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -88,7 +88,6 @@ namespace Xamarin.Android.Build.Tests
 					"Mono.Android.dll",
 					"System.Console.dll",
 					"System.Private.CoreLib.dll",
-					"System.Collections.Concurrent.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",
 				} :

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -410,10 +410,8 @@ namespace Xamarin.Android.Build.Tests
 					apk.AssertContainsEntry (apkPath, $"lib/{abi}/libmonosgen-2.0.so");
 					if (rids.Length > 1) {
 						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
-						apk.AssertContainsEntry (apkPath, $"assemblies/{abi}/System.Collections.Concurrent.dll", shouldContainEntry: expectEmbeddedAssembies);
 					} else {
 						apk.AssertContainsEntry (apkPath, "assemblies/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
-						apk.AssertContainsEntry (apkPath, "assemblies/System.Collections.Concurrent.dll", shouldContainEntry: expectEmbeddedAssembies);
 					}
 				}
 			}


### PR DESCRIPTION
Bump JI to get `ee7b6bb    [Java.Interop] Use lock+Dictionary, not ConcurrentDictionary (#791)`

Changes https://github.com/xamarin/java.interop/compare/cba613703e100e99ba005344da60d51448ecaf2a...ee7b6bbe382bf408cc1a991e6149819889ad8c6c?diff=unified

* xamarin/java.interop@52082e2    Remove Java.Interop.NamingCustomAttributes.shproj. (#787) 
* xamarin/java.interop@ee7b6bb    [Java.Interop] Use lock+Dictionary, not ConcurrentDictionary (#791)

apk size difference in BuildReleaseArm64False/net6 test:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      +          22 assemblies/Java.Interop.dll
      -         316 assemblies/System.Private.CoreLib.dll
      -         702 assemblies/System.Linq.dll
      -       8,471 assemblies/System.Collections.Concurrent.dll *1
    Summary:
      -       9,467 Assemblies -1.32% (of 719,277)
      -      15,872 Uncompressed assemblies -1.06% (of 1,491,456) 

Update `CheckIncludedAssemblies` test.