### PR TITLE
[ci] Migrate Windows build and test to new VMSS

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -40,7 +40,6 @@ variables:
   DotNetCoreVersion: 3.1.405
   DotNet5Version: 5.0.100
   HostedMacImage: macOS-10.15
-  VSEngWinVS2019: Xamarin-Android-Win2019-1120
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
   NUnit.NumberOfTestWorkers: 4
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -56,7 +56,7 @@ variables:
   DotNet5Version: 5.0.103
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: Xamarin-Android-Win2019-1120
+  VSEngWinVS2019: Xamarin-Android-Win2019
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)


### PR DESCRIPTION
As part of some Azure subscription clean up efforts I've created a new
Windows virtual machine scale set in our new
[Xamarin - SDK Engineering][0] Azure subscription.  This VMSS uses the
same base image as our existing Windows Build and Test pool and should
behave in the same way.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourceGroups/DEVDIV-VM-SCALE-SETS/providers/Microsoft.Compute/virtualMachineScaleSets/xawin2019-vmss/overview