### PR TITLE
[One .NET] rename to Microsoft.Android.Sdk.$(HostOS)

### DIFF
--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -90,8 +90,8 @@ packages with:
 Several `.nupkg` files will be output in `./bin/BuildDebug/nuget-unsigned`,
 but this is only part of the story. Your local
 `~/android-toolchain/dotnet/packs` directory will be populated with a
-local Android "workload" in `Microsoft.Android.Sdk.osx-x64` or
-`Microsoft.Android.Sdk.linux-x64` matching your operating system.
+local Android "workload" in `Microsoft.Android.Sdk.$(HostOS)` matching
+your operating system.
 
 To use the Android workload, you will need a `NuGet.config`:
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -105,7 +105,7 @@ Several `.nupkg` files will be output in `.\bin\BuildDebug\nuget-unsigned`,
 but this is only part of the story. Your local
 `%USERPROFILE%\android-toolchain\dotnet\packs` directory will be
 populated with a local Android "workload" in
-`Microsoft.Android.Sdk.win-x64` matching your operating system.
+`Microsoft.Android.Sdk.$(HostOS)` matching your operating system.
 
 To use the Android workload, you will need a `NuGet.config`:
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -500,7 +500,7 @@ stages:
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
-        cp $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.linux-x64*.nupkg
+        cp $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.Linux*.nupkg
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy linux sdk

--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -41,7 +41,7 @@
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\EnableWorkloadResolver.sentinel" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
-      <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.osx-x64\**\*" />
+      <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.Darwin\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.BundleTool\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\template-packs\Microsoft.Android.Templates.*.nupkg" />
     </ItemGroup>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -82,9 +82,9 @@
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=linux-x64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Linux' " />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=osx-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;"     Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidHostRID=win-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
+    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BundleTool.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Workload.Android.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
@@ -94,9 +94,7 @@
       DependsOnTargets="DeleteExtractedWorkloadPacks" >
     <ItemGroup>
       <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.NET.Workload.Android.*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.linux-x64.*.nupkg"   Condition=" '$(HostOS)' == 'Linux' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.osx-x64.*.nupkg"     Condition=" '$(HostOS)' == 'Darwin' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.win-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.$(HostOS).*.nupkg" />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.BundleTool.*.nupkg" />
       <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.*.nupkg" />
       <_WLTemplates Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Templates.*.nupkg" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -9,10 +9,7 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Linux' ">linux-x64</AndroidHostRID>
-    <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Darwin' ">osx-x64</AndroidHostRID>
-    <AndroidHostRID Condition=" '$(AndroidHostRID)' == '' and '$(HostOS)' == 'Windows' ">win-x64</AndroidHostRID>
-    <PackageId>Microsoft.Android.Sdk.$(AndroidHostRID)</PackageId>
+    <PackageId>Microsoft.Android.Sdk.$(HostOS)</PackageId>
     <Description>C# Tools and Bindings for the Android SDK</Description>
     <!-- Exclude mono bundle components declared in `create-installers.targets`. -->
     <IncludeMonoBundleComponents>false</IncludeMonoBundleComponents>
@@ -39,10 +36,10 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
       <AndroidSdkBuildTools Include="@(_MSBuildTargetsSrcFiles)" >
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
-      <AndroidSdkBuildTools Include="@(_MSBuildFilesWin)" Condition=" '$(AndroidHostRID)' == 'win-x64' ">
+      <AndroidSdkBuildTools Include="@(_MSBuildFilesWin)" Condition=" '$(HostOS)' == 'Windows' ">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
-      <AndroidSdkBuildTools Include="@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)" Condition=" '$(AndroidHostRID)' == 'linux-x64' or '$(AndroidHostRID)' == 'osx-x64' ">
+      <AndroidSdkBuildTools Include="@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)" Condition=" '$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin' ">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </AndroidSdkBuildTools>
       <!-- Remove items with '%(ExcludeFromAndroidNETSdk)' == 'true' metadata -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Workload.Android/WorkloadManifest.in.json
@@ -16,10 +16,11 @@
       "kind": "sdk",
       "version": "@SDK_PACK_VERSION@",
       "alias-to": {
-        "osx-x64": "Microsoft.Android.Sdk.osx-x64",
-        "osx-arm64": "Microsoft.Android.Sdk.osx-x64",
-        "win-x64": "Microsoft.Android.Sdk.win-x64",
-        "linux-x64": "Microsoft.Android.Sdk.linux-x64"
+        "osx-x64": "Microsoft.Android.Sdk.Darwin",
+        "osx-arm64": "Microsoft.Android.Sdk.Darwin",
+        "win-x86": "Microsoft.Android.Sdk.Windows",
+        "win-x64": "Microsoft.Android.Sdk.Windows",
+        "linux-x64": "Microsoft.Android.Sdk.Linux"
       }
     },
     "Microsoft.Android.Sdk.BundleTool": {


### PR DESCRIPTION
When reviewing our `WorkloadManifest.json`, we realized that 32-bit
Windows was not listed.

However, 32-bit Windows should already work because:

* We ship 32 & 64-bit `libzip.dll`
* `aapt2.exe` is 32-bit

`Microsoft.Android.Sdk` needs to support both 32 & 64-bit, because you
can run `MSBuild.exe` in either:

    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\MSBuild.exe"

By default MSBuild is 32-bit on Windows, as well as inside Visual Studio.

After reviewing the names of packages, using RIDs does not really make
sense. The `osx-x64` and `win-x64` packages are actually Mac & Windows
packages, regardless of the architecture.

Let's rename the packages to match the existing `$(HostOS)` variable
we have:

* Microsoft.Android.Sdk.Windows
* Microsoft.Android.Sdk.Darwin
* Microsoft.Android.Sdk.Linux

This cleans up things a bit, so we can drop the `$(AndroidHostRID)`
MSBuild property and just use `$(HostOS)` instead.