### PR TITLE
[ci] Bump CMake version used for OSS Linux builds

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -200,6 +200,14 @@ stages:
         sudo apt-get install -y ca-certificates-mono
       displayName: install mono preview
 
+    - script: >
+        sudo apt remove -y --purge --auto-remove cmake &&
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&
+        sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&
+        sudo apt-get update &&
+        sudo apt install -y cmake
+      displayName: install updated version of cmake
+
     - script: echo "##vso[task.setvariable variable=PATH]$PATH:$HOME/android-toolchain/$(XA.Jdk11.Folder)/bin"
       displayName: append jdk tools to PATH
 


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=38123&view=logs&j=1bd95447-8107-5fbe-3014-ec4d4db1e5a6&t=7df6c319-0f16-56cb-dcf7-1be9457aaeed

Our open source Linux builds have been failing when attempting to build
Java.Interop, as the version of CMake on the Ubuntu 18.04 VM image is
too old.  We can fix this issue by using https://apt.kitware.com/, which
currently provides a CMake version of 3.20.0.