### PR TITLE
[One .NET] <FixNuGetReferences/> should also work for netstandard2.1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tasks
 				var directory = Path.GetDirectoryName (item.ItemSpec);
 				var directoryName = Path.GetFileName (directory);
 				Log.LogDebugMessage ($"{directoryName} -> {item.ItemSpec}");
-				if (directoryName == "netstandard2.0") {
+				if (directoryName.StartsWith ("netstandard2", StringComparison.OrdinalIgnoreCase)) {
 					var parent = Directory.GetParent (directory);
 					foreach (var nugetDirectory in parent.EnumerateDirectories ()) {
 						var name = Path.GetFileName (nugetDirectory.Name);


### PR DESCRIPTION
I was attempting to build a project using some brand new Maui NuGet
packages and hit errors such as:

    The type or namespace name 'MauiAppCompatActivity' could not be found
    The type or namespace name 'MauiApplication<>' could not be found

These types are in:

    %userprofile%\.nuget\packages\microsoft.maui.core\6.0.100-preview.2.179\lib\net6.0-android30.0\Microsoft.Maui.dll

Unfortunately, the build actually used the `netstandard2.1` assembly:

    %userprofile%\.nuget\packages\microsoft.maui.core\6.0.100-preview.2.179\lib\netstandard2.1\Microsoft.Maui.dll

Our temporary `<FixNuGetReferences/>` MSBuild task should be the thing
that selects the correct assembly--but it didn't. When we have full
NuGet `$(TFM)` support, we won't need this task at all.

After reviewing the code, I think we need to check `.StartsWith("netstandard2")`.

I will add a test for this scenario when we have Maui packages we can
consume from a feed. We should build a sample Maui app on our CI.