### PR TITLE
[illink] Set LinkAttributes logical name

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -94,8 +94,9 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
-
-    <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml" />
+    <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml">
+      <LogicalName>ILLink.LinkAttributes.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/mono/linker/blob/main/docs/data-formats.md#custom-attributes-annotations-format

Change the logical name of attributes embedded resource to
`ILLink.LinkAttributes.xml` instead of current
`Android.ILLink.ILLink.LinkAttributes.xml`
