### PR TITLE
Bump to xamarin/Java.Interop/main@3824b974

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -132,6 +132,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jnienv-gen", "external\Java
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "check-boot-times", "build-tools\check-boot-times\check-boot-times.csproj", "{D28957BF-5E66-4D60-B528-22820C60AC82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "java-interop", "external\Java.Interop\src\java-interop\java-interop.csproj", "{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.Generator", "external\Java.Interop\src\Java.Interop.Tools.Generator\Java.Interop.Tools.Generator.csproj", "{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.SourceWriter", "external\Java.Interop\src\Xamarin.SourceWriter\Xamarin.SourceWriter.csproj", "{86A8DEFE-7ABB-4097-9389-C249581E243D}"
@@ -396,6 +398,10 @@ Global
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Debug|AnyCPU.Build.0 = Debug|anycpu
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Release|AnyCPU.ActiveCfg = Release|anycpu
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Release|AnyCPU.Build.0 = Release|anycpu
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -462,6 +468,7 @@ Global
 		{37FCD325-1077-4603-98E7-4509CAD648D6} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{88B746FF-8D6E-464D-9D66-FF2ECCF148E0} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/provisioning/vs2019.csx
+++ b/build-tools/provisioning/vs2019.csx
@@ -1,4 +1,3 @@
 VisualStudio (VisualStudioChannel.Stable, VisualStudioTier.Enterprise, 16, @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise", true)
     .Workload (VisualStudioWorkload.ManagedDesktop)
-    .Workload (VisualStudioWorkload.NativeDesktop)
     .Workload (VisualStudioWorkload.NetCrossPlat);

--- a/build-tools/provisioning/vs2019.csx
+++ b/build-tools/provisioning/vs2019.csx
@@ -1,4 +1,5 @@
 VisualStudio (VisualStudioChannel.Stable, VisualStudioTier.Enterprise, 16, @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise", true)
+    .Component (VisualStudioComponent.Microsoft_VisualStudio_Component_VC_Tools_x86_x64)
+    .Component (VisualStudioComponent.Microsoft_VisualStudio_Component_VC_CMake_Project)
     .Workload (VisualStudioWorkload.ManagedDesktop)
-    .Workload (VisualStudioWorkload.NativeDesktop)
     .Workload (VisualStudioWorkload.NetCrossPlat);

--- a/build-tools/provisioning/vs2019.csx
+++ b/build-tools/provisioning/vs2019.csx
@@ -1,5 +1,4 @@
 VisualStudio (VisualStudioChannel.Stable, VisualStudioTier.Enterprise, 16, @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise", true)
-    .Component (VisualStudioComponent.Microsoft_VisualStudio_Component_VC_Tools_x86_x64)
-    .Component (VisualStudioComponent.Microsoft_VisualStudio_Component_VC_CMake_Project)
     .Workload (VisualStudioWorkload.ManagedDesktop)
+    .Workload (VisualStudioWorkload.NativeDesktop)
     .Workload (VisualStudioWorkload.NetCrossPlat);

--- a/build-tools/provisioning/vs2019.csx
+++ b/build-tools/provisioning/vs2019.csx
@@ -1,3 +1,4 @@
 VisualStudio (VisualStudioChannel.Stable, VisualStudioTier.Enterprise, 16, @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise", true)
     .Workload (VisualStudioWorkload.ManagedDesktop)
+    .Workload (VisualStudioWorkload.NativeDesktop)
     .Workload (VisualStudioWorkload.NetCrossPlat);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -220,12 +220,21 @@
     </ReplaceFileContents>
     <PropertyGroup>
       <_HaveVcVars Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat') ">True</_HaveVcVars>
+      <_HaveVc Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC') ">True</_HaveVc>
     </PropertyGroup>
     <Message Text="# jonp: Does vcvarsall.bat exist? $(_HaveVcVars) " />
+    <Message Text="# jonp: Does VC exist? $(_HaveVc) " />
     <ItemGroup Condition=" '$(_HaveVcVars)' == '' And '$(OS)' == 'Windows_NT' ">
       <_Vcvars Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\**\vcvarsall.bat" />
     </ItemGroup>
     <Message Text="# jonp: Anywhere? @(_Vcvars, ';')" />
+    <ItemGroup Condition=" '$(_HaveVc)' != '' And '$(OS)' == 'Windows_NT' ">
+      <_VcScripts Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\**\*.bat" />
+      <_VcScripts Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\**\*.cmd" />
+    </ItemGroup>
+    <Message Text="# jonp: Any scripts?
+@(_VcScripts, '
+')" />
   </Target>
   <Target Name="_FindAndroidApiInfo">
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -220,21 +220,12 @@
     </ReplaceFileContents>
     <PropertyGroup>
       <_HaveVcVars Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat') ">True</_HaveVcVars>
-      <_HaveVc Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC') ">True</_HaveVc>
     </PropertyGroup>
     <Message Text="# jonp: Does vcvarsall.bat exist? $(_HaveVcVars) " />
-    <Message Text="# jonp: Does VC exist? $(_HaveVc) " />
     <ItemGroup Condition=" '$(_HaveVcVars)' == '' And '$(OS)' == 'Windows_NT' ">
       <_Vcvars Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\**\vcvarsall.bat" />
     </ItemGroup>
     <Message Text="# jonp: Anywhere? @(_Vcvars, ';')" />
-    <ItemGroup Condition=" '$(_HaveVc)' != '' And '$(OS)' == 'Windows_NT' ">
-      <_VcScripts Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\**\*.bat" />
-      <_VcScripts Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\**\*.cmd" />
-    </ItemGroup>
-    <Message Text="# jonp: Any scripts?
-@(_VcScripts, '
-')" />
   </Target>
   <Target Name="_FindAndroidApiInfo">
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -218,6 +218,14 @@
         DestinationFile="Xamarin.Android.Common.props"
         Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@NDK_ARMEABI_V7_API@=$(AndroidNdkApiLevel_ArmV7a);@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a);@NDK_X86_API@=$(AndroidNdkApiLevel_X86);@NDK_X86_64_API@=$(AndroidNdkApiLevel_X86_64);@BUNDLETOOL_VERSION@=$(XABundleToolVersion)">
     </ReplaceFileContents>
+    <PropertyGroup>
+      <_HaveVcVars Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat') ">True</_HaveVcVars>
+    </PropertyGroup>
+    <Message Text="# jonp: Does vcvarsall.bat exist? $(_HaveVcVars) " />
+    <ItemGroup Condition=" '$(_HaveVcVars)' == '' And '$(OS)' == 'Windows_NT' ">
+      <_Vcvars Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\**\vcvarsall.bat" />
+    </ItemGroup>
+    <Message Text="# jonp: Anywhere? @(_Vcvars, ';')" />
   </Target>
   <Target Name="_FindAndroidApiInfo">
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -218,14 +218,6 @@
         DestinationFile="Xamarin.Android.Common.props"
         Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@NDK_ARMEABI_V7_API@=$(AndroidNdkApiLevel_ArmV7a);@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a);@NDK_X86_API@=$(AndroidNdkApiLevel_X86);@NDK_X86_64_API@=$(AndroidNdkApiLevel_X86_64);@BUNDLETOOL_VERSION@=$(XABundleToolVersion)">
     </ReplaceFileContents>
-    <PropertyGroup>
-      <_HaveVcVars Condition=" Exists('C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat') ">True</_HaveVcVars>
-    </PropertyGroup>
-    <Message Text="# jonp: Does vcvarsall.bat exist? $(_HaveVcVars) " />
-    <ItemGroup Condition=" '$(_HaveVcVars)' == '' And '$(OS)' == 'Windows_NT' ">
-      <_Vcvars Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\**\vcvarsall.bat" />
-    </ItemGroup>
-    <Message Text="# jonp: Anywhere? @(_Vcvars, ';')" />
   </Target>
   <Target Name="_FindAndroidApiInfo">
     <ItemGroup>

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -294,7 +294,7 @@ if(NOT ANDROID)
 endif()
 
 if(WIN32 OR MINGW)
-  add_compile_definitions(WINDOWS NTDDI_VERSION=NTDDI_VISTA _WIN32_WINNT=_WIN32_WINNT_VISTA)
+  add_compile_definitions(WINDOWS NTDDI_VERSION=NTDDI_VISTA _WINDOWS _WIN32_WINNT=_WIN32_WINNT_VISTA)
 endif()
 
 # Compiler and linker flags


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/790

Changes: https://github.com/xamarin/java.interop/compare/bba1f077ae9886cdcc3e35fee35386937ce885dc...3824b974dada6f302ed5f7b7f97ffbd08990a82a

  * xamarin/java.interop@3824b974: [java-interop] Windows build system support (#816)
  * xamarin/java.interop@94c0c709: Bump to xamarin/xamarin-android-tools/main@554d45a (#813)
  * xamarin/java.interop@5c756b14: [Java.Interop-PerformanceTests] Support .NET Core 3.1 (#808)
  * xamarin/java.interop@daec07b6: [build] Fix various warnings (#812)
  * xamarin/java.interop@678c4bd2: [class-parse, generator] Allow showing Kotlin internals via metadata (#793)
  * xamarin/java.interop@cd4c8f80: [jnienv-gen] Generate a header file for the native functions (#809)
  * xamarin/java.interop@69767c1a: [param-name-importer] Fix NSE when updating JavaApi.AllPackages (#807)
  * xamarin/java.interop@a666a6f9: [Java.Runtime.Environment] Partial support for .NET Core (#804)