### PR TITLE
[Xamarin.Android.Build.Tasks] Xamarin.Android deployment fails unless project is cleaned first

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -158,8 +158,10 @@ namespace Xamarin.Android.Tasks
 							}
 							Log.LogDebugMessage ($"Deregistering item {entryName}");
 							existingEntries.Remove (entryName);
-							if (lastWriteInput <= lastWriteOutput)
+							if (lastWriteInput <= lastWriteOutput) {
+								Log.LogDebugMessage ($"Skipping to next item. {lastWriteInput} <= {lastWriteOutput}.");
 								continue;
+							}
 							if (apk.Archive.ContainsEntry (entryName)) {
 								ZipEntry e = apk.Archive.ReadEntry (entryName);
 								// check the CRC values as the ModifiedDate is always 01/01/1980 in the aapt generated file.
@@ -266,6 +268,9 @@ namespace Xamarin.Android.Tasks
 				}
 				// Clean up Removed files.
 				foreach (var entry in existingEntries) {
+					// never remove an AndroidManifest. It may be renamed when using aab.
+					if (string.Compare (Path.GetFileName (entry), "AndroidManifest.xml", StringComparison.OrdinalIgnoreCase) == 0)
+						continue;
 					Log.LogDebugMessage ($"Removing {entry} as it is not longer required.");
 					apk.Archive.DeleteEntry (entry);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Utilities;
 using System;
 using System.IO;
 using Xamarin.Tools.Zip;
+using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks
 {
@@ -32,9 +33,12 @@ namespace Xamarin.Android.Tasks
 		/// </summary>
 		protected override void FixupArchive (ZipArchiveEx zip)
 		{
-			if (!zip.Archive.ContainsEntry ("AndroidManifest.xml"))
+			if (!zip.Archive.ContainsEntry ("AndroidManifest.xml")) {
+				Log.LogDebugMessage ($"No AndroidManifest.xml. Skipping Fixup");
 				return;
+			}
 			var entry = zip.Archive.ReadEntry ("AndroidManifest.xml");
+			Log.LogDebugMessage ($"Fixing up AndroidManifest.xml to be manifest/AndroidManifest.xml.");
 			using (var stream = new MemoryStream ()) {
 				entry.Extract (stream);
 				stream.Position = 0;


### PR DESCRIPTION
Fixes https://work.azdo.io/1288593

This is a weird bug which I cannot reproduce locally. However reading
the code this code path is possible.

When trying to do incremental builds when using the `AndroidPackageFormat`
`aab` we get the following error

     [BT : 1.4.0] error : Module 'base' is missing mandatory file 'manifest/AndroidManifest.xml'.

The problem is the base.zip doesn't have ANY AndroidManifest.xml in it...
But why?

Well what seems to happen is in this case the input file `packaged_resources`
and the output `base.zip` are unchanged. `packaged_resources` has
an `AndroidManifest.xml` file and `base.zip` has a `manifest/AndroidManifest.xml`
file. Because it was renamed from `AndroidManifest.xml` to `manifest/AndroidManifest.xml`
on a previous build. This is so that our `base.zip` confirms to the expected
folder structure for an `aab`. So this is by design.

However, in this case because BOTH files are up to date, we DONT add
the `AndroidManifest.xml` file from `packaged_resources` to the `base.zip`.
A compounding problem is because no physical file `manifest/AndroidManifest.xml`
exists, that file is then removed from the `base.zip`.
As a result the `FixupArchive` which does the renaming of the `AndroidManifest.xml`
for `aab` files has nothing to do. Because its source file does not exist.

So we end up with a `base.zip` without ANY `AndroidManifest.xml` file in it.

The fix in this case is to NEVER remove an `AndroidManifest.xml` file from
the base.zip or apk. It is a protected file and should always exist.