### PR TITLE
[One .NET] drop the .21 from android RIDs

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -96,7 +96,7 @@ Instead use .NET's concept of [runtime identifiers][rids]:
 ```xml
 <PropertyGroup>
   <!-- Used going forward in .NET -->
-  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+  <RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 </PropertyGroup>
 ```
 

--- a/Documentation/guides/messages/xa0035.md
+++ b/Documentation/guides/messages/xa0035.md
@@ -20,7 +20,7 @@ property are valid:
 
 ```xml
 <PropertyGroup>
-  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+  <RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 </PropertyGroup>
 ```
 

--- a/Documentation/guides/messages/xa0036.md
+++ b/Documentation/guides/messages/xa0036.md
@@ -18,7 +18,7 @@ another text editor and remove `<AndroidSupportedAbis/>`. Use the
 
 ```xml
 <PropertyGroup>
-  <RuntimeIdentifiers>android.21-arm;android.21-arm64;android.21-x86;android.21-x64</RuntimeIdentifiers>
+  <RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 </PropertyGroup>
 ```
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -77,10 +77,10 @@
   <Target Name="CreateAllPacks"
       DependsOnTargets="BuildILLinkCustomStep;DeleteExtractedWorkloadPacks;_SetGlobalProperties">
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android.21-arm -p:AndroidABI=armeabi-v7a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android.21-arm64 -p:AndroidABI=arm64-v8a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android.21-x86 -p:AndroidABI=x86 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android.21-x64 -p:AndroidABI=x86_64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=linux-x64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=osx-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Darwin' " />

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -10,7 +10,7 @@ projects that use the Microsoft.Android framework in .NET 5.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <AndroidRID Condition=" '$(AndroidRID)' == '' ">android.21-arm64</AndroidRID>
+    <AndroidRID Condition=" '$(AndroidRID)' == '' ">android-arm64</AndroidRID>
     <AndroidABI Condition=" '$(AndroidABI)' == '' ">arm64-v8a</AndroidABI>
     <PackageId>Microsoft.Android.Runtime.$(AndroidRID)</PackageId>
     <Description>Microsoft.Android runtime components. Please do not reference directly.</Description>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -84,7 +84,7 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidNETAppRuntimePackRids Include="android.21-arm;android.21-arm64;android.21-x86;android.21-x64" />
+      <_AndroidNETAppRuntimePackRids Include="android-arm;android-arm64;android-x86;android-x64" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -55,7 +55,7 @@
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
-    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android.21-arm64;android.21-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x86</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">AndroidManifest.xml</AndroidManifest>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Build.Tests
 		public static string GetLinkedPath (ProjectBuilder builder, bool isRelease, string filename)
 		{
 			return Builder.UseDotNet && isRelease ?
-				builder.Output.GetIntermediaryPath (Path.Combine ("android.21-arm64", "linked", filename)) :
+				builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "linked", filename)) :
 				builder.Output.GetIntermediaryPath (Path.Combine ("android", "assets", filename));
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1370,7 +1370,7 @@ namespace Lib2
 				b.Build (proj);
 
 				var parameters = Builder.UseDotNet ?
-					new [] { $"{KnownProperties.RuntimeIdentifier}=android.21-x86" } :
+					new [] { $"{KnownProperties.RuntimeIdentifier}=android-x86" } :
 					new [] { $"{KnownProperties.AndroidSupportedAbis}=x86" };
 				b.Build (proj, parameters: parameters, doNotCleanupOnUpdate: true);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -300,35 +300,35 @@ namespace Xamarin.Android.Build.Tests
 
 		static readonly object [] DotNetBuildSource = new object [] {
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm",
+				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          false,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm64",
+				/* runtimeIdentifiers */ "android-arm64",
 				/* isRelease */          false,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-x86",
+				/* runtimeIdentifiers */ "android-x86",
 				/* isRelease */          false,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-x64",
+				/* runtimeIdentifiers */ "android-x64",
 				/* isRelease */          false,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm",
+				/* runtimeIdentifiers */ "android-arm",
 				/* isRelease */          true,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm;android.21-arm64;android.21-x86;android.21-x64",
+				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          false,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm;android.21-arm64;android.21-x86",
+				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86",
 				/* isRelease */          true,
 			},
 			new object [] {
-				/* runtimeIdentifiers */ "android.21-arm;android.21-arm64;android.21-x86;android.21-x64",
+				/* runtimeIdentifiers */ "android-arm;android-arm64;android-x86;android-x64",
 				/* isRelease */          true,
 			},
 		};
@@ -430,7 +430,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void DotNetPublish ([Values (false, true)] bool isRelease)
 		{
-			const string runtimeIdentifier = "android.21-arm";
+			const string runtimeIdentifier = "android-arm";
 			var proj = new XASdkProject {
 				IsRelease = isRelease
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -32,13 +32,13 @@ namespace Xamarin.ProjectTools
 		public static void SetRuntimeIdentifier (this IShortFormProject project, string androidAbi)
 		{
 			if (androidAbi == "armeabi-v7a") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm");
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-arm");
 			} else if (androidAbi == "arm64-v8a") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-arm64");
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-arm64");
 			} else if (androidAbi == "x86") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x86");
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-x86");
 			} else if (androidAbi == "x86_64") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android.21-x64");
+				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-x64");
 			}
 		}
 
@@ -47,13 +47,13 @@ namespace Xamarin.ProjectTools
 			var abis = new List<string> ();
 			foreach (var androidAbi in androidAbis) {
 				if (androidAbi == "armeabi-v7a") {
-					abis.Add ("android.21-arm");
+					abis.Add ("android-arm");
 				} else if (androidAbi == "arm64-v8a") {
-					abis.Add ("android.21-arm64");
+					abis.Add ("android-arm64");
 				} else if (androidAbi == "x86") {
-					abis.Add ("android.21-x86");
+					abis.Add ("android-x86");
 				} else if (androidAbi == "x86_64") {
-					abis.Add ("android.21-x64");
+					abis.Add ("android-x64");
 				}
 			}
 			project.SetProperty (KnownProperties.RuntimeIdentifiers, string.Join (";", abis));


### PR DESCRIPTION
When looking at the .NET runtime packs for iOS/Android:

    Microsoft.Android.Runtime.android.21-arm
    Microsoft.Android.Runtime.android.21-arm64
    Microsoft.Android.Runtime.android.21-x86
    Microsoft.Android.Runtime.android.21-x64
    Microsoft.iOS.Runtime.ios-arm
    Microsoft.iOS.Runtime.ios-arm64
    Microsoft.iOS.Runtime.ios-x86
    Microsoft.iOS.Runtime.ios-x64
    Microsoft.NETCore.App.Runtime.android-arm
    Microsoft.NETCore.App.Runtime.android-arm64
    Microsoft.NETCore.App.Runtime.android-x86
    Microsoft.NETCore.App.Runtime.android-x64
    Microsoft.NETCore.App.Runtime.ios-arm
    Microsoft.NETCore.App.Runtime.ios-arm64
    Microsoft.NETCore.App.Runtime.ios-x86
    Microsoft.NETCore.App.Runtime.ios-x64

It seems like we should not be putting the `.21` in the names of our
Android runtime packs.

In fact, this command does not work currently:

    > dotnet build HelloAndroid -r android-arm64
    ...
    Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(389,5): error NETSDK1082:
    There was no runtime pack for Microsoft.Android available for the specified RuntimeIdentifier 'android-arm64'.

For the above command to work, we need to drop the `.21` from our
runtime pack names.

This repo appears to be the only place `.21` is hardcoded. The code in
`xamarin-android-tools` looks like it will continue to work:

https://github.com/xamarin/xamarin-android-tools/blob/479931ce1449b39c0165315fc103e7e12812f34b/src/Microsoft.Android.Build.BaseTasks/AndroidRidAbiHelper.cs#L74-L91

After these changes, any of the following commands work:

    > dotnet build HelloAndroid -r android-arm64
    > dotnet build HelloAndroid -r android.21-arm64
    # Or any API level in between
    > dotnet build HelloAndroid -r android.30-arm64