### PR TITLE
Bump to xamarin/sqlite/3.35.0@e399aec07

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
-    branch = 3.34.0
+    branch = 3.35.0
 [submodule "external/xamarin-android-tools"]
     path = external/xamarin-android-tools
     url = https://github.com/xamarin/xamarin-android-tools


### PR DESCRIPTION
Context: https://sqlite.org/releaselog/3_35_0.html
Context: https://github.com/xamarin/sqlite/compare/3.34.1..3.35.0

The most important upstream changes are:

  * Fix a potential NULL pointer dereference when processing a
    syntactically incorrect SELECT statement with a correlated WHERE
    clause and a "HAVING 0" clause. (Also fixed in the 3.34.1 patch
    release.)
  * Fix a bug in the IN-operator optimization of version 3.33.0 that
    can cause an incorrect answer.
  * Fix incorrect answers from the LIKE operator if the pattern ends
    with "%" and there is an "ESCAPE '_'" clause.