### PR TITLE
[One .NET] set $(PackageType) of DotnetPlatform

### DIFF
--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <PackageType>DotnetPlatform</PackageType>
     <Authors>Microsoft</Authors>
     <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/nuget/create-packages/set-package-type
Context: https://github.com/dotnet/runtime/blob/86d5d16d31ee46d619b4d9af510f307ed7da4846/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs#L142-L149

This is the pattern to follow for a package that is part of .NET that
people should not install directly. It prevents you from being able to
use `@(PackageReference)` for our packages -- which would not work
anyway.

If I review `Microsoft.NetCore.App.Runtime.android-arm.nuspec`, this
is how `$(PackageType)` is expressed within the `.nupkg` file:

    <?xml version="1.0" encoding="utf-8"?>
    <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
      <metadata>
        <!-- ... -->
        <packageTypes>
          <packageType name="DotnetPlatform" />
        </packageTypes>
      </metadata>
    </package>

We should set this for all .NET 6 `.nupkg` files we produce except for
Microsoft.Android.Templates, which uses `PackageType=Template`.