### PR TITLE
[One .NET] fix support for uppercase file names in class libraries

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -18,7 +18,7 @@ projects.
     <_AarOutputPath>$(OutputPath)$(TargetName).aar</_AarOutputPath>
   </PropertyGroup>
 
-  <Target Name="_ResolveAars" Condition=" '$(AndroidApplication)' == 'true' ">
+  <Target Name="_ResolveAars">
     <ItemGroup>
       <_AarSearchDirectory   Include="@(_ReferencePath->'%(RootDir)%(Directory)')" />
       <_AarSearchDirectory   Include="@(_ReferenceDependencyPaths->'%(RootDir)%(Directory)')" />
@@ -26,10 +26,11 @@ projects.
       <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" />
     </ItemGroup>
     <ItemGroup Condition=" '@(_AarFromLibraries->Count())' != '0' ">
-      <AndroidAarLibrary Include="@(_AarFromLibraries)" Exclude="@(AndroidAarLibrary)" />
+      <!-- NOTE: set %(Pack) to false for located .aar files, we should not repackage into NuGets -->
+      <AndroidAarLibrary Include="@(_AarFromLibraries)" Exclude="@(AndroidAarLibrary)" Pack="false" />
       <!--
         NOTE: %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
-        Update in a second step, in case there is was an existing @(AndroidAarLibrary) with the same path.
+        Update in a second step, in case there was an existing @(AndroidAarLibrary) with the same path.
       -->
       <AndroidAarLibrary Update="@(_AarFromLibraries)" AndroidSkipResourceProcessing="false" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -53,7 +53,10 @@ namespace Xamarin.Android.Build.Tests
 				Sources = {
 					new BuildItem.Source ("Bar.cs") {
 						TextContent = () => "public class Bar { }",
-					}
+					},
+					new AndroidItem.AndroidResource (() => "Resources\\drawable\\IMALLCAPS.png") {
+						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
+					},
 				}
 			};
 			libC.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\bar\\bar.txt") {
@@ -70,7 +73,19 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 				Sources = {
 					new BuildItem.Source ("Foo.cs") {
-						TextContent = () => "public class Foo : Bar { }",
+						TextContent = () =>
+@"public class Foo : Bar
+{
+	public Foo ()
+	{
+		int x = LibraryB.Resource.Drawable.IMALLCAPS;
+	}
+}",
+					},
+					new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+						TextContent = () => {
+							return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ImageView xmlns:android=\"http://schemas.android.com/apk/res/android\" android:src=\"@drawable/IMALLCAPS\" />";
+						}
 					}
 				}
 			};


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Forms/tree/main-handler/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Resources/anim

When porting some projects to .NET in Xamarin.Forms/MAUI, given a file
name such as:

    Resources/anim/EnterFromRight.xml

The `Resource.designer.cs` file contained:

    public static int enterfromright = 2130771997;

However, in "legacy" Xamarin.Android the casing was preserved:

    public static int EnterFromRight = 2130771969;

I was able to reproduce this in `XASdkTests`. The problem was the new
`_ResolveAars` MSBuild target that resolves `.aar` files from
dependencies was not running in class libraries, only application
projects. My original thinking was that class libraries don't need
`@(AndroidAarLibrary)` defined, but they *do* for
`Resource.designer.cs` generation.

The only other consideration was to set `%(Pack)` to `false` by
default, considering the case:

    LibraryA.csproj -> <ProjectReference Include="..\LibraryB\LibraryB.csproj" />
    dotnet pack LibraryA.csproj -> LibraryA.nupkg
    dotnet pack LibraryB.csproj -> LibraryB.nupkg

We only want `LibraryB`'s `.aar` file in `LibraryB.nupkg`,
`LibraryA.nupkg` should not include it by default.