### PR TITLE
Update DotNet5Version to 5.0.3

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -53,7 +53,7 @@ variables:
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.405
-  DotNet5Version: 5.0.100
+  DotNet5Version: 5.0.103
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: Xamarin-Android-Win2019-1120


### PR DESCRIPTION
.NET 5.0.3 was released today, and now our CI `Dotnet Build and Smoke Test - Prepare Solution` breaks with:

```
"C:\Program Files\dotnet\dotnet.exe" build C:\a\1\s\Xamarin.Android.sln "-dl:CentralLogger,\"C:\a\_tasks\DotNetCoreCLI_5541a522-603c-47ad-91fc-a4b1d163081b\2.181.0\dotnet-build-helpers\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll\"*ForwardingLogger,\"C:\a\_tasks\DotNetCoreCLI_5541a522-603c-47ad-91fc-a4b1d163081b\2.181.0\dotnet-build-helpers\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll\"" -c Release -target:Prepare -m:1 -p:AutoProvision=true -bl:C:\a\1\s\bin\BuildRelease\dotnet-build-prepare.binlog
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '5.0.3' was not found.
  - The following frameworks were found:
      3.1.11 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      5.0.0 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.
```

Resolve this by updating to .NET 5.0.3 (SDK version: 5.0.103).