### PR TITLE
[One .NET] allow M1 macs to find the Android workload

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
@@ -17,6 +17,7 @@
       "version": "@SDK_PACK_VERSION@",
       "alias-to": {
         "osx-x64": "Microsoft.Android.Sdk.osx-x64",
+        "osx-arm64": "Microsoft.Android.Sdk.osx-x64",
         "win-x64": "Microsoft.Android.Sdk.win-x64",
         "linux-x64": "Microsoft.Android.Sdk.linux-x64"
       }


### PR DESCRIPTION
I got report of M1 Macs failing to build .NET 6 Android projects:

    Microsoft.NET.Sdk.ImportWorkloads.targets(24,5): error NETSDK1147: The following workload packs were not installed: Microsoft.Android.Sdk

Looking at our `WorkloadManifest.json`, we did not define an
`alias-to` for M1 Macs. Manually editing `WorkloadManifest.json`
solved the problem for them.

This gets us closer to M1 working.

There is now a new failure we can address next:

    Xamarin.Android.EmbeddedResource.targets(36,5): error XARLP7000: System.DllNotFoundException: Unable to load shared library 'libzip' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(liblibzip, 1): image not found
        at Xamarin.Tools.Zip.Native.zip_open(IntPtr path, OpenFlags flags, ErrorCode& errorp)
        at Xamarin.Tools.Zip.Native.zip_open(String path, OpenFlags flags, ErrorCode& errorp) in /Users/runner/work/1/s/Native.cs:line 97
        at Xamarin.Tools.Zip.ZipArchive.Open(String path, OpenFlags flags) in /Users/runner/work/1/s/ZipArchive.cs:line 159
        at Xamarin.Tools.Zip.ZipArchive.Open(String path, FileMode mode, String defaultExtractionDir, Boolean strictConsistencyChecks, IPlatformOptions options) in /Users/runner/work/1/s/ZipArchive.cs:line 230
        at Microsoft.Android.Build.Tasks.Files.ReadZipFile(String filename, Boolean strictConsistencyChecks) in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Files.cs:line 335
        at Xamarin.Android.Tasks.MonoAndroidHelper.ReadZipFile(String filename)
        at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments)
        at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask()
        at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17 [/Users/drasticactions/Developer/Projects/net6-mobile-samples/HelloAndroid/HelloAndroid.csproj]