### PR TITLE
[One .NET] AutoImport.props should include Transforms.xml

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -35,6 +35,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <!-- Default Asset file inclusion -->
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
     <!-- Default XPath transforms for bindings -->
+    <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />
     <!-- Default Java or native libraries -->
     <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(_DefaultJavaSourceJarPattern)" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -289,10 +289,17 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetBuildBinding ()
 		{
 			var proj = new XASdkProject (outputType: "Library");
+			// Both transform files should be applied
+			proj.Sources.Add (new AndroidItem.TransformFile ("Transforms.xml") {
+				TextContent = () =>
+@"<metadata>
+  <attr path=""/api/package[@name='com.xamarin.android.test.msbuildtest']"" name=""managedName"">FooBar</attr>
+</metadata>",
+			});
 			proj.Sources.Add (new AndroidItem.TransformFile ("Transforms\\Metadata.xml") {
 				TextContent = () =>
 @"<metadata>
-  <attr path=""/api/package[@name='com.xamarin.android.test.msbuildtest']"" name=""managedName"">MSBuildTest</attr>
+  <attr path=""/api/package[@managedName='FooBar']"" name=""managedName"">MSBuildTest</attr>
 </metadata>",
 			});
 			proj.Sources.Add (new AndroidItem.AndroidLibrary ("javaclasses.jar") {


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/tree/master/Android/Guava/source/Guava

Looking at some of the patterns in the XamarinComponents repo, many of
the bindings commonly have a single `Transforms.xml` in the root of
the project. I think this pattern makes complete sense, so let's add
this to `AutoImport.props` by default.

I updated a test for this scenario, the test relies on the
`@(TransformFile)` wildcards working.