### PR TITLE
[docs] Synchronize with MicrosoftDocs/xamarin-docs

### DIFF
--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -6,10 +6,10 @@ ms.assetid: 5EBEE1A5-3879-45DD-B1DE-5CD4327C2656
 ms.technology: xamarin-android
 author: jonpryor
 ms.author: jopryo
-ms.date: 09/23/2020
+ms.date: 03/01/2021
 ---
 
-# Build items
+# Build Items
 
 Build items control how a Xamarin.Android application
 or library project is built.
@@ -33,9 +33,9 @@ and `.jar` files will be included in the appropriate item groups.
 
 ## AndroidAotProfile
 
-Used to provide AOT profiles, for use with profile-guided AOT.
+Used to provide an AOT profile, for use with profile-guided AOT.
 
-It can be also used from Visual Studio by setting `AndroidAotProfile`
+It can be also used from Visual Studio by setting the `AndroidAotProfile`
 build action to a file containing an AOT profile.
 
 ## AndroidBoundLayout
@@ -93,17 +93,17 @@ The result of the above code snippet has a different effect for each
 Xamarin.Android project type:
 
 * Application and class library projects:
-  * `foo.jar` maps to [**AndroidJavaLibrary**](#androidjavalibrary)
-  * `bar.aar` maps to [**AndroidAarLibrary**](#androidaarlibrary)
+  * `foo.jar` maps to [**AndroidJavaLibrary**](#androidjavalibrary).
+  * `bar.aar` maps to [**AndroidAarLibrary**](#androidaarlibrary).
 * Java binding projects:
-  * `foo.jar` maps to [**EmbeddedJar**](#embeddedjar)
+  * `foo.jar` maps to [**EmbeddedJar**](#embeddedjar).
   * `foo.jar` maps to [**EmbeddedReferenceJar**](#embeddedreferencejar)
-    if `Bind="false"` metadata is added
-  * `bar.aar` maps to [**LibraryProjectZip**](#libraryprojectzip)
+    if `Bind="false"` metadata is added.
+  * `bar.aar` maps to [**LibraryProjectZip**](#libraryprojectzip).
 
 This simplification means you can use **AndroidLibrary** everywhere.
 
-Added in Xamarin.Android 11.2.
+This build action was added in Xamarin.Android 11.2.
 
 ## AndroidLintConfig
 
@@ -118,17 +118,17 @@ for more details.
 
 ## AndroidManifestOverlay
 
-The build action `AndroidManifestOverlay` can be used to provide additional
-`AndroidManifest.xml` files to the [Manifest Merger]([~/android/deploy-test/building-apps/build-properties.md#](https://developer.android.com/studio/build/manifest-merge)) tool.
+The `AndroidManifestOverlay` build action can be used to provide additional
+`AndroidManifest.xml` files to the [Manifest Merger](https://developer.android.com/studio/build/manifest-merge) tool.
 Files with this build action will be passed to the Manifest Merger along with
 the main `AndroidManifest.xml` file and any additional manifest files from
 references. These will then be merged into the final manifest.
 
 You can use this build action to provide additional changes and settings to
-your app depending on your build configuration. For example if you need to
+your app depending on your build configuration. For example, if you need to
 have a specific permission only while debugging, you can use the overlay to
-inject that permission when debugging. For example given the following
-overlay file contents
+inject that permission when debugging. For example, given the following
+overlay file contents:
 
 ```
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -136,7 +136,7 @@ overlay file contents
 </manifest>
 ```
 
-you can use the following to add this for a debug build.
+You can use the following to add this for a debug build:
 
 ```
 <ItemGroup>
@@ -144,7 +144,7 @@ you can use the following to add this for a debug build.
 </ItemGroup>
 ```
 
-Introduced in Xamarin.Android 11.2
+This build action was introduced in Xamarin.Android 11.2.
 
 ## AndroidNativeLibrary
 
@@ -202,7 +202,7 @@ example:
   <AndroidResource Include="Resources-Debug\values\strings.xml"/>
 </ItemGroup>
 <PropertyGroup>
-  <MonoAndroidResourcePrefix>Resources;Resources-Debug<MonoAndroidResourcePrefix>
+  <MonoAndroidResourcePrefix>Resources;Resources-Debug</MonoAndroidResourcePrefix>
 </PropertyGroup>
 ```
 
@@ -229,7 +229,7 @@ layout diagnostics tool. This is currently only used in the layout
 editor and not for build messages.
 
 See the [Android Resource Analysis
-documentation](https://aka.ms/androidresourceanalysis) for more
+documentation](../../user-interface/android-designer/diagnostics.md) for more
 details.
 
 Added in Xamarin.Android 10.2.
@@ -306,18 +306,18 @@ is parsed in order to extract parameter names.
 
 Only certain "Javadoc HTML dialects" are supported, including:
 
-  * JDK 1.7 `javadoc` output
-  * JDK 1.8 `javadoc` output
-  * Droiddoc output
+  * JDK 1.7 `javadoc` output.
+  * JDK 1.8 `javadoc` output.
+  * Droiddoc output.
 
 This build action is deprecated in Xamarin.Android 11.3, and will not be
 supported in .NET 6.
-The `@(JavaSourceJar)` build action should be preferred.
+The `@(JavaSourceJar)` build action is preferred.
 
 ## JavaSourceJar
 
 In a Xamarin.Android binding project, the **JavaSourceJar** build action
-is used on `.jar` files which contain *Java source code*, which contains
+is used on `.jar` files that contain *Java source code*, which contain
 [Javadoc documentation comments](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html).
 
 Prior to Xamarin.Android 11.3, the Javadoc would be converted into HTML
@@ -325,11 +325,10 @@ via the `javadoc` utility during build time, and later turned into
 XML documentation.
 
 Starting with Xamarin.Android 11.3, Javadoc will instead be converted into
-[C# XML Documentation Comments](https://docs.microsoft.com/en-us/dotnet/csharp/codedoc)
+[C# XML Documentation Comments](/dotnet/csharp/codedoc)
 within the generated binding source code.
 
-[`$(AndroidJavadocVerbosity)`](~/android/deploy-test/building-apps/build-properties.md#androidjavadocverbosity)
-controls how "verbose" or "complete" the imported Javadoc is.
+`$(AndroidJavadocVerbosity)` controls how "verbose" or "complete" the imported Javadoc is.
 
 Starting in Xamarin.Android 11.3, the following MSBuild metadata is supported:
 
@@ -357,7 +356,7 @@ application.
 > [!NOTE]
 > Only a single **LibraryProjectZip** can be included in a
 > Xamarin.Android binding project. This limitation will be removed
-> going forward in .NET 6.
+> in .NET 6.
 
 ## LinkDescription
 

--- a/Documentation/guides/building-apps/build-process.md
+++ b/Documentation/guides/building-apps/build-process.md
@@ -6,7 +6,7 @@ ms.assetid: 3BE5EE1E-3FF6-4E95-7C9F-7B443EE3E94C
 ms.technology: xamarin-android
 author: davidortinau
 ms.author: daortin
-ms.date: 09/11/2020
+ms.date: 03/01/2021
 ---
 
 # Build Process
@@ -28,38 +28,53 @@ In broad terms, there are two types of Android application packages
 (`.apk` files) which the Xamarin.Android build system can generate:
 
 - **Release** builds, which are fully self-contained and don't
-  require additional packages to execute. These are the
-  packages which would be provided to an App store.
+  require extra packages to execute. These are the
+  packages that are provided to an App store.
 
 - **Debug** builds, which are not.
 
-Not coincidentally, these match the MSBuild `Configuration` which
+These package types match the MSBuild `Configuration` which
 produces the package.
+
+## Shared Runtime
+
+Prior to Xamarin.Android 11.2, the *shared runtime* was a pair
+of extra Android packages which
+provide the Base Class Library (`mscorlib.dll`, etc.) and the
+Android binding library (`Mono.Android.dll`, etc.). Debug builds
+rely upon the shared runtime in lieu of including the Base Class Library and
+Binding assemblies within the Android application package, allowing the
+Debug package to be smaller.
+
+The shared runtime could be disabled in Debug builds by setting the
+[`$(AndroidUseSharedRuntime)`](~/android/deploy-test/building-apps/build-properties.md#androidusesharedruntime)
+property to `False`.
+
+Support for the Shared Runtime was removed in Xamarin.Android 11.2.
 
 <a name="Fast_Deployment"></a>
 
 ## Fast Deployment
 
 *Fast deployment* works by further shrinking Android application
-package size. This is done by not bundling the app's assemblies
-within the package. Instead, the are deployed directly to the
-application internal `files` directory. This is usually located
-in `/data/data/com.some.package`. This is not a global writable
-folder, so we need to use the `run-as` tool to run all the
-commands to copy the files into that diectory.
+package size. This is done by excluding the app's assemblies from the
+package, and instead deploying the app's assemblies directly to the
+application's internal `files` directory, usually located
+in `/data/data/com.some.package`. The internal `files` directory is
+not a globally writable folder, so the `run-as` tool is used to execute
+all the commands to copy the files into that directory.
 
-This process speeds up the build/deploy/debug cycle because
-if *only* assemblies are changed, the package is not reinstalled.
-Instead, only the updated assemblies are re-synchronized to the
-target device.
+This process speeds up the build/deploy/debug cycle because the package
+is not reinstalled when *only* assemblies are changed.
+Only the updated assemblies are resynchronized to the target device.
 
-Fast deployment is known to fail on devices which block `run-as`. This
-is usually devices of API 20 and lower.
+> [!WARNING]
+> Fast deployment is known to fail on devices which block `run-as`, which often includes devices older than Android 5.0.
 
 Fast deployment is enabled by default, and may be disabled in Debug builds
 by setting the `$(EmbedAssembliesIntoApk)` property to `True`.
 
-The [Enhanced Fast Deployment](~/android/deploy-test/building-apps/build-properties.md#AndroidFastDeploymentType) mode can
+The [Enhanced Fast Deployment](~/android/deploy-test/building-apps/build-properties.md#androidfastdeploymenttype) mode can
 be used in conjunction with this feature to speed up deployments even further.
 This will deploy both assemblies, native libraries, typemaps and dexes to the `files`
 directory. But you should only really need to enable this if you are changing
@@ -184,7 +199,7 @@ Extension points include:
 A word of caution about extending the build process: If not
 written correctly, build extensions can affect your build
 performance, especially if they run on every build. It is
-highly recommended that you read the MSBuild [documentation](https://docs.microsoft.com/visualstudio/msbuild/msbuild)
+highly recommended that you read the MSBuild [documentation](/visualstudio/msbuild/msbuild)
 before implementing such extensions.
 
 ## Target Definitions

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -6,7 +6,7 @@ ms.assetid: FC0DBC08-EBCB-4D2D-AB3F-76B54E635C22
 ms.technology: xamarin-android
 author: jonpryor
 ms.author: jopryo
-ms.date: 09/21/2020
+ms.date: 03/01/2021
 ---
 
 # Build Properties
@@ -14,7 +14,7 @@ ms.date: 09/21/2020
 MSBuild properties control the behavior of the
 [targets](~/android/deploy-test/building-apps/build-targets.md).
 They are specified within the project file, for example **MyApp.csproj**, within
-an [MSBuild PropertyGroup](https://docs.microsoft.com/visualstudio/msbuild/propertygroup-element-msbuild).
+an [MSBuild PropertyGroup](/visualstudio/msbuild/propertygroup-element-msbuild).
 
 ## AdbTarget
 
@@ -58,7 +58,7 @@ object collection.
 
 Defaults to `True` for Release configuration builds.
 
-Added in Xamarin.Android 11.2.
+This property was added in Xamarin.Android 11.2.
 
 ## AndroidAotCustomProfilePath
 
@@ -289,13 +289,13 @@ Added in Xamarin.Android 10.2.
 
 Allows deploying and debugging the application under guest
 or work accounts. The value is the `uid` value you get
-from the following adb command
+from the following adb command:
 
 ```
 adb shell pm list users
 ```
 
-This will return the following data
+This will return the following data:
 
 ```
 Users:
@@ -306,7 +306,7 @@ Users:
 The `uid` is the first integer value. In the example they
 are `0` and `10`.
 
-Added in Xamarin.Android 11.2
+This property was added in Xamarin.Android 11.2.
 
 ## AndroidDexTool
 
@@ -468,7 +468,6 @@ the `.apk` needs to be rebuilt, and the install process can be
 faster.) Valid values include:
 
 - `Assemblies`: Deploy application assemblies.
-
 - `Dexes`: Deploy `.dex` files, native libraries and typemaps.
   **This value can *only* be used on devices running
   Android 4.4 or later (API-19).**
@@ -479,7 +478,7 @@ Support for Fast Deploying resources and assets via that system was
 removed in commit [f0d565fe](https://github.com/xamarin/xamarin-android/commit/f0d565fe4833f16df31378c77bbb492ffd2904b9). This was becuase it required the use of
 deprecated API's to work.
 
-**Experimental**. Added in Xamarin.Android 6.1.
+**Experimental**. This property was added in Xamarin.Android 6.1.
 
 ## AndroidGenerateJniMarshalMethods
 
@@ -540,7 +539,7 @@ Controls the default
 the `System.Net.Http.HttpClient` default constructor. The value is an
 assembly-qualified type name of an `HttpMessageHandler` subclass, suitable
 for use with
-[`System.Type.GetType(string)`](https://docs.microsoft.com/dotnet/api/system.type.gettype#System_Type_GetType_System_String_).
+[`System.Type.GetType(string)`](/dotnet/api/system.type.gettype#System_Type_GetType_System_String_).
 The most common values for this property are:
 
 - `Xamarin.Android.Net.AndroidClientHandler`: Use the Android Java APIs
@@ -601,7 +600,7 @@ application startup/runtime behavior.
 
 The script is added to the project using the
 [`@(AndroidNativeLibrary)`](~/android/deploy-test/building-apps/build-items.md#androidnativelibrary)
-build action, because it is placed in the same directory where
+build action, because it is placed in the same directory as
 architecture-specific native libraries, and must be named `wrap.sh`.
 
 The easiest way to specify path to the `wrap.sh` script is to put it
@@ -658,7 +657,7 @@ This is an enum-style property, with possible values of `full` or
 
 The default value is `intellisense`.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## AndroidKeyStore
 
@@ -715,7 +714,7 @@ var view = FindViewById(Resources.Ids.foo);
 
 Any other scenarios (such as reflection) will not be supported.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3
 
 ## AndroidLinkSkip
 
@@ -895,9 +894,9 @@ mean the `mapping.txt` file will be produced in the `$(OutputPath)`
 folder. This file can then be used when uploading packages to the
 Google Play Store.
 
-Default value is `$(OutputPath)mapping.txt`
+The default value is `$(OutputPath)mapping.txt`.
 
-Added in Xamarin.Android 11.2
+This property was added in Xamarin.Android 11.2.
 
 ## AndroidR8IgnoreWarnings
 
@@ -1108,7 +1107,7 @@ in their `.csproj`. Alternatively provide the property on the command line:
 /p:AndroidUseAapt2=True
 ```
 
-Added in Xamarin.Android 8.3. Setting `AndroidUseAapt2` to `false` is
+This property was added in Xamarin.Android 8.3. Setting `AndroidUseAapt2` to `false` is
 deprecated in Xamarin.Android 11.2.
 
 ## AndroidUseApkSigner
@@ -1132,9 +1131,9 @@ Added in Xamarin.Android 10.1.
 A boolean property which causes the `.apk` to contain the mono
 *interpreter*, and not the normal JIT.
 
-***Experimental***.  Does not work on the x86 ABI.
+***Experimental***.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## AndroidUseLegacyVersionCode
 
@@ -1155,6 +1154,20 @@ than `aapt`.
 
 Added in Xamarin.Android 8.1.
 
+## AndroidUseSharedRuntime
+
+A boolean property that
+determines whether the *shared runtime packages* are required in
+order to run the Application on the target device. Relying on the
+shared runtime packages allows the Application package to be
+smaller, speeding up the package creation and deployment process,
+resulting in a faster build/deploy/debug turnaround cycle.
+
+Prior to Xamarin.Android 11.2, this property should be `True` for
+Debug builds, and `False` for Release projects.
+
+This property was *removed* in Xamarin.Android 11.2.
+
 ## AndroidVersionCode
 
 An MSBuild property that can be used as an alternative to
@@ -1172,7 +1185,7 @@ for each Google Play release. See the [Android documentation][manifest-element]
 for further details about the requirements for
 `/manifest/@android:versionCode`.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## AndroidVersionCodePattern
 
@@ -1249,7 +1262,7 @@ about the requirements for `/manifest/@package`.
 
 [manifest-element]: https://developer.android.com/guide/topics/manifest/manifest-element
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## ApplicationTitle
 
@@ -1262,7 +1275,7 @@ This will be the default going forward in .NET 6.
 See the [Android documentation][application-element] for further details
 about the requirements for `/manifest/application/@android:label`.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 [application-element]: https://developer.android.com/guide/topics/manifest/application-element
 
@@ -1277,7 +1290,7 @@ This will be the default going forward in .NET 6.
 See the [Android documentation][manifest-element] for further details
 about the requirements for `/manifest/@android:versionName`.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## AotAssemblies
 
@@ -1338,7 +1351,7 @@ string or `Full`.
 ## DebugType
 
 Specifies the
-[type of debug symbols](https://docs.microsoft.com/visualstudio/msbuild/csc-task)
+[type of debug symbols](/visualstudio/msbuild/csc-task)
 to generate as part of the build, which also impacts whether the
 Application is debuggable. Possible values include:
 
@@ -1414,7 +1427,7 @@ in the final [`AndroidManifest.xml`](~/android/platform/android-manifest.md) fil
 `$(GenerateApplicationManifest)` defaults to `true` in .NET 6 and
 `false` in "legacy" Xamarin.Android.
 
-Added in Xamarin.Android 11.3.
+Support for this property was added in Xamarin.Android 11.3.
 
 ## JavaMaximumHeapSize
 
@@ -1582,7 +1595,7 @@ debugging symbols enabled:
 [`$(EmbedAssembliesIntoApk)`](#embedassembliesintoapk) is True,
 [`$(DebugSymbols)`](~/android/deploy-test/building-apps/build-properties.md#debugsymbols)
  is True, and
-[`$(Optimize)`](https://docs.microsoft.com/visualstudio/msbuild/common-msbuild-project-properties)
+[`$(Optimize)`](/visualstudio/msbuild/common-msbuild-project-properties)
 is True.
 
 Added in Xamarin.Android 7.1.

--- a/Documentation/guides/building-apps/build-targets.md
+++ b/Documentation/guides/building-apps/build-targets.md
@@ -80,7 +80,7 @@ Android package may be installed to or removed from.
 MSBuild /t:Install ProjectName.csproj /p:AdbTarget=-e
 ```
 
-## SignAndroidPackage**
+## SignAndroidPackage
 
 Creates and signs the Android package (`.apk`) file.
 


### PR DESCRIPTION
Context: d8dea85c25f341224d6ef268fbf82620d9603b52
Context: https://github.com/MicrosoftDocs/xamarin-docs-pr/pull/2310
Context: https://github.com/MicrosoftDocs/xamarin-docs-pr/pull/2319

Commit MicrosoftDocs/xamarin-docs-pr#2310 was created by running:

	msbuild /t:ExportXamarinDocs /p:XamarinDocsPath=/path/to/xamarin-docs/ Xamarin.Android.sln

This export was then edited to remove references to features to be
introduced in Xamarin.Android 11.3, *and* copy-edited to appease
[the all-mighty grammar gods][0].

Import the copy-edited text, and preserve the new Xamarin.Android 11.3
features:

	msbuild /t:ImportXamarinDocs /p:XamarinDocsPath=/path/to/xamarin-docs/ Xamarin.Android.sln

[0]: https://github.com/Microsoft/vscode-docs-authoring