### PR TITLE
[Xamarin.Android.Build.Tests] Add support for testing on system applications.

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@75cf1a237380e95f684438b782e3829efc5109c6
+xamarin/monodroid:main@83de4b43c1de819f21c923bc3d6aeb37cc3949cd
 mono/mono:2020-02@be9218f4d1f7529fbe85d15c58f6fe78161909b3

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1041,6 +1041,16 @@ To use a file located at `C:\Users\user1\AndroidSigningPassword.txt`:
 > The `env:` prefix is not supported when [`$(AndroidPackageFormat)`](#androidpackageformat)
 > is set to `aab`.
 
+## AndroidSigningPlatformKey
+
+Specifies the key file to use to sign the apk.
+This is only used when building `system` applications.
+
+## AndroidSigningPlatformCert
+
+Specifies the certificate file to use to sign the apk.
+This is only used when building `system` applications.
+
 ## AndroidSupportedAbis
 
 A string property that contains a

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1046,10 +1046,14 @@ To use a file located at `C:\Users\user1\AndroidSigningPassword.txt`:
 Specifies the key file to use to sign the apk.
 This is only used when building `system` applications.
 
+Support for this property was added in Xamarin.Android 11.3.
+
 ## AndroidSigningPlatformCert
 
 Specifies the certificate file to use to sign the apk.
 This is only used when building `system` applications.
+
+Support for this property was added in Xamarin.Android 11.3.
 
 ## AndroidSupportedAbis
 

--- a/Documentation/guides/messages/xa4310.md
+++ b/Documentation/guides/messages/xa4310.md
@@ -8,17 +8,14 @@ ms.date: 03/09/2020
 ## Example messages
 
 ```
-error XA4310: `$(AndroidSigningKeyStore)` file `filename.keystore` could not be found.
+error XA4310: `$(Property)` file `filename.keystore` could not be found.
 ```
 
 ## Issue
 
-The specified `$(AndroidSigningKeyStore)` file could not be located on disk.
+The specified `$(Property)` file could not be located on disk.
 
 ## Solution
 
-Check that the `$(AndroidSigningKeyStore)` MSBuild property is set to a valid
-path of an existing keystore.
-
-This property corresponds to the **Keystore** field in the **Android Package
-Signing** section of the Visual Studio project property pages.
+Check that the `$(Property)` MSBuild property is set to a valid
+path of an existing file.

--- a/Documentation/release-notes/5708.md
+++ b/Documentation/release-notes/5708.md
@@ -1,0 +1,13 @@
+#### Application build and deployment
+
+* [Developer Community 1288717][0]:
+  *Support Fast Deployment for System Applications.*
+  Added support for fast deployment while building system based
+  applications. Applications developed in this mode need to be
+  signed with a platform key and have a special attribute
+
+  `android:sharedUserId="android.uid.system"`
+
+  in the `AndroidManifest.xml`.
+
+[0]: https://developercommunity.visualstudio.com/t/VS-2019-1690-Error-XA0130-XamarinAndr/1359238

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          AndroidSdkHome  {get; set;}
 		public                  string          Port            {get; set;}
 		public                  string          ImageName       {get; set;} = "XamarinAndroidTestRunner64";
+		public			string		Arguments	{get; set;}
 		public                  string          ToolPath        {get; set;}
 		public                  string          ToolExe         {get; set;}
 
@@ -62,7 +63,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"-verbose -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
+			var arguments = $"{Arguments ?? string.Empty} -verbose -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -173,3 +173,5 @@ stages:
   - template: yaml-templates/run-timezoneinfo-tests.yaml
     parameters:
       node_id: 4
+
+  - template: yaml-templates/run-systemapp-tests.yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -63,7 +63,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != AOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
   NUnit.NumberOfTestWorkers: 4
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
   CONVERT_JAVADOC_TO_XMLDOC: $[ne(variables['Build.DefinitionName'], 'Xamarin.Android-PR')]

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         useDotNet: $(UseDotNet)
         testRunTitle: MSBuildDeviceIntegration On Device - macOS - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
-        nunitConsoleExtraArgs: --where "cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
+        nunitConsoleExtraArgs: --where "cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
         dotNetTestExtraArgs: --filter "TestCategory != TimeZoneInfo & TestCategory != SmokeTests ${{ parameters.nunit_categories }}"
         testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 

--- a/build-tools/automation/yaml-templates/run-systemapp-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-systemapp-tests.yaml
@@ -1,0 +1,52 @@
+# Runs TimeZoneInfo tests against an emulator running on macOS
+
+jobs:
+  - job: mac_systemapp_tests
+    displayName: System App Emulator Tests
+    pool:
+      vmImage: $(HostedMacImage)
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: setup-test-environment.yaml
+
+    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
+      displayName: install emulator
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:AcquireAndroidTarget /p:TestEmulatorArguments=-writable-system /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - template: run-nunit-tests.yaml
+      parameters:
+        testRunTitle: System App On Device - macOS
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll
+        nunitConsoleExtraArgs: --where "cat == SystemApplication"
+        testResultsFile: TestResult-SystemApp--$(XA.Build.Configuration).xml
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - template: upload-results.yaml
+      parameters:
+        artifactName: Test Results - System App With Emulator - macOS
+
+    - template: fail-on-issue.yaml

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -65,6 +65,7 @@
     <StartAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         AndroidSdkHome="$(AndroidSdkDirectory)"
+        Arguments="$(TestEmulatorArguments)"
         ImageName="$(TestAvdName)"
         Port="$(_AdbEmulatorPort)"
         ToolExe="$(EmulatorToolExe)"

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -712,8 +712,10 @@ The following are literal names and should not be translated: ABI, 'libs/armeabi
     <comment>The following are literal names and should not be translated: MultiDexMainDexList</comment>
   </data>
   <data name="XA4310" xml:space="preserve">
-    <value>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</value>
-    <comment>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</comment>
+    <value>`{0}` file `{1}` could not be found.</value>
+    <comment>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</comment>
   </data>
   <data name="XA4311" xml:space="preserve">
     <value>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Soubor $(AndroidSigningKeyStore) {0} se nepovedlo najít.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">Soubor {0} {1} se nepovedlo najít.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Die $(AndroidSigningKeyStore)-Datei "{0}" wurde nicht gefunden.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">Die {0}-Datei "{1}" wurde nicht gefunden.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">No se ha encontrado el archivo "{0}" de "$(AndroidSigningKeyStore)".</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">No se ha encontrado el archivo "{1}" de "{0}".</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Le fichier '$(AndroidSigningKeyStore)' '{0}' est introuvable.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">Le fichier '{0}' '{1}' est introuvable.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Non è stato possibile trovare il file `{0}` di `$(AndroidSigningKeyStore)`.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">Non è stato possibile trovare il file `{1}` di `{0}`.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">'$(AndroidSigningKeyStore)' ファイル '{0}' が見つかりませんでした。</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">'{0}' ファイル '{1}' が見つかりませんでした。</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">'$(AndroidSigningKeyStore)' 파일 '{0}'을(를) 찾을 수 없습니다.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="needs-review-translation">'{0}' 파일 '{1}'을(를) 찾을 수 없습니다.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Nie można odnaleźć pliku „$(AndroidSigningKeyStore)” („{0}”).</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Não foi possível localizar o arquivo `{0}` de `$(AndroidSigningKeyStore)`.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">Не удалось найти файл "$(AndroidSigningKeyStore)" с именем "{0}".</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">`{0}` adlı `$(AndroidSigningKeyStore)` dosyası bulunamadı.</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">找不到“$(AndroidSigningKeyStore)”文件“{0}”。</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -744,9 +744,11 @@ In this message, "root element" refers to the root element of an XML file.
         <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA4310">
-        <source>`$(AndroidSigningKeyStore)` file `{0}` could not be found.</source>
-        <target state="translated">找不到 `$(AndroidSigningKeyStore)` 檔案 `{0}`。</target>
-        <note>The following are literal names and should not be translated: `$(AndroidSigningKeyStore)`</note>
+        <source>`{0}` file `{1}` could not be found.</source>
+        <target state="new">`{0}` file `{1}` could not be found.</target>
+        <note>{0} - The MSBuildProperty which contains the file name value.
+{1} - The value of the MSBuildProperty. Normally a filename.
+</note>
       </trans-unit>
       <trans-unit id="XA4311">
         <source>The application won't contain the paired Wear package because the Wear application package APK is not created yet. If building on the command line, be sure to build the "SignAndroidPackage" target.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -21,30 +21,30 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		[Output]
 		public string KeyStore { get; set; }
-		
+
 		[Required]
 		public string KeyAlias { get; set; }
-		
+
 		/// <summary>
 		/// The Password for the Key.
 		/// You can use the raw password here, however if you want to hide your password in logs
-		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// you can use a preview of env: or file: to point it to an Environment variable or
 		/// a file.
 		///
 		///   env:<PasswordEnvironentVariable>
-		///   file:<PasswordFile> 
+		///   file:<PasswordFile>
 		/// </summary>
 		[Required]
 		public string KeyPass { get; set; }
-		
+
 		/// <summary>
 		/// The Password for the Keystore.
 		/// You can use the raw password here, however if you want to hide your password in logs
-		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// you can use a preview of env: or file: to point it to an Environment variable or
 		/// a file.
 		///
 		///   env:<PasswordEnvironentVariable>
-		///   file:<PasswordFile> 
+		///   file:<PasswordFile>
 		/// </summary>
 		[Required]
 		public string StorePass { get; set; }
@@ -151,7 +151,7 @@ namespace Xamarin.Android.Tasks
 		protected override bool ValidateParameters ()
 		{
 			if (!string.IsNullOrEmpty (KeyStore) && !File.Exists (KeyStore)) {
-				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, KeyStore);
+				Log.LogCodedError ("XA4310", Properties.Resources.XA4310, "$(AndroidSigningKeyStore)", KeyStore);
 				return false;
 			}
 			return base.ValidateParameters ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -27,6 +28,16 @@ namespace Xamarin.Android.Build.Tests
 			using var m = new MemoryStream (checked ((int) s.Length));
 			s.CopyTo (m);
 			return m.ToArray ();
+		}
+
+		public static byte [] GetKeystore (string keyname = "test.keystore")
+		{
+			var assembly = typeof (XamarinAndroidCommonProject).Assembly;
+			using (var stream = assembly.GetManifestResourceStream ($"Xamarin.ProjectTools.Resources.Base.{keyname}")) {
+				var data = new byte [stream.Length];
+				stream.Read (data, 0, (int) stream.Length);
+				return data;
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2304,6 +2304,8 @@ because xbuild doesn't support framework reference assemblies.
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
 		StorePass="$(_ApkStorePass)"
+		PlatformKey="$(AndroidSigningPlatformKey)"
+		PlatformCert="$(AndroidSigningPlatformCert)"
 		ToolPath="$(JavaToolPath)"
 		ToolExe="$(JavaToolExe)"
 		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -15,16 +15,6 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Commercial"), Category ("UsesDevice")]
 	public class InstallTests : DeviceTest
 	{
-		static byte [] GetKeystore ()
-		{
-			var assembly = typeof (XamarinAndroidCommonProject).Assembly;
-			using (var stream = assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.test.keystore")) {
-				var data = new byte [stream.Length];
-				stream.Read (data, 0, (int) stream.Length);
-				return data;
-			}
-		}
-
 		string GetContentFromAllOverrideDirectories (string packageName, bool useRunAsCommand = true)
 		{
 			var adbShellArgs = $"shell run-as {packageName} ls";
@@ -114,7 +104,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var builder = CreateApkBuilder ()) {
 				// Use the default debug.keystore XA generates
 				Assert.IsTrue (builder.Install (proj), "first install should succeed.");
-				byte [] data = GetKeystore ();
+				byte [] data = ResourceData.GetKeystore ();
 				proj.OtherBuildItems.Add (new BuildItem (BuildActions.None, "test.keystore") {
 					BinaryContent = () => data
 				});
@@ -387,7 +377,7 @@ namespace Xamarin.Android.Build.Tests
 			string path = Path.Combine ("temp", TestName.Replace (expected, expected.Replace ("-", "_")));
 			string storepassfile = Path.Combine (Root, path, "storepass.txt");
 			string keypassfile = Path.Combine (Root, path, "keypass.txt");
-			byte [] data = GetKeystore ();
+			byte [] data = ResourceData.GetKeystore ();
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
@@ -587,6 +577,5 @@ namespace Xamarin.Android.Build.Tests
 					$"Fourth unchanged install: '{fourthInstalTime}' should be faster than clean install: '{firstInstallTime}' and incremental install: '{thirdInstallTime}'.");
 			}
 		}
-
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Text;
+using System.Xml.Linq;
+using System.Collections.Generic;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[NonParallelizable] //These tests deploy to devices
+	[Category ("Commercial"), Category ("UsesDevice")]
+	public class SystemApplicationTests : DeviceTest
+	{
+		// All Tests here require the emulator to be started with -writable-system
+		[Test, Category ("SystemApplication")]
+		public void SystemApplicationCanInstall ()
+		{
+			AssertCommercialBuild ();
+			AssertHasDevices ();
+
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = false,
+				EmbedAssembliesIntoApk = false,
+			};
+			proj.OtherBuildItems.Add (new BuildItem ("None", "platform.pk8") {
+				WebContent = "https://github.com/aosp-mirror/platform_build/raw/master/target/product/security/platform.pk8"
+			});
+			proj.OtherBuildItems.Add (new BuildItem ("None", "platform.x509.pem") {
+				WebContent = "https://github.com/aosp-mirror/platform_build/raw/master/target/product/security/platform.x509.pem"
+			});
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<manifest ", "<manifest android:sharedUserId=\"android.uid.system\" ");
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+
+
+			proj.SetDefaultTargetDevice ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				proj.SetProperty ("AndroidSigningPlatformKey", Path.Combine (Root, b.ProjectDirectory, "platform.pk8"));
+				proj.SetProperty ("AndroidSigningPlatformCert", Path.Combine (Root, b.ProjectDirectory, "platform.x509.pem"));
+				Assert.True (b.Install (proj), "Project should have installed.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Context https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1288717

The new fast deployment system broke fast deployment for system installed
applications. This commit adds unit tests to stop this kind of regression
in the future.

In order to install a `system` application we need a few things to happen

1. The emulator MUST be started with the `-writable-system` argument
2. The apk needs to be signed with a platform keystore.
3. The AndroidManifest must include `android:sharedUserId="android.uid.system"`
   in its `manifest` element.


- [x] Figure out a way to sign with the `platform` keys at https://github.com/aosp-mirror/platform_build/tree/master/target/product/security
- [x] Include https://github.com/xamarin/monodroid/pull/1177