### PR TITLE
[Xamarin.Android.Build.Tasks] Add properties holding the Final VersionCode/Name.

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -488,21 +488,30 @@ deprecated API's to work.
 
 **Experimental**. This property was added in Xamarin.Android 6.1.
 
-## AndroidFinalVersionCode
+## AndroidManifestVersions
 
-This is a string property which represents the final `android:versionCode` which
-was written to the `AndroidManifest.xml`.
-This is a read only property and is for information only.
+This is an ItemGroup which represents the final `android:versionCode` and
+'android:versionName' which were written to the `AndroidManifest.xml` files.
+
+This are read only and is for information only.
+
+Each item in the group will contain the path to the `AndroidManifest.xml` the
+data was retrieved from and two items of Metadata.
+
+* `VersionCode`: The final code used.
+* `VersionName`: The final name used.
+* `Abi`: The abi for this manifest.
+
+This is an item group because Xamarin.Android allows developers to generate
+multiple apk files per abi. Each Apk can have a slightly different `android:versionCode`.
+
+```xml
+<AndroidManifestVersions Include="com.foo.bar-x86.apk"
+  VersionCode="316241012" VersionName="1.0" Abi="x86" />
+```
 
 Added in Xamarin.Android 11.3.
 
-## AndroidFinalVersionName
-
-This is a string property which represents the final `android:versionName` which
-was written to the `AndroidManifest.xml`.
-This is a read only property and is for information only.
-
-Added in Xamarin.Android 11.3.
 
 ## AndroidGenerateJniMarshalMethods
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -506,7 +506,11 @@ This is an item group because Xamarin.Android allows developers to generate
 multiple apk files per abi. Each Apk can have a slightly different `android:versionCode`.
 
 ```xml
-<AndroidManifestVersions Include="com.foo.bar-x86.apk"
+<AndroidManifestVersions Include="com.foo.bar"
+  VersionCode="316241012" VersionName="1.0" Abi="all" />
+<AndroidManifestVersions Include="com.foo.bar-armeabi-v7a"
+  VersionCode="316241012" VersionName="1.0" Abi="armeabi-v7a" />
+<AndroidManifestVersions Include="com.foo.bar-x86"
   VersionCode="316241012" VersionName="1.0" Abi="x86" />
 ```
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -488,6 +488,22 @@ deprecated API's to work.
 
 **Experimental**. This property was added in Xamarin.Android 6.1.
 
+## AndroidFinalVersionCode
+
+This is a string property which represents the final `android:versionCode` which
+was written to the `AndroidManifest.xml`.
+This is a read only property and is for information only.
+
+Added in Xamarin.Android 11.3.
+
+## AndroidFinalVersionName
+
+This is a string property which represents the final `android:versionName` which
+was written to the `AndroidManifest.xml`.
+This is a read only property and is for information only.
+
+Added in Xamarin.Android 11.3.
+
 ## AndroidGenerateJniMarshalMethods
 
 A bool property which

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetManifestVersions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetManifestVersions.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	public class GetManifestVersions : AndroidTask
+	{
+		public override string TaskPrefix => "GAP";
+
+		public ITaskItem ManifestFile { get; set; }
+
+		[Output]
+		public string VersionCode { get; set; }
+
+		[Output]
+		public string VersionName { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (!string.IsNullOrEmpty (ManifestFile.ItemSpec) && File.Exists (ManifestFile.ItemSpec)) {
+				using var stream = File.OpenRead (ManifestFile.ItemSpec);
+				using var reader = XmlReader.Create (stream);
+				if (reader.MoveToContent () == XmlNodeType.Element) {
+					var versionCode = reader.GetAttribute ("versionCode");
+					if (!string.IsNullOrEmpty (versionCode)) {
+						VersionCode = versionCode;
+					}
+					var versionName = reader.GetAttribute ("versionName");
+					if (!string.IsNullOrEmpty (versionName)) {
+						VersionName = versionCode;
+					}
+				}
+			}
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetManifestVersions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetManifestVersions.cs
@@ -1,39 +1,58 @@
 using System.IO;
 using System.Xml;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
 using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
 	public class GetManifestVersions : AndroidTask
 	{
+		readonly HashSet<string> validPaths = new HashSet<string> {
+			"manifest",
+			"x86",
+			"x86_64",
+			"armeabi-v7a",
+			"arm64-v8a",
+		};
 		public override string TaskPrefix => "GAP";
 
-		public ITaskItem ManifestFile { get; set; }
+		public string ManifestPath { get; set; }
+
+		public string PackageName { get; set; }
 
 		[Output]
-		public string VersionCode { get; set; }
-
-		[Output]
-		public string VersionName { get; set; }
+		public ITaskItem[] ManifestVersions { get; set; }
 
 		public override bool RunTask ()
 		{
-			if (!string.IsNullOrEmpty (ManifestFile.ItemSpec) && File.Exists (ManifestFile.ItemSpec)) {
-				using var stream = File.OpenRead (ManifestFile.ItemSpec);
+			var versionInfo = new List<ITaskItem> ();
+			foreach (string manifestFile in Directory.GetFiles (ManifestPath, "AndroidManifest.xml", SearchOption.AllDirectories))
+			{
+				string folder = Path.GetFileName (Path.GetDirectoryName (manifestFile));
+				if (!validPaths.Contains (folder)) {
+					continue;
+				}
+				string versionCode = string.Empty;
+				string versionName = string.Empty;
+				using var stream = File.OpenRead (manifestFile);
 				using var reader = XmlReader.Create (stream);
 				if (reader.MoveToContent () == XmlNodeType.Element) {
-					var versionCode = reader.GetAttribute ("versionCode");
-					if (!string.IsNullOrEmpty (versionCode)) {
-						VersionCode = versionCode;
-					}
-					var versionName = reader.GetAttribute ("versionName");
-					if (!string.IsNullOrEmpty (versionName)) {
-						VersionName = versionCode;
-					}
+					versionCode = reader.GetAttribute ("android:versionCode");
+					versionName = reader.GetAttribute ("android:versionName");
+				}
+				if (!string.IsNullOrEmpty (versionCode) && !string.IsNullOrEmpty (versionName)) {
+					string suffix = folder == "manifest" ? "" : $"-{folder}";
+					var data = new TaskItem ($"{PackageName}{suffix}");
+					data.SetMetadata ("VersionCode", versionCode);
+					data.SetMetadata ("VersionName", versionName);
+					data.SetMetadata ("Abi", folder.Replace ("manifest", "all"));
+					versionInfo.Add (data);
 				}
 			}
+			ManifestVersions = versionInfo.ToArray ();
 			return !Log.HasLoggedErrors;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -497,6 +497,11 @@ namespace Bug12935
 					StringAssert.AreEqualIgnoringCase (expectedItems[i], vc.Value,
 						$"Version Code is incorrect. Found {vc.Value} expect {expectedItems[i]}");
 				}
+				var messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Task \"GetManifestVersions\""));
+				foreach (var item in expectedItems) {
+					StringAssertEx.Contains($"VersionCode={item}", messages, $"Build output should contain VersionCode={item}");
+				}
+
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetManifestVersionsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetManifestVersionsTests.cs
@@ -2,6 +2,7 @@ using System;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
 using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using System.Text;
@@ -17,14 +18,12 @@ namespace Xamarin.Android.Build.Tests {
 #pragma warning disable 414
 static object [] ReadManifestVersionsTestCases () => new object [] {
 	new object[] {
-		/* includeVersion */		true,
 		/* versionCode */		"55555",
 		/* versionName */		"33.4",
 		/* expectedVersionCode */	"55555" ,
 		/* expectedVersionName */	"33.4",
 	},
 	new object[] {
-		/* includeVersion */		false,
 		/* versionCode */		"1",
 		/* versionName */		"1.0",
 		/* expectedVersionCode */	"1" ,
@@ -35,27 +34,23 @@ static object [] ReadManifestVersionsTestCases () => new object [] {
 
 		[Test]
 		[TestCaseSource (nameof(ReadManifestVersionsTestCases))]
-		public void ReadManifestVersions (bool includeVersion, string versionCode, string versionName, string expectedVersionCode, string expectedVersionName)
+		public void ReadManifestVersions (string versionCode, string versionName, string expectedVersionCode, string expectedVersionName)
 		{
 			var path = Path.Combine ("temp", TestName);
-			Directory.CreateDirectory (path);
+			Directory.CreateDirectory (Path.Combine (path, "manifest"));
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			var task = new GetManifestVersions {
 				BuildEngine = engine
 			};
-			string versionBlock = string.Empty;
-			if (includeVersion)
-				versionBlock = $"android:versionCode='{versionCode}' android:versionName='{versionName}'";
-			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"),
+			string versionBlock = $"android:versionCode='{versionCode}' android:versionName='{versionName}'";
+			File.WriteAllText (Path.Combine (path, "manifest", "AndroidManifest.xml"),
 				$@"<?xml version='1.0' ?>
 <manifest xmlns:android='http://schemas.android.com/apk/res/android' {versionBlock} android:package='Foo.Foo' />");
-			task.VersionCode = versionCode;
-			task.VersionName = versionName;
-			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
+			task.ManifestPath = path;
 			Assert.IsTrue (task.Execute ());
-			Assert.IsNotNull (task.VersionCode);
-			Assert.IsNotNull (task.VersionName);
-
+			Assert.AreEqual (1, task.ManifestVersions.Count());
+			Assert.AreEqual (expectedVersionCode, task.ManifestVersions[0].GetMetadata ("VersionCode"));
+			Assert.AreEqual (expectedVersionName, task.ManifestVersions[0].GetMetadata ("VersionName"));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetManifestVersionsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetManifestVersionsTests.cs
@@ -1,0 +1,61 @@
+using System;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Text;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests {
+	[TestFixture]
+	[Category ("Node-2")]
+	[Parallelizable (ParallelScope.Children)]
+	public class GetManifestVersionsTests : BaseTest {
+
+#pragma warning disable 414
+static object [] ReadManifestVersionsTestCases () => new object [] {
+	new object[] {
+		/* includeVersion */		true,
+		/* versionCode */		"55555",
+		/* versionName */		"33.4",
+		/* expectedVersionCode */	"55555" ,
+		/* expectedVersionName */	"33.4",
+	},
+	new object[] {
+		/* includeVersion */		false,
+		/* versionCode */		"1",
+		/* versionName */		"1.0",
+		/* expectedVersionCode */	"1" ,
+		/* expectedVersionName */	"1.0",
+	},
+};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource (nameof(ReadManifestVersionsTestCases))]
+		public void ReadManifestVersions (bool includeVersion, string versionCode, string versionName, string expectedVersionCode, string expectedVersionName)
+		{
+			var path = Path.Combine ("temp", TestName);
+			Directory.CreateDirectory (path);
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new GetManifestVersions {
+				BuildEngine = engine
+			};
+			string versionBlock = string.Empty;
+			if (includeVersion)
+				versionBlock = $"android:versionCode='{versionCode}' android:versionName='{versionName}'";
+			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"),
+				$@"<?xml version='1.0' ?>
+<manifest xmlns:android='http://schemas.android.com/apk/res/android' {versionBlock} android:package='Foo.Foo' />");
+			task.VersionCode = versionCode;
+			task.VersionName = versionName;
+			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
+			Assert.IsTrue (task.Execute ());
+			Assert.IsNotNull (task.VersionCode);
+			Assert.IsNotNull (task.VersionName);
+
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1706,12 +1706,10 @@ because xbuild doesn't support framework reference assemblies.
     Condition="Exists ('$(_ManifestOutput)')"
     DependsOnTargets="_CreateBaseApk">
   <GetManifestVersions
-    VersionCode="$(_AndroidVersionCode)"
-    VersionName="$(_AndroidVersionName)"
-    ManifestFile="$(_ManifestOutput)"
+    ManifestPath="$(IntermediateOutputPath)android"
+    PackageName="$(_AndroidPackage)"
   >
-    <Output TaskParameter="VersionCode" PropertyName="AndroidFinalVersionCode" />
-    <Output TaskParameter="VersionName" PropertyName="AndroidFinalVersionName" />
+    <Output TaskParameter="ManifestVersions" ItemName="AndroidManifestVersions" />
   </GetManifestVersions>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -63,6 +63,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.GetConvertedJavaLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetFilesThatExist" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetJavaPlatformJar" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GetManifestVersions" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetMonoPlatformJar" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Javac" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.KeyTool" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1701,6 +1702,19 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
+<Target Name="_GetFinalManifestVersions"
+    Condition="Exists ('$(_ManifestOutput)')"
+    DependsOnTargets="_CreateBaseApk">
+  <GetManifestVersions
+    VersionCode="$(_AndroidVersionCode)"
+    VersionName="$(_AndroidVersionName)"
+    ManifestFile="$(_ManifestOutput)"
+  >
+    <Output TaskParameter="VersionCode" PropertyName="AndroidFinalVersionCode" />
+    <Output TaskParameter="VersionName" PropertyName="AndroidFinalVersionName" />
+  </GetManifestVersions>
+</Target>
+
 <Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ManifestMerger;_ConvertCustomView;$(_AfterConvertCustomView);_GenerateEnvironmentFiles;">
   <ItemGroup>
     <_JavaStubFiles Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java" />
@@ -1734,6 +1748,7 @@ because xbuild doesn't support framework reference assemblies.
 		_GetLibraryImports;
 		_CheckDuplicateJavaLibraries;
 		_CreateBaseApk;
+		_GetFinalManifestVersions;
 		_DetermineJavaLibrariesToCompile;
 		$(_CompileJavaDependsOnTargets)
 	</_CompileJavaDependsOnTargets>


### PR DESCRIPTION
Fixes https://work.azdo.io/1005105

Users sometime want to use the values of `versionCode` and/or `versionName`
from the `AndroidManifest.xml` in their post build events. The problem
is if they are using things like `AndroidVersionCodePattern`, these values
are calculated during the build.

Users can make use of Post Build Tasks and `XmlPeek` to manually get
these values, but it would be nice to have some official properties which
they can use to get the final values.