### PR TITLE
[One .NET] update $(PackageTargetFallback) for NuGet packages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
@@ -19,6 +19,8 @@ This file contains *temporary* workarounds for NuGet in .NET 5.
       It doesn't suffer from: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955
     -->
     <PackageTargetFallback>
+      net6.0-android$(TargetPlatformVersion).0;
+      monoandroid11.0;
       monoandroid10.0;
       monoandroid90;
       monoandroid81;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -355,6 +355,12 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XASdkProject {
 				IsRelease = isRelease,
+				ExtraNuGetConfigSources = {
+					"https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json"
+				},
+				PackageReferences = {
+					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.2.0.7-net6preview01" }
+				},
 				Sources = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {
 						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
@@ -364,6 +370,7 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
+			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": AndroidX.AppCompat.App.AppCompatActivity");
 			proj.OtherBuildItems.Add (new AndroidItem.InputJar ("javaclasses.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestJar,
 			});


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/blob/38bffe6c03a149c80f1c3b22787f33c794e71c76/accepted/2021/net6.0-tfms/net6.0-tfms.md

We don't have a complete implementation for .NET 6 & NuGet yet, so for
for things to work *at all* we have `Microsoft.Android.Sdk.NuGet.targets`
that contains workarounds that enable:

* Given some NuGet package, `Foo.nupkg`
* Try `lib/net6.0-android/Foo.dll`
* Try `lib/monoandroid10.0/Foo.dll`, other `$(TFV)` etc.

We can now test the above scenario with AndroidX NuGet packages:

* https://github.com/xamarin/AndroidX/pull/247
* https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json
* `<PackageReference Include="Xamarin.AndroidX.AppCompat" Version = "1.2.0.7-net6preview01" />`

Unfortunately, consuming `Xamarin.AndroidX.AppCompat` results in our
build using `lib/monoandroid90/Xamarin.AndroidX.AppCompat.dll` over
the .NET 6 one!

I was able to reproduce this failure in the `XASdkTests.DotNetBuild()`
test, as any `Release` build will fail during linking when using
`MonoAndroid` assemblies without `KnownPackages.AddDotNetCompatPackages()`.

To solve the problem, we need to list `net6.0-android30.0` in
`$(PackageTargetFallback)`. Now .NET 6 packages are preferred over
`MonoAndroid` ones. Lastly I added `MonoAndroid11.0`, because it was
missing.

Eventually I hope to delete `Microsoft.Android.Sdk.NuGet.targets`
completely when the NuGet implementation of TFMs in .NET 6 is
complete.