### PR TITLE
Make apk size decrease regression as well

### DIFF
--- a/Documentation/project-docs/ApkSizeRegressionChecks.md
+++ b/Documentation/project-docs/ApkSizeRegressionChecks.md
@@ -1,15 +1,18 @@
 # apk size regression checks
 
 We are checking the apk sizes for regression in CI PR builds.
-The `BuildReleaseArm64` test is used as the builds target both
-legacy monodroid and NET6 frameworks. It also builds simple XA
-app and XForms XA app. These are 4 important variations we
-measure and check for size regression, with `apkdiff` tool.
-https://www.nuget.org/packages/apkdiff/
+The `BuildReleaseArm64` test is used to collect apk size data.
 
-When we detect regression, the test fails in CI build. The test
-result file contains details about apk size and apk entries size
-differences.
+The test builds simple Xamarin Android and simple Xamarin Forms
+on Xamarin Android apps. We build it targeting legacy and NET6
+framworks, so this get us 4 variations to check.
+
+The measurements and checks for size regression are done
+with `apkdiff` tool. https://www.nuget.org/packages/apkdiff/
+
+When we detect regression, the test fails in CI build and
+the result file contains details about apk size and apk entries
+size differences.
 
 Note that the size decrease is also reported as regression. We
 do that to keep the reference files up-to-date.
@@ -17,18 +20,27 @@ do that to keep the reference files up-to-date.
 # How to resolve regression
 
 * Check whether the size change is result of unwanted changes and
-in this case fix the source of the regression.
+in such case fix the source of the regression.
 
 * If the size change is intended (for example size decrease as
 result of optimization or reasonable increase after runtime
 update/bump), the reference files need to be updated.
 
-The reference files are located
+The new reference files can be obtained from the test results
+archive - artifact of the CI build. Or they can be obtained
+from local build using the `build-tools/scripts/UpdateApkSizeReference.ps1`
+script.
+
+The reference files itself are located
 in `src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base`
 directory. During the test run, we save `.apkdesc` files, with
-current sizes. Copy these files to the above mentioned directory
-to become new reference.
+current sizes. These files can be used a new reference. The 4 files
+are named like this:
 
-This can be done for example in the powershell:
+    .../Base/BuildReleaseArm64SimpleDotNet.apkdesc
+    .../Base/BuildReleaseArm64SimpleLegacy.apkdesc
+    .../Base/BuildReleaseArm64XFormsDotNet.apkdesc
+    .../Base/BuildReleaseArm64XFormsLegacy.apkdesc
 
-    Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\
+Note that the new reference files need to be obtained
+from Xamarin Android build, built with Release configuration.

--- a/Documentation/project-docs/ApkSizeRegressionChecks.md
+++ b/Documentation/project-docs/ApkSizeRegressionChecks.md
@@ -31,4 +31,4 @@ to become new reference.
 
 This can be done for example in the powershell:
 
-    Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTols\Resources\Base\
+    Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/Documentation/project-docs/ApkSizeRegressionChecks.md
+++ b/Documentation/project-docs/ApkSizeRegressionChecks.md
@@ -1,0 +1,34 @@
+# apk size regression checks
+
+We are checking the apk sizes for regression in CI PR builds.
+The `BuildReleaseArm64` test is used as the builds target both
+legacy monodroid and NET6 frameworks. It also builds simple XA
+app and XForms XA app. These are 4 important variations we
+measure and check for size regression, with `apkdiff` tool.
+https://www.nuget.org/packages/apkdiff/
+
+When we detect regression, the test fails in CI build. The test
+result file contains details about apk size and apk entries size
+differences.
+
+Note that the size decrease is also reported as regression. We
+do that to keep the reference files up-to-date.
+
+# How to resolve regression
+
+* Check whether the size change is result of unwanted changes and
+in this case fix the source of the regression.
+
+* If the size change is intended (for example size decrease as
+result of optimization or reasonable increase after runtime
+update/bump), the reference files need to be updated.
+
+The reference files are located
+in `src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base`
+directory. During the test run, we save `.apkdesc` files, with
+current sizes. Copy these files to the above mentioned directory
+to become new reference.
+
+This can be done for example in the powershell:
+
+    Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTols\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -1,8 +1,15 @@
+# Run BuildReleaseArm64 tests and update the apkdesc reference files
+
+if (-not (Test-Path bin/Release)) {
+    Write-Output "bin/Release doesn't exists, please build XA in release configuration, before running this script"
+    exit 1
+}
+
 Write-Output "Building xabuild"
-msbuild /restore .\tools\xabuild\xabuild.csproj
+msbuild /p:Configuration=Release /restore .\tools\xabuild\xabuild.csproj
 Write-Output "Building legacy BuildReleaseArm64 tests"
-msbuild Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"
+msbuild /p:Configuration=Release Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"
 Write-Output "Building DotNet BuildReleaseArm64 tests"
-~\android-toolchain\dotnet\dotnet test -v diag --filter BuildTest.BuildReleaseArm64 .\bin\TestDebug\netcoreapp3.1\Xamarin.Android.Build.Tests.dll
+~\android-toolchain\dotnet\dotnet test -p:Configuration=Release --filter BuildTest.BuildReleaseArm64 .\bin\TestRelease\netcoreapp3.1\Xamarin.Android.Build.Tests.dll
 Write-Output "Updating reference files"
-Copy-Item -Verbose bin\TestDebug\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\
+Copy-Item -Verbose bin\TestRelease\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -1,1 +1,8 @@
-Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\
+Write-Output "Building xabuild"
+msbuild /restore .\tools\xabuild\xabuild.csproj
+Write-Output "Building legacy BuildReleaseArm64 tests"
+msbuild Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"
+Write-Output "Building DotNet BuildReleaseArm64 tests"
+~\android-toolchain\dotnet\dotnet test -v diag --filter BuildTest.BuildReleaseArm64 .\bin\TestDebug\netcoreapp3.1\Xamarin.Android.Build.Tests.dll
+Write-Output "Updating reference files"
+Copy-Item -Verbose bin\TestDebug\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -1,0 +1,1 @@
+Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTls\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -1,1 +1,1 @@
-Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTls\Resources\Base\
+Get-ChildItem -r -Filter Build*apkdesc .\bin\TestDebug\temp\BuildReleaseArm64* | Copy-Item -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Build.Tests
 				const int ApkSizeThreshold = 5 * 1024;
 				const int AssemblySizeThreshold = 5 * 1024;
 				var apkFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + "-Signed.apk");
-				var apkDescPath = Path.Combine (Root, b.ProjectDirectory, apkDescFilename);
+				var apkDescPath = Path.Combine (Root, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);
 				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression --test-apk-size-regression={ApkSizeThreshold} --test-assembly-size-regression={AssemblySizeThreshold} {apkDescReferencePath} {apkFile}");
 				Assert.IsTrue (code == 0, $"apkdiff regression test failed with exit code: {code}\nstdOut: {stdOut}\nstdErr: {stdErr}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -103,8 +103,8 @@ namespace Xamarin.Android.Build.Tests
 					: Path.Combine (proj.Root, b.ProjectDirectory, depsFilename);
 				FileAssert.Exists (depsFile);
 
-				const int ApkSizeThreshold = 50 * 1024;
-				const int AssemblySizeThreshold = 50 * 1024;
+				const int ApkSizeThreshold = 5 * 1024;
+				const int AssemblySizeThreshold = 5 * 1024;
 				var apkFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + "-Signed.apk");
 				var apkDescPath = Path.Combine (Root, b.ProjectDirectory, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Android.Build.Tests
 				var apkFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + "-Signed.apk");
 				var apkDescPath = Path.Combine (Root, b.ProjectDirectory, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);
-				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --test-apk-size-regression={ApkSizeThreshold} --test-assembly-size-regression={AssemblySizeThreshold} {apkDescReferencePath} {apkFile}");
+				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression --test-apk-size-regression={ApkSizeThreshold} --test-assembly-size-regression={AssemblySizeThreshold} {apkDescReferencePath} {apkFile}");
 				Assert.IsTrue (code == 0, $"apkdiff regression test failed with exit code: {code}\nstdOut: {stdOut}\nstdErr: {stdErr}");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -29,7 +29,7 @@
       "Size": 316880
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3098
+      "Size": 3095
     },
     "assemblies/System.Console.dll": {
       "Size": 6257
@@ -38,13 +38,13 @@
       "Size": 16470
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 532892
+      "Size": 530811
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 63841
+      "Size": 57657
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87135
+      "Size": 82694
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -80,5 +80,5 @@
       "Size": 2385
     }
   },
-  "PackageSize": 2951103
+  "PackageSize": 2934719
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -26,59 +26,56 @@
       "Size": 1724
     },
     "classes.dex": {
-      "Size": 316880
+      "Size": 316728
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 3095
     },
     "assemblies/System.Console.dll": {
-      "Size": 6257
+      "Size": 6253
     },
     "assemblies/System.Linq.dll": {
-      "Size": 16470
+      "Size": 10951
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 530811
+      "Size": 528679
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 57657
+      "Size": 57615
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 82694
+      "Size": 82604
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 776216
+      "Size": 776168
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 75872
+      "Size": 75824
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.OpenSsl.so": {
-      "Size": 100464
+      "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3796008
+      "Size": 3754992
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 247312
-    },
-    "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65480
+      "Size": 341856
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37408
+      "Size": 37096
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 2512
+      "Size": 2405
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2385
+      "Size": 2278
     }
   },
-  "PackageSize": 2934719
+  "PackageSize": 2910062
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -26,25 +26,25 @@
       "Size": 1724
     },
     "classes.dex": {
-      "Size": 316876
+      "Size": 316880
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2959
+      "Size": 3098
     },
     "assemblies/System.Console.dll": {
-      "Size": 6202
+      "Size": 6257
     },
     "assemblies/System.Linq.dll": {
-      "Size": 15122
+      "Size": 16470
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 513489
+      "Size": 532892
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 63151
+      "Size": 63841
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 86291
+      "Size": 87135
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -80,5 +80,5 @@
       "Size": 2385
     }
   },
-  "PackageSize": 2926527
+  "PackageSize": 2951103
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -26,7 +26,7 @@
       "Size": 1724
     },
     "classes.dex": {
-      "Size": 316848
+      "Size": 316700
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 2869
@@ -35,13 +35,13 @@
       "Size": 67718
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 246170
+      "Size": 246077
     },
     "assemblies/mscorlib.dll": {
       "Size": 769322
     },
     "assemblies/System.Core.dll": {
-      "Size": 28192
+      "Size": 28193
     },
     "assemblies/System.dll": {
       "Size": 9180
@@ -50,10 +50,10 @@
       "Size": 68560
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 247872
+      "Size": 263536
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65184
+      "Size": 65200
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
@@ -74,5 +74,5 @@
       "Size": 2098
     }
   },
-  "PackageSize": 3954388
+  "PackageSize": 3958484
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -29,22 +29,22 @@
       "Size": 316848
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2873
+      "Size": 2869
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 75153
+      "Size": 67718
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 264429
+      "Size": 246170
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769825
+      "Size": 769322
     },
     "assemblies/System.Core.dll": {
-      "Size": 28191
+      "Size": 28192
     },
     "assemblies/System.dll": {
-      "Size": 12986
+      "Size": 9180
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -56,13 +56,13 @@
       "Size": 65184
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
-      "Size": 2160056
+      "Size": 1613872
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 6819144
+      "Size": 4033248
     },
     "lib/arm64-v8a/libmono-native.so": {
-      "Size": 1150064
+      "Size": 707024
     },
     "META-INF/ANDROIDD.SF": {
       "Size": 2225
@@ -74,5 +74,5 @@
       "Size": 2098
     }
   },
-  "PackageSize": 5011156
+  "PackageSize": 3954388
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -29,16 +29,16 @@
       "Size": 316848
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2863
+      "Size": 2873
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 75279
+      "Size": 75153
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 264424
+      "Size": 264429
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769789
+      "Size": 769825
     },
     "assemblies/System.Core.dll": {
       "Size": 28191

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1667,76 +1667,76 @@
       "Size": 8094
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6456
+      "Size": 6461
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122430
+      "Size": 122426
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6535
+      "Size": 6539
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7296
+      "Size": 7298
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18095
+      "Size": 18091
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 103785
+      "Size": 103783
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
       "Size": 15324
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42768
+      "Size": 42771
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6636
+      "Size": 6633
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7007
+      "Size": 7008
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7167
+      "Size": 7166
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3555
+      "Size": 3553
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13487
+      "Size": 13484
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92062
+      "Size": 92061
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5409
+      "Size": 5406
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11150
+      "Size": 11147
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19319
+      "Size": 19318
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43258
+      "Size": 43254
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7170
+      "Size": 7171
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524852
+      "Size": 524849
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384987
+      "Size": 384983
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55867
+      "Size": 55865
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117202
+      "Size": 117200
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
       "Size": 4224
@@ -1775,7 +1775,7 @@
       "Size": 37534
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 11338
+      "Size": 10593
     },
     "assemblies/System.Drawing.Primitives.dll": {
       "Size": 20337
@@ -1901,13 +1901,13 @@
       "Size": 6737
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 739870
+      "Size": 738873
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 72151
+      "Size": 64759
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 458713
+      "Size": 434018
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
@@ -2057,5 +2057,5 @@
       "Size": 82480
     }
   },
-  "PackageSize": 9977111
+  "PackageSize": 9940247
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1631,7 +1631,7 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3455828
+      "Size": 3455720
     },
     "assemblies/Microsoft.Win32.SystemEvents.dll": {
       "Size": 8713
@@ -1667,34 +1667,34 @@
       "Size": 8094
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6461
+      "Size": 6501
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122426
+      "Size": 122687
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6539
+      "Size": 6577
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7298
+      "Size": 7340
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18091
+      "Size": 18173
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 103783
+      "Size": 104259
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15324
+      "Size": 15402
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42771
+      "Size": 42954
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6633
+      "Size": 6687
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7008
+      "Size": 7034
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
       "Size": 7166
@@ -1703,25 +1703,25 @@
       "Size": 3553
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13484
+      "Size": 13555
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92061
+      "Size": 92308
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5406
+      "Size": 5441
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11147
+      "Size": 11182
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19318
+      "Size": 19391
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43254
+      "Size": 43413
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7171
+      "Size": 7222
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 524849
@@ -1739,199 +1739,196 @@
       "Size": 117200
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 4224
+      "Size": 4223
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12497
+      "Size": 12495
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 11665
+      "Size": 11660
     },
     "assemblies/System.Collections.Specialized.dll": {
-      "Size": 12638
+      "Size": 12635
     },
     "assemblies/System.Collections.dll": {
-      "Size": 24042
+      "Size": 24040
     },
     "assemblies/System.ComponentModel.EventBasedAsync.dll": {
-      "Size": 2595
+      "Size": 2593
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 7957
+      "Size": 7960
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 55524
+      "Size": 55517
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2639
+      "Size": 2638
     },
     "assemblies/System.Console.dll": {
-      "Size": 6772
+      "Size": 6770
     },
     "assemblies/System.Data.Common.dll": {
-      "Size": 2534
+      "Size": 2533
     },
     "assemblies/System.Diagnostics.Process.dll": {
-      "Size": 37534
+      "Size": 37531
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 10593
+      "Size": 10594
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 20337
+      "Size": 20335
     },
     "assemblies/System.Formats.Asn1.dll": {
       "Size": 26961
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12438
+      "Size": 12437
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19954
+      "Size": 19950
     },
     "assemblies/System.IO.FileSystem.dll": {
       "Size": 29138
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11793
+      "Size": 11791
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 191893
+      "Size": 192028
     },
     "assemblies/System.Linq.dll": {
-      "Size": 32864
+      "Size": 21228
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 216910
+      "Size": 217046
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 11006
+      "Size": 11005
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18362
+      "Size": 18361
     },
     "assemblies/System.Net.Primitives.dll": {
       "Size": 44363
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37661
+      "Size": 37660
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 52358
+      "Size": 52393
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 68066
+      "Size": 68071
     },
     "assemblies/System.Net.ServicePoint.dll": {
-      "Size": 3330
+      "Size": 3329
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 64504
+      "Size": 64517
     },
     "assemblies/System.Net.WebClient.dll": {
       "Size": 8015
     },
     "assemblies/System.Net.WebHeaderCollection.dll": {
-      "Size": 6428
+      "Size": 6427
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12837
+      "Size": 12834
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 206618
+      "Size": 206623
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42505
+      "Size": 42506
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16089
+      "Size": 16088
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 501648
+      "Size": 501641
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
       "Size": 1792
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 4401
+      "Size": 4399
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 22538
+      "Size": 22535
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
       "Size": 4223
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4374
+      "Size": 4373
     },
     "assemblies/System.Security.AccessControl.dll": {
-      "Size": 4685
+      "Size": 4686
     },
     "assemblies/System.Security.Claims.dll": {
       "Size": 8341
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40888
+      "Size": 40889
     },
     "assemblies/System.Security.Cryptography.Csp.dll": {
-      "Size": 5418
+      "Size": 5417
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12734
+      "Size": 12723
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
       "Size": 15317
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9803
+      "Size": 9805
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 93791
+      "Size": 94605
     },
     "assemblies/System.Security.Principal.Windows.dll": {
-      "Size": 5056
+      "Size": 5057
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 81745
+      "Size": 81741
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 15961
+      "Size": 15960
     },
     "assemblies/System.Threading.dll": {
-      "Size": 6737
+      "Size": 6735
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 738873
+      "Size": 733457
     },
     "assemblies/Java.Interop.dll": {
       "Size": 64759
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 434018
+      "Size": 433914
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
-      "Size": 776216
+      "Size": 776168
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 75872
+      "Size": 75824
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.OpenSsl.so": {
-      "Size": 100464
+      "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3796008
+      "Size": 3754992
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 247312
-    },
-    "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65480
+      "Size": 341856
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37408
+      "Size": 37096
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -2048,14 +2045,14 @@
       "Size": 339
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 82607
+      "Size": 82500
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 82480
+      "Size": 82373
     }
   },
-  "PackageSize": 9940247
+  "PackageSize": 9907398
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1631,7 +1631,7 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3454884
+      "Size": 3455828
     },
     "assemblies/Microsoft.Win32.SystemEvents.dll": {
       "Size": 8713
@@ -1667,247 +1667,247 @@
       "Size": 8094
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6260
+      "Size": 6456
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122179
+      "Size": 122430
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6334
+      "Size": 6535
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7096
+      "Size": 7296
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17878
+      "Size": 18095
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 103568
+      "Size": 103785
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15129
+      "Size": 15324
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42572
+      "Size": 42768
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6439
+      "Size": 6636
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6801
+      "Size": 7007
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6968
+      "Size": 7167
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3351
+      "Size": 3555
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13288
+      "Size": 13487
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 91870
+      "Size": 92062
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5207
+      "Size": 5409
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10940
+      "Size": 11150
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19126
+      "Size": 19319
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43063
+      "Size": 43258
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7039
+      "Size": 7170
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524708
+      "Size": 524852
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384810
+      "Size": 384987
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55730
+      "Size": 55867
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117066
+      "Size": 117202
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 4156
+      "Size": 4224
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12119
+      "Size": 12497
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 10971
+      "Size": 11665
     },
     "assemblies/System.Collections.Specialized.dll": {
-      "Size": 12569
+      "Size": 12638
     },
     "assemblies/System.Collections.dll": {
-      "Size": 22926
+      "Size": 24042
     },
     "assemblies/System.ComponentModel.EventBasedAsync.dll": {
-      "Size": 2529
+      "Size": 2595
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 7878
+      "Size": 7957
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 55452
+      "Size": 55524
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2565
+      "Size": 2639
     },
     "assemblies/System.Console.dll": {
-      "Size": 6701
+      "Size": 6772
     },
     "assemblies/System.Data.Common.dll": {
-      "Size": 2460
+      "Size": 2534
     },
     "assemblies/System.Diagnostics.Process.dll": {
-      "Size": 36726
+      "Size": 37534
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 11286
+      "Size": 11338
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 20248
+      "Size": 20337
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 26895
+      "Size": 26961
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12332
+      "Size": 12438
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19829
+      "Size": 19954
     },
     "assemblies/System.IO.FileSystem.dll": {
-      "Size": 29073
+      "Size": 29138
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11722
+      "Size": 11793
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 177866
+      "Size": 191893
     },
     "assemblies/System.Linq.dll": {
-      "Size": 31736
+      "Size": 32864
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 216085
+      "Size": 216910
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 10951
+      "Size": 11006
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18292
+      "Size": 18362
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 44263
+      "Size": 44363
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37526
+      "Size": 37661
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 52250
+      "Size": 52358
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 67914
+      "Size": 68066
     },
     "assemblies/System.Net.ServicePoint.dll": {
-      "Size": 3265
+      "Size": 3330
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 64436
+      "Size": 64504
     },
     "assemblies/System.Net.WebClient.dll": {
-      "Size": 7947
+      "Size": 8015
     },
     "assemblies/System.Net.WebHeaderCollection.dll": {
-      "Size": 6363
+      "Size": 6428
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12327
+      "Size": 12837
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 206497
+      "Size": 206618
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42428
+      "Size": 42505
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16028
+      "Size": 16089
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 500538
+      "Size": 501648
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1728
+      "Size": 1792
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 4333
+      "Size": 4401
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 22482
+      "Size": 22538
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 4156
+      "Size": 4223
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4307
+      "Size": 4374
     },
     "assemblies/System.Security.AccessControl.dll": {
-      "Size": 4618
+      "Size": 4685
     },
     "assemblies/System.Security.Claims.dll": {
-      "Size": 8223
+      "Size": 8341
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40795
+      "Size": 40888
     },
     "assemblies/System.Security.Cryptography.Csp.dll": {
-      "Size": 5340
+      "Size": 5418
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12665
+      "Size": 12734
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
-      "Size": 15248
+      "Size": 15317
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9735
+      "Size": 9803
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 93658
+      "Size": 93791
     },
     "assemblies/System.Security.Principal.Windows.dll": {
-      "Size": 4993
+      "Size": 5056
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 81308
+      "Size": 81745
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 14663
+      "Size": 15961
     },
     "assemblies/System.Threading.dll": {
-      "Size": 6643
+      "Size": 6737
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 728128
+      "Size": 739870
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 71652
+      "Size": 72151
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 453637
+      "Size": 458713
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
@@ -2057,5 +2057,5 @@
       "Size": 82480
     }
   },
-  "PackageSize": 9927959
+  "PackageSize": 9977111
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -1640,106 +1640,106 @@
       "Size": 7211
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7693
+      "Size": 7691
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6644
+      "Size": 6641
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 125331
+      "Size": 125330
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7361
+      "Size": 7358
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18268
+      "Size": 18266
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131928
+      "Size": 131924
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15426
+      "Size": 15422
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43133
+      "Size": 43130
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6712
+      "Size": 6713
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7059
+      "Size": 7054
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7190
+      "Size": 7189
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4865
+      "Size": 4866
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
       "Size": 13582
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102327
+      "Size": 102323
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
       "Size": 6269
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11265
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
       "Size": 19420
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524733
+      "Size": 524735
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384867
+      "Size": 384869
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56878
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55799
+      "Size": 55798
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43494
+      "Size": 43496
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 110638
+      "Size": 110644
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 186658
+      "Size": 186654
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 76345
+      "Size": 68652
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 588526
+      "Size": 557041
     },
     "assemblies/mscorlib.dll": {
-      "Size": 915451
+      "Size": 915446
     },
     "assemblies/System.Core.dll": {
-      "Size": 164046
+      "Size": 164044
     },
     "assemblies/System.dll": {
-      "Size": 389383
+      "Size": 388893
     },
     "assemblies/System.Xml.dll": {
-      "Size": 395689
+      "Size": 395685
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 15685
+      "Size": 15681
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 12360
+      "Size": 12355
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26591
+      "Size": 26586
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68488
+      "Size": 68486
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 139944
@@ -1751,13 +1751,13 @@
       "Size": 65184
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
-      "Size": 2160056
+      "Size": 1613872
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 6819144
+      "Size": 4033248
     },
     "lib/arm64-v8a/libmono-native.so": {
-      "Size": 1150064
+      "Size": 707024
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -1883,5 +1883,5 @@
       "Size": 75731
     }
   },
-  "PackageSize": 10537118
+  "PackageSize": 9468062
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -1631,7 +1631,7 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3455212
+      "Size": 3455100
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 116885
@@ -1664,7 +1664,7 @@
       "Size": 43130
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6713
+      "Size": 6712
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
       "Size": 7054
@@ -1685,7 +1685,7 @@
       "Size": 6269
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11269
+      "Size": 11268
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
       "Size": 19420
@@ -1709,13 +1709,13 @@
       "Size": 110644
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 186654
+      "Size": 186653
     },
     "assemblies/Java.Interop.dll": {
       "Size": 68652
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 557041
+      "Size": 556942
     },
     "assemblies/mscorlib.dll": {
       "Size": 915446
@@ -1727,7 +1727,7 @@
       "Size": 388893
     },
     "assemblies/System.Xml.dll": {
-      "Size": 395685
+      "Size": 395684
     },
     "assemblies/System.Numerics.dll": {
       "Size": 15681
@@ -1745,10 +1745,10 @@
       "Size": 139944
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 247872
+      "Size": 263536
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65184
+      "Size": 65200
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
@@ -1883,5 +1883,5 @@
       "Size": 75731
     }
   },
-  "PackageSize": 9468062
+  "PackageSize": 9476254
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -1631,10 +1631,10 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3454264
+      "Size": 3455212
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 116878
+      "Size": 116885
     },
     "assemblies/FormsViewGroup.dll": {
       "Size": 7211
@@ -1658,7 +1658,7 @@
       "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15425
+      "Size": 15426
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
       "Size": 43133
@@ -1712,10 +1712,10 @@
       "Size": 186658
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 76477
+      "Size": 76345
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 588522
+      "Size": 588526
     },
     "assemblies/mscorlib.dll": {
       "Size": 915451
@@ -1739,7 +1739,7 @@
       "Size": 26591
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68487
+      "Size": 68488
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 139944


### PR DESCRIPTION
To make us have the reference files up-to-date.

Use new apkdiff's `--descrease-is-regression` option is used.

Added documentation, explain how to obtain the reference files. Also added
new simple powershell script to update the reference files locally.

Lower the thresholds to catch smaller regressions.

Also mention the need of Release XA builds. Context: https://github.com/xamarin/xamarin-android/issues/5675