### PR TITLE
One directory higher then the immediate prefix of mono worked for me..

### DIFF
--- a/Documentation/workflow/UsingYourBuild.md
+++ b/Documentation/workflow/UsingYourBuild.md
@@ -20,7 +20,7 @@ the `$(prefix)` make variable:
 
 In order for `xbuild` or `msbuild` within `$PATH` to resolve the
 Xamarin.Android assemblies, you must install Xamarin.Android into the
-same prefix as mono.
+same prefix as mono; e.g. if mono is at /usr/bin/mono then prefix=/usr.
 
 
 ## Windows System-Wide Installation


### PR DESCRIPTION
I'm on: 
Ubuntu 20.04  
Microsoft (R) Build Engine version 16.6.0 for Mono. 
Mono JIT compiler version 6.12.0.122 (tarball Mon Feb 22 17:33:28 UTC 2021)
All installed with defaults. The Xamarin.Android source also built with defaults.

My mono is at /usr/bin/mono.   Doing "make install prefix=/usr/bin"  and then building the sample HelloWorld with MSBuild was giving the following error:
/home/..../xamarin-android/samples/HelloWorld/HelloWorld.csproj(78,3): error MSB4019: The imported project "/usr/lib/mono/xbuild/Xamarin/Android/Xamarin.Android.CSharp.targets" was not found. Confirm that the expression in the Import declaration "/usr/lib/mono/xbuild/Xamarin/Android/Xamarin.Android.CSharp.targets" is correct, and that the file exists on disk.

Took me a long time to track the source of the error.  Changing make install's prefix from /usr/bin to /usr fixed the error and msbuild successfully built the sample HelloWorld without any errors or warnings.