### PR TITLE
[build] Use netstandard2.0 for all workload packs

### DIFF
--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -2,12 +2,16 @@
   <Import Project="..\..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageType>DotnetPlatform</PackageType>
     <Authors>Microsoft</Authors>
     <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- Remove the `<group targetFramework=".NETStandard2.0" />` entry from the .nuspec. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <!-- Ignore TargetFramework reference group related warnings, these are workload packs not functional NuGets. -->
+    <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
+++ b/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
@@ -11,6 +11,8 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
     <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
+    <!-- Remove the `<group targetFramework=".NETStandard2.0" />` entry from the .nuspec. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4614104&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=9492f091-fb29-57d7-1f68-ecbf86da9c24

After bumping msbuild on macOS we ran into an issue when packing our
workload .nupkg files:

    /Users/builder/.dotnet/sdk/5.0.103/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(141,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 6.0.  Either target .NET Core 5.0 or lower, or use a version of the .NET SDK that supports .NET Core 6.0. [/Users/builder/azdo/_work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]

The target framework used by the projects that create our workload packs
should not matter.  Updating them to netstandard2.0 should improve
compatibility when restoring, packing, or otherwise using these projects
to invoke other targets.

The target framework does end up in the .nuspec file in these packages
however, but we can prevent this with:

    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

Finally, these packages use the DotnetPlatform or Template PackageType
and are not intended to be functional NuGets.  We can supress certain
nuspec related warnings to clean up build output:

    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: - Add lib or ref assemblies for the netstandard2.0 target framework [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5130: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder have compatible matches, but not exact matches in the other location. Unless intentional, consult the list of actions below: [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5130: - Add a dependency group for net6.0 to the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: References were found in the nuspec, but some reference assemblies were not found in both the nuspec and ref folder. Add the following reference assemblies: [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add Java.Interop.dll to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add Mono.Android.dll to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add Mono.Android.Export.dll to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add mono.android.jar to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add mono.android.dex to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]
    C:\Program Files\dotnet\sdk\5.0.201\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5131: - Add AndroidApiInfo.xml to the net6.0 reference group in the nuspec [C:\Users\Peter\source\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj]