### PR TITLE
Update desktop Mono to 6.12.0.137 and MSBuild 16.9

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -93,8 +93,8 @@
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
-    <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/45/d90665a422e9f8d015585b3ca381d74faa033cc4/MonoFramework-MDK-6.12.0.43.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
-    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.12.0.43</MonoRequiredMinimumVersion>
+    <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/144/b4a385816ed4f1398d0184c38f19f560e868fd80/MonoFramework-MDK-6.12.0.137.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
+    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.12.0.137</MonoRequiredMinimumVersion>
     <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.12.99</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' And '$(RunningOnCI)' == 'true' ">False</IgnoreMaxMonoVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.Aidl"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Build.Tasks", "src\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj", "{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Android.Sdk.ILLink", "src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj", "{71FE54FA-0BF5-48EF-ACAA-17557B28C9F4}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.Bytecode", "external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj", "{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{864062D3-A415-4A6F-9324-5820237BA058}"
@@ -198,6 +200,10 @@ Global
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{71FE54FA-0BF5-48EF-ACAA-17557B28C9F4}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{71FE54FA-0BF5-48EF-ACAA-17557B28C9F4}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{71FE54FA-0BF5-48EF-ACAA-17557B28C9F4}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{71FE54FA-0BF5-48EF-ACAA-17557B28C9F4}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
 		{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}.Release|AnyCPU.ActiveCfg = Release|Any CPU

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -188,12 +188,12 @@ stages:
         versionSpec: 5.x
 
     - script: >
-        sudo apt-get install -y gnupg ca-certificates &&
+        sudo apt remove -y --purge --auto-remove mono-devel &&
+        sudo apt install -y gnupg ca-certificates &&
         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
         (echo "deb https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list) &&
-        sudo apt-get update &&
-        sudo apt-get install -y mono-devel &&
-        sudo apt-get install -y ca-certificates-mono
+        sudo apt update &&
+        sudo apt install -y mono-devel
       displayName: install mono preview
 
     - script: >

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -462,11 +462,13 @@ stages:
         forceReinstallCredentialProvider: true
 
     - script: >
+        sudo apt remove -y --purge --auto-remove mono-complete &&
+        sudo apt remove -y --purge --auto-remove mono-devel &&
         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list &&
-        sudo apt-get update &&
-        sudo apt-get install -y --no-install-recommends apt-transport-https mono-complete nuget
-      displayName: install mono
+        echo "deb https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list &&
+        sudo apt update &&
+        sudo apt install -y mono-devel
+      displayName: install mono preview
 
     - task: NuGetToolInstaller@0
       inputs:
@@ -1142,6 +1144,7 @@ stages:
     - template: designer/android-designer-tests.yaml@yaml
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/UITools/Designer
+        runAddinTests: false
 
     - task: CopyFiles@2
       displayName: 'Copy binlogs'

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -45,6 +45,7 @@ steps:
     msbuildArguments: /restore
 
 - script: >
+    pgrep -lfi VBCSCompiler.exe | awk '{system("kill -HUP " $1)}' &&
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI &&
     mono ${{ parameters.xaSourcePath }}/build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidTestDependencies --no-emoji --run-mode=CI
   displayName: install test dependencies

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -75,12 +75,8 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildILLinkCustomStep">
-    <Exec Command="dotnet build -p:Configuration=$(Configuration) &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj&quot;" />
-  </Target>
-
   <Target Name="CreateAllPacks"
-      DependsOnTargets="BuildILLinkCustomStep;DeleteExtractedWorkloadPacks;_SetGlobalProperties">
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties">
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />


### PR DESCRIPTION
The desktop mono version has been bumped to include a major MSBuild
update from 16.6 to 16.9.  This MSBuild version supports net5.0, and
as such it allows us to add `Microsoft.Android.Sdk.ILLink` to the
`Xamarin.Android.sln` build.