### PR TITLE
[ci] Use NugetAuthenicate for commercial builds

### DIFF
--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -15,6 +15,11 @@ steps:
   parameters:
     version: $(DotNetCoreVersion)
 
+- task: NuGetAuthenticate@0
+  displayName: authenticate with azure artifacts
+  inputs:
+    forceReinstallCredentialProvider: true
+
 - template: install-certificates.yml@yaml
   parameters:
     DeveloperIdApplication: $(developer-id-application)


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=4463506&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=65256bb7-a34c-5353-bc4d-c02ee25dc133&l=17445

Xamarin.Android pipeline builds have been failing during android-sdk-installer
NuGet restore attempts.  I am not yet sure why PR builds haven't been failing
in the same way, but this should hopefully fix the issue.