### PR TITLE
[Mono.Android-Tests] Update ignored .NET 6 tests

### DIFF
--- a/tests/Mono.Android-Tests/Android.Runtime/XmlReaderPullParserTest.cs
+++ b/tests/Mono.Android-Tests/Android.Runtime/XmlReaderPullParserTest.cs
@@ -13,7 +13,6 @@ namespace Android.RuntimeTests {
 	public class XmlReaderPullParserTest {
 
 		[Test]
-		[Category ("DotNetIgnore")] // Missing crypto / networking support.
 		public void ToLocalJniHandle ()
 		{
 			var p = Application.Context.Resources.GetXml (MyResource.Xml.XmlReaderResourceParser);

--- a/tests/Mono.Android-Tests/Android.Runtime/XmlReaderResourceParserTest.cs
+++ b/tests/Mono.Android-Tests/Android.Runtime/XmlReaderResourceParserTest.cs
@@ -13,7 +13,6 @@ namespace Android.RuntimeTests {
 	public class XmlReaderResourceParserTest {
 
 		[Test]
-		[Category ("DotNetIgnore")] // Missing crypto / networking support.
 		public void ToLocalJniHandle ()
 		{
 			var p = Application.Context.Resources.GetXml (MyResource.Xml.XmlReaderResourceParser);

--- a/tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -219,7 +219,6 @@ namespace Java.InteropTests
 		}
 
 		[Test]
-		[Category ("DotNetIgnore")] // https://github.com/xamarin/xamarin-android/issues/5265
 		public void CreateTypeWithExportedMethods ()
 		{
 			using (var e = new ContainsExportedMethods ()) {
@@ -454,9 +453,7 @@ namespace Java.InteropTests
 			Constructed = true;
 		}
 
-#if !NET // https://github.com/xamarin/xamarin-android/issues/5265
 		[Export]
-#endif
 		public void Exported ()
 		{
 			Count++;

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -20,7 +20,7 @@
     <_MonoAndroidTestPackage>Mono.Android.NET_Tests</_MonoAndroidTestPackage>
     <PlotDataLabelSuffix>-NET6</PlotDataLabelSuffix>
     <!-- TODO: Fix excluded tests -->
-    <ExcludeCategories>DotNetIgnore:InetAccess</ExcludeCategories>
+    <ExcludeCategories>DotNetIgnore</ExcludeCategories>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
+++ b/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 namespace System.Drawing {
 
 	[TestFixture]
-	[NUnit.Framework.Category ("DotNetIgnore")] // https://github.com/xamarin/xamarin-android/issues/5275
 	public class TypeConverterTest {
 
 		[Test]

--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace System.NetTests {
 
-	[TestFixture, Category ("InetAccess")]
+	[TestFixture, Category ("InetAccess"), Category ("DotNetIgnore")]
 	public class SslTest
 	{
 		bool ShouldIgnoreException (WebException wex)

--- a/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
+++ b/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
@@ -9,7 +9,7 @@ namespace System.NetTests
 	[TestFixture]
 	public class WebSocketTests
 	{
-		[Test, Category ("InetAccess")]
+		[Test, Category ("InetAccess"), Category ("DotNetIgnore")] // https://github.com/xamarin/xamarin-android/issues/5801
 		public void TestSocketConnection()
 		{
 			string testMessage = "This is a test!";

--- a/tests/Mono.Android-Tests/System/TimeZoneTest.cs
+++ b/tests/Mono.Android-Tests/System/TimeZoneTest.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Android.RuntimeTests
 	public class TimeZoneTest
 	{
 		[Test]
-		[Category ("DotNetIgnore")] // https://github.com/dotnet/runtime/issues/44358
 		public void TestDaylightSavingsTime ()
 		{
 			using (var jtz = Java.Util.TimeZone.Default) {

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -249,7 +249,7 @@ namespace Xamarin.Android.NetTests {
 			return innerHandler.GetType ();
 		}
 
-		[Test]
+		[Test, Category ("DotNetIgnore")]
 		public void Sanity_Tls_1_2_Url_WithMonoClientHandlerFails ()
 		{
 			var tlsProvider   = global::System.Environment.GetEnvironmentVariable ("XA_TLS_PROVIDER");


### PR DESCRIPTION
A few tests which were previously failing have been fixed and can now
be enabled.  Additionally, now that dotnet/runtime has removed the
incomplete OpenSSL support on Android, we can enable more tests
that used various System.Security.Cryptography APIs directly or
indirectly.

There are still some SSL related test failures that are being ignored
that are generally being tracked in https://github.com/dotnet/runtime/issues/45741.