### PR TITLE
Avoids to remove the launch profiles capability when the _KeepLaunchProfiles property is true

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ProjectCapabilities.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ProjectCapabilities.targets
@@ -17,8 +17,7 @@ Docs about @(ProjectCapability):
     <ProjectCapability Include="Mobile" />
     <ProjectCapability Include="Android" />
     <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
-    <!-- Conflicts with our targets generator in VS+CPS: See https://work.azdo.io/1112733 -->
-    <ProjectCapability Remove="LaunchProfiles" />
+    <ProjectCapability Condition="'$(_KeepLaunchProfiles)' != 'true'" Remove="LaunchProfiles" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- this property will be defined on single projects to use launch profiles capability required on VisualStudio
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1291512

When a single-project is loaded on VisualStudio, to enable the switch between target frameworks the LaunchProfiles capability need to be enabled. 

By default, it is enabled but this capability is removed by our SDKs because the HEAD projects (Android and iOS) does not use this IDE feature to display devices on the start button.

The _KeepLaunchProfiles property avoids that removal in order to have LaunchProfiles enabled on VisualStudio.

MAUI targets adds _KeepLaunchProfiles with the value true to enable it for single-project.
