### PR TITLE
[xaprepare] Provision Microsoft OpenJDK 11

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Android.Prepare
 	partial class Configurables
 	{
 		const string JetBrainsOpenJDKOperatingSystem = "linux-x64";
+		const string MicrosoftOpenJDKOperatingSystem = "linux/x64";
 
 		partial class Defaults
 		{

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Android.Prepare
 	partial class Configurables
 	{
 		const string JetBrainsOpenJDKOperatingSystem = "osx-x64";
+		const string MicrosoftOpenJDKOperatingSystem = "macOS/x64";
 
 		partial class Defaults
 		{

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
@@ -5,6 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
+		const string MicrosoftOpenJDKFileExtension   = "tar.gz";
+
 		partial class Defaults
 		{
 			public const string DefaultCompiler = "cc";

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Android.Prepare
 	partial class Configurables
 	{
 		const string JetBrainsOpenJDKOperatingSystem = "windows-x64";
+		const string MicrosoftOpenJDKOperatingSystem = "windows/x64";
+		const string MicrosoftOpenJDKFileExtension   = "zip";
 
 		partial class Defaults
 		{

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,9 +15,11 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string JetBrainsOpenJDK11Version = "11.0.7";
-		const string JetBrainsOpenJDK11Release = "944.14";
-		static readonly string JetBrainsOpenJDK11DownloadVersion = JetBrainsOpenJDK11Version.Replace ('.', '_');
+		const string MicrosoftOpenJDK11Version      = "11.0.10";
+		const string MicrosoftOpenJDK11Release      = "9.1";
+		const string MicrosoftOpenJDK11RootDirName  = "jdk-11.0.10+9";
+		const string MicrosoftOpenJDK11DirVersion   = MicrosoftOpenJDK11RootDirName + ".1";
+		const string MicrosoftOpenJDK11FileVersion  = "11.0.10.9";
 
 		const string JetBrainsOpenJDK8VersionMinor = "8";
 		const string JetBrainsOpenJDK8VersionRevision = "202";
@@ -37,10 +39,10 @@ namespace Xamarin.Android.Prepare
 			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-8u202-windows-x64-b1483.37.tar.gz
 			public static readonly Uri JetBrainsOpenJDK8 = new Uri ($"https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-{JetBrainsOpenJDK8DownloadVersion}-{JetBrainsOpenJDKOperatingSystem}-b{JetBrainsOpenJDK8Release}.tar.gz");
 
-			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-linux-x64-b944.14.tar.gz
-			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-osx-x64-b944.14.tar.gz
-			// https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-11_0_7-windows-x64-b944.14.tar.gz
-			public static readonly Uri JetBrainsOpenJDK11 = new Uri ($"https://bintray.com/jetbrains/intellij-jbr/download_file?file_path=jbrsdk-{JetBrainsOpenJDK11DownloadVersion}-{JetBrainsOpenJDKOperatingSystem}-b{JetBrainsOpenJDK11Release}.tar.gz");
+			// https://msopenjdk.azureedge.net/jdk11u/jdk-11.0.10+9.1/linux/x64/microsoft-jdk-11.0.10.9-linux-x64.tar.gz
+			// https://msopenjdk.azureedge.net/jdk11u/jdk-11.0.10+9.1/macOS/x64/microsoft-jdk-11.0.10.9-macOS-x64.tar.gz
+			// https://msopenjdk.azureedge.net/jdk11u/jdk-11.0.10+9.1/windows/x64/microsoft-jdk-11.0.10.9-windows-x64.zip
+			public static readonly Uri MicrosoftOpenJDK11 = new Uri ($"https://msopenjdk.azureedge.net/jdk11u/{MicrosoftOpenJDK11DirVersion}/{MicrosoftOpenJDKOperatingSystem}/microsoft-jdk-{MicrosoftOpenJDK11FileVersion}-{MicrosoftOpenJDKOperatingSystem.Replace ('/', '-')}.{MicrosoftOpenJDKFileExtension}");
 
 			/// <summary>
 			///   Base URL for all Android SDK and NDK downloads. Used in <see cref="AndroidToolchain"/>
@@ -58,8 +60,9 @@ namespace Xamarin.Android.Prepare
 
 			public static readonly string JdkFolder                        = "jdk-11";
 
-			public static readonly Version JetBrainsOpenJDK11Version = new Version (Configurables.JetBrainsOpenJDK11Version);
-			public static readonly Version JetBrainsOpenJDK11Release = new Version (Configurables.JetBrainsOpenJDK11Release);
+			public static readonly Version MicrosoftOpenJDK11Version = new Version (Configurables.MicrosoftOpenJDK11Version);
+			public static readonly Version MicrosoftOpenJDK11Release = new Version (Configurables.MicrosoftOpenJDK11Release);
+			public static readonly string  MicrosoftOpenJDK11RootDirName   = Configurables.MicrosoftOpenJDK11RootDirName;
 
 			public static readonly Version JetBrainsOpenJDK8Version = new Version (Configurables.JetBrainsOpenJDK8VersionFull);
 			public static readonly Version JetBrainsOpenJDK8Release = new Version (Configurables.JetBrainsOpenJDK8Release);

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 		{
 			Steps.Add (new Step_InstallDotNetPreview ());
 			Steps.Add (new Step_InstallJetBrainsOpenJDK8 ());
-			Steps.Add (new Step_InstallJetBrainsOpenJDK11 ());
+			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
 			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));
 
 			// disable installation of missing programs...

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Prepare
 			Steps.Add (new Step_ShowEnabledRuntimes ());
 			Steps.Add (new Step_InstallDotNetPreview ());
 			Steps.Add (new Step_InstallJetBrainsOpenJDK8 ());
-			Steps.Add (new Step_InstallJetBrainsOpenJDK11 ());
+			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
 			Steps.Add (new Step_Android_SDK_NDK ());
 			Steps.Add (new Step_GenerateFiles (atBuildStart: true));
 			Steps.Add (new Step_PrepareProps ());

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Linux.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	partial class Step_InstallJetBrainsOpenJDK
+	partial class Step_InstallOpenJDK
 	{
 		async Task<bool> Unpack (string fullArchivePath, string destinationDirectory, bool cleanDestinationBeforeUnpacking = false)
 		{

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.MacOS.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	partial class Step_InstallJetBrainsOpenJDK
+	partial class Step_InstallOpenJDK
 	{
 		async Task<bool> Unpack (string fullArchivePath, string destinationDirectory, bool cleanDestinationBeforeUnpacking = false)
 		{

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	partial class Step_InstallJetBrainsOpenJDK
+	partial class Step_InstallOpenJDK
 	{
 		async Task<bool> Unpack (string fullArchivePath, string destinationDirectory, bool cleanDestinationBeforeUnpacking = false)
 		{
@@ -17,10 +17,6 @@ namespace Xamarin.Android.Prepare
 				destinationDirectory = Path.Combine (destinationDirectory, RootDirName);
 			}
 
-			// On Windows we don't have Tar available and the Windows package is a .tar.gz
-			// 7zip can unpack tar.gz but it's a two-stage process - first it decompresses the package, then it can be
-			// invoked again to extract the actual tar contents.
-
 			if (cleanDestinationBeforeUnpacking)
 				Utilities.DeleteDirectorySilent (destinationDirectory);
 			Utilities.CreateDirectory (destinationDirectory);
@@ -29,15 +25,6 @@ namespace Xamarin.Android.Prepare
 			Log.DebugLine ($"Uncompressing {fullArchivePath} to {destinationDirectory}");
 			if (!await sevenZip.Extract (fullArchivePath, destinationDirectory)) {
 				Log.DebugLine ($"Failed to decompress {fullArchivePath}");
-				return false;
-			}
-
-			string tarPath = Path.Combine (destinationDirectory, Path.GetFileNameWithoutExtension (fullArchivePath));
-			bool ret = await sevenZip.Extract (tarPath, destinationDirectory);
-			Utilities.DeleteFileSilent (tarPath);
-
-			if (!ret) {
-				Log.DebugLine ($"Failed to extract TAR contents from {tarPath}");
 				return false;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -135,12 +135,12 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		/// <summary>
-		/// See: http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/sun/security/tools/jarsigner/Resources.java
-		/// </summary>
 		static readonly string [] IgnoredWarnings = new [] {
+			// See: http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/sun/security/tools/jarsigner/Resources.java
 			"certificate is self-signed",
 			"No -tsa or -tsacert is provided",
+			// FIXME: warning encountered when using: https://aka.ms/getopenjdk
+			"POSIX file permission and/or symlink attributes detected"
 		};
 
 		protected override string ToolName


### PR DESCRIPTION
Context: https://aka.ms/getopenjdk
Context: https://devblogs.microsoft.com/java/tag/openjdk/

Begin provisioning and using Microsoft OpenJDK 11 for
integration test purposes.