### PR TITLE
Bump to .NET 6.0.100-preview.2.21155.3

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -77,9 +77,9 @@
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <!-- Please update DotNetRuntimePacksVersion below accordingly -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.2.21153.28</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.2.21155.3</DotNetPreviewVersionFull>
     <!-- This version comes from the a file in the dotnet distribution: sdk/$(DotNetPreviewVersionFull)/dotnet.runtimeconfig.json (the `runtimeOptions/framework/version key`) -->
-    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21123.7</DotNetRuntimePacksVersion>
+    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21154.6</DotNetRuntimePacksVersion>
     <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>
     <ILLinkVersionFull Condition=" '$(ILLinkVersionFull)' == '' ">$(ILLinkVersionBand)-alpha.1.21109.1</ILLinkVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -29,22 +29,22 @@
       "Size": 316728
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3084
+      "Size": 3094
     },
     "assemblies/System.Console.dll": {
-      "Size": 5961
+      "Size": 5966
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10651
+      "Size": 10657
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 528399
+      "Size": 528426
     },
     "assemblies/Java.Interop.dll": {
       "Size": 57475
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 82497
+      "Size": 82535
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -62,7 +62,7 @@
       "Size": 3742608
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 341640
+      "Size": 346816
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
       "Size": 37096
@@ -77,5 +77,5 @@
       "Size": 2278
     }
   },
-  "PackageSize": 2901870
+  "PackageSize": 2905966
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1667,247 +1667,247 @@
       "Size": 8094
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6252
+      "Size": 6260
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122435
+      "Size": 122445
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6319
+      "Size": 6327
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7085
+      "Size": 7093
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17898
+      "Size": 17908
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 104053
+      "Size": 104060
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15145
+      "Size": 15153
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42701
+      "Size": 42707
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6427
+      "Size": 6436
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6774
+      "Size": 6782
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6895
+      "Size": 6903
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3284
+      "Size": 3296
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13306
+      "Size": 13318
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92074
+      "Size": 92083
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5195
+      "Size": 5205
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10941
+      "Size": 10948
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19137
+      "Size": 19145
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43153
+      "Size": 43164
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7205
+      "Size": 7217
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524838
+      "Size": 524846
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384970
+      "Size": 384980
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55851
+      "Size": 55863
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117185
+      "Size": 117198
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 3927
+      "Size": 3934
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12292
+      "Size": 12296
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 11451
+      "Size": 11467
     },
     "assemblies/System.Collections.Specialized.dll": {
-      "Size": 12421
+      "Size": 12425
     },
     "assemblies/System.Collections.dll": {
-      "Size": 23831
+      "Size": 23837
     },
     "assemblies/System.ComponentModel.EventBasedAsync.dll": {
-      "Size": 2386
+      "Size": 2393
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 7761
+      "Size": 7772
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
       "Size": 55306
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2446
+      "Size": 2452
     },
     "assemblies/System.Console.dll": {
-      "Size": 6465
+      "Size": 6471
     },
     "assemblies/System.Data.Common.dll": {
-      "Size": 2320
+      "Size": 2325
     },
     "assemblies/System.Diagnostics.Process.dll": {
-      "Size": 37271
+      "Size": 37276
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 10388
+      "Size": 10393
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 20126
+      "Size": 20129
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 26636
+      "Size": 26641
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12162
+      "Size": 12170
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19673
+      "Size": 19680
     },
     "assemblies/System.IO.FileSystem.dll": {
-      "Size": 28866
+      "Size": 28873
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11523
+      "Size": 11527
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 191824
+      "Size": 191828
     },
     "assemblies/System.Linq.dll": {
       "Size": 20912
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 216737
+      "Size": 216745
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 10730
+      "Size": 10737
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18099
+      "Size": 18104
     },
     "assemblies/System.Net.Primitives.dll": {
       "Size": 44522
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37406
+      "Size": 37409
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 52118
+      "Size": 52130
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 67799
+      "Size": 67800
     },
     "assemblies/System.Net.ServicePoint.dll": {
-      "Size": 3132
+      "Size": 3138
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 64274
+      "Size": 64273
     },
     "assemblies/System.Net.WebClient.dll": {
-      "Size": 7809
+      "Size": 7816
     },
     "assemblies/System.Net.WebHeaderCollection.dll": {
-      "Size": 6217
+      "Size": 6224
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12639
+      "Size": 12648
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 206413
+      "Size": 206422
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42292
+      "Size": 42296
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 15889
+      "Size": 15890
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 501487
+      "Size": 501491
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
       "Size": 1418
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 4104
+      "Size": 4108
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 22335
+      "Size": 22345
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 4013
+      "Size": 4019
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4182
+      "Size": 4187
     },
     "assemblies/System.Security.AccessControl.dll": {
-      "Size": 4335
+      "Size": 4340
     },
     "assemblies/System.Security.Claims.dll": {
-      "Size": 8138
+      "Size": 8144
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40628
+      "Size": 40633
     },
     "assemblies/System.Security.Cryptography.Csp.dll": {
-      "Size": 5134
+      "Size": 5141
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12433
+      "Size": 12442
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
-      "Size": 14945
+      "Size": 14953
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9614
+      "Size": 9623
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 94334
+      "Size": 94335
     },
     "assemblies/System.Security.Principal.Windows.dll": {
-      "Size": 4589
+      "Size": 4594
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 81539
+      "Size": 81538
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 15724
+      "Size": 15728
     },
     "assemblies/System.Threading.dll": {
-      "Size": 6536
+      "Size": 6540
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 734414
+      "Size": 734450
     },
     "assemblies/Java.Interop.dll": {
       "Size": 64624
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 433929
+      "Size": 433831
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
@@ -1925,7 +1925,7 @@
       "Size": 3742608
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 341640
+      "Size": 346816
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
       "Size": 37096


### PR DESCRIPTION
Changes: https://github.com/dotnet/installer/compare/e858d570...1a9103db

Also used the runtime pack version from:

    > cat ~\android-toolchain\dotnet\sdk\6.0.100-preview.2.21155.3\dotnet.runtimeconfig.json
    {
      "runtimeOptions": {
        "tfm": "net6.0",
        "framework": {
          "name": "Microsoft.NETCore.App",
          "version": "6.0.0-preview.2.21154.6"
        }
      }
    }

`BuildReleaseArm64` test, net6 apk size difference before/after

Simple XA:
```
Summary:
  +           0 Other entries 0.00% (of 58,410)
  +           0 Dalvik executables 0.00% (of 316,728)
  +          81 Assemblies 0.01% (of 688,072)
  -         144 Shared libraries -0.00% (of 5,147,624)
  +           0 Uncompressed assemblies 0.00% (of 1,345,024)
  +           0 Package size difference 0.00% (of 2,905,966)
```
XF/XA:
```
Summary:
  +           0 Other entries 0.00% (of 917,033)
  +           0 Dalvik executables 0.00% (of 3,455,720)
  +         323 Assemblies 0.01% (of 5,650,122)
  -         144 Shared libraries -0.00% (of 5,222,816)
  +           0 Uncompressed assemblies 0.00% (of 12,650,496)
  +           0 Package size difference 0.00% (of 9,886,918)
```