### PR TITLE
[ci] fixes for apkdiff and Dotnet Build phase

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -394,14 +394,18 @@ stages:
       inputs:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-*.xml
-        testRunTitle: Java Interop Tests - Windows Build Tree
+        testRunTitle: Java Interop Tests - Windows Dotnet Build
+
+    - script: 'dotnet tool update apkdiff -g'
+      displayName: install apkdiff dotnet tool
+      continueOnError: true
 
     # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
     # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
     # Only run a subset of the Xamarin.Android.Build.Tests against the local Windows build tree.
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
-        testRunTitle: Smoke MSBuild Tests - Windows Build Tree
+        testRunTitle: Smoke MSBuild Tests - Windows Dotnet Build
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\net472\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-SmokeMSBuildTests-WinDotnetBuildTree-$(XA.Build.Configuration).xml
         nunitConsoleExtraArgs: --where "cat == SmokeTests"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -248,7 +248,7 @@ namespace Xamarin.Android.Build.Tests
 				return RunProcessWithExitCode ("apkdiff" + ext, args);
 			} catch (System.ComponentModel.Win32Exception) {
 				// apkdiff's location might not be in the $PATH, try known location
-				var profileDir = Environment.GetEnvironmentVariable ("USERPROFILE");
+				var profileDir = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
 				return RunProcessWithExitCode (Path.Combine (profileDir, ".dotnet", "tools", "apkdiff" + ext), args);
 			}


### PR DESCRIPTION
Fixes? https://github.com/xamarin/xamarin-android/issues/5674
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4513530&view=ms.vss-test-web.build-test-results-tab&runId=19361000&resultId=100033&paneView=debug

Occasionally, we are seeing a test failure:

    BuildReleaseArm64(True)
    System.ComponentModel.Win32Exception : The system cannot find the file specified
        at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
        at Xamarin.Android.Build.Tests.BaseTest.RunProcessWithExitCode(String exe, String args) in C:\a\1\s\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\BaseTest.cs:line 287
        at Xamarin.Android.Build.Tests.BaseTest.RunApkDiffCommand(String args) in C:\a\1\s\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\BaseTest.cs:line 251
        at Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64(Boolean forms) in C:\a\1\s\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\BuildTest.cs:line 111

Also, we notice the `Dotnet Build and Smoke Test` job is overall
green, even though there were test failures.

I saw two problems that seem to cause this issue:

1. This job doesn't install `apkdiff`. So it happens to work (sometimes?) if `apkdiff` was already installed.
2. This job uses the same test results names as the `Windows Build and Smoke Test` job. I think this is contributing to the weird green build behavior.

Lastly, I fixed the `RunApkDiffCommand()` method, so it would also
work on macOS. It uses `$USERPROFILE`, which wouldn't work on macOS. I
changed this to use `Environment.SpecialFolder.UserProfile` instead.
This isn't contributing to the problem here, but I thought I should go
ahead and fix it.