### PR TITLE
[azdo] add triggers for .NET 6 release branches

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -15,6 +15,7 @@ schedules:
     include:
     - main
     - d16-9
+    - 6.0.*
 
 # External sources, scripts, tests, and yaml template files.
 resources:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -5,6 +5,7 @@ name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 trigger:
 - main
 - d16-*
+- 6.0.*
 
 pr:
   autoCancel: false
@@ -12,6 +13,7 @@ pr:
     include:
     - main
     - d16-*
+    - 6.0.*
 
 # Global variables
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -5,6 +5,7 @@ name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 trigger:
   - main
   - d16-*
+  - 6.0.*
 
 # External sources, scripts, tests, and yaml template files.
 resources:


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/598

In a252b1a6, we bumped to a .NET 6 Preview 4 (main) build.

I created a release branch for preview 3:

https://github.com/xamarin/xamarin-android/tree/6.0.1xx-preview3

Let's setup CI triggers for the new .NET 6 branch names.