### PR TITLE
Remove support for the Android SDK Tools Package

### DIFF
--- a/build-tools/check-boot-times/Program.cs
+++ b/build-tools/check-boot-times/Program.cs
@@ -531,8 +531,6 @@ namespace Xamarin.Android.Tools
 							$"{sdkPath}/cmdline-tools/1.0/bin",
 							$"{sdkPath}/cmdline-tools/latest/bin",
 							$"{sdkPath}/emulator",
-							$"{sdkPath}/tools",
-							$"{sdkPath}/tools/bin",
 						});
 					} else {
 						potentialLocations.AddRange (new []{
@@ -540,20 +538,14 @@ namespace Xamarin.Android.Tools
 							"AppData/Local/Android/Sdk/cmdline-tools/1.0/bin",
 							"AppData/Local/Android/Sdk/cmdline-tools/latest/bin",
 							"AppData/Local/Android/Sdk/emulator",
-							"AppData/Local/Android/Sdk/tools",
-							"AppData/Local/Android/Sdk/tools/bin",
 							"Library/Android/sdk/platform-tools",
 							"Library/Android/sdk/cmdline-tools/1.0/bin",
 							"Library/Android/sdk/cmdline-tools/latest/bin",
 							"Library/Android/sdk/emulator",
-							"Library/Android/sdk/tools",
-							"Library/Android/sdk/tools/bin",
 							"android-toolchain/sdk/platform-tools",
 							"android-toolchain/sdk/cmdline-tools/1.0/bin",
 							"android-toolchain/sdk/cmdline-tools/latest/bin",
 							"android-toolchain/sdk/emulator",
-							"android-toolchain/sdk/tools",
-							"android-toolchain/sdk/tools/bin",
 						});
 
 						if (RunningOnWindowsEnvironment) {
@@ -562,8 +554,6 @@ namespace Xamarin.Android.Tools
 								"C:/Program Files (x86)/Android/android-sdk/cmdline-tools/1.0/bin",
 								"C:/Program Files (x86)/Android/android-sdk/cmdline-tools/latest/bin",
 								"C:/Program Files (x86)/Android/android-sdk/emulator",
-								"C:/Program Files (x86)/Android/android-sdk/tools",
-								"C:/Program Files (x86)/Android/android-sdk/tools/bin",
 							});
 						}
 					}

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -354,7 +354,7 @@
   <Target Name="InstallAvdImage" >
     <!-- SDK component installation can be frail, try a few times. -->
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
@@ -364,7 +364,7 @@
         Condition=" '$(_SdkManagerExitCode)' != '0' "
     />
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
@@ -375,7 +375,7 @@
         Condition=" '$(_SdkManagerExitCode)' != '0' "
     />
     <Exec
-        Command="&quot;$(AndroidSdkDirectory)\tools\bin\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
+        Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
         EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -109,7 +109,6 @@ namespace Xamarin.Android.Prepare
 			string[] sdkManagerPaths = new[]{
 				Path.Combine (sdkRoot, "cmdline-tools", context.Properties [KnownProperties.CommandLineToolsFolder], "bin", "sdkmanager"),
 				Path.Combine (sdkRoot, "cmdline-tools", "latest", "bin", "sdkmanager"),
-				Path.Combine (sdkRoot, "tools", "bin", "sdkmanager"),
 			};
 			string sdkManager = "";
 			foreach (var sdkManagerPath in sdkManagerPaths) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -29,8 +29,6 @@ namespace Xamarin.Android.Tasks
 
 		public string PlatformToolsVersion { get; set; }
 
-		public string ToolsVersion { get; set; }
-
 		public string NdkVersion { get; set; }
 
 		public bool NdkRequired { get; set; }
@@ -67,9 +65,6 @@ namespace Xamarin.Android.Tasks
 			}
 			if (!string.IsNullOrEmpty (CommandLineToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ($"cmdline-tools/{CommandLineToolsVersion}", CommandLineToolsVersion));
-			}
-			if (!string.IsNullOrEmpty (ToolsVersion)) {
-				dependencies.Add (CreateAndroidDependency ("tools", ToolsVersion));
 			}
 			if (!string.IsNullOrEmpty (NdkVersion) && NdkRequired) {
 				dependencies.Add (CreateAndroidDependency ("ndk-bundle", NdkVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetDependenciesTests.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Android.Build.Tests {
 			};
 
 			task.PlatformToolsVersion = "26.0.3";
-			task.ToolsVersion = "26.0.1";
 			task.NdkVersion = "12.1";
 			task.NdkRequired = ndkRequred;
 			task.BuildToolsVersion = "26.0.1";
@@ -37,11 +36,9 @@ namespace Xamarin.Android.Build.Tests {
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
-			Assert.AreEqual (ndkRequred ? 5 : 4, task.Dependencies.Length);
+			Assert.AreEqual (ndkRequred ? 4 : 3, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contains a tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
@@ -70,7 +67,6 @@ namespace Xamarin.Android.Build.Tests {
 			};
 
 			task.PlatformToolsVersion = "26.0.3";
-			task.ToolsVersion = "26.0.1";
 			task.NdkVersion = "12.1";
 			task.NdkRequired = true;
 			task.BuildToolsVersion = "26.0.1";
@@ -78,11 +74,9 @@ namespace Xamarin.Android.Build.Tests {
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
-			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.AreEqual (4, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contains a tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
@@ -114,7 +108,6 @@ namespace Xamarin.Android.Build.Tests {
 </manifest>");
 
 			task.PlatformToolsVersion = "26.0.3";
-			task.ToolsVersion = "26.0.1";
 			task.NdkVersion = "12.1";
 			task.NdkRequired = true;
 			task.BuildToolsVersion = "26.0.1";
@@ -122,11 +115,9 @@ namespace Xamarin.Android.Build.Tests {
 			task.ManifestFile = new TaskItem (manifestFile);
 			Assert.IsTrue(task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
-			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.AreEqual (4, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contains a tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2570,7 +2570,6 @@ because xbuild doesn't support framework reference assemblies.
     ManifestFile="$(_ProjectAndroidManifest)"
     BuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
     PlatformToolsVersion="$(AndroidSdkPlatformToolsVersion)"
-    ToolsVersion="$(AndroidSdkToolsVersion)"
     NdkVersion="$(AndroidNdkVersion)"
     NdkRequired="$(_NdkRequired)"
   >


### PR DESCRIPTION
Context: https://developer.android.com/studio/releases/sdk-tools

The Android SDK Tools package has been deprecated since 2017 and is
no longer receiving updates.

Remove all usage of the Android SDK Tools package.