### PR TITLE
[build] Use arcade dependency management tooling

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -75,7 +75,7 @@
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
-    <!-- TODO: Calculate based on $(MicrosoftNETSdkPackageVersion) -->
+    <!-- TODO: Calculate based on $(MicrosoftDotnetSdkInternalPackageVersion) -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.18.1</AndroidCmakeVersion>

--- a/Configuration.props
+++ b/Configuration.props
@@ -75,8 +75,6 @@
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
-    <!-- TODO: Calculate based on $(MicrosoftDotnetSdkInternalPackageVersion) -->
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.18.1</AndroidCmakeVersion>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Windows' And '$(AndroidCmakeUrlPrefix)' == '' ">7c386a739f915f5bd60051f2572c24782388e807.</AndroidCmakeUrlPrefix>

--- a/Configuration.props
+++ b/Configuration.props
@@ -3,6 +3,7 @@
   <!--
     Note: This file *must* be imported *after* `$(Configuration)` is set.
   -->
+  <Import Project="$(MSBuildThisFileDirectory)eng\Versions.props" />
   <Import
       Project="$(MSBuildThisFileDirectory)Build$(Configuration)\Configuration.Generated.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Build$(Configuration)\Configuration.Generated.props')"
@@ -74,14 +75,8 @@
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
-    <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
-    <!-- Please update DotNetRuntimePacksVersion below accordingly -->
+    <!-- TODO: Calculate based on $(MicrosoftNETSdkPackageVersion) -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.3.21161.23</DotNetPreviewVersionFull>
-    <!-- This version comes from the a file in the dotnet distribution: sdk/$(DotNetPreviewVersionFull)/dotnet.runtimeconfig.json (the `runtimeOptions/framework/version key`) -->
-    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.3.21159.16</DotNetRuntimePacksVersion>
-    <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>
-    <ILLinkVersionFull Condition=" '$(ILLinkVersionFull)' == '' ">$(ILLinkVersionBand)-alpha.1.21109.1</ILLinkVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.18.1</AndroidCmakeVersion>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Windows' And '$(AndroidCmakeUrlPrefix)' == '' ">7c386a739f915f5bd60051f2572c24782388e807.</AndroidCmakeUrlPrefix>

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,9 +6,9 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-
-     <!-- This is needed (currently) for the Xamarin.Android.Deploy.Installer dependency, getting the installer -->
-     <!-- Android binary, to support delta APK install -->
-     <add key="xamarin.android util" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json" />
+    <!-- This is needed (currently) for the Xamarin.Android.Deploy.Installer dependency, getting the installer -->
+    <!-- Android binary, to support delta APK install -->
+    <add key="xamarin.android util" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json" />
   </packageSources>
+  <disabledPackageSources />
 </configuration>

--- a/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
+++ b/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
@@ -74,7 +74,7 @@
         Template="$(_WixTemplate)"
         DestinationFile="$(_WixFile)"
         DotNetPath="$(DotNetPreviewPath)"
-        DotNetVersion="$(DotNetPreviewVersionFull)"
+        DotNetVersion="$(MicrosoftNETSdkPackageVersion)"
         MSIVersion="$(AndroidMSIVersion)"
     />
     <ItemGroup>

--- a/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
+++ b/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
@@ -74,7 +74,7 @@
         Template="$(_WixTemplate)"
         DestinationFile="$(_WixFile)"
         DotNetPath="$(DotNetPreviewPath)"
-        DotNetVersion="$(MicrosoftNETSdkPackageVersion)"
+        DotNetVersion="$(MicrosoftDotnetSdkInternalPackageVersion)"
         MSIVersion="$(AndroidMSIVersion)"
     />
     <ItemGroup>

--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -38,7 +38,7 @@
       <DotNetPayloadDir>$(PayloadDir)\usr\local\share\dotnet\</DotNetPayloadDir>
     </PropertyGroup>
     <ItemGroup>
-      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(MicrosoftNETSdkPackageVersion)\EnableWorkloadResolver.sentinel" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\EnableWorkloadResolver.sentinel" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.osx-x64\**\*" />

--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -38,7 +38,7 @@
       <DotNetPayloadDir>$(PayloadDir)\usr\local\share\dotnet\</DotNetPayloadDir>
     </PropertyGroup>
     <ItemGroup>
-      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(DotNetPreviewVersionFull)\EnableWorkloadResolver.sentinel" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(MicrosoftNETSdkPackageVersion)\EnableWorkloadResolver.sentinel" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.osx-x64\**\*" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\</_MonoAndroidNETOutputDir>
-    <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(MicrosoftNETSdkPackageVersion)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
+    <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
   </PropertyGroup>
 
   <!-- LICENSE setup -->

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\</_MonoAndroidNETOutputDir>
-    <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(DotNetPreviewVersionFull)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
+    <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(MicrosoftNETSdkPackageVersion)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
   </PropertyGroup>
 
   <!-- LICENSE setup -->

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -22,7 +22,6 @@ namespace Xamarin.Android.Prepare
 		public const string CommandLineToolsFolder              = nameof (CommandLineToolsFolder);
 		public const string DotNetPreviewPath                   = "DotNetPreviewPath";
 		public const string MicrosoftDotnetSdkInternalPackageVersion = "MicrosoftDotnetSdkInternalPackageVersion";
-		public const string MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion = "MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion";
 		public const string EmulatorVersion                     = "EmulatorVersion";
 		public const string EmulatorPkgRevision                 = "EmulatorPkgRevision";
 		public const string HostOS                              = "HostOS";

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -21,8 +21,8 @@ namespace Xamarin.Android.Prepare
 		public const string CommandLineToolsVersion             = nameof (CommandLineToolsVersion);
 		public const string CommandLineToolsFolder              = nameof (CommandLineToolsFolder);
 		public const string DotNetPreviewPath                   = "DotNetPreviewPath";
-		public const string DotNetPreviewVersionFull            = "DotNetPreviewVersionFull";
-		public const string DotNetRuntimePacksVersion           = "DotNetRuntimePacksVersion";
+		public const string MicrosoftNETSdkPackageVersion       = "MicrosoftNETSdkPackageVersion";
+		public const string MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion = "MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion";
 		public const string EmulatorVersion                     = "EmulatorVersion";
 		public const string EmulatorPkgRevision                 = "EmulatorPkgRevision";
 		public const string HostOS                              = "HostOS";

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Prepare
 		public const string CommandLineToolsVersion             = nameof (CommandLineToolsVersion);
 		public const string CommandLineToolsFolder              = nameof (CommandLineToolsFolder);
 		public const string DotNetPreviewPath                   = "DotNetPreviewPath";
-		public const string MicrosoftNETSdkPackageVersion       = "MicrosoftNETSdkPackageVersion";
+		public const string MicrosoftDotnetSdkInternalPackageVersion = "MicrosoftDotnetSdkInternalPackageVersion";
 		public const string MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion = "MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion";
 		public const string EmulatorVersion                     = "EmulatorVersion";
 		public const string EmulatorPkgRevision                 = "EmulatorPkgRevision";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.CommandLineToolsFolder,              StripQuotes ("@CommandLineToolsFolder@"));
 			properties.Add (KnownProperties.CommandLineToolsVersion,             StripQuotes ("@CommandLineToolsVersion@"));
 			properties.Add (KnownProperties.DotNetPreviewPath,                   StripQuotes (@"@DotNetPreviewPath@"));
-			properties.Add (KnownProperties.MicrosoftNETSdkPackageVersion,       StripQuotes ("@MicrosoftNETSdkPackageVersion@"));
+			properties.Add (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion, StripQuotes ("@MicrosoftDotnetSdkInternalPackageVersion@"));
 			properties.Add (KnownProperties.MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion, StripQuotes ("@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@"));
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));
 			properties.Add (KnownProperties.EmulatorPkgRevision,                 StripQuotes ("@EmulatorPkgRevision@"));

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -25,8 +25,8 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.CommandLineToolsFolder,              StripQuotes ("@CommandLineToolsFolder@"));
 			properties.Add (KnownProperties.CommandLineToolsVersion,             StripQuotes ("@CommandLineToolsVersion@"));
 			properties.Add (KnownProperties.DotNetPreviewPath,                   StripQuotes (@"@DotNetPreviewPath@"));
-			properties.Add (KnownProperties.DotNetPreviewVersionFull,            StripQuotes ("@DotNetPreviewVersionFull@"));
-			properties.Add (KnownProperties.DotNetRuntimePacksVersion,           StripQuotes ("@DotNetRuntimePacksVersion@"));
+			properties.Add (KnownProperties.MicrosoftNETSdkPackageVersion,       StripQuotes ("@MicrosoftNETSdkPackageVersion@"));
+			properties.Add (KnownProperties.MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion, StripQuotes ("@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@"));
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));
 			properties.Add (KnownProperties.EmulatorPkgRevision,                 StripQuotes ("@EmulatorPkgRevision@"));
 			properties.Add (KnownProperties.HostOS,                              StripQuotes ("@HostOS@"));

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -26,7 +26,6 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.CommandLineToolsVersion,             StripQuotes ("@CommandLineToolsVersion@"));
 			properties.Add (KnownProperties.DotNetPreviewPath,                   StripQuotes (@"@DotNetPreviewPath@"));
 			properties.Add (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion, StripQuotes ("@MicrosoftDotnetSdkInternalPackageVersion@"));
-			properties.Add (KnownProperties.MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion, StripQuotes ("@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@"));
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));
 			properties.Add (KnownProperties.EmulatorPkgRevision,                 StripQuotes ("@EmulatorPkgRevision@"));
 			properties.Add (KnownProperties.HostOS,                              StripQuotes ("@HostOS@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -403,7 +403,7 @@ namespace Xamarin.Android.Prepare
 				return Path.Combine (
 					XAPackagesDir,
 					$"microsoft.netcore.app.runtime.android-{androidTarget}",
-					ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion),
+					ctx.BundledPreviewRuntimePackVersion,
 					"runtimes",
 					$"android-{androidTarget}"
 				);

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -403,7 +403,7 @@ namespace Xamarin.Android.Prepare
 				return Path.Combine (
 					XAPackagesDir,
 					$"microsoft.netcore.app.runtime.android-{androidTarget}",
-					ctx.Properties.GetRequiredValue (KnownProperties.DotNetRuntimePacksVersion),
+					ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion),
 					"runtimes",
 					$"android-{androidTarget}"
 				);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Prepare
 		{
 			var dotnetPath = context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewPath);
 			dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
-			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewVersionFull);
+			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftNETSdkPackageVersion);
 			var dotnetTestRuntimeVersion = Configurables.Defaults.DotNetTestRuntimeVersion;
 
 			// Delete any custom Microsoft.Android packs that may have been installed by test runs. Other ref/runtime packs will be ignored.

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Prepare
 		{
 			var dotnetPath = context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewPath);
 			dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
-			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftNETSdkPackageVersion);
+			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion);
 			var dotnetTestRuntimeVersion = Configurables.Defaults.DotNetTestRuntimeVersion;
 
 			// Delete any custom Microsoft.Android packs that may have been installed by test runs. Other ref/runtime packs will be ignored.

--- a/build-tools/xaprepare/xaprepare/package-download.proj
+++ b/build-tools/xaprepare/xaprepare/package-download.proj
@@ -1,0 +1,25 @@
+<!--
+***********************************************************************************************
+package-download.proj
+
+Downloads .NET runtime packs using the version specified in $(DotNetRuntimePacksVersion) if set.
+Otherwise, the $(BundledNETCoreAppPackageVersion) version specified in the Microsoft.NET.Sdk that
+is building/restoring this project will be used.  $(BundledNETCoreAppPackageVersion) is set in 
+dotnet\sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\Microsoft.NETCoreSdk.BundledVersions.props
+***********************************************************************************************
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' " >$(BundledNETCoreAppPackageVersion)</DotNetRuntimePacksVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x86" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x64" Version="[$(DotNetRuntimePacksVersion)]" />
+  </ItemGroup>
+
+</Project>

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -60,10 +60,5 @@
   </ItemGroup>
 
   <Import Project="xaprepare.targets" Condition=" $(MSBuildToolsPath.IndexOf('omnisharp')) &lt; 0 " />
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x64" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x86" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
-  </ItemGroup>
+
 </Project>

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -61,9 +61,9 @@
 
   <Import Project="xaprepare.targets" Condition=" $(MSBuildToolsPath.IndexOf('omnisharp')) &lt; 0 " />
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x64" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x86" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm64" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x64" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-arm" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.android-x86" Version="[$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)]" />
   </ItemGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -59,8 +59,8 @@
       <Replacement Include="@CommandLineToolsFolder@=$(CommandLineToolsFolder)" />
       <Replacement Include="@CommandLineToolsVersion@=$(CommandLineToolsVersion)" />
       <Replacement Include="@DotNetPreviewPath@=$(DotNetPreviewPath)" />
-      <Replacement Include="@DotNetPreviewVersionFull@=$(DotNetPreviewVersionFull)" />
-      <Replacement Include="@DotNetRuntimePacksVersion@=$(DotNetRuntimePacksVersion)" />
+      <Replacement Include="@MicrosoftNETSdkPackageVersion@=$(MicrosoftNETSdkPackageVersion)" />
+      <Replacement Include="@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@=$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)" />
       <Replacement Include="@EmulatorVersion@=$(EmulatorVersion)" />
       <Replacement Include="@EmulatorPkgRevision@=$(EmulatorPkgRevision)" />
       <Replacement Include="@HostOS@=$(HostOS)" />

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -60,7 +60,6 @@
       <Replacement Include="@CommandLineToolsVersion@=$(CommandLineToolsVersion)" />
       <Replacement Include="@DotNetPreviewPath@=$(DotNetPreviewPath)" />
       <Replacement Include="@MicrosoftDotnetSdkInternalPackageVersion@=$(MicrosoftDotnetSdkInternalPackageVersion)" />
-      <Replacement Include="@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@=$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)" />
       <Replacement Include="@EmulatorVersion@=$(EmulatorVersion)" />
       <Replacement Include="@EmulatorPkgRevision@=$(EmulatorPkgRevision)" />
       <Replacement Include="@HostOS@=$(HostOS)" />

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -59,7 +59,7 @@
       <Replacement Include="@CommandLineToolsFolder@=$(CommandLineToolsFolder)" />
       <Replacement Include="@CommandLineToolsVersion@=$(CommandLineToolsVersion)" />
       <Replacement Include="@DotNetPreviewPath@=$(DotNetPreviewPath)" />
-      <Replacement Include="@MicrosoftNETSdkPackageVersion@=$(MicrosoftNETSdkPackageVersion)" />
+      <Replacement Include="@MicrosoftDotnetSdkInternalPackageVersion@=$(MicrosoftDotnetSdkInternalPackageVersion)" />
       <Replacement Include="@MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion@=$(MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion)" />
       <Replacement Include="@EmulatorVersion@=$(EmulatorVersion)" />
       <Replacement Include="@EmulatorPkgRevision@=$(EmulatorPkgRevision)" />

--- a/eng/README.md
+++ b/eng/README.md
@@ -1,0 +1,57 @@
+The `eng` folder contains and is used by parts of the https://github.com/dotnet/arcade SDK.
+
+## Dependency Management
+The Arcade SDK contains a tool known as [`darc`][0], which can be used to manage
+and query the relationships between repositories in the dotnet ecosystem.
+
+The `eng/Version.Details.xml` and `eng/Versions.props` files contain information
+about the products and tooling that this repository depends on.
+
+Many dotnet repositories use a publishing workflow that will push build artifact data
+to a central location known as the "Build Asset Registry".  This data includes
+a "channel" association, which is used to determine when an update for a particular
+product or tool is available.  Local updates and automatic update "subscriptions"
+compare the version files in the repository against the versions avalable in the
+channel that you are interested in.  The `darc` tool is used facilitate these updates.
+
+To work with `darc` locally, see the [setting up your darc client docs][1].
+You'll need to run a script in the dotnet/arcade repo to install the dotnet global
+tool, join the `arcade-contrib` GitHub team, and run the [`darc authenticate`][2]
+command to add the PATs required by the tool.
+
+The GitHub PAT that you add must have the full `repo` scope enabled if you want to
+work with any of the `subcription` commands.  Subscriptions control the automated
+creation of dependency update pull requests.
+
+
+To add a new dependency, run the [`darc add-dependency`][3] command at the root
+of the repository:
+```
+darc add-dependency -n Microsoft.NetCore.App.Runtime.android-arm64 -t product -v 6.0.0-preview.2.21154.6 -r https://github.com/dotnet/runtime
+```
+
+To update all dependencies, use the [`darc update-dependencies`][4] command:
+```
+darc update-dependencies --channel ".NET 6"
+```
+
+To configure automatic updates, use the [`darc add-subscription`][5] command
+to enroll a target repo/branch into updates from a particular channel:
+```
+darc add-subscription --channel ".NET 6" --source-repo https://github.com/dotnet/installer --target-repo https://github.com/xamarin/xamarin-android --target-branch main --update-frequency everyWeek --standard-automerge
+```
+
+Once a subscription is configured, pull requests will be created automatically
+by the dotnet Maestro bot whenever dependency updates are available.
+
+Subscriptions need to be manually managed at this time.  For example, when a
+release branch is created, someone with `darc` installed locally will need to
+run the `add-subscription` command to configure updates against that new branch.
+
+
+[0]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md
+[1]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#setting-up-your-darc-client
+[2]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#authenticate
+[3]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-dependency
+[4]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#update-dependencies
+[5]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-subscription

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21167.10">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21168.18">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>18a633b84588c419939a55ee9504727eeb2e9714</Sha>
+      <Sha>823c1dfceb916ff19de20c7ddccab0ea145508a3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21167.4">
+    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21168.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>75b1c3003bc12139c3a918705da5a4c12e7cb37b</Sha>
+      <Sha>9eff8c6ce48cb15cafb8eef4aaf853675b05f9d9</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21160.15">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21167.10">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>a28ceebdcd4601c69f86d4ec1341ad95295f5020</Sha>
+      <Sha>18a633b84588c419939a55ee9504727eeb2e9714</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.android-arm64" Version="6.0.0-preview.3.21160.15">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>b38ea6a4f067b571a007b2ac69f3e4431cb100e7</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21160.1">
+    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21167.4">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>bb923d296a0aa9afa499ffe29dcf71e66ee54352</Sha>
+      <Sha>75b1c3003bc12139c3a918705da5a4c12e7cb37b</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,0 +1,16 @@
+<Dependencies>
+  <ProductDependencies>
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-preview.2.21155.3">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha />
+    </Dependency>
+    <Dependency Name="Microsoft.NetCore.App.Runtime.android-arm64" Version="6.0.0-preview.2.21154.6">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.0-alpha.1.21109.1">
+      <Uri>https://github.com/mono/linker</Uri>
+      <Sha />
+    </Dependency>
+  </ProductDependencies>
+</Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-preview.2.21155.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-preview.3.21160.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha />
+      <Sha>614ad848c30fb2a2fc8901f82fb8732053090bcf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NetCore.App.Runtime.android-arm64" Version="6.0.0-preview.2.21154.6">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.android-arm64" Version="6.0.0-preview.3.21160.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
+      <Sha>b38ea6a4f067b571a007b2ac69f3e4431cb100e7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.0-alpha.1.21109.1">
+    <Dependency Name="Microsoft.NET.ILLink" Version="6.0.100-preview.2.21160.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha />
+      <Sha>bb923d296a0aa9afa499ffe29dcf71e66ee54352</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,8 +1,8 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-preview.3.21160.14">
-      <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>614ad848c30fb2a2fc8901f82fb8732053090bcf</Sha>
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.3.21160.15">
+      <Uri>https://github.com/dotnet/installer</Uri>
+      <Sha>a28ceebdcd4601c69f86d4ec1341ad95295f5020</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.android-arm64" Version="6.0.0-preview.3.21160.15">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,0 +1,8 @@
+<Project>
+  <!--Package versions-->
+  <PropertyGroup>
+    <MicrosoftNETSdkPackageVersion>6.0.100-preview.2.21155.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion>6.0.0-preview.2.21154.6</MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion>
+    <MicrosoftNETILLinkPackageVersion>6.0.0-alpha.1.21109.1</MicrosoftNETILLinkPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,11 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21160.15</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>6.0.0-preview.3.21160.15</MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>
-    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21160.1</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21167.10</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21167.4</MicrosoftNETILLinkPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Trim all characters after first `-` or `+` is encountered. -->
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace($(MicrosoftDotnetSdkInternalPackageVersion), `[-+].*$`, ""))</DotNetPreviewVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>6.0.100-preview.2.21155.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion>6.0.0-preview.2.21154.6</MicrosoftNetCoreAppRuntimeandroidarm64PackageVersion>
-    <MicrosoftNETILLinkPackageVersion>6.0.0-alpha.1.21109.1</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-preview.3.21160.14</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>6.0.0-preview.3.21160.15</MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>
+    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21160.1</MicrosoftNETILLinkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>6.0.100-preview.3.21160.14</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21160.15</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>6.0.0-preview.3.21160.15</MicrosoftNETCoreAppRuntimeandroidarm64PackageVersion>
     <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21160.1</MicrosoftNETILLinkPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21167.10</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21167.4</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.3.21168.18</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21168.1</MicrosoftNETILLinkPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Trim all characters after first `-` or `+` is encountered. -->

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-    "msbuild-sdks": {
-        "Microsoft.Build.NoTargets": "2.0.1",
-        "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20555.6",
-        "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
-    }
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "2.0.1",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20555.6",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
+  }
 }

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -7,7 +7,7 @@
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink" Version="$(ILLinkVersionFull)" />
+    <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkPackageVersion)" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=netcoreapp3.1" />
 
     <Compile Include="..\Xamarin.Android.Build.Tasks\obj\$(Configuration)\Profile.g.cs" Link="Profile.g.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -29,22 +29,22 @@
       "Size": 316728
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3084
+      "Size": 3075
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10653
+      "Size": 10654
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 3384
+      "Size": 3382
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 515824
+      "Size": 519161
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 57083
+      "Size": 57089
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 81984
+      "Size": 82011
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 68560
@@ -59,13 +59,13 @@
       "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3737376
+      "Size": 3725688
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346960
+      "Size": 346768
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37096
+      "Size": 37064
     },
     "META-INF/ANDROIDD.SF": {
       "Size": 2429
@@ -77,5 +77,5 @@
       "Size": 2302
     }
   },
-  "PackageSize": 2889606
+  "PackageSize": 2877318
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1634,208 +1634,208 @@
       "Size": 3455260
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6252
+      "Size": 6246
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122435
+      "Size": 122431
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6319
+      "Size": 6313
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7085
+      "Size": 7076
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17898
+      "Size": 17891
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 104053
+      "Size": 104046
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15145
+      "Size": 15134
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42701
+      "Size": 42692
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6427
+      "Size": 6419
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6774
+      "Size": 6766
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6895
+      "Size": 6889
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3284
+      "Size": 3278
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13306
+      "Size": 13302
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92074
+      "Size": 92067
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5195
+      "Size": 5189
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10941
+      "Size": 10932
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19137
+      "Size": 19126
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43153
+      "Size": 43148
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7205
+      "Size": 7197
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524838
+      "Size": 524830
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384970
+      "Size": 384961
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55851
+      "Size": 55842
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117185
+      "Size": 117180
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 3991
+      "Size": 3941
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12209
+      "Size": 12206
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 9076
+      "Size": 9079
     },
     "assemblies/System.Collections.dll": {
-      "Size": 21670
+      "Size": 21622
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
       "Size": 2787
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6374
+      "Size": 6375
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2188
+      "Size": 2189
     },
     "assemblies/System.Console.dll": {
       "Size": 6385
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 7265
+      "Size": 7264
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12458
+      "Size": 12459
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 26714
+      "Size": 26606
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12200
+      "Size": 12203
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19748
+      "Size": 19634
     },
     "assemblies/System.IO.FileSystem.dll": {
       "Size": 25875
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11485
+      "Size": 11410
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 191828
+      "Size": 191772
     },
     "assemblies/System.Linq.dll": {
-      "Size": 20956
+      "Size": 20423
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 216025
+      "Size": 216624
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 10669
+      "Size": 10670
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18141
+      "Size": 18074
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 43167
+      "Size": 43114
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37414
+      "Size": 37416
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 67451
+      "Size": 67407
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 56476
+      "Size": 57042
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12420
+      "Size": 12421
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
       "Size": 197526
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 40715
+      "Size": 40555
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 15853
+      "Size": 15856
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 261841
+      "Size": 261442
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 3384
+      "Size": 3382
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 3091
+      "Size": 3094
     },
     "assemblies/System.Runtime.Numerics.dll": {
       "Size": 22340
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 3023
+      "Size": 2862
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4183
+      "Size": 4110
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40331
+      "Size": 40327
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12505
+      "Size": 12524
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
-      "Size": 3546
+      "Size": 3545
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9564
+      "Size": 9482
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 94292
+      "Size": 94297
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 79409
+      "Size": 79258
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 15726
+      "Size": 15649
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 681719
+      "Size": 686103
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 64243
+      "Size": 64249
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 433276
+      "Size": 433318
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 142120
@@ -1850,13 +1850,13 @@
       "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3737376
+      "Size": 3725688
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346960
+      "Size": 346768
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37096
+      "Size": 37064
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -1982,5 +1982,5 @@
       "Size": 79643
     }
   },
-  "PackageSize": 8746124
+  "PackageSize": 8733836
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md

The dotnet core engineering group has some dependency management tooling
(known as `darc`) that we'd like to adopt.  Integrating this tooling in
to the build system will make it easier to stay up to date with the
latest .NET 6 SDK changes.

Many dotnet repos use a [publishing workflow][0] that will push build
artifact data to a central location known as the "Build Asset Registry".
This data includes a "[Channel][1]" association, which is the key to
dependency updating.  Local updates and automatic update "Subscriptions"
compare the version files in a given repo against the product versions
avalable in the channel that you are interested in.

We hope to be able to publish Xamarin SDK build information to this
central registry in the near future, so that other products can take a
dependency on us as needed (MAUI for instance).

The `darc` tool looks for four different files in a repo when adding a
dependency or when checking for an update:

 * eng/Version.Details.xml
 * eng/Versions.props
 * nuget.config
 * global.json

Both of the `Version` files present in the `eng` folder are updated when
a new dependency is available.

To work with `darc` locally you'll need to install the global tool, join
the `arcade-contrib` GitHub team, and configure your [auth settings][2].

To add a new dependency, use the [`darc add-dependency`][3] command:

    darc add-dependency -n Microsoft.NetCore.App.Runtime.android-arm64 -t product -v 6.0.0-preview.2.21154.6 -r https://github.com/dotnet/runtime

To update all dependencies, use the [`darc update-dependencies`][4]
command:

    darc update-dependencies --channel ".NET 6"

To configure automatic updates, use the [`darc add-subscription`][5]
command to enroll a target repo/branch into updates from a particular
channel:

     darc add-subscription --channel ".NET 6" --source-repo https://github.com/dotnet/installer --target-repo https://github.com/xamarin/xamarin-android --target-branch main --update-frequency everyWeek --standard-automerge

Once a subscription is configured, [a pull request][6] will be created
automatically by the dotnet Maestro bot when dependency updates are
available.

---

This PR also contains a bump to .NET 6.0.100-preview.3.21168.18.
Changes: https://github.com/dotnet/installer/compare/19e22a76...823c1dfce

The .NET 6 .apkdesc files have been updated accordingly. It seems that
`System.Private.CoreLib.dll` grew in size, however reductions in native
libraries and other files results in overall smaller package sizes.

Simple XA:

```diff
-"PackageSize": 2889606
+"PackageSize": 2877318
```

XF/XA:

```diff
-"PackageSize": 8746124
+"PackageSize": 8733836
```

[0]: https://github.com/dotnet/arcade/blob/681511f2f63a3563494f1f27904b2842abef6b35/Documentation/CorePackages/Publishing.md#what-is-v3-publishing-how-is-it-different-from-v2
[1]: https://github.com/dotnet/arcade/blob/main/Documentation/BranchesChannelsAndSubscriptions.md#branches-channels-and-subscriptions-explained
[2]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#setting-up-your-darc-client
[3]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-dependency
[4]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#update-dependencies
[5]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-subscription
[6]: https://github.com/xamarin/xamarin-android/pull/5744

