### PR TITLE
Bump to net6 preview2 (6.0.100-preview.2.21114.3)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -79,7 +79,7 @@
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
     <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.2.21114.3</DotNetPreviewVersionFull>
     <!-- This version comes from the a file in the dotnet distribution: sdk/$(DotNetPreviewVersionFull)/dotnet.runtimeconfig.json (the `runtimeOptions/framework/version key`) -->
-    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21108.2</DotNetRuntimePacksVersion>
+    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21114.2</DotNetRuntimePacksVersion>
     <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>
     <ILLinkVersionFull Condition=" '$(ILLinkVersionFull)' == '' ">$(ILLinkVersionBand)-alpha.1.21109.1</ILLinkVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>

--- a/Configuration.props
+++ b/Configuration.props
@@ -77,7 +77,7 @@
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <!-- Please update DotNetRuntimePacksVersion below accordingly -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.1.21109.8</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.2.21114.3</DotNetPreviewVersionFull>
     <!-- This version comes from the a file in the dotnet distribution: sdk/$(DotNetPreviewVersionFull)/dotnet.runtimeconfig.json (the `runtimeOptions/framework/version key`) -->
     <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21108.2</DotNetRuntimePacksVersion>
     <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>

--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Temporary workaround for crash in GlobalizationNative_GetSortHandle, context: https://github.com/xamarin/xamarin-android/pull/5669 -->
+<linker>
+	<assembly fullname="System.Private.CoreLib">
+		<type fullname="System.Globalization.GlobalizationMode" />
+	</assembly>
+</linker>

--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -105,6 +105,7 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 				continue;
 		}
 
+#if !defined(NET6)
 		if (utils.ends_with (file_name, ".config") && bundled_assemblies != nullptr) {
 			char *assembly_name = strdup (basename (file_name));
 			// Remove '.config' suffix
@@ -115,6 +116,7 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 
 			continue;
 		}
+#endif // ndef NET6
 
 		if (!utils.ends_with (file_name, ".dll"))
 			continue;

--- a/src/monodroid/jni/mkbundle-api.h
+++ b/src/monodroid/jni/mkbundle-api.h
@@ -5,19 +5,13 @@
 using namespace xamarin::android;
 #endif
 
-#if defined(NET6)
-#define MDLEGACY(x)
-#else
-#define MDLEGACY(x) x
-#endif // ndef NET6
-
 typedef struct BundleMonoAPI
 {
 	void (*mono_register_bundled_assemblies) (const MonoBundledAssembly **assemblies);
-	MDLEGACY(void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml));
+	void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml);
 	void (*mono_jit_set_aot_mode) (int mode);
 	void (*mono_aot_register_module) (void** aot_info);
-	MDLEGACY(void (*mono_config_parse_memory) (const char *buffer));
+	void (*mono_config_parse_memory) (const char *buffer);
 	void (*mono_register_machine_config) (const char *config_xml);
 } BundleMonoAPI;
 

--- a/src/monodroid/jni/mkbundle-api.h
+++ b/src/monodroid/jni/mkbundle-api.h
@@ -5,13 +5,19 @@
 using namespace xamarin::android;
 #endif
 
+#if defined(NET6)
+#define MDLEGACY(x)
+#else
+#define MDLEGACY(x) x
+#endif // ndef NET6
+
 typedef struct BundleMonoAPI
 {
 	void (*mono_register_bundled_assemblies) (const MonoBundledAssembly **assemblies);
-	void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml);
+	MDLEGACY(void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml));
 	void (*mono_jit_set_aot_mode) (int mode);
 	void (*mono_aot_register_module) (void** aot_info);
-	void (*mono_config_parse_memory) (const char *buffer);
+	MDLEGACY(void (*mono_config_parse_memory) (const char *buffer));
 	void (*mono_register_machine_config) (const char *config_xml);
 } BundleMonoAPI;
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -803,11 +803,15 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 			.mono_register_bundled_assemblies = mono_register_bundled_assemblies,
 #if !defined(NET6)
 			.mono_register_config_for_assembly = mono_register_config_for_assembly,
+#else
+			.mono_register_config_for_assembly = nullptr,
 #endif // ndef NET6
 			.mono_jit_set_aot_mode = reinterpret_cast<void (*)(int)>(mono_jit_set_aot_mode),
 			.mono_aot_register_module = mono_aot_register_module,
 #if !defined(NET6)
 			.mono_config_parse_memory = mono_config_parse_memory,
+#else
+			.mono_config_parse_memory = nullptr,
 #endif // ndef NET6
 			.mono_register_machine_config = reinterpret_cast<void (*)(const char *)>(mono_register_machine_config),
 		};

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -801,10 +801,14 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	if (mono_mkbundle_initialize_mono_api) {
 		BundleMonoAPI bundle_mono_api = {
 			.mono_register_bundled_assemblies = mono_register_bundled_assemblies,
+#if !defined(NET6)
 			.mono_register_config_for_assembly = mono_register_config_for_assembly,
+#endif // ndef NET6
 			.mono_jit_set_aot_mode = reinterpret_cast<void (*)(int)>(mono_jit_set_aot_mode),
 			.mono_aot_register_module = mono_aot_register_module,
+#if !defined(NET6)
 			.mono_config_parse_memory = mono_config_parse_memory,
+#endif // ndef NET6
 			.mono_register_machine_config = reinterpret_cast<void (*)(const char *)>(mono_register_machine_config),
 		};
 
@@ -813,7 +817,14 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	}
 
 	if (mono_mkbundle_init)
-		mono_mkbundle_init (mono_register_bundled_assemblies, mono_register_config_for_assembly, reinterpret_cast<void (*)(int)>(mono_jit_set_aot_mode));
+		mono_mkbundle_init (
+			mono_register_bundled_assemblies,
+#if defined(NET6)
+			nullptr,
+#else
+			mono_register_config_for_assembly,
+#endif // def NET6
+			reinterpret_cast<void (*)(int)>(mono_jit_set_aot_mode));
 
 	/*
 	 * Assembly preload hooks are invoked in _reverse_ registration order.

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -65,6 +65,11 @@ namespace Xamarin.Android.Build.Tests
 
 		double GetDurationFromBinLog (ProjectBuilder builder)
 		{
+			//TODO: BuildEventArgsReader.Read() returns null in .NET 6 Preview 2
+			// See: https://github.com/dotnet/msbuild/issues/6225
+			if (Builder.UseDotNet)
+				Assert.Ignore ("Cannot currently parse .binlog files in .NET 6 Preview 2");
+
 			var duration = TimeSpan.Zero;
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, "msbuild.binlog");
 			FileAssert.Exists (binlog);


### PR DESCRIPTION
Bump net6 preview2 version, be in sync with iOS https://github.com/xamarin/xamarin-macios/blob/871e7b1cd0ca0e8434e94c8eedb168f33d5da2e8/Make.config#L500

Bump runtime pack version.

Added `System.Private.CoreLib.xml` as workaround for the crash in `GlobalizationNative_GetSortHandle`.
Context: https://github.com/dotnet/runtime/issues/49073

Stop using `mono_register_config_for_assembly` and `mono_config_parse_memory` functions,
they are gone from net6 runtime.

`BuildReleaseArm64` test, net6 apk size difference before/after

Simple XA:
```
Summary:
  +           0 Other entries 0.00% (of 58,410)
  +           0 Dalvik executables 0.00% (of 316,728)
  -       7,699 Assemblies -1.10% (of 696,896)
  -      41,704 Shared libraries -0.80% (of 5,196,608)
  -      14,848 Uncompressed assemblies -1.09% (of 1,361,408)
  -      36,864 Package size difference -1.25% (of 2,946,926)
```
XF/XA:
```
Summary:
  +           0 Other entries 0.00% (of 917,033)
  +           0 Dalvik executables 0.00% (of 3,455,720)
  -      15,978 Assemblies -0.28% (of 5,682,747)
  -      41,704 Shared libraries -0.79% (of 5,271,800)
  -      31,232 Uncompressed assemblies -0.25% (of 12,712,960)
  -      45,056 Package size difference -0.45% (of 9,952,454)
```