### PR TITLE
Bump to aapt2 4.1.2-6503028

### DIFF
--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <Aapt2Version>4.1.1-6503028</Aapt2Version>
+    <Aapt2Version>4.1.2-6503028</Aapt2Version>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5707

Will wait to see if this version actually *fixes* the issue, or we might need to use an even newer version of `aapt2`.