### PR TITLE
[tests] reenable .NET 6 build performance tests

### DIFF
--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.5" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.303" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Logging;
+using Microsoft.Build.Logging.StructuredLogger;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
 
@@ -65,30 +65,13 @@ namespace Xamarin.Android.Build.Tests
 
 		double GetDurationFromBinLog (ProjectBuilder builder)
 		{
-			//TODO: BuildEventArgsReader.Read() returns null in .NET 6 Preview 2
-			// See: https://github.com/dotnet/msbuild/issues/6225
-			if (Builder.UseDotNet)
-				Assert.Ignore ("Cannot currently parse .binlog files in .NET 6 Preview 2");
-
-			var duration = TimeSpan.Zero;
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, "msbuild.binlog");
 			FileAssert.Exists (binlog);
 
-			using (var fileStream = File.OpenRead (binlog))
-			using (var gzip = new GZipStream (fileStream, CompressionMode.Decompress))
-			using (var binaryReader = new BinaryReader (gzip)) {
-				int fileFormatVersion = binaryReader.ReadInt32 ();
-				var buildReader = new BuildEventArgsReader (binaryReader, fileFormatVersion);
-				BuildEventArgs args;
-				var started = new Stack<DateTime> ();
-				while ((args = buildReader.Read ()) != null) {
-					if (args is ProjectStartedEventArgs projectStarted) {
-						started.Push (projectStarted.Timestamp);
-					} else if (args is ProjectFinishedEventArgs projectFinished) {
-						duration += projectFinished.Timestamp - started.Pop ();
-					}
-				}
-			}
+			var build = BinaryLog.ReadBuild (binlog);
+			var duration = build
+				.FindChildrenRecursive<Project> ()
+				.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
 
 			if (duration == TimeSpan.Zero)
 				throw new InvalidDataException ($"No project build duration found in {binlog}");


### PR DESCRIPTION
Context: https://github.com/dotnet/msbuild/issues/6225
Context: https://www.nuget.org/packages/MSBuild.StructuredLogger/

In .NET 6 Preview 2, the `.binlog` file format version increased. This
means we can no longer use the latest MSBuild NuGet packages to parse
these files. 16.9.0 isn't recent enough:

https://www.nuget.org/packages/Microsoft.Build/16.9.0

Instead, we can use the MSBuild.StructuredLogger package used by the
[MSBuild binlog viewer](https://msbuildlog.com), as it is able to read the new
`.binlog` format. It also is quite a bit less code to do what we need.

Going forward, this package should be the best for parsing `.binlog`
files when using .NET 6 Preview builds.