### PR TITLE
[illink] Do not fallback to S.Console in Logger

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -358,7 +358,7 @@ namespace Android.Runtime {
 		internal static bool VSAndroidDesignerIsEnabled { get; } = InitializeVSAndroidDesignerIsEnabled ();
 
 		static bool InitializeVSAndroidDesignerIsEnabled () =>
-		    !AppContext.TryGetSwitch ("Java.Interop.TypeManager.VSAndroidDesignerIsEnabled", out bool isEnabled) || isEnabled;
+		    !AppContext.TryGetSwitch ("Xamarin.Android.VSAndroidDesigner.IsSupported", out bool isEnabled) || isEnabled;
 
 		class _Proxy : IWebProxy {
 			readonly ProxySelector selector = ProxySelector.Default!;

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -355,6 +355,11 @@ namespace Android.Runtime {
 			return Activator.CreateInstance (handlerType);
 		}
 
+		internal static bool VSAndroidDesignerIsEnabled { get; } = InitializeVSAndroidDesignerIsEnabled ();
+
+		static bool InitializeVSAndroidDesignerIsEnabled () =>
+		    !AppContext.TryGetSwitch ("Java.Interop.TypeManager.VSAndroidDesignerIsEnabled", out bool isEnabled) || isEnabled;
+
 		class _Proxy : IWebProxy {
 			readonly ProxySelector selector = ProxySelector.Default!;
 

--- a/src/Mono.Android/Android.Runtime/Logger.cs
+++ b/src/Mono.Android/Android.Runtime/Logger.cs
@@ -55,7 +55,7 @@ namespace Android.Runtime {
 						hasNoLibLog = true;
 					}
 				}
-				if (hasNoLibLog)
+				if (AndroidEnvironment.VSAndroidDesignerIsEnabled && hasNoLibLog)
 					System.Console.WriteLine ("[{0}] {1}: {2}", level, appname, line);
 			}
 		}

--- a/src/Mono.Android/ILLink/ILLink.Substitutions.xml
+++ b/src/Mono.Android/ILLink/ILLink.Substitutions.xml
@@ -1,7 +1,9 @@
 <linker>
   <assembly fullname="Mono.Android">
-    <type fullname="Java.Interop.TypeManager" feature="Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled" featurevalue="false">
-      <method signature="System.Boolean get_TypeRegistrationFallbackIsEnabled()" body="stub" value="false" />
+    <type fullname="Android.Runtime.AndroidEnvironment" feature="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled" featurevalue="false">
+      <method signature="System.Boolean get_VSAndroidDesignerIsEnabled()" body="stub" value="false" />
+    </type>
+    <type fullname="Java.Interop.TypeManager" feature="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled" featurevalue="false">
       <method signature="System.Type TypeRegistrationFallback()" body="stub" value="null" />
       <method signature="System.Void RegisterPackage(System.String,System.Converter`2&lt;System.String,System.Type&gt;)" body="stub" />
       <method signature="System.Void RegisterPackages(System.String[],System.Converter`2&lt;System.String,System.Type&gt;[])" body="stub" />

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -212,10 +212,6 @@ namespace Java.Interop {
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		static extern Type monodroid_typemap_java_to_managed (string java_type_name);
 
-		static bool TypeRegistrationFallbackIsEnabled { get; } = InitializeTypeRegistrationFallbackIsEnabled ();
-		static bool InitializeTypeRegistrationFallbackIsEnabled () =>
-		    !AppContext.TryGetSwitch ("Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled", out bool isEnabled) || isEnabled;
-
 		internal static Type? GetJavaToManagedType (string class_name)
 		{
 			Type? type = monodroid_typemap_java_to_managed (class_name);
@@ -229,7 +225,7 @@ namespace Java.Interop {
 				return null;
 			}
 
-			if (TypeRegistrationFallbackIsEnabled)
+			if (AndroidEnvironment.VSAndroidDesignerIsEnabled)
 				return TypeRegistrationFallback (class_name);
 
 			return null;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -74,7 +74,7 @@
     <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
 
     <!-- XA feature switches defaults -->
-    <XATypeRegistrationFallback Condition="'$(XATypeRegistrationFallback)' == ''">false</XATypeRegistrationFallback>
+    <VSAndroidDesigner Condition="'$(VSAndroidDesigner)' == ''">false</VSAndroidDesigner>
 
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidApplication)' == 'true' and '$(GenerateApplicationManifest)' == 'true' ">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -14,9 +14,9 @@ This file contains the .NET 5-specific targets to customize ILLink
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths;_CreatePropertiesCache">
     <ItemGroup>
-      <RuntimeHostConfigurationOption Include="Java.Interop.TypeManager.TypeRegistrationFallbackIsEnabled"
-          Condition="'$(XATypeRegistrationFallback)' != ''"
-          Value="$(XATypeRegistrationFallback)"
+      <RuntimeHostConfigurationOption Include="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled"
+          Condition="'$(VSAndroidDesigner)' != ''"
+          Value="$(VSAndroidDesigner)"
           Trim="true" />
       <!-- Mark all assemblies to be linked for AndroidLinkMode=Full -->
       <ResolvedFileToPublish

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -86,7 +86,6 @@ namespace Xamarin.Android.Build.Tests
 				new [] {
 					"Java.Interop.dll",
 					"Mono.Android.dll",
-					"System.Console.dll",
 					"System.Private.CoreLib.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -431,7 +431,7 @@ namespace UnnamedProject {
 
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			if (enabled)
-				proj.SetProperty (proj.ActiveConfigurationProperties, "XATypeRegistrationFallback", "true");
+				proj.SetProperty (proj.ActiveConfigurationProperties, "VSAndroidDesigner", "true");
 
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -29,25 +29,22 @@
       "Size": 316728
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3094
-    },
-    "assemblies/System.Console.dll": {
-      "Size": 5966
+      "Size": 3075
     },
     "assemblies/System.Linq.dll": {
       "Size": 10657
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 528426
+      "Size": 514928
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 57475
+      "Size": 57483
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 82535
+      "Size": 82533
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 68560
+      "Size": 68496
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776168
@@ -62,20 +59,20 @@
       "Size": 3742608
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346816
+      "Size": 346768
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37096
+      "Size": 37064
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 2405
+      "Size": 2304
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2278
+      "Size": 2177
     }
   },
-  "PackageSize": 2905966
+  "PackageSize": 2885411
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1667,76 +1667,76 @@
       "Size": 8094
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6260
+      "Size": 6246
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122445
+      "Size": 122431
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6327
+      "Size": 6313
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7093
+      "Size": 7076
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17908
+      "Size": 17891
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 104060
+      "Size": 104046
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15153
+      "Size": 15134
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42707
+      "Size": 42692
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6436
+      "Size": 6419
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6782
+      "Size": 6766
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6903
+      "Size": 6889
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3296
+      "Size": 3278
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13318
+      "Size": 13302
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92083
+      "Size": 92067
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5205
+      "Size": 5189
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10948
+      "Size": 10932
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19145
+      "Size": 19126
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43164
+      "Size": 43148
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7217
+      "Size": 7197
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524846
+      "Size": 524830
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384980
+      "Size": 384961
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55863
+      "Size": 55842
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117198
+      "Size": 117180
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
       "Size": 3934
@@ -1766,7 +1766,7 @@
       "Size": 2452
     },
     "assemblies/System.Console.dll": {
-      "Size": 6471
+      "Size": 6417
     },
     "assemblies/System.Data.Common.dll": {
       "Size": 2325
@@ -1901,13 +1901,13 @@
       "Size": 6540
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 734450
+      "Size": 734384
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 64624
+      "Size": 64628
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 433831
+      "Size": 433845
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 143752
@@ -1925,10 +1925,10 @@
       "Size": 3742608
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346816
+      "Size": 346768
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37096
+      "Size": 37064
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5622

Do not fallback to `System.Console.WriteLine` in our logger on devices.
We still need that for designer. That saves another 2.83% of assembly
size in simple XA `BuildReleaseArm64` test app.

Lets use the type registration fallback feature switch to hide
the fallback and rename it to `VSAndroidDesigner` as both
of these fallbacks are only used by the designer. Also move
it to `AndroidEnvironment` class.

Update the `CheckIncludedAssemblies` test, we just got rid of another
assembly :-)

Size savings, simple XA/net6 `BuildReleaseArm64` test:

    Summary:
      -         202 Other entries -0.35% (of 58,410)
      +           0 Dalvik executables 0.00% (of 316,728)
      -      19,471 Assemblies -2.83% (of 688,072)
      -          64 Shared libraries -0.00% (of 5,147,624)
      -      37,888 Uncompressed assemblies -2.82% (of 1,345,024)
      -      20,555 Package size difference -0.71% (of 2,905,966)

XForms/XA/net6 `BuildReleaseArm64` test:

    Summary:
      +           0 Other entries 0.00% (of 917,033)
      +           0 Dalvik executables 0.00% (of 3,455,720)
      +         177 Assemblies 0.00% (of 5,650,122)
      +           0 Shared libraries 0.00% (of 5,222,816)
      -       1,024 Uncompressed assemblies -0.01% (of 12,650,496)
      +           0 Package size difference 0.00% (of 9,886,918)