### PR TITLE
[build] Add Microsoft.DotNet.ApiCompat dependency

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -10,8 +10,8 @@
   <Import Project="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\MSBuildReferences.projitems" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20181.7" IncludeAssets="none" />
-    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20181.7" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatPackageVersion)" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetApiCompatPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,4 +9,10 @@
       <Sha>26d9440e6683b44c4db5f45b25e9c857a6563bb8</Sha>
     </Dependency>
   </ProductDependencies>
+  <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21179.7">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>fd5f55c64d48b7894516cc841fba1253b2e79ffd</Sha>
+    </Dependency>
+  </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.4.21179.4</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21180.1</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>6.0.0-beta.21179.7</MicrosoftDotNetApiCompatPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Trim all characters after first `-` or `+` is encountered. -->


### PR DESCRIPTION
Adds the Microsoft.DotNet.ApiCompat package to our dotnet dependency
management files so that it can be automatically updated as needed
in the future.  This package version can also be used for
Microsoft.DotNet.GenAPI, as both nugets are produced by the same build.