### PR TITLE
[One .NET] default $(SuppressTrimAnalysisWarnings) to true

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -52,6 +52,7 @@
     <TrimMode Condition=" '$(PublishTrimmed)' == 'true' and '$(TrimMode)' == '' ">link</TrimMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
+    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x86</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -393,10 +393,7 @@ namespace Xamarin.Android.Build.Tests
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 
-			// TODO: run for release once illink warnings are gone
-			// context: https://github.com/xamarin/xamarin-android/issues/4708
-			if (!isRelease)
-				Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
 
 			var outputPath = Path.Combine (FullProjectDirectory, proj.OutputPath);
 			var intermediateOutputPath = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5751

After bumping to .NET 6 Preview 3, we get hundreds of ILLINK warnings.
This is because of:

https://github.com/dotnet/sdk/pull/16327

We need to default `$(SuppressTrimAnalysisWarnings)` to ignore these
warnings for now.

We should continue to use `TrimMode=link`, as that is the behavior
Xamarin developers get today.