### PR TITLE
[Mono.Android] Fix incorrect mapping of Android.Content.PM.ForegroundService.

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -1909,8 +1909,8 @@
 29, android.app, AppOpsManager, startWatchingMode, flags, Android.App.Admin.WatchForeground
 29, android.app, RemoteInput.Builder, setEditChoicesBeforeSending, editChoicesBeforeSending, Android.App.EditChoices
 29, android.app, RemoteInput, getEditChoicesBeforeSending, return, Android.App.EditChoices
-29, android.app, Service, getForegroundServiceType, return, Android.App.ForegroundService
-29, android.app, Service, startForeground, foregroundServiceType, Android.App.ForegroundService
+29, android.app, Service, getForegroundServiceType, return, Android.Content.PM.ForegroundService
+29, android.app, Service, startForeground, foregroundServiceType, Android.Content.PM.ForegroundService
 // Cannot change this at this state.
 // 27, android.app, WallpaperManager.OnColorsChangedListener, onColorsChanged, which, Android.App.WallpaperManagerFlags
 29, android.content, Context, bindIsolatedService, flags, Android.App.Bind

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -2519,8 +2519,8 @@
 29, android.app, AppOpsManager, startWatchingMode, flags, Android.App.WatchForeground
 29, android.app, RemoteInput.Builder, setEditChoicesBeforeSending, editChoicesBeforeSending, Android.App.EditChoices
 29, android.app, RemoteInput, getEditChoicesBeforeSending, return, Android.App.EditChoices
-29, android.app, Service, getForegroundServiceType, return, Android.App.ForegroundService
-29, android.app, Service, startForeground, foregroundServiceType, Android.App.ForegroundService
+29, android.app, Service, getForegroundServiceType, return, Android.Content.PM.ForegroundService
+29, android.app, Service, startForeground, foregroundServiceType, Android.Content.PM.ForegroundService
 // Cannot change this at this state.
 // 27, android.app, WallpaperManager.OnColorsChangedListener, onColorsChanged, which, Android.App.WallpaperManagerFlags
 29, android.content, Context, bindIsolatedService, flags, Android.App.Bind


### PR DESCRIPTION
The Android API methods:
```
Android.App.Service.GetForegroundServiceType ()
Android.App.Service.StartForeground (int, Android.App.Notification, Android.App.ForegroundService)
```

do not appear in `Mono.Android.dll` due to these warnings:

```
warning BG8700: Unknown return type 'Android.App.ForegroundService' for member 'Android.App.Service.GetForegroundServiceType ()'.
warning BG8800: Unknown parameter type 'Android.App.ForegroundService' for member 'Android.App.Service.StartForeground (int, Android.App.Notification, Android.App.ForegroundService)'.
```

This is because the return/parameter enum is mapped as `Android.App.ForegroundService` which does not exist.  Instead it should be `Android.Content.PM.ForegroundService`.

Update the mapping so these methods will get bound.