### PR TITLE
[ci] Build and pack updates, bump to .NET 5.0.201

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -39,7 +39,7 @@ variables:
   InstallerArtifactName: installers-unsigned
   TestAssembliesArtifactName: test-assemblies
   DotNetCoreVersion: 3.1.405
-  DotNet5Version: 5.0.100
+  DotNet5Version: 5.0.201
   HostedMacImage: macOS-10.15
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
   NUnit.NumberOfTestWorkers: 4

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -27,7 +27,7 @@ variables:
   EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
   DotNetCoreVersion: 3.1.405
-  DotNet5Version: 5.0.100
+  DotNet5Version: 5.0.201
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
 
 stages:
@@ -110,16 +110,10 @@ stages:
       displayName: make jenkins
 
     - script: >
-        echo "make create-pkg create-vsix V=1 CONFIGURATION=$(XA.Build.Configuration)" &&
-        make create-pkg create-vsix V=1 CONFIGURATION=$(XA.Build.Configuration)
+        echo "make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)" &&
+        make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: create installers
-
-    - script: >
-        echo "make package-oss CONFIGURATION=$(XA.Build.Configuration) V=1" &&
-        make package-oss CONFIGURATION=$(XA.Build.Configuration) V=1
-      workingDirectory: $(Build.SourcesDirectory)
-      displayName: package oss
 
     - script: >
         mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&
@@ -134,6 +128,12 @@ stages:
         artifactName: $(InstallerArtifactName) - macOS and Windows
         targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
 
+    - task: PublishPipelineArtifact@1
+      displayName: upload nupkgs
+      inputs:
+        artifactName: $(NuGetArtifactName) - macOS
+        targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+
     - script: >
         echo "all-tests CONFIGURATION=$(XA.Build.Configuration) V=1" &&
         make all-tests CONFIGURATION=$(XA.Build.Configuration) V=1
@@ -145,19 +145,6 @@ stages:
         make package-build-status CONFIGURATION=$(XA.Build.Configuration) V=1
       workingDirectory: $(Build.SourcesDirectory)
       displayName: package build status
-
-    - task: MSBuild@1
-      displayName: pack all nupkgs
-      inputs:
-        solution: $(Build.SourcesDirectory)/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateAllPacks /restore /bl:$(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload nupkgs
-      inputs:
-        artifactName: $(NuGetArtifactName) - macOS
-        targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - script: >
         echo "make run-performance-tests CONFIGURATION=$(XA.Build.Configuration) V=1" &&
@@ -185,6 +172,15 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNet5Version)
+        remove_dotnet: true
+
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: $(DotNetCoreVersion)
 
     - task: NuGetToolInstaller@1
       displayName: 'Use NuGet 5.x'
@@ -214,15 +210,11 @@ stages:
     - script: make jenkins V=1 PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make jenkins
 
+    - script: make create-nupkgs V=1 CONFIGURATION=$(XA.Build.Configuration)
+      displayName: make create-nupkgs
+
     - script: make package-deb V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make package-deb
-
-    - task: MSBuild@1
-      displayName: pack all nupkgs
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateAllPacks /restore /bl:$(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/linux-artifacts &&

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -54,7 +54,7 @@ variables:
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.11.1
   DotNetCoreVersion: 3.1.405
-  DotNet5Version: 5.0.103
+  DotNet5Version: 5.0.201
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: Xamarin-Android-Win2019
@@ -158,7 +158,7 @@ stages:
     - template: yaml-templates/upload-results.yaml
       parameters:
         solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-        artifactName: Build Results - Nightly macOS
+        artifactName: Build Results - macOS
 
     - script: mono $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=DetermineApplicableTests --no-emoji --run-mode=CI
       displayName: determine which test stages to run
@@ -357,11 +357,12 @@ stages:
         projects: Xamarin.Android.sln
         arguments: '-c $(XA.Build.Configuration) -target:Prepare -m:1 -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
 
+    # Build, pack .nupkgs, and extract workload packs to dotnet preview test directory
     - task: DotNetCoreCLI@2
       displayName: Build Solution
       inputs:
         projects: Xamarin.Android.sln
-        arguments: '-c $(XA.Build.Configuration) -m:1 -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog'
+        arguments: '-t:PackDotNet -c $(XA.Build.Configuration) -m:1 -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog'
 
     - task: MSBuild@1
       displayName: msbuild create-vsix
@@ -369,14 +370,6 @@ stages:
         solution: build-tools\create-vsix\create-vsix.csproj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: /p:CreateVsixContainer=True /p:ZipPackageCompressionLevel=Normal /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-create-vsix.binlog
-
-    # Pack .nupkgs and extract workload packs to dotnet preview test directory
-    - task: MSBuild@1
-      displayName: PackDotNet
-      inputs:
-        solution: Xamarin.Android.sln
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:PackDotNet /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-packdotnet.binlog
 
     - task: MSBuild@1
       displayName: msbuild xabuild
@@ -414,15 +407,13 @@ stages:
       displayName: install apkdiff dotnet tool
       continueOnError: true
 
-    # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
-    # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
-    # Only run a subset of the Xamarin.Android.Build.Tests against the local Windows build tree.
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
+        useDotNet: true
         testRunTitle: Smoke MSBuild Tests - Windows Dotnet Build
-        testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\net472\Xamarin.Android.Build.Tests.dll
+        testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\netcoreapp3.1\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-SmokeMSBuildTests-WinDotnetBuildTree-$(XA.Build.Configuration).xml
-        nunitConsoleExtraArgs: --where "cat == SmokeTests"
+        dotNetTestExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
 
     - template: yaml-templates\upload-results.yaml
       parameters:
@@ -489,15 +480,13 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make jenkins
 
-    - task: MSBuild@1
-      displayName: pack all nupkgs
+    - task: DotNetCoreCLI@2
+      displayName: extract workload packs
       inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /t:CreateAllPacks,ExtractWorkloadPacks /restore
-          /p:NuGetLicense=$(System.DefaultWorkingDirectory)/xamarin-android/external/monodroid/tools/scripts/License.txt
-          /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+        projects: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
+        arguments: >-
+          -t:CreateAllPacks,ExtractWorkloadPacks -c $(XA.Build.Configuration)
+          -bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -86,27 +86,15 @@ steps:
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-pkg-content.binlog
 
-# Create and upload .nupkgs
-- task: MSBuild@1
-  displayName: pack all nupkgs
-  inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: >-
-      /t:CreateAllPacks
-      /restore
-      /p:NuGetLicense=${{ parameters.xaSourcePath }}/external/monodroid/tools/scripts/License.txt
-      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+- script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: make create-installers
 
 - task: PublishPipelineArtifact@1
   displayName: upload nupkgs
   inputs:
     artifactName: $(NuGetArtifactName)
     targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
-
-- script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
-  workingDirectory: ${{ parameters.xaSourcePath }}
-  displayName: make create-installers
 
 - script: >
     mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -17,6 +17,7 @@
 
   <!-- LICENSE setup -->
   <PropertyGroup>
+    <NuGetLicense Condition="Exists('$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt')">$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt</NuGetLicense>
     <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)LICENSE</NuGetLicense>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
@@ -71,23 +72,23 @@
   </Target>
 
   <Target Name="BuildILLinkCustomStep">
-    <Exec Command="$(DotNetPreviewTool) build -p:Configuration=$(Configuration) &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj&quot;" />
+    <Exec Command="dotnet build -p:Configuration=$(Configuration) &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj&quot;" />
   </Target>
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="BuildILLinkCustomStep;DeleteExtractedWorkloadPacks;_SetGlobalProperties">
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BundleTool.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Workload.Android.proj&quot;" />
-    <Exec Command="$(DotNetPreviewTool) pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.BundleTool.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Workload.Android.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
   </Target>
 
   <Target Name="ExtractWorkloadPacks"

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -59,7 +59,6 @@ core workload sdk packs imported by Microsoft.NET.Workload.Android.
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.dll" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.runtimeconfig.json" PackagePath="tools" />
-      <_PackageFiles Include="$(NetCoreAppToolsSourceDir)Java.Interop.Tools.Generator.dll" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)javadoc-to-mdoc.dll" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)javadoc-to-mdoc.runtimeconfig.json" PackagePath="tools" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\Version*" PackagePath="tools" />

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -5,7 +5,10 @@ USE_COMMERCIAL_INSTALLER_NAME=true
 EXPERIMENTAL=false
 endif
 
-create-installers: create-pkg create-vsix
+create-installers: create-nupkgs create-pkg create-vsix
+
+create-nupkgs:
+	$(call DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
 
 create-pkg:
 	MONO_IOMAP=all MONO_OPTIONS="$(MONO_OPTIONS)" $(call MSBUILD_BINLOG,create-pkg) /p:Configuration=$(CONFIGURATION) /t:CreatePkg \

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -23,6 +23,8 @@
 #   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
 
 MSBUILD       = msbuild
+DOTNET_TOOL   = dotnet
+DOTNET_VERB   = build
 MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 
 ifeq ($(OS_NAME),Darwin)
@@ -41,6 +43,12 @@ ifeq ($(USE_MSBUILD),1)
 define MSBUILD_BINLOG
 	$(if $(2),$(2),$(MSBUILD)) $(MSBUILD_FLAGS) /v:normal \
 		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/$(if $(3),$(3),Build)$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
+endef
+
+# $(call DOTNET_BINLOG,name,dotnet=$(DOTNET_TOOL)) build=$(DOTNET_VERB)
+define DOTNET_BINLOG
+	$(if $(2),$(2),$(DOTNET_TOOL)) $(DOTNET_VERB) -c $(CONFIGURATION) -v:n \
+		-bl:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 
 else    # $(MSBUILD) != 1

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>NET5_LINKER</DefineConstants>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>


### PR DESCRIPTION

I've been encountering various issues when building and packing .NET 6
content with `dotnet build`.

Using an older version of `dotnet` with `<Exec/>` tasks that invoke a
newer version of `dotnet` seems to be problematic:

    (CreateAllPacks target) -> 
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: The "ResolvePackageAssets" task failed unexpectedly. [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: System.IO.FileNotFoundException: Could not load file or assembly 'NuGet.ProjectModel, Version=5.9.0.7122, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified. [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: File name: 'NuGet.ProjectModel, Version=5.9.0.7122, Culture=neutral, PublicKeyToken=31bf3856ad364e35' [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader.CreateReaderFromMemory(ResolvePackageAssets task, Byte[] settingsHash) [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader..ctor(ResolvePackageAssets task) [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ReadItemGroups() [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ExecuteCore() [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.NET.Build.Tasks.TaskBase.Execute() [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/.dotnet/sdk/5.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error MSB4018: at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj] [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
      /Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Directory.Build.targets(81,5): error MSB3073: The command "/Users/builder/Library/Android/dotnet/dotnet pack -p:Configuration=Release -p:NuGetLicense=/Users/builder/azdo/_work/2/s/xamarin-android/external/monodroid/tools/scripts/License.txt -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 "/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Runtime.proj"" exited with code 1. [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]

The same scenario fails even earlier if the nested project build also
targets a newer .NET SDK version:

    BuildILLinkCustomStep:
      C:\Users\Peter\android-toolchain\dotnet\dotnet build -p:Configuration=Release "C:\Users\Peter\source\pj\xamarin-android\src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj"
      Microsoft (R) Build Engine version 16.10.0-preview-21175-01+afd0b6210 for .NET
      Copyright (C) Microsoft Corporation. All rights reserved.

      Determining projects to restore...
      C:\Program Files\dotnet\sdk\5.0.201\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(141,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 6.0.  Either target .NET 5.0 or lower, or use a version of the .NET SDK that supports .NET 6.0. [C:\Users\Peter\source\pj\xamarin-android\src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj] [C:\Users\Peter\source\pj\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]

We do not need to build any of our .NET 6 content with .NET 6.  All of
our .NET 6 sources and dependencies can be built and packed with a 
target framework of `netstandard2.0` or `net5.0`.  To fix these issues
and simplify things, our .NET 6 build and packaging targets have been
updated to use the system `dotnet`. This version has been bumped to
.NET 5.0.201 in CI.

A new make rule `create-nupkgs` has been added to reduce the number of
places where we were previously calling msbuild /t:CreateAllPacks in
yaml.  The `create-installers` rule now depends on this new rule.

The Windows Dotnet Build and Smoke Test job has been updated to run
tests against the netcoreapp3.1 version of Xamarin.Android.Build.Tests.
A duplicate solution build has also been removed, as the `PackDotNet`
target will build the entire Xamarin.Android.sln.

A duplicate file reference for `Java.Interop.Tools.Generator.dll` has
been removed from the Microsoft.Android.Sdk packs.