### PR TITLE
[Xamarin.Android.Build.Tasks] bump to System.Collections.Immutable 1.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,7 @@
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
     <LZ4PackageVersion>1.1.11</LZ4PackageVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>
+    <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>
   </PropertyGroup>
 
   <!-- Properties to help us run managed assemblies on various runtimes.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetApiPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetApiPackageVersion)" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/tools/decompress-assemblies/decompress-assemblies.csproj
+++ b/tools/decompress-assemblies/decompress-assemblies.csproj
@@ -17,7 +17,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="$(LZ4PackageVersion)" />

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
I keep getting this error in VS Windows:

    Detected package downgrade: System.Collections.Immutable from 1.7.1 to 1.7.0. Reference the package directly from the project to select a different version.
        Xamarin.Android.Build.Tasks -> Microsoft.Android.Build.BaseTasks -> System.Collections.Immutable (>= 1.7.1)
        Xamarin.Android.Build.Tasks -> System.Collections.Immutable (>= 1.7.0)

But command-line it seems to work fine?

It does seem like this package is behind compared to one used in
`xamarin-android-tools`, so let's just update it.

I also went ahead and created `$(SystemCollectionsImmutableVersion)`
in `Directory.Build.props` as this NuGet package is used in a few
places.