### PR TITLE
[ci] Upload build asset data to darc/maestro

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1334,6 +1334,9 @@ stages:
     pool: VSEng-MicroBuildVS2019
     workspace:
       clean: all
+    variables:
+    - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+      - group: Publish-Build-Assets
     steps:
     - checkout: self
       submodules: recursive
@@ -1354,6 +1357,24 @@ stages:
           artifactName: net6-pkg-unsigned
         downloadPath: $(System.DefaultWorkingDirectory)\installer-artifacts
         patterns: Microsoft.*.pkg
+
+    - powershell: >-
+        & dotnet build -v:n -c $(XA.Build.Configuration)
+        -t:PushManifestToBuildAssetRegistry
+        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+        $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
+        -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
+      displayName: generate and publish BAR manifest
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    - powershell: |
+        $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+      displayName: add build to default darc channel
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - template: yaml-templates\install-microbuild-tooling.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -85,9 +85,8 @@ steps:
     artifactName: $(NuGetArtifactName)
     downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/$(NuGetArtifactName)
 
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: extract workload packs
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
-    configuration: ${{ parameters.configuration }}
-    msbuildArguments: /t:ExtractWorkloadPacks /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog
+    projects: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
+    arguments: -t:ExtractWorkloadPacks -c ${{ parameters.configuration }} -v:n -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog

--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageType>DotnetPlatform</PackageType>
     <Authors>Microsoft</Authors>
-    <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
+    <OutputPath>$(BootstrapOutputDirectory)nuget-unsigned\</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Remove the `<group targetFramework=".NETStandard2.0" />` entry from the .nuspec. -->

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -1,14 +1,17 @@
 <Project>
+  <Import Project="..\..\Configuration.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.20120.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20120.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\installers\create-installers.targets" />
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
-  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
 
   <PropertyGroup>
     <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\netcoreapp3.1\</_MonoAndroidNETOutputDir>
@@ -44,7 +47,7 @@
       <FrameworkListRootAttributes Include="FrameworkName" Value="Microsoft.Android" />
     </ItemGroup>
 
-    <!-- https://github.com/dotnet/arcade/blob/1924d7ea148c9f26ca3d82b60f0a775a5389ed22/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs -->
+    <!-- https://github.com/dotnet/arcade/blob/5824baf1c9a900ee00c167f96201c750bba6a574/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs -->
     <CreateFrameworkListFile
         Files="@(_PackageFiles)"
         FileClassifications="@(FrameworkListFileClass)"
@@ -68,6 +71,7 @@
     <ItemGroup>
       <_GlobalProperties Include="-p:Configuration=$(Configuration)" />
       <_GlobalProperties Include="-p:NuGetLicense=$(NuGetLicense)" />
+      <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
   </Target>
 
@@ -142,6 +146,45 @@
     </ItemGroup>
     <RemoveDir Directories="%(_PackFilesToDelete.RootDir)%(_PackFilesToDelete.Directory)" />
     <Delete Files="$(_WorkloadResolverFlagFile)" />
+  </Target>
+
+  <Target Name="PushManifestToBuildAssetRegistry" >
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutputPath)*.nupkg" />
+    </ItemGroup>
+
+    <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
+
+    <ItemGroup>
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
+      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
+    <GenerateBuildManifest
+        Artifacts="@(BuildArtifacts)"
+        OutputPath="$(OutputPath)bar-manifests\AssetManifest.xml"
+        BuildId="$(BUILD_BUILDNUMBER)"
+        BuildData="@(ManifestBuildData)"
+        RepoUri="$(BUILD_REPOSITORY_URI)"
+        RepoBranch="$(BUILD_SOURCEBRANCH)"
+        RepoCommit="$(BUILD_SOURCEVERSION)"
+        PublishingVersion="3" />
+
+    <MSBuild
+        Targets="Restore"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
+    />
+
+    <MSBuild
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
+    />
   </Target>
 
 </Project>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -71,7 +71,6 @@
     <ItemGroup>
       <_GlobalProperties Include="-p:Configuration=$(Configuration)" />
       <_GlobalProperties Include="-p:NuGetLicense=$(NuGetLicense)" />
-      <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -71,6 +71,7 @@
     <ItemGroup>
       <_GlobalProperties Include="-p:Configuration=$(Configuration)" />
       <_GlobalProperties Include="-p:NuGetLicense=$(NuGetLicense)" />
+      <_GlobalProperties Include="-p:IncludeSymbols=False" />
     </ItemGroup>
   </Target>
 

--- a/eng/README.md
+++ b/eng/README.md
@@ -49,9 +49,26 @@ release branch is created, someone with `darc` installed locally will need to
 run the `add-subscription` command to configure updates against that new branch.
 
 
+#### Build Asset Manifest Promotion
+
+Builds from main and release branches will push NuGet package metadata to the
+darc/maestro Build Asset Registry.  This build information will also be promoted
+to a default darc/maestro channel if one is configured.  Default channels are
+manually managed at this time.  To configure a new default repo+branch <-> channel
+association, run the [`darc add-default-channel`][6] command:
+```
+darc add-default-channel --channel ".NET 6" --branch "main" --repo https://github.com/xamarin/xamarin-android
+```
+
+Other products/tools can consume our package version info in the following way:
+```
+darc add-dependency -n Microsoft.Android.Sdk.Windows -t product -r https://github.com/xamarin/xamarin-android -v 1.2.3
+```
+
 [0]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md
 [1]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#setting-up-your-darc-client
 [2]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#authenticate
 [3]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-dependency
 [4]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#update-dependencies
 [5]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-subscription
+[6]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#add-default-channel

--- a/eng/README.md
+++ b/eng/README.md
@@ -60,10 +60,16 @@ association, run the [`darc add-default-channel`][6] command:
 darc add-default-channel --channel ".NET 6" --branch "main" --repo https://github.com/xamarin/xamarin-android
 ```
 
+When a new release branch is created, this command should look something like this:
+```
+darc add-default-channel --channel ".NET 6.0.1xx SDK Preview 4" --branch "release/6.0.1xx-preview4" --repo https://github.com/xamarin/xamarin-android
+```
+
 Other products/tools can consume our package version info in the following way:
 ```
 darc add-dependency -n Microsoft.Android.Sdk.Windows -t product -r https://github.com/xamarin/xamarin-android -v 1.2.3
 ```
+
 
 [0]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md
 [1]: https://github.com/dotnet/arcade/blob/ea609b8e036359934332480de9336d98fcbb3f91/Documentation/Darc.md#setting-up-your-darc-client

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,5 +14,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6ee69696ea00da39f35066c22c21a00ceab93d00</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21212.6">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>db49d790a4bfa977a9ed7436bf2aa242cefae45e</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,6 +4,7 @@
     <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.4.21179.4</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkPackageVersion>6.0.100-preview.2.21205.2</MicrosoftNETILLinkPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.20181.7</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Trim all characters after first `-` or `+` is encountered. -->

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20555.6",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20120.1"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20555.6"
   }
 }


### PR DESCRIPTION
The `dotnet_create_msi` job has been updated to publish information
about Android .NET 6 .nupkg files to the dotnet Maestro server.

With this data being published, the `darc` tool can now be used to
manage an Android .NET 6 product dependency:

    darc add-dependency -n Microsoft.Android.Sdk.Windows -t product -r https://github.com/xamarin/xamarin-android -v 1.2.3

    darc update-dependencies --channel "General Testing Internal"

        Looking up latest build of https://github.com/xamarin/xamarin-android on General Testing Internal   
        Updating 'Microsoft.Android.Sdk.Windows': '1.2.3' => '11.0.200-ci.publish-bar-manifest.197' (from build 'publish-bar-manifest-41c7adffb2669c313e96607f98f8ab05c820e56f-1' of 'https://github.com/xamarin/xamarin-android')


For dependency updating to work, we must configure "default channel"
associations for all xamarin-android branches that other products may
be interested in tracking.  The `darc` tool can be used to do this
manually:

    darc add-default-channel --channel ".NET 6" --branch "main" --repo https://github.com/xamarin/xamarin-android

This default channel configuration ensures that all new builds produced
by our main branch will be associated with the .NET 6 channel.  Android
consumers can then update to the latest build available from main with
the `update-dependencies` command:

    darc update-dependencies --channel ".NET 6"

