### PR TITLE
[monodroid] Use MONO_AOT_MODE_INTERP_ONLY when available

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -660,9 +660,9 @@ AndroidSystem::setup_environment ()
 #if !defined (NET6)
 				aotMode = MonoAotMode::MONO_AOT_MODE_LAST;
 				aot_mode_last_is_interpreter = true;
-#else
+#else   // defined (NET6)
 				aotMode = MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
-#endif
+#endif  // !defined (NET6)
 				break;
 
 			default:

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -657,8 +657,12 @@ AndroidSystem::setup_environment ()
 				break;
 
 			case 'i':
+#if !defined (NET6)
 				aotMode = MonoAotMode::MONO_AOT_MODE_LAST;
 				aot_mode_last_is_interpreter = true;
+#else
+				aotMode = MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
+#endif
 				break;
 
 			default:

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -104,9 +104,9 @@ namespace xamarin::android::internal
 #if !defined (NET6)
 			// HACK! See below
 			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_LAST && is_aot_mode_last_really_interpreter_mode ();
-#else
+#else   // defined (NET6)
 			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
-#endif
+#endif  // !defined (NET6)
 		}
 
 		// Hack, see comment for `aot_mode_last_is_interpreter` at the bottom of the class declaration
@@ -114,9 +114,9 @@ namespace xamarin::android::internal
 		{
 #if !defined(NET6)
 			return aot_mode_last_is_interpreter;
-#else
+#else   // defined (NET6)
 			return false;
-#endif
+#endif  // !defined (NET6)
 		}
 
 		void set_running_in_emulator (bool yesno)
@@ -170,7 +170,7 @@ namespace xamarin::android::internal
 		// See also: https://github.com/mono/mono/issues/18893
 		//
 		bool aot_mode_last_is_interpreter = false;
-#endif
+#endif  // !defined (NET6)
 	};
 }
 #endif // !__ANDROID_SYSTEM_H

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -101,14 +101,22 @@ namespace xamarin::android::internal
 
 		bool is_interpreter_enabled () const
 		{
+#if !defined (NET6)
 			// HACK! See below
 			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_LAST && is_aot_mode_last_really_interpreter_mode ();
+#else
+			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
+#endif
 		}
 
 		// Hack, see comment for `aot_mode_last_is_interpreter` at the bottom of the class declaration
 		bool is_aot_mode_last_really_interpreter_mode () const
 		{
+#if !defined(NET6)
 			return aot_mode_last_is_interpreter;
+#else
+			return false;
+#endif
 		}
 
 		void set_running_in_emulator (bool yesno)
@@ -151,6 +159,7 @@ namespace xamarin::android::internal
 		MonoAotMode aotMode = MonoAotMode::MONO_AOT_MODE_NONE;
 		bool running_in_emulator = false;
 
+#if !defined (NET6)
 		// This is a hack because of the way Mono currently switches the full interpreter (no JIT) mode. In Mono
 		// **internal** headers there's an AOT mode macro, `MONO_EE_MODE_INTERP`, whose value is exactly the same as
 		// MonoAotMode::MONO_AOT_MODE_LAST.  However, we use `MonoAotMode::MONO_AOT_MODE_LAST` as a sentinel to indicate
@@ -161,6 +170,7 @@ namespace xamarin::android::internal
 		// See also: https://github.com/mono/mono/issues/18893
 		//
 		bool aot_mode_last_is_interpreter = false;
+#endif
 	};
 }
 #endif // !__ANDROID_SYSTEM_H

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1807,6 +1807,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	MonoAotMode mode = MonoAotMode::MONO_AOT_MODE_NONE;
 	if (androidSystem.is_mono_aot_enabled ()) {
 		mode = androidSystem.get_mono_aot_mode ();
+#if !defined (NET6)
 		if (mode == MonoAotMode::MONO_AOT_MODE_LAST) {
 			// Hack. See comments in android-system.hh
 			if (!androidSystem.is_interpreter_enabled ()) {
@@ -1821,6 +1822,13 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 				log_info (LOG_DEFAULT, "Enabling Mono Interpreter");
 			}
 		}
+#else
+		if (mode != MonoAotMode::MONO_AOT_MODE_INTERP_ONLY) {
+			log_info (LOG_DEFAULT, "Enabling AOT mode in Mono");
+		} else {
+			log_info (LOG_DEFAULT, "Enabling Mono Interpreter");
+		}
+#endif
 	}
 	mono_jit_set_aot_mode (mode);
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1822,13 +1822,13 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 				log_info (LOG_DEFAULT, "Enabling Mono Interpreter");
 			}
 		}
-#else
+#else   // defined (NET6)
 		if (mode != MonoAotMode::MONO_AOT_MODE_INTERP_ONLY) {
 			log_info (LOG_DEFAULT, "Enabling AOT mode in Mono");
 		} else {
 			log_info (LOG_DEFAULT, "Enabling Mono Interpreter");
 		}
-#endif
+#endif  // !defined (NET6)
 	}
 	mono_jit_set_aot_mode (mode);
 


### PR DESCRIPTION
This depends on a fix to mono/mono#18893 (make interp only mode distinct from `MONO_AOT_MODE_LAST`) which was done in mono/mono#20159 but only for .NET 6, not previous Mono releases.

Fixes https://github.com/xamarin/xamarin-android/issues/5633