### PR TITLE
[runtime] Add Support for `/data/local/tmp/` override path.

### DIFF
--- a/src/java-runtime/java/mono/android/DebugRuntime.java
+++ b/src/java-runtime/java/mono/android/DebugRuntime.java
@@ -4,5 +4,5 @@ public class DebugRuntime {
 	private DebugRuntime ()
 	{}
 
-	public static native void init (String[] apks, String runtimeLibDir, String[] appDirs);
+	public static native void init (String[] apks, String runtimeLibDir, String[] appDirs, String packageName);
 }

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -43,6 +43,7 @@ public class MonoPackageManager {
 				ClassLoader loader  = context.getClassLoader ();
 				String runtimeDir = getNativeLibraryPath (runtimePackage);
 				String[] appDirs = new String[] {filesDir, cacheDir, dataDir};
+				String packageName  = context.getPackageName();
 
 				//
 				// Preload DSOs libmonodroid.so depends on so that the dynamic
@@ -73,7 +74,7 @@ public class MonoPackageManager {
 				//
 				if (BuildConfig.Debug) {
 					System.loadLibrary ("xamarin-debug-app-helper");
-					DebugRuntime.init (apks, runtimeDir, appDirs);
+					DebugRuntime.init (apks, runtimeDir, appDirs, packageName);
 				} else {
 					System.loadLibrary("monosgen-2.0");
 				}

--- a/src/monodroid/jni/basic-android-system.hh
+++ b/src/monodroid/jni/basic-android-system.hh
@@ -51,7 +51,7 @@ namespace xamarin::android::internal
 		static constexpr char SYSTEM_LIB_PATH[] = "";
 #endif
 
-		static constexpr size_t MAX_OVERRIDES = 1;
+		static constexpr size_t MAX_OVERRIDES = 2;
 		static char* override_dirs [MAX_OVERRIDES];
 		static const char **app_lib_directories;
 		static size_t app_lib_directories_size;

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -83,7 +83,7 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, [[maybe_unused]] jclass klass,
 
 	if (packageName != nullptr) {
 		jstr = packageName;
-		androidSystem.set_override_dir (1, utils.string_concat ("/data/local/tmp/.", jstr.get_cstr ()));
+		androidSystem.set_override_dir (1, utils.string_concat ("/data/local/tmp/.xamarin/", jstr.get_cstr ()));
 	}
 
 	if (runtimeNativeLibDir != nullptr) {

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -69,7 +69,7 @@ JNI_OnLoad ([[maybe_unused]] JavaVM *vm, [[maybe_unused]] void *reserved)
 
 JNIEXPORT void JNICALL
 Java_mono_android_DebugRuntime_init (JNIEnv *env, [[maybe_unused]] jclass klass, jobjectArray runtimeApksJava,
-                                     jstring runtimeNativeLibDir, jobjectArray appDirs)
+                                     jstring runtimeNativeLibDir, jobjectArray appDirs, jstring packageName)
 {
 	jstring_array_wrapper applicationDirs (env, appDirs);
 	jstring_array_wrapper runtimeApks (env, runtimeApksJava);
@@ -80,6 +80,11 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, [[maybe_unused]] jclass klass,
 	androidSystem.setup_app_library_directories (runtimeApks, applicationDirs);
 
 	jstring_wrapper jstr (env);
+
+	if (packageName != nullptr) {
+		jstr = packageName;
+		androidSystem.set_override_dir (1, utils.string_concat ("/data/local/tmp/.", jstr.get_cstr ()));
+	}
 
 	if (runtimeNativeLibDir != nullptr) {
 		jstr = runtimeNativeLibDir;

--- a/src/monodroid/jni/debug-app-helper.hh
+++ b/src/monodroid/jni/debug-app-helper.hh
@@ -12,6 +12,6 @@ extern "C" {
 	 * Signature: ([Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String);[Ljava/lang/String);Ljava/lang/String;IZ)V
 	 */
 	JNIEXPORT void JNICALL Java_mono_android_DebugRuntime_init
-	(JNIEnv *, jclass, jobjectArray, jstring, jobjectArray);
+	(JNIEnv *, jclass, jobjectArray, jstring, jobjectArray, jstring);
 }
 #endif // _Included_mono_android_DebugRuntime


### PR DESCRIPTION
We are getting allot of reports from users that the new fast deployment
system is not working. The decision made to not support
fast dev on devices which do not support `run-as` might well have been
incorrect.

So we need a backup path. The only known writeable area on a device is
`/data/local/tmp`. So the idea will be that IF the device does NOT support
`run-as` we will fall back to `/data/local/tmp`.

This backup path will not be as quick since we will be using the standard
`adb push` commands. Also it will have the disadvantage of the directory
NOT being deleted when the app is removed from the device. So files will
be left in place until the OS decides to clean them up. So it is not ideal
but it might help customers who need to develop on older hardware.

- [ ] monodroid Fast Deployment changes.
- [ ] Add Unit test to test the backup path.