### PR TITLE
[nunit3-console.cmd] fix exit codes

### DIFF
--- a/build-tools/scripts/nunit3-console.cmd
+++ b/build-tools/scripts/nunit3-console.cmd
@@ -1,4 +1,5 @@
 @echo off
+SETLOCAL
 set NUNIT_VERSION=3.11.1
 set PACKAGES_PATH=
 set MYDIR=%~dp0
@@ -7,7 +8,7 @@ if defined NUGET_PACKAGES (
   set PACKAGES_PATH=%NUGET_PACKAGES%
   goto got_location
 )
- 
+
 set NUGET_PATH=%MYDIR%..\..\.nuget\NuGet.exe
 if exist "%NUGET_PATH%" (
   for /f "tokens=1,2" %%a in ('"%NUGET_PATH%" locals -list global-packages') do set PACKAGES_PATH=%%b
@@ -18,8 +19,3 @@ set PACKAGES_PATH="%userprofile%\.nuget\packages"
 
 :got_location
 "%PACKAGES_PATH%\nunit.consolerunner\%NUNIT_VERSION%\tools\nunit3-console.exe" %*
-
-rem clean up - in cmd environment variables set in a batch file stay in the environment of the caller
-set PACKAGES_PATH=
-set MYDIR=
-set NUNIT_VERSION=


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5674
Context: https://www.tutorialspoint.com/batch_script/batch_script_variables.htm
Context: https://github.com/xamarin/xamarin-android/issues/5674#issuecomment-789012754

We noticed test failures on Windows do not fail the build:

    Test Run Summary
    Overall result: Failed
    Test Count: 65, Passed: 63, Failed: 2, Warnings: 0, Inconclusive: 0, Skipped: 0
        Failed Tests - Failures: 2, Errors: 0, Invalid: 0
    Start time: 2021-03-02 12:33:22Z
        End time: 2021-03-02 13:13:27Z
        Duration: 2404.467 seconds
    Results (nunit3) saved as TestResult-SmokeMSBuildTests-WinBuildTree-Release.xml
    ##[debug]$LASTEXITCODE: 0
    ##[debug]Exit code: 0

Reviewing `nunit3-console.cmd` it calls `set` at the end of the script
so it doesn't modify global variables:

    set PACKAGES_PATH=
    set MYDIR=
    set NUNIT_VERSION=

This makes the exit code always 0, even if tests failed.

I removed these `set` commands in favor of `SETLOCAL`, so the variables
will be local to this script.

Now it appears to work as expected from powershell:

    > & cmd /c .\build-tools\scripts\nunit3-console.cmd idontexist.dll
    ...
    > $LASTEXITCODE
    -2