### PR TITLE
[ci] Use JDK 1.8 for legacy MSBuild test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -773,6 +773,7 @@ stages:
       job_name: mac_msbuild_tests_1
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -781,6 +782,7 @@ stages:
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
       run_extra_tests: true
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -788,6 +790,7 @@ stages:
       job_name: mac_msbuild_tests_3
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   # Xamarin.Android (Test MSBuild Legacy - Windows)
   - template: yaml-templates\run-msbuild-win-tests.yaml
@@ -796,6 +799,7 @@ stages:
       job_name: win_msbuild_tests_1
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -804,6 +808,7 @@ stages:
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
       run_extra_tests: true
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -811,6 +816,7 @@ stages:
       job_name: win_msbuild_tests_3
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
 - stage: msbuild_dotnet
   displayName: One .NET Tests
@@ -877,6 +883,7 @@ stages:
     parameters:
       job_name: mac_msbuilddevice_tests
       job_suffix: Legacy
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
@@ -939,12 +946,7 @@ stages:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
-
-    - script: echo "##vso[task.setvariable variable=JavaSdkDirectory]$HOME/Library/Android/$(XA.Jdk8.Folder)"
-      displayName: set JavaSdkDirectory
-
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk8.Folder)"
-      displayName: reset JI_JAVA_HOME for Designer
+        jdkTestFolder: $(XA.Jdk8.Folder)
 
     - template: designer/android-designer-build-mac.yaml@yaml
       parameters:
@@ -1019,15 +1021,7 @@ stages:
     - template: yaml-templates\setup-test-environment.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)\xamarin-android
-
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk8.Folder)"
-      displayName: reset JI_JAVA_HOME for Designer
-      condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
-
-    - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk8.Folder)
-      displayName: reset JI_JAVA_HOME for Designer
-      condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+        jdkTestFolder: $(XA.Jdk8.Folder)
 
     - template: designer\android-designer-build-win.yaml@yaml
       parameters:

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -5,6 +5,7 @@ parameters:
   job_suffix: ''
   nunit_categories: ''
   target_framework: 'net472'
+  jdkTestFolder: $(XA.Jdk11.Folder)
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -19,6 +20,8 @@ jobs:
       UseDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}
     steps:
     - template: setup-test-environment.yaml
+      parameters:
+        jdkTestFolder: ${{ parameters.jdkTestFolder }}
 
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
       displayName: install emulator

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -7,6 +7,7 @@ parameters:
   nunit_categories: ''
   target_framework: 'net472'
   run_extra_tests: false
+  jdkTestFolder: $(XA.Jdk11.Folder)
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -21,6 +22,8 @@ jobs:
       UseDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}
     steps:
     - template: setup-test-environment.yaml
+      parameters:
+        jdkTestFolder: ${{ parameters.jdkTestFolder }}
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -7,6 +7,7 @@ parameters:
   nunit_categories: ''
   target_framework: 'net472'
   run_extra_tests: false
+  jdkTestFolder: $(XA.Jdk11.Folder)
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -27,6 +28,7 @@ jobs:
     - template: setup-test-environment.yaml
       parameters:
         updateVS: true
+        jdkTestFolder: ${{ parameters.jdkTestFolder }}
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -3,6 +3,7 @@ parameters:
   provisionExtraArgs: -vv -f
   xaSourcePath: $(System.DefaultWorkingDirectory)
   updateVS: false
+  jdkTestFolder: $(XA.Jdk11.Folder)
 
 steps:
 - checkout: self
@@ -18,12 +19,12 @@ steps:
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
-- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/$(XA.Jdk11.Folder)"
+- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/${{ parameters.jdkTestFolder }}"
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: |
-    echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)
+    echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\${{ parameters.jdkTestFolder }}
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1659,25 +1659,11 @@ namespace App1
 			}
 		}
 
-		/// <summary>
-		/// Works around a bug in lint.bat on Windows: https://issuetracker.google.com/issues/68753324
-		/// - We may want to remove this if a future Android SDK tools, no longer has this issue
-		/// </summary>
-		void FixLintOnWindows ()
-		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-				var androidSdk = AndroidSdkResolver.GetAndroidSdkPath ();
-				var androidSdkTools = Path.Combine (androidSdk, "tools");
-				if (Directory.Exists (androidSdkTools)) {
-					Environment.SetEnvironmentVariable ("JAVA_OPTS", $"\"-Dcom.android.tools.lint.bindir={androidSdkTools}\"", EnvironmentVariableTarget.Process);
-				}
-			}
-		}
-
 		[Test]
 		public void CheckLintResourceFileReferencesAreFixed ()
 		{
-			FixLintOnWindows ();
+			if (TestEnvironment.IsUsingJdk8)
+				Assert.Ignore ("https://github.com/xamarin/xamarin-android/issues/5698");
 
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageReferences = {
@@ -1720,7 +1706,8 @@ namespace App1
 		[NonParallelizable]
 		public void CheckLintErrorsAndWarnings ()
 		{
-			FixLintOnWindows ();
+			if (TestEnvironment.IsUsingJdk8)
+				Assert.Ignore ("https://github.com/xamarin/xamarin-android/issues/5698");
 
 			string disabledIssues = "StaticFieldLeak,ObsoleteSdkInt,AllowBackup,ExportedReceiver";
 
@@ -1785,7 +1772,8 @@ namespace App1
 		[Test]
 		public void CheckLintConfigMerging ()
 		{
-			FixLintOnWindows ();
+			if (TestEnvironment.IsUsingJdk8)
+				Assert.Ignore ("https://github.com/xamarin/xamarin-android/issues/5698");
 
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidLintEnabled", true.ToString ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 
 namespace Xamarin.ProjectTools
 {
@@ -58,6 +59,30 @@ namespace Xamarin.ProjectTools
 			if (string.IsNullOrEmpty (JavaSdkPath))
 				JavaSdkPath = Path.GetFullPath (Path.Combine (ToolchainPath, "jdk"));
 			return JavaSdkPath;
+		}
+
+		static string JavaSdkVersionString;
+
+		public static string GetJavaSdkVersionString ()
+		{
+			if (string.IsNullOrEmpty (JavaSdkVersionString)) {
+				var javaPath = Path.Combine (GetJavaSdkPath (), "bin", "java");
+				var psi = new ProcessStartInfo (javaPath, "-version") {
+					CreateNoWindow = true,
+					RedirectStandardOutput = true,
+					RedirectStandardError = true,
+					WindowStyle = ProcessWindowStyle.Hidden,
+					UseShellExecute = false,
+				};
+				var output = new StringBuilder ();
+				using (var p = Process.Start (psi)) {
+					p.WaitForExit ();
+					output.AppendLine (p.StandardOutput.ReadToEnd ());
+					output.AppendLine (p.StandardError.ReadToEnd ());
+					JavaSdkVersionString = output.ToString ();
+				}
+			}
+			return JavaSdkVersionString;
 		}
 
 		// Cache the result, so we don't run MSBuild on every call

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -391,7 +391,7 @@ namespace Xamarin.ProjectTools
 							stdout.Set ();
 					};
 					p.StartInfo = psi;
-					Console.WriteLine ($"{psi.FileName} {psi.Arguments} {string.Join (" ", File.ReadAllLines (responseFile))}");
+					Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
 					p.Start ();
 					p.BeginOutputReadLine ();
 					p.BeginErrorReadLine ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -391,7 +391,7 @@ namespace Xamarin.ProjectTools
 							stdout.Set ();
 					};
 					p.StartInfo = psi;
-					Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
+					Console.WriteLine ($"{psi.FileName} {psi.Arguments} {string.Join (" ", File.ReadAllLines (responseFile))}");
 					p.Start ();
 					p.BeginOutputReadLine ();
 					p.BeginErrorReadLine ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -96,6 +96,10 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		}
+
+		public static bool IsUsingJdk8 => AndroidSdkResolver.GetJavaSdkVersionString ().Contains ("1.8.0");
+
+		public static bool IsUsingJdk11 => AndroidSdkResolver.GetJavaSdkVersionString ().Contains ("11.0");
 	}
 }
 


### PR DESCRIPTION
The legacy MSBuild test jobs have been updated to use JDK 1.8 in order
to retain some JDK 1.8 test coverage.  JDK 1.8 is still installed by VS
and VS Mac, and it is likely what the vast majority of our customers
use today.

The Xamarin.ProjectTools.Builder and Xamarin.ProjectTools.DotNetCLI
classes are used for all Xamarin.Android.Build tests that need to invoke
msbuild or dotnet build.  Both of these wrapper classes will append
`/p:JavaSdkDirectory=$PATH` to all msbuild/dotnet build invocations, and
they use the same logic from Xamarin.ProjectTools.AndroidSdkResolver to
look up the JDK path.  See 16e971f29fc39639a9a245811e10bf9fd3c5047e for
more details.

This look up first checks to see if `$(JavaSdkDirectory)` is set in
Configuration.OperatingSystem.props.  This file is generated by an
xaprepare step that does not run on our test jobs, so the look up will
then check the value of `$JI_JAVA_HOME`. Overriding this environment
variable should ensure that all of our legacy MSBuild test jobs run
against JDK 1.8.

A few lint tests have been disabled when running against JDK 1.8. See 
https://github.com/xamarin/xamarin-android/issues/5698 for more info.

The `FixLintOnWindows` workaround has been removed. The xaprepare
tool installs the cmdline-tools Android SDK package, and the versions
of lint included in this package do not have this issue.  Our test
environments will never attempt to use the old version of lint found in
the tools folder.
