### PR TITLE
[automation] Fix typo in commit 952e67be

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -70,7 +70,7 @@ stages:
       parameters:
         makeMSBuildArgs: /p:EnableRoslynAnalyzers=true
 
-    - template: yaml-templatesupload-results.yaml
+    - template: yaml-templates/upload-results.yaml
       parameters:
         solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         artifactName: Build Results - Nightly macOS


### PR DESCRIPTION
In commit 952e67be nightly build script was missing a `/` in one of the templates
this was causing

```
/build-tools/automation/azure-pipelines-nightly.yaml:
  Could not find /build-tools/automation/yaml-templatesupload-results.yaml
  in repository self hosted on https://github.com/ using commit
  952e67be871b517208aa62ad6ae6679043669d8f.
  GitHub reported the error, "Not Found"
```