### PR TITLE
Bump to xamarin/sqlite/3.35.2@afa0437d

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
-    branch = 3.35.0
+    branch = 3.35.2
 [submodule "external/xamarin-android-tools"]
     path = external/xamarin-android-tools
     url = https://github.com/xamarin/xamarin-android-tools


### PR DESCRIPTION
Context: https://sqlite.org/releaselog/3_35_1.html
Context: https://sqlite.org/releaselog/3_35_2.html

The most important upstream changes are:

  * Fix a [bug][0] in the new DROP COLUMN feature when used on columns that
    are indexed and that are quoted in the index definition.
  * Fix a problem in the appendvfs.c extension that was introduced into
    version 3.35.0.

[0]: https://www.sqlite.org/src/info/1c24a659e6d7f3a1