### PR TITLE
[xaprepare] Fix JetBrains JDK 1.8 provisioning on Windows

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
@@ -28,6 +28,20 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
+			if (fullArchivePath.EndsWith ("tar.gz", StringComparision.OrdinalIgnoreCase)) {
+				// On Windows we don't have Tar available and the Windows package is a .tar.gz
+				// 7zip can unpack tar.gz but it's a two-stage process - first it decompresses the package, then it can be
+				// invoked again to extract the actual tar contents.
+				string tarPath = Path.Combine (destinationDirectory, Path.GetFileNameWithoutExtension (fullArchivePath));
+				bool ret = await sevenZip.Extract (tarPath, destinationDirectory);
+				Utilities.DeleteFileSilent (tarPath);
+
+				if (!ret) {
+					Log.DebugLine ($"Failed to extract TAR contents from {tarPath}");
+					return false;
+				}
+			}
+
 			return true;
 		}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallJetBrainsOpenJDK.Windows.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			if (fullArchivePath.EndsWith ("tar.gz", StringComparision.OrdinalIgnoreCase)) {
+			if (fullArchivePath.EndsWith ("tar.gz", StringComparison.OrdinalIgnoreCase)) {
 				// On Windows we don't have Tar available and the Windows package is a .tar.gz
 				// 7zip can unpack tar.gz but it's a two-stage process - first it decompresses the package, then it can be
 				// invoked again to extract the actual tar contents.


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4605864&view=logs&jobId=fb3518d4-6415-56d8-56e7-3e01113bd696&j=fb3518d4-6415-56d8-56e7-3e01113bd696&t=cdc044ef-b869-5235-56df-ac4b6018a01e
Context: https://discord.com/channels/732297728826277939/732297837953679412/826969920184778782
Context: https://github.com/xamarin/xamarin-android/commit/60b54d5ae8f63b9dce0ea7e7db2e9a3b09e041fd#diff-57d44829988dde5ea93a4c3f65fa77d5b04bd82c1ac87c4b300c0316f94f85a3L20

After 60b54d5a was merged, occasionally we would see the
**Legacy Tests** > **MSBuild Legacy - Windows** jobs fail in the
`nuget restore Xamarin.Android-Tests.sln` task:

	##[error]The nuget command failed with exit code(1) and error(C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Tooling.targets(64,5):
	warning XA5300: An exception occurred while validating the Java SDK installation in 'C:\Users\AzDevOps\android-toolchain\jdk-1.8' that was found while searching the paths from '$JI_JAVA_HOME'.
	  Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured.
	  To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.
	  Exception: Could not find required file `jar` within `C:\Users\AzDevOps\android-toolchain\jdk-1.8`; is this a valid JDK?
	C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Tooling.targets(64,5):
	error XA5300: The Java SDK directory could not be found.
	  Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured.
	  To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.
	  [C:\a\1\s\tests\TestRunner.Core\TestRunner.Core.csproj]

Subsequent investigation in PR #5805 found the culprit:

	    Directory: C:\Users\AzDevOps\android-toolchain\jdk-1.8
	Mode                LastWriteTime         Length Name
	----                -------------         ------ ----
	-a----         3/6/2019  10:40 AM      268267520 jbrsdk-8u202-windows-x64-b1483.37.tar
	-a----        3/31/2021  10:12 PM              9 xa_jdk_version.txt

We provisioned JetBrains JDK 1.8, but we didn't *finish* provisioning
JDK 1.8!

The problem was introduced in commit 60b54d5a: Microsoft OpenJDK 11
ships as a `.zip` file, not a `.tar.gz`, and thus didn't need two
separate `7z` invocations to fully extract it.  Thus, the second `7z`
invocation was removed.

This second `7z` removal was a mistake, as JDK 1.8 continues to be
downloaded as a `.tar.gz`, and thus continues to require two `7z`
invocations in order to fully provision JetBrains JDK 1.8.

(This only occasionally failed on CI because if it ran on a machine
which already had `%USERPROFILE%\android-toolchain\jdk-1.8`, JDK 1.8
wouldn't be re-installed, and everything would work.)

Update the `Step_InstallOpenJDK.UnPack()` method so that when
`fullArchivePath` ends with `.tar.gz`, `7z` is executed a second time
on the `.tar` file, ensuring that JDK 1.8 is provisioned.