### PR TITLE
[NRefactory] Switch to Xamarin fork that contains SDK style csproj.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
     branch = master
 [submodule "external/nrefactory"]
     path = external/nrefactory
-    url = https://github.com/icsharpcode/NRefactory.git
+    url = https://github.com/xamarin/NRefactory.git
     branch = master
 [submodule "external/opentk"]
     path = external/opentk


### PR DESCRIPTION
In order to target .NET 5/6 we need to build with `dotnet build`, which requires SDK style projects.

One set of `csproj` files that need to be updated is NRefactory.  The unit tests in Xamarin.Android use these assemblies along with the Mono debugging assemblies to ensure that changes do not break the ability to debug XA applications.

The "official" NRefactory repository that we currently use has been archived.  However, there already exists a Xamarin fork that the VSMac team uses.  The relevant project files we need in that repo have been converted to SDK style, so we simply need to point our git submodule to that fork.
