### PR TITLE
[net6] Bump DotNetPreview version to 6.0.100-preview.1.21109.8

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -76,7 +76,7 @@
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.1.21103.13</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.1.21109.8</DotNetPreviewVersionFull>
     <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>
     <ILLinkVersionFull Condition=" '$(ILLinkVersionFull)' == '' ">$(ILLinkVersionBand)-alpha.1.21109.1</ILLinkVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -51,6 +51,9 @@ namespace Microsoft.Android.Sdk.ILLink
 			InsertAfter (subSteps1, "SetupStep");
 
 			// temporary workaround: this call forces illink to process all the assemblies
+			if (getReferencedAssembliesMethod == null)
+				throw new InvalidOperationException ($"Temporary linker workaround failed, {nameof (getReferencedAssembliesMethod)} is null.");
+
 			foreach (var assembly in (IEnumerable<AssemblyDefinition>)getReferencedAssembliesMethod.Invoke (Context, null))
 				Context.LogMessage ($"Reference assembly to process: {assembly}");
 

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Android.Sdk.ILLink
 			subSteps2.Add (new PreserveRegistrations (cache));
 			subSteps2.Add (new PreserveJavaInterfaces ());
 
-			InsertAfter (new FixAbstractMethodsStep (cache), "RemoveUnreachableBlocksStep");
-			InsertAfter (subSteps2, "RemoveUnreachableBlocksStep");
-			InsertAfter (subSteps1, "RemoveUnreachableBlocksStep");
+			InsertAfter (new FixAbstractMethodsStep (cache), "SetupStep");
+			InsertAfter (subSteps2, "SetupStep");
+			InsertAfter (subSteps1, "SetupStep");
 
 			string proguardPath;
 			if (Context.TryGetCustomData ("ProguardConfiguration", out proguardPath))

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Java.Interop.Tools.Cecil;
+using Mono.Cecil;
 using Mono.Linker;
 using Mono.Linker.Steps;
 using Mono.Tuner;
@@ -50,7 +51,8 @@ namespace Microsoft.Android.Sdk.ILLink
 			InsertAfter (subSteps1, "SetupStep");
 
 			// temporary workaround: this call forces illink to process all the assemblies
-			getReferencedAssembliesMethod.Invoke (Context, null);
+			foreach (var assembly in (IEnumerable<AssemblyDefinition>)getReferencedAssembliesMethod.Invoke (Context, null))
+				Context.LogMessage ($"Reference assembly to process: {assembly}");
 
 			string proguardPath;
 			if (Context.TryGetCustomData ("ProguardConfiguration", out proguardPath))

--- a/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/SetupStep.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Java.Interop.Tools.Cecil;
-using Mono.Cecil;
 using Mono.Linker;
 using Mono.Linker.Steps;
 using Mono.Tuner;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -72,7 +72,7 @@ This file contains the .NET 5-specific targets to customize ILLink
     <ItemGroup>
       <!-- add our custom steps -->
       <_TrimmerCustomSteps Include="$(MSBuildThisFileDirectory)..\tools\Microsoft.Android.Sdk.ILLink.dll">
-        <BeforeStep>LoadReferencesStep</BeforeStep>
+        <BeforeStep>MarkStep</BeforeStep>
         <Type>Microsoft.Android.Sdk.ILLink.SetupStep</Type>
       </_TrimmerCustomSteps>
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -26,25 +26,25 @@
       "Size": 1724
     },
     "classes.dex": {
-      "Size": 316988
+      "Size": 316876
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 2959
     },
     "assemblies/System.Console.dll": {
-      "Size": 6214
+      "Size": 6202
     },
     "assemblies/System.Linq.dll": {
-      "Size": 15127
+      "Size": 15122
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 516700
+      "Size": 513489
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 63117
+      "Size": 63151
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 86318
+      "Size": 86291
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -59,16 +59,16 @@
       "Size": 100464
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3831000
+      "Size": 3796008
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 250136
+      "Size": 247312
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 65480
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 31672
+      "Size": 37408
     },
     "META-INF/ANDROIDD.SF": {
       "Size": 2512
@@ -80,5 +80,5 @@
       "Size": 2385
     }
   },
-  "PackageSize": 2938815
+  "PackageSize": 2926527
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -26,22 +26,22 @@
       "Size": 1724
     },
     "classes.dex": {
-      "Size": 316956
+      "Size": 316848
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2862
+      "Size": 2863
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 75153
+      "Size": 75279
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 264429
+      "Size": 264424
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769824
+      "Size": 769789
     },
     "assemblies/System.Core.dll": {
-      "Size": 28190
+      "Size": 28191
     },
     "assemblies/System.dll": {
       "Size": 12986
@@ -50,7 +50,7 @@
       "Size": 68560
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 250696
+      "Size": 247872
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 65184

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1631,7 +1631,7 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3454992
+      "Size": 3454884
     },
     "assemblies/Microsoft.Win32.SystemEvents.dll": {
       "Size": 8713
@@ -1658,7 +1658,7 @@
       "Size": 4385
     },
     "assemblies/System.Security.Permissions.dll": {
-      "Size": 40093
+      "Size": 40080
     },
     "assemblies/System.Threading.AccessControl.dll": {
       "Size": 8293
@@ -1739,175 +1739,175 @@
       "Size": 117066
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 4160
+      "Size": 4156
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12122
+      "Size": 12119
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 10977
+      "Size": 10971
     },
     "assemblies/System.Collections.Specialized.dll": {
       "Size": 12569
     },
     "assemblies/System.Collections.dll": {
-      "Size": 24343
+      "Size": 22926
     },
     "assemblies/System.ComponentModel.EventBasedAsync.dll": {
-      "Size": 2536
+      "Size": 2529
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 8563
+      "Size": 7878
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 50368
+      "Size": 55452
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2571
+      "Size": 2565
     },
     "assemblies/System.Console.dll": {
-      "Size": 6707
+      "Size": 6701
     },
     "assemblies/System.Data.Common.dll": {
-      "Size": 2467
+      "Size": 2460
     },
     "assemblies/System.Diagnostics.Process.dll": {
-      "Size": 36909
+      "Size": 36726
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 12901
+      "Size": 11286
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 19930
+      "Size": 20248
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 26896
+      "Size": 26895
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12337
+      "Size": 12332
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19824
+      "Size": 19829
     },
     "assemblies/System.IO.FileSystem.dll": {
-      "Size": 29075
+      "Size": 29073
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11728
+      "Size": 11722
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 116584
+      "Size": 177866
     },
     "assemblies/System.Linq.dll": {
-      "Size": 31706
+      "Size": 31736
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 217145
+      "Size": 216085
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 10956
+      "Size": 10951
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18297
+      "Size": 18292
     },
     "assemblies/System.Net.Primitives.dll": {
       "Size": 44263
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37753
+      "Size": 37526
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 51094
+      "Size": 52250
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 68057
+      "Size": 67914
     },
     "assemblies/System.Net.ServicePoint.dll": {
-      "Size": 3270
+      "Size": 3265
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 63988
+      "Size": 64436
     },
     "assemblies/System.Net.WebClient.dll": {
-      "Size": 8019
+      "Size": 7947
     },
     "assemblies/System.Net.WebHeaderCollection.dll": {
-      "Size": 6367
+      "Size": 6363
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12904
+      "Size": 12327
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 217493
+      "Size": 206497
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42358
+      "Size": 42428
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 17359
+      "Size": 16028
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 585318
+      "Size": 500538
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1726
+      "Size": 1728
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 4291
+      "Size": 4333
     },
     "assemblies/System.Runtime.Numerics.dll": {
       "Size": 22482
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 4161
+      "Size": 4156
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4506
+      "Size": 4307
     },
     "assemblies/System.Security.AccessControl.dll": {
-      "Size": 4625
+      "Size": 4618
     },
     "assemblies/System.Security.Claims.dll": {
-      "Size": 8233
+      "Size": 8223
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40772
+      "Size": 40795
     },
     "assemblies/System.Security.Cryptography.Csp.dll": {
-      "Size": 2645
+      "Size": 5340
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12659
+      "Size": 12665
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
-      "Size": 15254
+      "Size": 15248
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9744
+      "Size": 9735
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 93563
+      "Size": 93658
     },
     "assemblies/System.Security.Principal.Windows.dll": {
-      "Size": 3219
+      "Size": 4993
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 81316
+      "Size": 81308
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 14665
+      "Size": 14663
     },
     "assemblies/System.Threading.dll": {
-      "Size": 6646
+      "Size": 6643
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 726683
+      "Size": 728128
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 71614
+      "Size": 71652
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 453799
+      "Size": 453637
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
@@ -1922,16 +1922,16 @@
       "Size": 100464
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3831000
+      "Size": 3796008
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 250136
+      "Size": 247312
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 65480
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 31672
+      "Size": 37408
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -2057,5 +2057,5 @@
       "Size": 82480
     }
   },
-  "PackageSize": 9964823
+  "PackageSize": 9927959
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -1631,64 +1631,64 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3454376
+      "Size": 3454264
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 116877
+      "Size": 116878
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7210
+      "Size": 7211
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 7693
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6643
+      "Size": 6644
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
       "Size": 125331
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7360
+      "Size": 7361
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
       "Size": 18268
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131927
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
       "Size": 15425
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43131
+      "Size": 43133
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
       "Size": 6712
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7058
+      "Size": 7059
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7184
+      "Size": 7190
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
       "Size": 4865
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13583
+      "Size": 13582
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102326
+      "Size": 102327
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6270
+      "Size": 6269
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11269
+      "Size": 11265
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19418
+      "Size": 19420
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 524733
@@ -1700,7 +1700,7 @@
       "Size": 56878
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55798
+      "Size": 55799
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
       "Size": 43494
@@ -1709,43 +1709,43 @@
       "Size": 110638
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 186659
+      "Size": 186658
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 76345
+      "Size": 76477
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 588526
+      "Size": 588522
     },
     "assemblies/mscorlib.dll": {
-      "Size": 915442
+      "Size": 915451
     },
     "assemblies/System.Core.dll": {
       "Size": 164046
     },
     "assemblies/System.dll": {
-      "Size": 389382
+      "Size": 389383
     },
     "assemblies/System.Xml.dll": {
-      "Size": 395688
+      "Size": 395689
     },
     "assemblies/System.Numerics.dll": {
       "Size": 15685
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 12359
+      "Size": 12360
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26590
+      "Size": 26591
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68486
+      "Size": 68487
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 139944
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 250696
+      "Size": 247872
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 65184

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -47,6 +47,8 @@
       <ApkSizesResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>
     </TestApk>
     <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0-preview.1.21102.12" />
   </ItemGroup>
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -50,4 +50,6 @@
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />
 
+  <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12"/>
+
 </Project>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -50,6 +50,6 @@
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />
 
-  <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12"/>
+  <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
 
 </Project>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -46,10 +46,9 @@
       <ApkSizesDefinitionFilename>$(XamarinAndroidSourcePath)build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>
     </TestApk>
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
   </ItemGroup>
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />
-
-  <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
 
 </Project>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -46,9 +46,14 @@
       <ApkSizesDefinitionFilename>$(XamarinAndroidSourcePath)build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>
     </TestApk>
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0-preview.1.21102.12" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.IO.Ports" Version="6.0.0-preview.1.21102.12" />
     <PackageReference Include="System.Security.Permissions" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="System.Threading.AccessControl" Version="6.0.0-preview.1.21102.12" />
   </ItemGroup>
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />


### PR DESCRIPTION
Bump `DotNetPreview` version to `6.0.100-preview.1.21109.8`

Add linker reflection based workaround, till
the [new API](https://github.com/mono/linker/pull/1774) is ready to use.
It forces the `ILLink` to process all the referenced assemblies in our steps,
without it, no assemblies are processed before `MarkStep`.

Updated apk size reference files. The NET6 linker has more optimizations
enabled, assembly sizes decreased about 0.5% and native shared libraries
are smaller as well - about 0.7%.

Comparison of `BuildReleaseArm64` apk test sizes before/after
```
Simple XA NET6

Summary:
  +           0 Other entries 0.00% (of 52,514)
  +           0 Dalvik executables 0.00% (of 316,876)
  -       3,237 Assemblies -0.47% (of 690,451)
  -      34,992 Shared libraries -0.67% (of 5,202,312)
  -       7,680 Uncompressed assemblies -0.57% (of 1,357,824)
  -      10,670 Package size difference -0.36% (of 2,927,336)

XForms XA NET6

Summary:
  +           0 Other entries 0.00% (of 750,947)
  +           0 Dalvik executables 0.00% (of 3,454,884)
  -      29,117 Assemblies -0.51% (of 5,696,363)
  -      34,992 Shared libraries -0.66% (of 5,277,504)
  -      66,048 Uncompressed assemblies -0.51% (of 12,839,424)
  -      36,556 Package size difference -0.37% (of 9,899,330)

Simple XA legacy monodroid

Summary:
  +           0 Other entries 0.00% (of 52,485)
  +           0 Dalvik executables 0.00% (of 316,848)
  +           1 Assemblies 0.00% (of 1,153,531)
  +           0 Shared libraries 0.00% (of 10,510,880)
  +           0 Uncompressed assemblies 0.00% (of 2,765,312)
  -         116 Package size difference -0.00% (of 5,001,423)

XForms XA legacy monodroid

Summary:
  +           0 Other entries 0.00% (of 750,918)
  +           0 Dalvik executables 0.00% (of 3,454,264)
  -           2 Assemblies -0.00% (of 4,674,321)
  +           0 Shared libraries 0.00% (of 10,582,264)
  +           0 Uncompressed assemblies 0.00% (of 11,293,696)
  -          12 Package size difference -0.00% (of 10,476,653)
```