### PR TITLE
[build] Include Configuration.OperatingSystem.props earlier

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -3,6 +3,10 @@
   <!--
     Note: This file *must* be imported *after* `$(Configuration)` is set.
   -->
+  <Import
+      Project="$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props"
+      Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
+  />
   <Import Project="$(MSBuildThisFileDirectory)eng\Versions.props" />
   <Import
       Project="$(MSBuildThisFileDirectory)Build$(Configuration)\Configuration.Generated.props"
@@ -11,10 +15,6 @@
   <Import
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
-  />
-  <Import
-      Project="$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props"
-      Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
     <!-- TFV for all projects, try v4.7.2 but fallback if needed -->


### PR DESCRIPTION
This allows the other files (e.g. `Configuration.Override.props`) to
rely on the properties (e.g. `$(HostOS)`) defined in
`Configuration.OperatingSystem.props`. This is helpful when sharing the
override file between various operating systems as it allows one to
specify the ABIS to build in a straightforward manner, e.g.:

    <!-- This is Configuration.Override.props -->
    <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
      <PropertyGroup>
        <AndroidSupportedHostJitAbis>$(HostOS):mxe-Win32:mxe-Win64</AndroidSupportedHostJitAbis>
      </PropertyGroup>
    </Project>