### PR TITLE
[xa-prep-tasks] use AzDO env var for branch detection

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -28,14 +28,23 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GitBranch)}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
 
+			var build_sourcebranchname = Environment.GetEnvironmentVariable ("BUILD_SOURCEBRANCHNAME");
+			if (!string.IsNullOrEmpty (build_sourcebranchname) && build_sourcebranchname != "merge") {
+				Log.LogMessage ("Using $BUILD_SOURCEBRANCHNAME");
+				Branch = build_sourcebranchname;
+				return true;
+			}
+
 			string gitHeadFile = Path.Combine (WorkingDirectory.ItemSpec, ".git", "HEAD");
 			if (File.Exists (gitHeadFile)) {
+				Log.LogMessage ($"Using {gitHeadFile}");
 				string gitHeadFileContent = File.ReadAllText (gitHeadFile);
 				Match match = GitHeadRegex.Match (gitHeadFileContent);
 				Branch = match.Value;
 			}
 
 			if (string.IsNullOrEmpty (Branch)) {
+				Log.LogMessage ("Using git command");
 				base.Execute ();
 			}
 


### PR DESCRIPTION
I noticed the version from our builds on `main` has an odd version
number:

    Microsoft.NET.Workload.Android.11.0.200-ci.171cccd1fa1486df9ced3a5eb34001b9ac65d4b0.186.nupkg

When I look at logs, it seems like this command:

    > git name-rev --name-only --exclude=tags/* HEAD
    171cccd1fa1486df9ced3a5eb34001b9ac65d4b0

But locally, I get:

    > git name-rev --name-only --exclude=tags/* HEAD
    main

When I look at the logs for checkout, it seems like Azure DevOps has
fundamentally changed how it checks out a branch?

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4596532&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=0d8be578-6249-5b90-d8fc-9284fb350946&l=1097

    From https://github.com/xamarin/xamarin-android
    * [new ref]           171cccd1fa1486df9ced3a5eb34001b9ac65d4b0 -> origin/171cccd1fa1486df9ced3a5eb34001b9ac65d4b0
    ...
    Note: switching to '171cccd1fa1486df9ced3a5eb34001b9ac65d4b0'.
    You are in 'detached HEAD' state. You can look around, make experimental
    ...

Let's add a check for `$BUILD_SOURCEBRANCHNAME` in the `<GitBranch/>`
MSBuild task, so that we use Azure DevOp's built-in variable for the
current branch:

https://docs.microsoft.com/azure/devops/pipelines/build/variables

This variable is set to `merge` for PRs, so I ignored it in that case.

I also add a few log messages to the `<GitBranch/>` MSBuild task to
help with diagnosing issues in the future.