### PR TITLE
[net6] Fix the `InstallWithoutSharedRuntime` test

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -204,10 +204,16 @@ namespace Xamarin.Android.Build.Tests
 					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
 				using (var apk = ZipHelper.OpenZip (apkPath)) {
 					foreach (var abi in abis) {
-						var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Runtime == "debug");
+						string runtimeAbiName;
+						if (Builder.UseDotNet) {
+							runtimeAbiName = $"{abi}-net6";
+						} else {
+							runtimeAbiName = abi;
+						}
+						var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == runtimeAbiName && x.Runtime == "debug");
 						Assert.IsNotNull (runtime, "Could not find the expected runtime.");
 						var inApk = ZipHelper.ReadFileFromZip (apk, String.Format ("lib/{0}/{1}", abi, runtime.Name));
-						var inApkRuntime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Size == inApk.Length);
+						var inApkRuntime = runtimeInfo.FirstOrDefault (x => x.Abi == runtimeAbiName && x.Size == inApk.Length);
 						Assert.IsNotNull (inApkRuntime, "Could not find the actual runtime used.");
 						Assert.AreEqual (runtime.Size, inApkRuntime.Size, "expected {0} got {1}", "debug", inApkRuntime.Runtime);
 					}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/0cd890bdf7fb0255f11d8c14e3de69c9e2691117

0cd890bd was committed despite one test,
`Xamarin.Android.Build.Tests.InstallTests.InstallWithoutSharedRuntime`,
failing. The test was failing because it didn't take into account that
the newly added native runtime builds stored their output in a directory
suffixed with `-net6` and it assumed that ABI name (e.g. `armeabi-v7a`)
was identical to directory name, thus failing to find the correct
runtime when running tests under NET6

Fix the issue by properly appending the `-net6` suffix when looking for
a matching runtime name while executing the test for NET6