### PR TITLE
[build/ci] Rename installer and nuget artifacts

### DIFF
--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -87,7 +87,7 @@ packages with:
 
     make pack-dotnet
 
-Several `.nupkg` files will be output in `./bin/BuildDebug/nupkgs`,
+Several `.nupkg` files will be output in `./bin/BuildDebug/nuget-unsigned`,
 but this is only part of the story. Your local
 `~/android-toolchain/dotnet/packs` directory will be populated with a
 local Android "workload" in `Microsoft.Android.Sdk.osx-x64` or
@@ -100,12 +100,12 @@ To use the Android workload, you will need a `NuGet.config`:
 <configuration>
   <packageSources>
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="local-xa" value="/full/path/to/bin/BuildDebug/nupkgs" />
+    <add key="local-xa" value="/full/path/to/bin/BuildDebug/nuget-unsigned" />
   </packageSources>
 </configuration>
 ```
 
-The local package source in the `bin/BuildDebug/nupkgs` directory is
+The local package source in the `bin/BuildDebug/nuget-unsigned` directory is
 currently needed for the Android runtime packages.
 
 Then use a `.csproj` file such as:

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -101,7 +101,7 @@ the .NET 6 packages with:
 
     msbuild Xamarin.Android.sln /t:PackDotNet
 
-Several `.nupkg` files will be output in `.\bin\BuildDebug\nupkgs`,
+Several `.nupkg` files will be output in `.\bin\BuildDebug\nuget-unsigned`,
 but this is only part of the story. Your local
 `%USERPROFILE%\android-toolchain\dotnet\packs` directory will be
 populated with a local Android "workload" in
@@ -114,12 +114,12 @@ To use the Android workload, you will need a `NuGet.config`:
 <configuration>
   <packageSources>
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="local-xa" value="C:\full\path\to\bin\BuildDebug\nupkgs" />
+    <add key="local-xa" value="C:\full\path\to\bin\BuildDebug\nuget-unsigned" />
   </packageSources>
 </configuration>
 ```
 
-The local package source in the `bin\BuildDebug\nupkgs` directory is
+The local package source in the `bin\BuildDebug\nuget-unsigned` directory is
 currently needed for the Android runtime packages.
 
 Then use a `.csproj` file such as:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -34,8 +34,8 @@ variables:
   RunningOnCI: true
   XA.Build.Configuration: Release
   XA.Jdk8.Folder: jdk-1.8
-  NuGetArtifactName: nupkgs
-  InstallerArtifactName: installers
+  NuGetArtifactName: nuget-unsigned
+  InstallerArtifactName: installers-unsigned
   TestAssembliesArtifactName: test-assemblies
   DotNetCoreVersion: 3.1.405
   DotNet5Version: 5.0.100
@@ -69,6 +69,11 @@ stages:
     - template: yaml-templates/commercial-build.yaml
       parameters:
         makeMSBuildArgs: /p:EnableRoslynAnalyzers=true
+
+    - template: yaml-templatesupload-results.yaml
+      parameters:
+        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        artifactName: Build Results - Nightly macOS
 
 - stage: test
   displayName: Test

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -20,8 +20,8 @@ variables:
   XA.Jdk8.Folder: jdk-1.8
   XA.Jdk11.Folder: jdk-11
   XA.Build.Configuration: Release
-  NuGetArtifactName: nupkgs
-  InstallerArtifactName: Installers
+  NuGetArtifactName: nuget-unsigned
+  InstallerArtifactName: installers-unsigned
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.405

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -48,8 +48,8 @@ resources:
 variables:
   XA.Jdk8.Folder: jdk-1.8
   XA.Jdk11.Folder: jdk-11
-  NuGetArtifactName: nupkgs
-  InstallerArtifactName: installers
+  NuGetArtifactName: nuget-unsigned
+  InstallerArtifactName: installers-unsigned
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.405
@@ -144,7 +144,20 @@ stages:
     - checkout: self
       submodules: recursive
 
+    - template: yaml-templates/install-microbuild-tooling.yaml
+      parameters:
+        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
     - template: yaml-templates/commercial-build.yaml
+
+    - template: yaml-templates/remove-microbuild-tooling.yaml
+      parameters:
+        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        artifactName: Build Results - Nightly macOS
 
     - script: mono $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=DetermineApplicableTests --no-emoji --run-mode=CI
       displayName: determine which test stages to run
@@ -486,17 +499,17 @@ stages:
           /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
 
     - script: >
-        mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nupkg-linux &&
+        mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
         cp $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.linux-x64*.nupkg
-        $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nupkg-linux
+        $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy linux sdk
 
     - task: PublishPipelineArtifact@1
       displayName: upload linux sdk
       inputs:
-        artifactName: nupkg-linux
-        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nupkg-linux
+        artifactName: nuget-linux-unsigned
+        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
     - script: dotnet tool update apkdiff -g
       displayName: install apkdiff dotnet tool
@@ -1218,7 +1231,7 @@ stages:
   # Check - "Xamarin.Android (.NET 6 Preview Installers Sign NuGets)"
   - template: sign-artifacts/jobs/v2.yml@yaml
     parameters:
-      artifactName: nupkgs
+      artifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
       usePipelineArtifactTasks: true
       condition: eq(variables['MicroBuildSignType'], 'Real')
@@ -1309,7 +1322,10 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: upload pkg
       inputs:
-        artifactName: net6-pkg
+        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: net6-pkg-signed
+        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: net6-pkg-unsigned
         targetPath: $(XA.NET6.Pkg)
 
     - template: yaml-templates/remove-microbuild-tooling.yaml
@@ -1342,7 +1358,10 @@ stages:
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifactName: net6-pkg
+        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: net6-pkg-signed
+        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
+          artifactName: net6-pkg-unsigned
         downloadPath: $(System.DefaultWorkingDirectory)\installer-artifacts
         patterns: Microsoft.*.pkg
 

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -68,10 +68,6 @@ steps:
     artifactName: $(TestAssembliesArtifactName)
     targetPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
 
-- template: install-microbuild-tooling.yaml
-  parameters:
-    condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
 - task: MSBuild@1
   displayName: msbuild /t:Restore sign-pkg-content.proj
@@ -125,17 +121,8 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: create updateinfo file
 
-- template: remove-microbuild-tooling.yaml
-  parameters:
-    condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
-
 - task: PublishPipelineArtifact@1
   displayName: upload installers
   inputs:
     artifactName: $(InstallerArtifactName)
     targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
-
-- template: upload-results.yaml
-  parameters:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-    artifactName: Build Results - macOS

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackageType>DotnetPlatform</PackageType>
     <Authors>Microsoft</Authors>
-    <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
+    <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -76,7 +76,7 @@
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="BuildILLinkCustomStep;DeleteExtractedWorkloadPacks;_SetGlobalProperties">
-    <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs" />
+    <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -93,15 +93,15 @@
   <Target Name="ExtractWorkloadPacks"
       DependsOnTargets="DeleteExtractedWorkloadPacks" >
     <ItemGroup>
-      <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.NET.Workload.Android.*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.linux-x64.*.nupkg"   Condition=" '$(HostOS)' == 'Linux' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.osx-x64.*.nupkg"     Condition=" '$(HostOS)' == 'Darwin' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.win-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Sdk.BundleTool.*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Ref.*.nupkg" />
-      <_WLTemplates Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Templates.*.nupkg" />
+      <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.NET.Workload.Android.*.nupkg" />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.linux-x64.*.nupkg"   Condition=" '$(HostOS)' == 'Linux' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.osx-x64.*.nupkg"     Condition=" '$(HostOS)' == 'Darwin' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.win-x64.*.nupkg" Condition=" '$(HostOS)' == 'Windows' " />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.BundleTool.*.nupkg" />
+      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.*.nupkg" />
+      <_WLTemplates Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Templates.*.nupkg" />
       <!-- Runtime packs are not yet supported by workloads -->
-      <!-- <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\Microsoft.Android.Runtime.*.nupkg" /> -->
+      <!-- <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Runtime.*.nupkg" /> -->
     </ItemGroup>
     <PropertyGroup>
       <_WLPackVersion>@(_WLManifest->'%(Filename)'->Replace('Microsoft.NET.Workload.Android.', ''))</_WLPackVersion>

--- a/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
+++ b/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
@@ -10,7 +10,7 @@
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
-    <OutputPath>..\..\bin\Build$(Configuration)\nupkgs\</OutputPath>
+    <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -101,7 +101,7 @@ $@"<Project>
 
 				// Feeds only needed for .NET 5+
 				ExtraNuGetConfigSources = new List<string> {
-					Path.Combine (XABuildPaths.BuildOutputDirectory, "nupkgs"),
+					Path.Combine (XABuildPaths.BuildOutputDirectory, "nuget-unsigned"),
 					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				};
 			} else {

--- a/tests/Mono.Android-Tests/Directory.Build.targets
+++ b/tests/Mono.Android-Tests/Directory.Build.targets
@@ -35,7 +35,7 @@
 
   <Target Name="GenerateNuGetConfig" >
     <PropertyGroup>
-      <LocalNupkgDirectory Condition=" '$(LocalNupkgDirectory)' == '' ">$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nupkgs\</LocalNupkgDirectory>
+      <LocalNupkgDirectory Condition=" '$(LocalNupkgDirectory)' == '' ">$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\</LocalNupkgDirectory>
       <AndroidNETTestConfigOutputDir Condition=" '$(AndroidNETTestConfigOutputDir)' == '' ">$(MSBuildThisFileDirectory)Runtime-Microsoft.Android.Sdk\</AndroidNETTestConfigOutputDir>
       <AndroidNETTestConfigOutputDir>$([MSBuild]::EnsureTrailingSlash($(AndroidNETTestConfigOutputDir)))</AndroidNETTestConfigOutputDir>
       <NuGetConfigContent>
@@ -45,7 +45,7 @@
     <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="xa-nupkgs" value="$(LocalNupkgDirectory)" />
+    <add key="local-xa" value="$(LocalNupkgDirectory)" />
   </packageSources>
 </configuration>
 ]]>


### PR DESCRIPTION
The `installers`, `nupkg`, `nupkg-linux`, and `net6-pkg` Azure Pipelines
Artifacts have been renamed to better indicate their signing statuses.
The first three artifacts have been renamed to `installers-unsigned`,
`nuget-unsigned`, and `nuget-linux-unsigned` respectively.  The
`net6-pkg` artifact will be uploaded as `net6-pkg-unsigned` or
`net6-pkg-signed` depending on whether or not real signing occurred
before upload.

Additionally, the MicroBuild tooling installation/uninstallation has
been removed from the commercial-build.yaml template. While the existing
condition will prevent these tasks from running, the fact that they
exist at all in the nightly YAML is [halting the job][0].  We don't want
to grant this permission on this pipeline, and we can fix it by moving
the MicroBuild tasks out of template.

[0]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4572826&view=results