### PR TITLE
[monodroid] Handle Mono log messages in XA runtime

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -463,6 +463,7 @@ set(XAMARIN_MONODROID_SOURCES
 
 if(ANDROID)
   list(APPEND XAMARIN_MONODROID_SOURCES
+    ${SOURCES_DIR}/mono-log-adapter.cc
     ${LZ4_SOURCES}
     )
 

--- a/src/monodroid/jni/build-info.hh
+++ b/src/monodroid/jni/build-info.hh
@@ -1,0 +1,59 @@
+#if !defined (__BUILD_INFO_HH)
+#define __BUILD_INFO_HH
+
+#if defined (ANDROID)
+#include <android/ndk-version.h>
+#endif // def ANDROID
+
+namespace xamarin::android::internal
+{
+#define STRINGIFY(_val_) #_val_
+#define VERSION_STRING(_major_, _minor_, _build_) STRINGIFY(_major_) "." STRINGIFY(_minor_) "." STRINGIFY(_build_)
+
+	class BuildInfo final
+	{
+	public:
+		static constexpr char xa_version[] = XA_VERSION;
+		static constexpr char date[] = __DATE__;
+
+		static constexpr bool is_net6 =
+#if NET6
+			true;
+#else // def NET6
+			false;
+#endif // ndef NET6
+
+		static constexpr char kind[] =
+#if defined (DEBUG)
+			"Debug";
+#else // ndef DEBUG
+			"Release";
+#endif
+
+		static constexpr char architecture[] =
+#if defined (__aarch64__)
+			"ARM64";
+#elif defined (__arm__)
+			"ARM32";
+#elif defined (__amd64__) || defined (__x86_64__)
+			"X86_64";
+#elif defined (__i386__)
+			"X86";
+#endif
+
+		static constexpr char ndk_version[] =
+#if defined (ANDROID)
+			VERSION_STRING (__NDK_MAJOR__, __NDK_MINOR__, __NDK_BUILD__);
+#else // def ANDROID
+			"";
+#endif // // ndef ANDROID
+
+		static constexpr char ndk_api_level[] =
+#if defined (__ANDROID_API__)
+			STRINGIFY(__ANDROID_API__);
+#else // def __ANDROID_API__
+			"";
+#endif // ndef __ANDROID_API__
+	};
+}
+#endif // ndef __BUILD_INFO_HH

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -61,7 +61,7 @@ __android_log_vprint (int prio, const char* tag, const char* fmt, va_list ap)
 }
 #endif
 
-unsigned int log_categories;
+unsigned int log_categories = LOG_NONE;
 unsigned int log_timing_categories;
 int gc_spew_enabled;
 
@@ -122,10 +122,13 @@ init_reference_logging (const char *override_dir)
 }
 
 void
-init_logging_categories ()
+init_logging_categories (char*& mono_log_mask, char*& mono_log_level)
 {
 	char *value;
 	char **args, **ptr;
+
+	mono_log_mask = nullptr;
+	mono_log_level = nullptr;
 
 #if !ANDROID
 	log_categories = LOG_DEFAULT;
@@ -164,6 +167,11 @@ init_logging_categories ()
 
 #undef CATEGORY
 
+		constexpr char MONO_LOG_MASK_ARG[] = "mono_log_mask=";
+		constexpr size_t MONO_LOG_MASK_ARG_LEN = sizeof(MONO_LOG_MASK_ARG) - 1;
+		constexpr char MONO_LOG_LEVEL_ARG[] = "mono_log_level=";
+		constexpr size_t MONO_LOG_LEVEL_ARG_LEN = sizeof(MONO_LOG_LEVEL_ARG) - 1;
+
 		if (!strncmp (arg, "gref=", 5)) {
 			log_categories  |= LOG_GREF;
 			gref_file        = arg + 5;
@@ -178,6 +186,10 @@ init_logging_categories ()
 			light_lref       = 1;
 		} else if (!strncmp (arg, "timing=bare", 11)) {
 			log_timing_categories |= LOG_TIMING_BARE;
+		} else if (strncmp (arg, MONO_LOG_MASK_ARG, MONO_LOG_MASK_ARG_LEN) == 0) {
+			mono_log_mask = utils.strdup_new (arg + MONO_LOG_MASK_ARG_LEN);
+		} else if (strncmp (arg, MONO_LOG_LEVEL_ARG, MONO_LOG_LEVEL_ARG_LEN) == 0) {
+			mono_log_level = utils.strdup_new (arg + MONO_LOG_LEVEL_ARG_LEN);
 		}
 #if !defined (WINDOWS) && defined (DEBUG)
 		else if (!strncmp (arg, "debugger-log-level=", 19)) {

--- a/src/monodroid/jni/logger.hh
+++ b/src/monodroid/jni/logger.hh
@@ -17,7 +17,7 @@ typedef enum android_LogPriority {
 } android_LogPriority;
 #endif
 
-void init_logging_categories ();
+void init_logging_categories (char*& mono_log_mask, char*& mono_log_level);
 
 void init_reference_logging (const char *override_dir);
 

--- a/src/monodroid/jni/mono-log-adapter.cc
+++ b/src/monodroid/jni/mono-log-adapter.cc
@@ -1,0 +1,57 @@
+#include <android/log.h>
+#include <mono/utils/mono-logger.h>
+
+#include "monodroid-glue-internal.hh"
+#include "strings.hh"
+#include "logger.hh"
+
+using namespace xamarin::android::internal;
+
+void
+MonodroidRuntime::mono_log_handler (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, [[maybe_unused]] void *user_data)
+{
+	android_LogPriority prio = ANDROID_LOG_DEFAULT;
+
+	if (log_level != nullptr && *log_level != '\0') {
+		switch (*log_level) {
+			case 'e':
+				prio = ANDROID_LOG_ERROR;
+				break;
+
+			case 'c':
+				prio = ANDROID_LOG_FATAL;
+				break;
+
+			case 'w':
+				prio = ANDROID_LOG_WARN;
+				break;
+
+			case 'u':
+			case 'm':
+				prio = ANDROID_LOG_VERBOSE;
+				break;
+
+			case 'i':
+				prio = ANDROID_LOG_INFO;
+				break;
+
+			case 'd':
+				prio = ANDROID_LOG_DEBUG;
+				break;
+		}
+	}
+
+	__android_log_write (prio, log_domain, message);
+	if (fatal) {
+		abort ();
+	}
+}
+
+void
+MonodroidRuntime::mono_log_standard_streams_handler (const char *str, mono_bool is_stdout)
+{
+	static constexpr char mono_stdout[] = "mono-stdout";
+	static constexpr char mono_stderr[] = "mono-stderr";
+
+	__android_log_write (ANDROID_LOG_DEFAULT, is_stdout ? mono_stdout : mono_stderr, str);
+}

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -127,12 +127,6 @@ namespace xamarin::android::internal
 		static constexpr char API_DSO_NAME[] = MAKE_API_DSO_NAME (so);
 #endif  // defined(WINDOWS)
 	public:
-		static constexpr bool is_net6 =
-#if NET6
-		true;
-#else // def NET6
-		false;
-#endif // ndef NET6
 		static constexpr int XA_LOG_COUNTERS = MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS | MONO_COUNTER_INTERP;
 
 	public:
@@ -201,6 +195,13 @@ namespace xamarin::android::internal
 		char*	get_java_class_name_for_TypeManager (jclass klass);
 
 	private:
+#if defined (ANDROID)
+		static void mono_log_handler (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
+		static void mono_log_standard_streams_handler (const char *str, mono_bool is_stdout);
+		void setup_mono_tracing (char const* const& mono_log_mask);
+		void install_logging_handlers ();
+#endif // def ANDROID
+
 		unsigned int convert_dl_flags (int flags);
 #if defined (WINDOWS) || defined (APPLE_OS_X)
 		static const char* get_my_location (bool remove_file_name = true);

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -30,6 +30,7 @@
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-dl-fallback.h>
+#include <mono/utils/mono-logger.h>
 
 #include "mono_android_Runtime.h"
 
@@ -80,6 +81,7 @@
 #include "xamarin-app.hh"
 #include "timing.hh"
 #include "xa-internal-api-impl.hh"
+#include "build-info.hh"
 
 #ifndef WINDOWS
 #include "xamarin_getifaddrs.h"
@@ -1697,12 +1699,102 @@ MonodroidRuntime::get_my_location (bool remove_file_name)
 }
 #endif  // defined(WINDOWS)
 
+#if defined (ANDROID)
+force_inline void
+MonodroidRuntime::setup_mono_tracing (char const* const& mono_log_mask)
+{
+	bool have_log_assembly = (log_categories & LOG_ASSEMBLY) != 0;
+	bool have_log_gc = (log_categories & LOG_GC) != 0;
+
+	constexpr char   MASK_ASM[] = "asm";
+	constexpr size_t MASK_ASM_LEN = sizeof(MASK_ASM) - 1;
+	constexpr char   MASK_DLL[] = "dll";
+	constexpr size_t MASK_DLL_LEN = sizeof(MASK_DLL) - 1;
+	constexpr char   MASK_GC[] = "gc";
+	constexpr size_t MASK_GC_LEN = sizeof(MASK_GC) - 1;
+
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> log_mask;
+	if (mono_log_mask == nullptr || *mono_log_mask == '\0') {
+		if (have_log_assembly) {
+			log_mask.append (MASK_ASM);
+			log_mask.append (",");
+			log_mask.append (MASK_DLL);
+		}
+
+		if (have_log_gc) {
+			if (log_mask.length () > 0) {
+				log_mask.append (",");
+			}
+			log_mask.append (MASK_GC);
+		}
+
+		// empty string turns off all Mono VM tracing
+		mono_trace_set_mask_string (log_mask.get ());
+		return;
+	}
+
+	if (!have_log_assembly && !have_log_gc)  {
+		mono_trace_set_mask_string (mono_log_mask);
+		return;
+	}
+
+	bool need_asm = have_log_assembly, need_dll = have_log_assembly, need_gc = have_log_gc;
+	dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN> input_log_mask;
+	input_log_mask.assign (mono_log_mask);
+
+	string_segment token;
+	while (input_log_mask.next_token (',', token)) {
+		if (need_asm && token.equal (MASK_ASM, MASK_ASM_LEN)) {
+			need_asm = false;
+		} else if (need_dll && token.equal (MASK_DLL, MASK_DLL_LEN)) {
+			need_dll = false;
+		} else if (need_gc && token.equal (MASK_GC, MASK_GC_LEN)) {
+			need_gc = false;
+		}
+
+		if (!need_asm && !need_dll && !need_gc) {
+			mono_trace_set_mask_string (mono_log_mask);
+			return;
+		}
+	}
+
+	if (need_asm) {
+		input_log_mask.append (",");
+		input_log_mask.append (MASK_ASM);
+	}
+
+	if (need_dll) {
+		input_log_mask.append (",");
+		input_log_mask.append (MASK_DLL);
+	}
+
+	if (need_gc) {
+		input_log_mask.append (",");
+		input_log_mask.append (MASK_GC);
+	}
+
+	mono_trace_set_mask_string (input_log_mask.get ());
+}
+
+force_inline void
+MonodroidRuntime::install_logging_handlers ()
+{
+	mono_trace_set_log_handler (mono_log_handler, nullptr);
+	mono_trace_set_print_handler (mono_log_standard_streams_handler);
+	mono_trace_set_printerr_handler (mono_log_standard_streams_handler);
+}
+
+#endif // def ANDROID
+
 inline void
 MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                                           jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
                                                           jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator)
 {
-	init_logging_categories ();
+	char *mono_log_mask = nullptr;
+	char *mono_log_level = nullptr;
+
+	init_logging_categories (mono_log_mask, mono_log_level);
 
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
@@ -1759,6 +1851,21 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 #endif
 
 	setup_bundled_app ("libmonodroid_bundle_app.so");
+
+#if defined (ANDROID)
+	if (mono_log_level == nullptr || *mono_log_level == '\0') {
+		mono_trace_set_level_string ("error");
+	} else {
+		// `mono_log_level` cannot be freed here, Mono VM stores it internally
+		mono_trace_set_level_string (mono_log_level);
+	}
+
+	setup_mono_tracing (mono_log_mask);
+
+#if defined (NET6)
+	install_logging_handlers ();
+#endif // def NET6
+#endif
 
 	if (runtimeNativeLibDir != nullptr) {
 		jstr = runtimeNativeLibDir;
@@ -1881,13 +1988,33 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	/* the first assembly is used to initialize the AppDomain name */
 	create_and_initialize_domain (env, klass, runtimeApks, assemblies, nullptr, assembliesPaths, loader, /*is_root_domain:*/ true, /*force_preload_assemblies:*/ false);
 
+#if defined (ANDROID) && !defined (NET6)
+	// Mono from mono/mono has a bug which requires us to install the handlers after `mono_init_jit_version` is called
+	install_logging_handlers ();
+#endif // def ANDROID && ndef NET6
+
 	// Install our dummy exception handler on Desktop
 	if constexpr (is_running_on_desktop) {
 		mono_add_internal_call ("System.Diagnostics.Debugger::Mono_UnhandledException_internal(System.Exception)",
 		                                 reinterpret_cast<const void*> (monodroid_Mono_UnhandledException_internal));
 	}
 
-	log_info (LOG_DEFAULT, "Xamarin.Android version: %s; MonoVM version: %s", XA_VERSION, mono_get_runtime_build_info ());
+	if (XA_UNLIKELY (utils.should_log (LOG_DEFAULT))) {
+		log_info_nocheck (
+			LOG_DEFAULT,
+			"Xamarin.Android version: %s (%s; %s); built on %s",
+			BuildInfo::xa_version,
+			BuildInfo::architecture,
+			BuildInfo::kind,
+			BuildInfo::date
+		);
+
+#if defined (ANDROID)
+		log_info_nocheck (LOG_DEFAULT, "NDK version: %s; API level: %s", BuildInfo::ndk_version, BuildInfo::ndk_api_level);
+		log_info_nocheck (LOG_DEFAULT, "MonoVM version: %s", mono_get_runtime_build_info ());
+#endif // def ANDROID
+	}
+
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
 

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
@@ -2,166 +2,7 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 3684
-    },
-    "classes.dex": {
-      "Size": 2198984
-    },
-    "lib/armeabi-v7a/libmono-btls-shared.so": {
-      "Size": 856580
-    },
-    "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 203664
-    },
-    "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
-      "Size": 4607636
-    },
-    "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 714476
-    },
-    "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 3816228
-    },
-    "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 105736
-    },
-    "lib/x86/libmono-btls-shared.so": {
-      "Size": 1311172
-    },
-    "lib/x86/libmonodroid.so": {
-      "Size": 271140
-    },
-    "lib/x86/libmonodroid_bundle_app.so": {
-      "Size": 4607272
-    },
-    "lib/x86/libmono-native.so": {
-      "Size": 788196
-    },
-    "lib/x86/libmonosgen-2.0.so": {
-      "Size": 3799820
-    },
-    "lib/x86/libxamarin-app.so": {
-      "Size": 105416
-    },
-    "META-INF/android.arch.core_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata-core.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_viewmodel.version": {
-      "Size": 6
-    },
-    "META-INF/android.support.design_material.version": {
-      "Size": 12
-    },
-    "META-INF/ANDROIDD.RSA": {
-      "Size": 1205
-    },
-    "META-INF/ANDROIDD.SF": {
-      "Size": 103126
-    },
-    "META-INF/androidx.appcompat_appcompat.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.browser_browser.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cardview_cardview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.core_core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cursoradapter_cursoradapter.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.customview_customview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.documentfile_documentfile.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.drawerlayout_drawerlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.fragment_fragment.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.interpolator_interpolator.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-v4.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.loader_loader.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.media_media.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.mediarouter_mediarouter.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.palette_palette.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.print_print.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.recyclerview_recyclerview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.transition_transition.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.viewpager_viewpager.version": {
-      "Size": 6
-    },
-    "META-INF/com.google.android.material_material.version": {
-      "Size": 10
-    },
-    "META-INF/MANIFEST.MF": {
-      "Size": 103018
-    },
-    "META-INF/proguard/androidx-annotations.pro": {
-      "Size": 308
+      "Size": 3748
     },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
@@ -223,6 +64,12 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
+    },
     "res/animator/design_fab_hide_motion_spec.xml": {
       "Size": 796
     },
@@ -231,6 +78,9 @@
     },
     "res/animator/mtrl_btn_state_list_anim.xml": {
       "Size": 2624
+    },
+    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
+      "Size": 2664
     },
     "res/animator/mtrl_btn_unelevated_state_list_anim.xml": {
       "Size": 120
@@ -250,17 +100,8 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
-    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
-      "Size": 2664
-    },
     "res/animator-v21/design_appbar_state_list_animator.xml": {
       "Size": 1216
-    },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
-    },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -490,11 +331,20 @@
     "res/drawable/abc_ratingbar_indicator_material.xml": {
       "Size": 664
     },
+    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
+      "Size": 704
+    },
     "res/drawable/abc_ratingbar_material.xml": {
       "Size": 664
     },
+    "res/drawable-v21/abc_ratingbar_material.xml": {
+      "Size": 704
+    },
     "res/drawable/abc_ratingbar_small_material.xml": {
       "Size": 664
+    },
+    "res/drawable-v21/abc_ratingbar_small_material.xml": {
+      "Size": 704
     },
     "res/drawable/abc_seekbar_thumb_material.xml": {
       "Size": 1100
@@ -635,13 +485,295 @@
       "Size": 484
     },
     "res/drawable/xamarin_logo.png": {
-      "Size": 9799
+      "Size": 9794
     },
-    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
-      "Size": 540
+    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
+      "Size": 372
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/drawable-v21/$avd_hide_password__0.xml": {
+      "Size": 1176
+    },
+    "res/drawable-v21/$avd_hide_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_hide_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/$avd_show_password__0.xml": {
+      "Size": 1136
+    },
+    "res/drawable-v21/$avd_show_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_show_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/abc_btn_colored_material.xml": {
+      "Size": 1716
+    },
+    "res/drawable-v21/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable-v21/abc_edit_text_material.xml": {
+      "Size": 1172
+    },
+    "res/drawable-v21/abc_list_divider_material.xml": {
+      "Size": 516
+    },
+    "res/drawable-v21/avd_hide_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/avd_show_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/design_password_eye.xml": {
+      "Size": 816
+    },
+    "res/drawable-v21/notification_action_background.xml": {
+      "Size": 1180
+    },
+    "res/drawable-v23/abc_control_background_material.xml": {
+      "Size": 304
+    },
+    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
+      "Size": 267
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
+      "Size": 321
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
+      "Size": 356
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
+      "Size": 754
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
+      "Size": 825
+    },
+    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
+      "Size": 216
+    },
+    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
+      "Size": 173
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 251
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
+      "Size": 152
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
+      "Size": 139
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
+      "Size": 270
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
+      "Size": 193
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
+      "Size": 364
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
+      "Size": 467
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
+      "Size": 253
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
+      "Size": 167
+    },
+    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
+      "Size": 222
+    },
+    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
+      "Size": 211
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
+      "Size": 541
+    },
+    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
+      "Size": 776
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
+      "Size": 159
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
+      "Size": 197
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
+      "Size": 194
+    },
+    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 327
+    },
+    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
+      "Size": 395
+    },
+    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
+      "Size": 311
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
+      "Size": 187
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
+      "Size": 181
+    },
+    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility.png": {
+      "Size": 309
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
+      "Size": 351
+    },
+    "res/drawable-mdpi-v4/ic_audiotrack_dark.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/ic_audiotrack_light.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/ic_dialog_close_dark.png": {
+      "Size": 168
+    },
+    "res/drawable-mdpi-v4/ic_dialog_close_light.png": {
+      "Size": 164
+    },
+    "res/drawable-mdpi-v4/ic_media_pause_dark.png": {
+      "Size": 90
+    },
+    "res/drawable-mdpi-v4/ic_media_pause_light.png": {
+      "Size": 101
+    },
+    "res/drawable-mdpi-v4/ic_media_play_dark.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/ic_media_play_light.png": {
+      "Size": 208
+    },
+    "res/drawable-mdpi-v4/ic_media_stop_dark.png": {
+      "Size": 90
+    },
+    "res/drawable-mdpi-v4/ic_media_stop_light.png": {
+      "Size": 99
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disabled_dark.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disabled_light.png": {
+      "Size": 301
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disconnected_dark.png": {
+      "Size": 406
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disconnected_light.png": {
+      "Size": 389
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_grey.png": {
+      "Size": 268
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_dark.png": {
+      "Size": 256
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_dark.png": {
+      "Size": 250
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_light.png": {
+      "Size": 256
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_light.png": {
+      "Size": 255
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_tv_dark.png": {
+      "Size": 128
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_tv_light.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
+      "Size": 98
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 127
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 253
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 318
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -879,330 +1011,6 @@
     },
     "res/drawable-ldrtl-hdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 345
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 127
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 253
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 318
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 494
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 417
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 260
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 705
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 525
-    },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 325
-    },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 905
-    },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 437
-    },
-    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
-      "Size": 267
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
-      "Size": 321
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
-      "Size": 356
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
-      "Size": 754
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
-      "Size": 825
-    },
-    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
-      "Size": 216
-    },
-    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
-      "Size": 173
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 251
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 152
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 139
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 270
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 193
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 364
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 467
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 253
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
-      "Size": 167
-    },
-    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
-      "Size": 222
-    },
-    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
-      "Size": 211
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
-      "Size": 541
-    },
-    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
-      "Size": 776
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
-      "Size": 159
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
-      "Size": 197
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
-      "Size": 194
-    },
-    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 327
-    },
-    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
-      "Size": 395
-    },
-    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 311
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 187
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
-      "Size": 181
-    },
-    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
-    "res/drawable-mdpi-v4/ic_audiotrack_dark.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/ic_audiotrack_light.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/ic_dialog_close_dark.png": {
-      "Size": 168
-    },
-    "res/drawable-mdpi-v4/ic_dialog_close_light.png": {
-      "Size": 164
-    },
-    "res/drawable-mdpi-v4/ic_media_pause_dark.png": {
-      "Size": 90
-    },
-    "res/drawable-mdpi-v4/ic_media_pause_light.png": {
-      "Size": 101
-    },
-    "res/drawable-mdpi-v4/ic_media_play_dark.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/ic_media_play_light.png": {
-      "Size": 208
-    },
-    "res/drawable-mdpi-v4/ic_media_stop_dark.png": {
-      "Size": 90
-    },
-    "res/drawable-mdpi-v4/ic_media_stop_light.png": {
-      "Size": 99
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disabled_dark.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disabled_light.png": {
-      "Size": 301
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disconnected_dark.png": {
-      "Size": 406
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disconnected_light.png": {
-      "Size": 389
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_grey.png": {
-      "Size": 268
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_dark.png": {
-      "Size": 256
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_dark.png": {
-      "Size": 250
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_light.png": {
-      "Size": 256
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_light.png": {
-      "Size": 255
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_tv_dark.png": {
-      "Size": 128
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_tv_light.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
-      "Size": 98
-    },
-    "res/drawable-v21/$avd_hide_password__0.xml": {
-      "Size": 1176
-    },
-    "res/drawable-v21/$avd_hide_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_hide_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/$avd_show_password__0.xml": {
-      "Size": 1136
-    },
-    "res/drawable-v21/$avd_show_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_show_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/abc_btn_colored_material.xml": {
-      "Size": 1716
-    },
-    "res/drawable-v21/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable-v21/abc_edit_text_material.xml": {
-      "Size": 1172
-    },
-    "res/drawable-v21/abc_list_divider_material.xml": {
-      "Size": 516
-    },
-    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
-      "Size": 704
-    },
-    "res/drawable-v21/abc_ratingbar_material.xml": {
-      "Size": 704
-    },
-    "res/drawable-v21/abc_ratingbar_small_material.xml": {
-      "Size": 704
-    },
-    "res/drawable-v21/avd_hide_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/avd_show_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/design_password_eye.xml": {
-      "Size": 816
-    },
-    "res/drawable-v21/notification_action_background.xml": {
-      "Size": 1180
-    },
-    "res/drawable-v23/abc_control_background_material.xml": {
-      "Size": 304
-    },
-    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
-      "Size": 372
     },
     "res/drawable-xhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 280
@@ -1804,6 +1612,15 @@
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
     },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 178
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 494
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 417
+    },
     "res/drawable-xxhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 286
     },
@@ -2389,6 +2206,15 @@
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 1647
     },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 260
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 705
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 525
+    },
     "res/drawable-xxxhdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
       "Size": 275
     },
@@ -2572,6 +2398,21 @@
     "res/drawable-xxxhdpi-v4/ic_mr_button_grey.png": {
       "Size": 879
     },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 325
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 905
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 437
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
+      "Size": 540
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
+    },
     "res/interpolator/mr_fast_out_slow_in.xml": {
       "Size": 400
     },
@@ -2617,6 +2458,9 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 748
     },
+    "res/layout-v17/abc_action_mode_close_item_material.xml": {
+      "Size": 840
+    },
     "res/layout/abc_activity_chooser_view.xml": {
       "Size": 1684
     },
@@ -2626,17 +2470,29 @@
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1492
     },
+    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1536
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
     "res/layout/abc_alert_dialog_material.xml": {
       "Size": 2480
     },
     "res/layout/abc_alert_dialog_title_material.xml": {
       "Size": 1424
     },
+    "res/layout-v17/abc_alert_dialog_title_material.xml": {
+      "Size": 1516
+    },
     "res/layout/abc_cascading_menu_item_layout.xml": {
       "Size": 1868
     },
     "res/layout/abc_dialog_title_material.xml": {
       "Size": 1028
+    },
+    "res/layout-v17/abc_dialog_title_material.xml": {
+      "Size": 1072
     },
     "res/layout/abc_expanded_menu_layout.xml": {
       "Size": 388
@@ -2656,6 +2512,9 @@
     "res/layout/abc_popup_menu_header_item_layout.xml": {
       "Size": 804
     },
+    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
+      "Size": 848
+    },
     "res/layout/abc_popup_menu_item_layout.xml": {
       "Size": 2072
     },
@@ -2671,17 +2530,29 @@
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1452
     },
+    "res/layout-v21/abc_screen_toolbar.xml": {
+      "Size": 1504
+    },
     "res/layout/abc_search_dropdown_item_icons_2line.xml": {
       "Size": 1916
     },
     "res/layout/abc_search_view.xml": {
       "Size": 3428
     },
+    "res/layout-v17/abc_search_view.xml": {
+      "Size": 3472
+    },
     "res/layout/abc_select_dialog_material.xml": {
       "Size": 932
     },
+    "res/layout-v17/abc_select_dialog_material.xml": {
+      "Size": 976
+    },
     "res/layout/abc_tooltip.xml": {
       "Size": 972
+    },
+    "res/layout-v17/abc_tooltip.xml": {
+      "Size": 1056
     },
     "res/layout/bottomtablayout.xml": {
       "Size": 816
@@ -2689,8 +2560,14 @@
     "res/layout/browser_actions_context_menu_page.xml": {
       "Size": 1576
     },
+    "res/layout-v17/browser_actions_context_menu_page.xml": {
+      "Size": 1660
+    },
     "res/layout/browser_actions_context_menu_row.xml": {
       "Size": 1032
+    },
+    "res/layout-v17/browser_actions_context_menu_row.xml": {
+      "Size": 1164
     },
     "res/layout/design_bottom_navigation_item.xml": {
       "Size": 1488
@@ -2703,6 +2580,9 @@
     },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1344
+    },
+    "res/layout-v17/design_layout_snackbar_include.xml": {
+      "Size": 1436
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -2743,14 +2623,26 @@
     "res/layout/mr_cast_group_item.xml": {
       "Size": 860
     },
+    "res/layout-v17/mr_cast_group_item.xml": {
+      "Size": 944
+    },
     "res/layout/mr_cast_group_volume_item.xml": {
       "Size": 1292
+    },
+    "res/layout-v17/mr_cast_group_volume_item.xml": {
+      "Size": 1416
     },
     "res/layout/mr_cast_media_metadata.xml": {
       "Size": 2056
     },
+    "res/layout-v17/mr_cast_media_metadata.xml": {
+      "Size": 2140
+    },
     "res/layout/mr_cast_route_item.xml": {
       "Size": 1720
+    },
+    "res/layout-v17/mr_cast_route_item.xml": {
+      "Size": 1804
     },
     "res/layout/mr_chooser_dialog.xml": {
       "Size": 1656
@@ -2767,11 +2659,20 @@
     "res/layout/mr_dialog_header_item.xml": {
       "Size": 472
     },
+    "res/layout-v17/mr_dialog_header_item.xml": {
+      "Size": 556
+    },
     "res/layout/mr_picker_dialog.xml": {
       "Size": 960
     },
+    "res/layout-v17/mr_picker_dialog.xml": {
+      "Size": 1000
+    },
     "res/layout/mr_picker_route_item.xml": {
       "Size": 848
+    },
+    "res/layout-v17/mr_picker_route_item.xml": {
+      "Size": 932
     },
     "res/layout/mr_playback_control.xml": {
       "Size": 1548
@@ -2785,11 +2686,20 @@
     "res/layout/mtrl_layout_snackbar_include.xml": {
       "Size": 1304
     },
+    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
+      "Size": 1396
+    },
     "res/layout/notification_action.xml": {
       "Size": 1092
     },
+    "res/layout-v17/notification_action.xml": {
+      "Size": 1156
+    },
     "res/layout/notification_action_tombstone.xml": {
       "Size": 1268
+    },
+    "res/layout-v17/notification_action_tombstone.xml": {
+      "Size": 1332
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -2800,14 +2710,32 @@
     "res/layout/notification_template_big_media.xml": {
       "Size": 1504
     },
+    "res/layout-v17/notification_template_big_media.xml": {
+      "Size": 1696
+    },
     "res/layout/notification_template_big_media_custom.xml": {
       "Size": 2760
+    },
+    "res/layout-v17/notification_template_big_media_custom.xml": {
+      "Size": 3044
     },
     "res/layout/notification_template_big_media_narrow.xml": {
       "Size": 1564
     },
+    "res/layout-v17/notification_template_big_media_narrow.xml": {
+      "Size": 1824
+    },
     "res/layout/notification_template_big_media_narrow_custom.xml": {
       "Size": 2868
+    },
+    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
+      "Size": 3216
+    },
+    "res/layout-v16/notification_template_custom_big.xml": {
+      "Size": 3012
+    },
+    "res/layout-v17/notification_template_custom_big.xml": {
+      "Size": 3208
     },
     "res/layout/notification_template_icon_group.xml": {
       "Size": 392
@@ -2815,11 +2743,20 @@
     "res/layout/notification_template_lines_media.xml": {
       "Size": 2660
     },
+    "res/layout-v17/notification_template_lines_media.xml": {
+      "Size": 2872
+    },
     "res/layout/notification_template_media.xml": {
       "Size": 1200
     },
+    "res/layout-v17/notification_template_media.xml": {
+      "Size": 1292
+    },
     "res/layout/notification_template_media_custom.xml": {
       "Size": 2528
+    },
+    "res/layout-v17/notification_template_media_custom.xml": {
+      "Size": 2756
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -2836,8 +2773,14 @@
     "res/layout/select_dialog_multichoice_material.xml": {
       "Size": 780
     },
+    "res/layout-v17/select_dialog_multichoice_material.xml": {
+      "Size": 864
+    },
     "res/layout/select_dialog_singlechoice_material.xml": {
       "Size": 780
+    },
+    "res/layout-v17/select_dialog_singlechoice_material.xml": {
+      "Size": 864
     },
     "res/layout/shellcontent.xml": {
       "Size": 1140
@@ -2851,110 +2794,20 @@
     "res/layout/toolbar.xml": {
       "Size": 452
     },
+    "res/layout-v21/toolbar.xml": {
+      "Size": 496
+    },
     "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
       "Size": 520
     },
     "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
       "Size": 520
     },
-    "res/layout-v16/notification_template_custom_big.xml": {
-      "Size": 3012
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
     },
-    "res/layout-v17/abc_action_mode_close_item_material.xml": {
-      "Size": 840
-    },
-    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1536
-    },
-    "res/layout-v17/abc_alert_dialog_title_material.xml": {
-      "Size": 1516
-    },
-    "res/layout-v17/abc_dialog_title_material.xml": {
-      "Size": 1072
-    },
-    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
-      "Size": 848
-    },
-    "res/layout-v17/abc_search_view.xml": {
-      "Size": 3472
-    },
-    "res/layout-v17/abc_select_dialog_material.xml": {
-      "Size": 976
-    },
-    "res/layout-v17/abc_tooltip.xml": {
-      "Size": 1056
-    },
-    "res/layout-v17/browser_actions_context_menu_page.xml": {
-      "Size": 1660
-    },
-    "res/layout-v17/browser_actions_context_menu_row.xml": {
-      "Size": 1164
-    },
-    "res/layout-v17/design_layout_snackbar_include.xml": {
-      "Size": 1436
-    },
-    "res/layout-v17/mr_cast_group_item.xml": {
-      "Size": 944
-    },
-    "res/layout-v17/mr_cast_group_volume_item.xml": {
-      "Size": 1416
-    },
-    "res/layout-v17/mr_cast_media_metadata.xml": {
-      "Size": 2140
-    },
-    "res/layout-v17/mr_cast_route_item.xml": {
-      "Size": 1804
-    },
-    "res/layout-v17/mr_dialog_header_item.xml": {
-      "Size": 556
-    },
-    "res/layout-v17/mr_picker_dialog.xml": {
-      "Size": 1000
-    },
-    "res/layout-v17/mr_picker_route_item.xml": {
-      "Size": 932
-    },
-    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
-      "Size": 1396
-    },
-    "res/layout-v17/notification_action.xml": {
-      "Size": 1156
-    },
-    "res/layout-v17/notification_action_tombstone.xml": {
-      "Size": 1332
-    },
-    "res/layout-v17/notification_template_big_media.xml": {
-      "Size": 1696
-    },
-    "res/layout-v17/notification_template_big_media_custom.xml": {
-      "Size": 3044
-    },
-    "res/layout-v17/notification_template_big_media_narrow.xml": {
-      "Size": 1824
-    },
-    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
-      "Size": 3216
-    },
-    "res/layout-v17/notification_template_custom_big.xml": {
-      "Size": 3208
-    },
-    "res/layout-v17/notification_template_lines_media.xml": {
-      "Size": 2872
-    },
-    "res/layout-v17/notification_template_media.xml": {
-      "Size": 1292
-    },
-    "res/layout-v17/notification_template_media_custom.xml": {
-      "Size": 2756
-    },
-    "res/layout-v17/select_dialog_multichoice_material.xml": {
-      "Size": 864
-    },
-    "res/layout-v17/select_dialog_singlechoice_material.xml": {
-      "Size": 864
-    },
-    "res/layout-v21/abc_screen_toolbar.xml": {
-      "Size": 1504
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
     },
     "res/layout-v21/notification_action.xml": {
       "Size": 1052
@@ -2968,24 +2821,177 @@
     "res/layout-v21/notification_template_icon_group.xml": {
       "Size": 988
     },
-    "res/layout-v21/toolbar.xml": {
-      "Size": 496
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
-    },
     "res/layout-v26/abc_screen_toolbar.xml": {
       "Size": 1560
     },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
-    },
     "resources.arsc": {
       "Size": 493672
+    },
+    "classes.dex": {
+      "Size": 2774432
+    },
+    "lib/armeabi-v7a/libxamarin-app.so": {
+      "Size": 104912
+    },
+    "lib/x86/libxamarin-app.so": {
+      "Size": 104132
+    },
+    "lib/armeabi-v7a/libmonodroid.so": {
+      "Size": 216940
+    },
+    "lib/x86/libmonodroid.so": {
+      "Size": 272124
+    },
+    "lib/armeabi-v7a/libxa-internal-api.so": {
+      "Size": 48620
+    },
+    "lib/x86/libxa-internal-api.so": {
+      "Size": 61312
+    },
+    "lib/armeabi-v7a/libmono-btls-shared.so": {
+      "Size": 1113088
+    },
+    "lib/x86/libmono-btls-shared.so": {
+      "Size": 1459984
+    },
+    "lib/armeabi-v7a/libmonosgen-2.0.so": {
+      "Size": 4456372
+    },
+    "lib/x86/libmonosgen-2.0.so": {
+      "Size": 4212484
+    },
+    "lib/armeabi-v7a/libmono-native.so": {
+      "Size": 736764
+    },
+    "lib/x86/libmono-native.so": {
+      "Size": 803736
+    },
+    "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
+      "Size": 4272008
+    },
+    "lib/x86/libmonodroid_bundle_app.so": {
+      "Size": 4271648
+    },
+    "META-INF/proguard/androidx-annotations.pro": {
+      "Size": 308
+    },
+    "META-INF/androidx.legacy_legacy-support-v4.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.mediarouter_mediarouter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cardview_cardview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.appcompat_appcompat.version": {
+      "Size": 6
+    },
+    "META-INF/android.support.design_material.version": {
+      "Size": 12
+    },
+    "META-INF/com.google.android.material_material.version": {
+      "Size": 10
+    },
+    "META-INF/androidx.browser_browser.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.media_media.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.print_print.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cursoradapter_cursoradapter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.customview_customview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_viewmodel.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.documentfile_documentfile.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.palette_palette.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.transition_transition.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.recyclerview_recyclerview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.interpolator_interpolator.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.fragment_fragment.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.core_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.viewpager_viewpager.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.core_core.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata-core.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.drawerlayout_drawerlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.loader_loader.version": {
+      "Size": 6
+    },
+    "META-INF/ANDROIDD.SF": {
+      "Size": 103239
+    },
+    "META-INF/ANDROIDD.RSA": {
+      "Size": 1205
+    },
+    "META-INF/MANIFEST.MF": {
+      "Size": 103131
     }
   },
-  "PackageSize": 16119692
+  "PackageSize": 16173046
 }


### PR DESCRIPTION
Mono produces a lot of messages at various levels of severity which, if
enabled, can quickly fill the logcat buffer also contributing to a
higher signal-to-noise ratio for those users who don't need the
messages.  In order to put the amount of logging under control, this
commit implements logging handlers which take over the logging
responsibility from Mono and put it on Xamarin.Android.  Three log
handlers are registered:

  * Mono tracing+logging
  * `stdout`
  * `stderr`

At the same time, the `debug.mono.log` system property gains two new
options, `mono_log_mask` and `mono_log_level`.  Both of them require a
value (described below), following the equals sign.

`mono_log_mask` corresponds to the `MONO_LOG_MASK` environment
variable (described in detail in the `mono(1)` manpage) and it accepts a
comma-separated list of categories for which to enable logging.  The
currently known categories are:

  * `asm` (assembly loader)
  * `type`
  * `dll` (native library loader)
  * `gc` (garbage collector)
  * `cfg` (config file loader)
  * `aot` (precompiler)
  * `security` (e.g. Moonlight CoreCLR support)
  * `threadpool` (thread pool generic)
  * `io-selector` (async socket operations)
  * `io-layer` (all of I/O layer - processes, files, sockets, events,
     semaphores, mutexes and  handles), or more finely grained:
    * `io-layer-process`
    * `io-layer-file`
    * `io-layer-socket`
    * `io-layer-event`
    * `io-layer-semaphore`
    * `io-layer-mutex`
    * `io-layer-handle`
  * `all`

By default Xamarin.Android disables all Mono logging, unless the
`assembly` or `gc` categories are enabled in the `debug.mono.log` system
property.  In such instance, `assembly` enables the `dll` and `asm` Mono
categories whicle `gc` enables the Mono `gc` category.

`mono_log_level` corresponds to the `MONO_LOG_LEVEL` environment
variable and accepts as its value one of the following log levels:

  * `error`
  * `critical`
  * `warning`
  * `message`
  * `info`
  * `debug`

`mono_log_level` defaults to `error`.

Additionally, this commit adds some more version information optionally
logged at the application startup:

  * NDK version Xamarin.Android was built with
  * NDK API level Xamarin.Android was built for
  * Machine architecture for which Xamarin.Android was built
  * Configuration for which Xamarin.Android was built (`Release` or
    `Debug`)
  * Date on which Xamarin.Android was built

Currently, we don't do any processing or filtering on the Mono log
messages, but it is possible to add such ability (e.g. log to a
different logcat buffer than the default one, log to file, ignore
certain messages etc) in the future, if needed.