### PR TITLE
[net6] Remove duplicate property defaults

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -2,8 +2,6 @@
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
-    <LatestSupportedJavaVersion Condition=" '$(LatestSupportedJavaVersion)' == '' ">11.0.99</LatestSupportedJavaVersion>
     <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>


### PR DESCRIPTION
A default value for `$(AndroidCommandLineToolsVersion)` is set in
xamarin/xamarin-android-tools, and we shouldn't override that value.

The default value of `11.0.99` for `$(LatestSupportedJavaVersion)` is
set in Xamarin.Android.Common.props.  The additional declaration in this
file is redundant.