### PR TITLE
[illink] Type registrations fallback switch

### DIFF
--- a/src/Mono.Android/ILLink/ILLink.Substitutions.xml
+++ b/src/Mono.Android/ILLink/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="Mono.Android">
+    <type fullname="Java.Interop.TypeManager" feature="Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled" featurevalue="false">
+      <method signature="System.Boolean get_TypeRegistrationFallbackIsEnabled()" body="stub" value="false" />
+      <method signature="System.Type TypeRegistrationFallback()" body="stub" value="null" />
+      <method signature="System.Void RegisterPackage(System.String,System.Converter`2&lt;System.String,System.Type&gt;)" body="stub" />
+      <method signature="System.Void RegisterPackages(System.String[],System.Converter`2&lt;System.String,System.Type&gt;[])" body="stub" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -212,9 +212,9 @@ namespace Java.Interop {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		static extern Type monodroid_typemap_java_to_managed (string java_type_name);
 
-		private static bool TypeRegistrationFallbackIsEnabled { get; } = InitializeTypeRegistrationFallbackIsEnabled ();
-		private static bool InitializeTypeRegistrationFallbackIsEnabled () =>
-		    AppContext.TryGetSwitch ("Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled", out bool isEnabled) ? isEnabled : true;
+		static bool TypeRegistrationFallbackIsEnabled { get; } = InitializeTypeRegistrationFallbackIsEnabled ();
+		static bool InitializeTypeRegistrationFallbackIsEnabled () =>
+		    !AppContext.TryGetSwitch ("Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled", out bool isEnabled) || isEnabled;
 
 		internal static Type? GetJavaToManagedType (string class_name)
 		{
@@ -370,7 +370,7 @@ namespace Java.Interop {
 		static void LazyInitPackageLookup ()
 		{
 			if (packageLookup == null)
-				packageLookup = new Dictionary<string, List<Converter<string, Type?>>> ();
+				packageLookup = new Dictionary<string, List<Converter<string, Type?>>> (StringComparer.Ordinal);
 		}
 
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -212,6 +212,10 @@ namespace Java.Interop {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		static extern Type monodroid_typemap_java_to_managed (string java_type_name);
 
+		private static bool TypeRegistrationFallbackIsEnabled { get; } = InitializeTypeRegistrationFallbackIsEnabled ();
+		private static bool InitializeTypeRegistrationFallbackIsEnabled () =>
+		    AppContext.TryGetSwitch ("Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled", out bool isEnabled) ? isEnabled : true;
+
 		internal static Type? GetJavaToManagedType (string class_name)
 		{
 			Type? type = monodroid_typemap_java_to_managed (class_name);
@@ -225,10 +229,18 @@ namespace Java.Interop {
 				return null;
 			}
 
+			if (TypeRegistrationFallbackIsEnabled)
+				return TypeRegistrationFallback (class_name);
+
+			return null;
+		}
+
+		internal static Type? TypeRegistrationFallback (string class_name)
+		{
 			__TypeRegistrations.RegisterPackages ();
 
-			type = null;
-			int ls      = class_name.LastIndexOf ('/');
+			Type? type = null;
+			int ls = class_name.LastIndexOf ('/');
 			var package = ls >= 0 ? class_name.Substring (0, ls) : "";
 			if (packageLookup.TryGetValue (package, out var mappers)) {
 				foreach (Converter<string, Type?> c in mappers) {
@@ -353,10 +365,18 @@ namespace Java.Interop {
 			}
 		}
 
-		static Dictionary<string, List<Converter<string, Type?>>> packageLookup = new Dictionary<string, List<Converter<string, Type?>>> ();
+		static Dictionary<string, List<Converter<string, Type?>>>? packageLookup;
+
+		static void LazyInitPackageLookup ()
+		{
+			if (packageLookup == null)
+				packageLookup = new Dictionary<string, List<Converter<string, Type?>>> ();
+		}
 
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)
 		{
+			LazyInitPackageLookup ();
+
 			lock (packageLookup) {
 				if (!packageLookup.TryGetValue (package, out var lookups))
 					packageLookup.Add (package, lookups = new List<Converter<string, Type?>> ());
@@ -366,6 +386,8 @@ namespace Java.Interop {
 
 		public static void RegisterPackages (string[] packages, Converter<string, Type?>[] lookups)
 		{
+			LazyInitPackageLookup ();
+
 			if (packages == null)
 				throw new ArgumentNullException ("packages");
 			if (lookups == null)

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -97,6 +97,9 @@
     <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml">
       <LogicalName>ILLink.LinkAttributes.xml</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="ILLink/ILLink.Substitutions.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -22,6 +22,7 @@ This file contains the .NET 5-specific targets to customize ILLink
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
+    <XATypeRegistrationFallback Condition="'$(XATypeRegistrationFallback)' == ''">false</XATypeRegistrationFallback>
   </PropertyGroup>
 
   <Target Name="_PrepareLinking"
@@ -29,6 +30,10 @@ This file contains the .NET 5-specific targets to customize ILLink
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths;_CreatePropertiesCache">
     <ItemGroup>
+      <RuntimeHostConfigurationOption Include="Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled"
+          Condition="'$(XATypeRegistrationFallback)' != ''"
+          Value="$(XATypeRegistrationFallback)"
+          Trim="true" />
       <!-- Mark all assemblies to be linked for AndroidLinkMode=Full -->
       <ResolvedFileToPublish
           Update="@(ResolvedFileToPublish)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -399,7 +399,7 @@ namespace UnnamedProject {
 		public void TypeRegistrationsFallback ([Values (true, false)] bool enabled)
 		{
 			if (!Builder.UseDotNet)
-				return;
+				Assert.Ignore ("Test only valid on .NET 6");
 
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			if (enabled)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -394,5 +394,28 @@ namespace UnnamedProject {
 				}
 			}
 		}
+
+		[Test]
+		public void TypeRegistrationsFallback ([Values (true, false)] bool enabled)
+		{
+			if (!Builder.UseDotNet)
+				return;
+
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
+			if (enabled)
+				proj.SetProperty (proj.ActiveConfigurationProperties, "XATypeRegistrationFallback", "true");
+
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var assemblyFile = "Mono.Android.dll";
+				var assemblyPath = BuildTest.GetLinkedPath (b, true, assemblyFile);
+				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
+					Assert.IsTrue (assembly != null);
+
+					var td = assembly.MainModule.GetType ("Java.Interop.__TypeRegistrations");
+					Assert.IsTrue ((td != null) == enabled);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5515
Context: https://github.com/dotnet/runtime/blob/master/docs/workflow/trimming/feature-switches.md#adding-new-feature-switch

Add new feature switch `XATypeRegistrationFallback` for type
registrations fallback. The switch default value is `false` for linked
net6 apps.

We can remove the fallback by the linker, because all the java to
managed type names lookup is now handled by typemap, so we should not
need this fallback anymore - at least not on device.

On desktop we still need it for Designer, which uses unlinked
assemblies and thus the fallback still works.

Also add lazy initialization of `packageLookup` field. That allows
linker to link the field away. That also improves startup performance,
as we don't create the dictionary in the static constructor.

apk size savings, `BuildReleaseArm64False/net6` test:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      -         221 assemblies/System.Private.CoreLib.dll
        Type System.String
          -          13 Method public string ToUpperInvariant ()
          -          20 Method public int LastIndexOf (char)
        Type System.Char
          -           8 Method public static char ToUpperInvariant (char)
        Type System.Globalization.TextInfo
          -         214 Method static string ToUpperAsciiInvariant (string)
          -          36 Method static char ToUpperInvariant (char)
          -          37 Method public string ToUpper (string)
          -          22 Method static char ToUpperAsciiInvariant (char)
      -      21,506 assemblies/Mono.Android.dll
        -             Type Java.Interop.__TypeRegistrations
        Type Java.Interop.TypeManager
          -             Field static System.Collections.Generic.Dictionary`2<string,System.Collections.Generic.List`1<System.Converter`2<string,System.Type>>> packageLookup
          +             Field static readonly bool <TypeRegistrationFallbackIsEnabled>k__BackingField
          +             Property bool TypeRegistrationFallbackIsEnabled { get; }
          -         184 Method static System.Type GetJavaToManagedType (string)
          -         110 Method public static void RegisterPackage (string, System.Converter`2<string,System.Type>)
          -         218 Method public static void RegisterPackages (string[], System.Converter`2<string,System.Type>[])
          +           3 Method static bool get_TypeRegistrationFallbackIsEnabled ()
          +          31 Method static bool InitializeTypeRegistrationFallbackIsEnabled ()
        Type Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager
          -          86 Method public static string ToCliType (string)
          -          98 Method static string ToCliTypePart (string)
          -          67 Method static string ToPascalCase (string, int)
    Summary:
      -      21,727 Assemblies -3.05% (of 712,159)
      -     122,880 Uncompressed assemblies -8.30% (of 1,480,704)