### PR TITLE
Bump LibZipSharp to 1.0.24

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@dade1f497271f3ae5ceb1fe8c6c672b399a369ec
+xamarin/monodroid:main@e6f0c0ffa19fed461f137ce735882c736dc8764e
 mono/mono:2020-02@c66141a8c7ba2566c578c2dd012b2b723e006213

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>1.0.22</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.23</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>1.0.23</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.24</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -305,7 +305,9 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libzip.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-as.exe" />


### PR DESCRIPTION
Changes Changes: https://github.com/xamarin/libzipsharp/compare/1.0.22...1.0.24

needs

- [x] https://github.com/xamarin/xamarin-android-tools/pull/109
- [x] https://github.com/xamarin/androidtools/pull/274
- [x] https://github.com/xamarin/monodroid/pull/1170