### PR TITLE
Bump to .NET 6.0.100-preview.3.21161.23

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -77,9 +77,9 @@
     <!-- Version number from: https://github.com/dotnet/installer#installers-and-binaries -->
     <!-- Please update DotNetRuntimePacksVersion below accordingly -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">6.0.100</DotNetPreviewVersionBand>
-    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.2.21155.3</DotNetPreviewVersionFull>
+    <DotNetPreviewVersionFull Condition=" '$(DotNetPreviewVersionFull)' == '' ">$(DotNetPreviewVersionBand)-preview.3.21161.23</DotNetPreviewVersionFull>
     <!-- This version comes from the a file in the dotnet distribution: sdk/$(DotNetPreviewVersionFull)/dotnet.runtimeconfig.json (the `runtimeOptions/framework/version key`) -->
-    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.2.21154.6</DotNetRuntimePacksVersion>
+    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' ">6.0.0-preview.3.21159.16</DotNetRuntimePacksVersion>
     <ILLinkVersionBand Condition=" '$(ILLinkVersionBand)' == '' ">6.0.0</ILLinkVersionBand>
     <ILLinkVersionFull Condition=" '$(ILLinkVersionFull)' == '' ">$(ILLinkVersionBand)-alpha.1.21109.1</ILLinkVersionFull>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>

--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
@@ -3,5 +3,6 @@
 <linker>
 	<assembly fullname="System.Private.CoreLib">
 		<type fullname="System.Globalization.GlobalizationMode" />
+		<type fullname="System.Runtime.CompilerServices.InternalsVisibleToAttribute" />
 	</assembly>
 </linker>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -35,9 +35,6 @@ This file contains the .NET 5-specific targets to customize ILLink
     <PropertyGroup>
       <!-- make the output verbose to see what the linker is doing. FIXME: make dependent upon verbosity level -->
       <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --verbose --deterministic --custom-data XATargetFrameworkDirectories="$(_XATargetFrameworkDirectories)"</_ExtraTrimmerArgs>
-
-      <!-- we don't want to ignore stuff we can't find -->
-      <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --skip-unresolved false</_ExtraTrimmerArgs>
       <_AdditionalTaskAssemblyDirectory>$(XamarinSdkRootDirectory)tools/dotnet-linker/</_AdditionalTaskAssemblyDirectory>
       <_AdditionalTaskAssembly>$(_AdditionalTaskAssemblyDirectory)dotnet-linker.dll</_AdditionalTaskAssembly>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -151,9 +151,6 @@ namespace Xamarin.Android.Build.Tests
 					KnownPackages.SupportV7AppCompat_27_0_2_1,
 				},
 			};
-			if (Builder.UseDotNet) {
-				proj.AddDotNetCompatPackages ();
-			}
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
 				var Rdrawable = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", "android", "support", "v7", "appcompat", "R$drawable.class"));
@@ -989,9 +986,6 @@ namespace Lib1 {
 				},
 			};
 			appProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
-			if (Builder.UseDotNet) {
-				appProj.AddDotNetCompatPackages ();
-			}
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, libProj.ProjectName), false, false)) {
 				libBuilder.AutomaticNuGetRestore = false;
 				Assert.IsTrue (libBuilder.RunTarget (libProj, "Restore"), "Library project should have restored.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -78,9 +78,6 @@ namespace Xamarin.Android.Build.Tests
 			if (forms) {
 				proj.PackageReferences.Clear ();
 				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
-
-				if (Builder.UseDotNet)
-					proj.AddDotNetCompatPackages ();
 			}
 
 			byte [] apkDescData;
@@ -2039,9 +2036,7 @@ namespace App1
 				}
 			};
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
-			if (Builder.UseDotNet) {
-				proj.AddDotNetCompatPackages ();
-			} else {
+			if (!Builder.UseDotNet) {
 				//NOTE: Mono.Data.Sqlite and Mono.Posix do not exist in .NET 5+
 				proj.References.Add (new BuildItem.Reference ("Mono.Data.Sqlite"));
 				proj.References.Add (new BuildItem.Reference ("Mono.Posix"));
@@ -2564,8 +2559,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					KnownPackages.AndroidSupportV4_27_0_2_1,
 				},
 			};
-			if (Builder.UseDotNet)
-				proj.AddDotNetCompatPackages ();
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var assets = b.Output.GetIntermediaryAsText (Path.Combine ("..", "project.assets.json"));
@@ -2659,8 +2652,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				string build_props = b.Output.GetIntermediaryPath ("build.props");
 				FileAssert.Exists (build_props, "build.props should exist after first build.");
 				proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-				if (Builder.UseDotNet)
-					proj.AddDotNetCompatPackages ();
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded.");
 				FileAssert.Exists (build_props, "build.props should exist after second build.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -87,6 +87,7 @@ namespace Xamarin.Android.Build.Tests
 					"Java.Interop.dll",
 					"Mono.Android.dll",
 					"System.Private.CoreLib.dll",
+					"System.Runtime.CompilerServices.Unsafe.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",
 				} :

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -4,20 +4,6 @@ namespace Xamarin.ProjectTools
 {
 	public static class KnownPackages
 	{
-		/// <summary>
-		/// Adds additional dependencies for Xamarin.Forms, support libraries, etc. on .NET 5+
-		/// to workaround the issue similar to https://github.com/mono/linker/issues/1139
-		/// </summary>
-		public static void AddDotNetCompatPackages (this IShortFormProject project)
-		{
-			project.PackageReferences.Add (SystemCodeDom_5_0_0_preview_3_20214_6);
-			project.PackageReferences.Add (SystemDiagnosticsEventLog_5_0_0_preview_3_20214_6);
-			project.PackageReferences.Add (SystemDiagnosticsPerformanceCounter_5_0_0_preview_3_20214_6);
-			project.PackageReferences.Add (SystemIOPorts_5_0_0_preview_3_20214_6);
-			project.PackageReferences.Add (SystemSecurityPermissions_5_0_0_preview_3_20214_6);
-			project.PackageReferences.Add (SystemThreadingAccessControl_5_0_0_preview_3_20214_6);
-		}
-
 		public static Package AndroidSupportV4_27_0_2_1 = new Package () {
 			Id = "Xamarin.Android.Support.v4",
 			Version = "27.0.2.1",
@@ -222,38 +208,6 @@ namespace Xamarin.ProjectTools
 			Version = "4.7.0.1142",
 			TargetFramework = "MonoAndroid10.0",
 		};
-		/* additional packages for XForms 4.5 on NET5 */
-		public static Package SystemCodeDom_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.CodeDom",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		public static Package SystemDiagnosticsEventLog_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.Diagnostics.EventLog",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		public static Package SystemDiagnosticsPerformanceCounter_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.Diagnostics.PerformanceCounter",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		public static Package SystemIOPorts_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.IO.Ports",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		public static Package SystemSecurityPermissions_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.Security.Permissions",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		public static Package SystemThreadingAccessControl_5_0_0_preview_3_20214_6 = new Package {
-			Id = "System.Threading.AccessControl",
-			Version = "5.0.0-preview.3.20214.6",
-			TargetFramework = "netcoreapp3.0",
-		};
-		/* end of additional packages for XForms 4.5 on NET5 */
 		public static Package XamarinFormsMaps_4_0_0_425677 = new Package {
 			Id = "Xamarin.Forms.Maps",
 			Version = "4.0.0.425677",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -89,10 +89,6 @@ namespace Xamarin.ProjectTools
 					PackageReferences.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider);
 					Sources.Remove (resourceDesigner);
 					OtherBuildItems.Add (new BuildItem.NoActionResource (() => "Resources\\Resource.designer" + Language.DefaultDesignerExtension) { TextContent = () => string.Empty });
-
-					if (Builder.UseDotNet) {
-						this.AddDotNetCompatPackages ();
-					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -31,9 +31,6 @@ namespace Xamarin.ProjectTools
 			TargetFrameworkVersion = Versions.KitkatWatch;
 			UseLatestPlatformSdk = true;
 			PackageReferences.Add (KnownPackages.AndroidWear_2_2_0);
-			if (Builder.UseDotNet) {
-				this.AddDotNetCompatPackages ();
-			}
 
 			MainActivity = default_main_activity;
 			StringsXml = default_strings_xml;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -43,7 +43,6 @@ namespace Xamarin.ProjectTools
 		{
 			if (Builder.UseDotNet) {
 				PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
-				this.AddDotNetCompatPackages ();
 			} else {
 				PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsXASdkProject.cs
@@ -45,7 +45,6 @@ namespace Xamarin.ProjectTools
 			: base (outputType, packageName)
 		{
 			PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
-			this.AddDotNetCompatPackages ();
 
 			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
 			Imports.Add (new Import (() => "Directory.Build.targets") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -29,22 +29,25 @@
       "Size": 316728
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3075
+      "Size": 3084
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10657
+      "Size": 10653
+    },
+    "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
+      "Size": 3384
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 514928
+      "Size": 515824
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 57483
+      "Size": 57083
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 82533
+      "Size": 81984
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 68496
+      "Size": 68560
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776168
@@ -56,23 +59,23 @@
       "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3742608
+      "Size": 3737376
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346768
+      "Size": 346960
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37064
+      "Size": 37096
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 2304
+      "Size": 2429
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2177
+      "Size": 2302
     }
   },
-  "PackageSize": 2885411
+  "PackageSize": 2889606
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1631,286 +1631,214 @@
       "Size": 341040
     },
     "classes.dex": {
-      "Size": 3455720
-    },
-    "assemblies/Microsoft.Win32.SystemEvents.dll": {
-      "Size": 8713
-    },
-    "assemblies/System.CodeDom.dll": {
-      "Size": 77266
-    },
-    "assemblies/System.Configuration.ConfigurationManager.dll": {
-      "Size": 177614
-    },
-    "assemblies/System.Diagnostics.EventLog.dll": {
-      "Size": 18766
-    },
-    "assemblies/System.Diagnostics.PerformanceCounter.dll": {
-      "Size": 17104
-    },
-    "assemblies/System.Drawing.Common.dll": {
-      "Size": 186681
-    },
-    "assemblies/System.IO.Ports.dll": {
-      "Size": 32495
-    },
-    "assemblies/System.Security.Cryptography.ProtectedData.dll": {
-      "Size": 4385
-    },
-    "assemblies/System.Security.Permissions.dll": {
-      "Size": 40080
-    },
-    "assemblies/System.Threading.AccessControl.dll": {
-      "Size": 8293
-    },
-    "assemblies/System.Windows.Extensions.dll": {
-      "Size": 8094
+      "Size": 3455260
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6246
+      "Size": 6252
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 122431
+      "Size": 122435
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6313
+      "Size": 6319
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7076
+      "Size": 7085
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17891
+      "Size": 17898
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 104046
+      "Size": 104053
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15134
+      "Size": 15145
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 42692
+      "Size": 42701
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6419
+      "Size": 6427
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6766
+      "Size": 6774
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6889
+      "Size": 6895
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3278
+      "Size": 3284
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13302
+      "Size": 13306
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 92067
+      "Size": 92074
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5189
+      "Size": 5195
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10932
+      "Size": 10941
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19126
+      "Size": 19137
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43148
+      "Size": 43153
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7197
+      "Size": 7205
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524830
+      "Size": 524838
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384961
+      "Size": 384970
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56872
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55842
+      "Size": 55851
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117180
+      "Size": 117185
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 3934
+      "Size": 3991
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12296
+      "Size": 12209
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 11467
-    },
-    "assemblies/System.Collections.Specialized.dll": {
-      "Size": 12425
+      "Size": 9076
     },
     "assemblies/System.Collections.dll": {
-      "Size": 23837
-    },
-    "assemblies/System.ComponentModel.EventBasedAsync.dll": {
-      "Size": 2393
+      "Size": 21670
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 7772
+      "Size": 2787
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 55306
+      "Size": 6374
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2452
+      "Size": 2188
     },
     "assemblies/System.Console.dll": {
-      "Size": 6417
-    },
-    "assemblies/System.Data.Common.dll": {
-      "Size": 2325
-    },
-    "assemblies/System.Diagnostics.Process.dll": {
-      "Size": 37276
+      "Size": 6385
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 10393
+      "Size": 7265
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 20129
+      "Size": 12458
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 26641
+      "Size": 26714
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12170
+      "Size": 12200
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 19680
+      "Size": 19748
     },
     "assemblies/System.IO.FileSystem.dll": {
-      "Size": 28873
+      "Size": 25875
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 11527
+      "Size": 11485
     },
     "assemblies/System.Linq.Expressions.dll": {
       "Size": 191828
     },
     "assemblies/System.Linq.dll": {
-      "Size": 20912
+      "Size": 20956
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 216745
+      "Size": 216025
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 10737
+      "Size": 10669
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18104
+      "Size": 18141
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 44522
+      "Size": 43167
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 37409
-    },
-    "assemblies/System.Net.Requests.dll": {
-      "Size": 52130
+      "Size": 37414
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 67800
-    },
-    "assemblies/System.Net.ServicePoint.dll": {
-      "Size": 3138
+      "Size": 67451
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 64273
-    },
-    "assemblies/System.Net.WebClient.dll": {
-      "Size": 7816
-    },
-    "assemblies/System.Net.WebHeaderCollection.dll": {
-      "Size": 6224
+      "Size": 56476
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12648
+      "Size": 12420
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 206422
+      "Size": 197526
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42296
+      "Size": 40715
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 15890
+      "Size": 15853
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 501491
+      "Size": 261841
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1418
+      "Size": 3384
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 4108
+      "Size": 3091
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 22345
+      "Size": 22340
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 4019
+      "Size": 3023
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4187
-    },
-    "assemblies/System.Security.AccessControl.dll": {
-      "Size": 4340
-    },
-    "assemblies/System.Security.Claims.dll": {
-      "Size": 8144
+      "Size": 4183
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 40633
-    },
-    "assemblies/System.Security.Cryptography.Csp.dll": {
-      "Size": 5141
+      "Size": 40331
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 12442
+      "Size": 12505
     },
     "assemblies/System.Security.Cryptography.OpenSsl.dll": {
-      "Size": 14953
+      "Size": 3546
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 9623
+      "Size": 9564
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 94335
-    },
-    "assemblies/System.Security.Principal.Windows.dll": {
-      "Size": 4594
+      "Size": 94292
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 81538
+      "Size": 79409
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 15728
-    },
-    "assemblies/System.Threading.dll": {
-      "Size": 6540
+      "Size": 15726
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 734384
+      "Size": 681719
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 64628
+      "Size": 64243
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 433845
+      "Size": 433276
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 143752
+      "Size": 142120
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776168
@@ -1922,13 +1850,13 @@
       "Size": 100408
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3742608
+      "Size": 3737376
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 346768
+      "Size": 346960
     },
     "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37064
+      "Size": 37096
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -2045,14 +1973,14 @@
       "Size": 339
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 82500
+      "Size": 79770
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 82373
+      "Size": 79643
     }
   },
-  "PackageSize": 9886918
+  "PackageSize": 8746124
 }

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -68,15 +68,21 @@ namespace Xamarin.Android.Build.Tests
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, "msbuild.binlog");
 			FileAssert.Exists (binlog);
 
-			var build = BinaryLog.ReadBuild (binlog);
-			var duration = build
-				.FindChildrenRecursive<Project> ()
-				.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
+			try {
+				var build = BinaryLog.ReadBuild (binlog);
+				var duration = build
+					.FindChildrenRecursive<Project> ()
+					.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
 
-			if (duration == TimeSpan.Zero)
-				throw new InvalidDataException ($"No project build duration found in {binlog}");
+				if (duration == TimeSpan.Zero)
+					throw new InvalidDataException ($"No project build duration found in {binlog}");
 
-			return duration.TotalMilliseconds;
+				return duration.TotalMilliseconds;
+			} catch (NotSupportedException) {
+				// See: https://github.com/dotnet/msbuild/issues/6225
+				Assert.Ignore ($"Test requires an updated MSBuild.StructuredLogger");
+				return 0;
+			}
 		}
 
 		ProjectBuilder CreateBuilderWithoutLogFile (string directory = null, bool isApp = true)

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -46,14 +46,6 @@
       <ApkSizesDefinitionFilename>$(XamarinAndroidSourcePath)build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(XamarinAndroidSourcePath)TestResult-$(_MonoAndroidTestPackage)-values-$(Configuration).csv</ApkSizesResultsFilename>
     </TestApk>
-    <PackageReference Include="System.CodeDom" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.IO.Ports" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Security.Permissions" Version="6.0.0-preview.1.21102.12" />
-    <PackageReference Include="System.Threading.AccessControl" Version="6.0.0-preview.1.21102.12" />
   </ItemGroup>
 
   <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />


### PR DESCRIPTION
At first, Android "Hello World" fails with:

    > dotnet build -c Release
    ILLink : error IL1009: Assembly 'System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' reference 'System.Configuration.ConfigurationManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' could not be resolved

Dropping the `--skip-unresolved false` switch passed to ILLink solves
this issue. This was a recommendation from Sven Boemer on the .NET team.

A nice, side-effect, is we no longer need workarounds like this any
longer:

    <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
      <PackageReference Include="System.CodeDom" Version="6.0.0-*" />
      <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0-*" />
      <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0-*" />
      <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0-*" />
      <PackageReference Include="System.Drawing.Common" Version="6.0.0-*" />
      <PackageReference Include="System.IO.Ports" Version="6.0.0-*" />
      <PackageReference Include="System.Threading.AccessControl" Version="6.0.0-*" />
    </ItemGroup>

I removed these from several tests.

`BuildReleaseArm64` test, net6 apk size difference before/after

Simple XA:

```diff
-"PackageSize": 2885411
+"PackageSize": 2889606
```

XF/XA

```diff
-"PackageSize": 9886918
+"PackageSize": 8746124
```

The Xamarin.Forms app saw quite a bit of improvement, since we don't
have to bring in these `@(PackageReference)` anymore.

## Other changes ##

I updated `PerformanceTest` to ignore `NotSupportedException` due to:

    System.NotSupportedException : Unsupported log file format. Latest supported version is 10, the log file has version 11.

We need to use a new version of this package when it is available:

https://www.nuget.org/packages/MSBuild.StructuredLogger/2.1.303