### PR TITLE
[Xamarin.Android.Build.Tasks] fix for .NET 6 targeting pack locations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -55,11 +55,11 @@ projects.
          See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
     -->
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
-      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(ResolvedTargetingPack->'%(Path)\ref\%(TargetFramework)')" Condition=" '@(ResolvedTargetingPack)' == '@(FrameworkReference)' and '%(Identity)' != '' " />
+      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />
     </ItemGroup>
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(_ResolveSdksFrameworkRefAssemblyPaths)</_XATargetFrameworkDirectories>
+      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(_ResolveSdksFrameworkRefAssemblyPaths->Distinct())</_XATargetFrameworkDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"


### PR DESCRIPTION
In .NET 6, we set a `$(_XATargetFrameworkDirectories)` MSBuild
property to be used throughout the legacy MSBuild targets:

    _XATargetFrameworkDirectories =
        ...\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.0-preview.2.21154.6\ref\net6.0\
        ...\dotnet\packs\Microsoft.Android.Ref\11.0.200-ci.main.148\ref\net6.0\

However, when testing a new workload for .NET Maui we hit the error:

    error XARSD7004: System.ArgumentException: `...\dotnet\packs\Microsoft.Maui.Controls.Ref\0.0.1-alpha1\ref\net6.0` must be a directory! (Parameter 'frameworkDirectories')
    error XARSD7004:    at Xamarin.Android.Tools.AndroidVersions..ctor(IEnumerable`1 frameworkDirectories) in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs:line 30
    error XARSD7004:    at Xamarin.Android.Tasks.MonoAndroidHelper.RefreshSupportedVersions(String[] referenceAssemblyPaths)
    error XARSD7004:    at Xamarin.Android.Tasks.ResolveSdks.RunTask()
    error XARSD7004:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17

The `net6.0` directory does not exist, because the assemblies are in
platform-specific directories such as `net6.0-android30.0`,
`net6.0-ios13.6`, `net6.0-maccatalyst13.5`, etc.

The problem with the current logic:

    <_ResolveSdksFrameworkRefAssemblyPaths Include="@(ResolvedTargetingPack->'%(Path)\ref\%(TargetFramework)')" Condition=" '@(ResolvedTargetingPack)' == '@(FrameworkReference)' and '%(Identity)' != '' " />

The `%(TargetFramework)` item metadata is `net6.0`, but we somehow
need to use the `net6.0-android30.0` directory.

The `ResolvedTargetingPackAssets` MSBuild target from the dotnet/sdk
sets `@(Reference)` for each assembly that comes from a "targeting
pack". The `@(Reference)` item group that contains item metadata such
as:

    ...\dotnet\packs\Microsoft.Maui.Controls.Ref\0.0.1-alpha1\ref\net6.0-android30.0\Microsoft.Maui.dll
        AssemblyVersion = 1.0.0.0
        ExternallyResolved = true
        FileVersion = 1.0.0.0
        FrameworkReferenceName = Microsoft.Maui.Controls
        FrameworkReferenceVersion = 0.0.1-alpha1
        NuGetPackageId = Microsoft.Maui.Controls.Ref
        NuGetPackageVersion = 0.0.1-alpha1
        Private = false
        PublicKeyToken =

If we grab directories of each item with `%(FrameworkReferenceName)`
filled out, which means they come from a "targeting pack":

    <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'%(RootDir)%(Directory)')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />

Then as long as we use `->Distinct()`, we now get correct values for
`$(_XATargetFrameworkDirectories)`:

    _XATargetFrameworkDirectories =
        ...\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.0-preview.2.21154.6\ref\net6.0\
        ...\dotnet\packs\Microsoft.Android.Ref\11.0.200-ci.main.148\ref\net6.0\
        ...\dotnet\packs\Microsoft.Maui.Controls.Ref\0.0.1-alpha1\ref\net6.0-android30.0\

After this change, I'm able to build projects with the .NET Maui
workload targeting Android. I think this logic should be correct going
forward in .NET 6.