### PR TITLE
[ci] Skip Linux stage when building PRs from forks

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -431,9 +431,11 @@ stages:
     - template: yaml-templates\fail-on-issue.yaml
 
 # Check - "Xamarin.Android (Linux Build and Smoke Test)"
+# TODO: Azure artifact authentication is not working against PR builds from forks.
 - stage: linux_build_test
   displayName: Linux
   dependsOn: []
+  condition: ne(variables['System.PullRequest.IsFork'], 'true')
   jobs:
   - job: linux_build_test
     displayName: Build and Smoke Test


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4613841&view=logs&jobId=94c79d37-c271-5f89-fbfd-be54dda94a90&j=8100f0f7-e86c-5b6e-6a78-6808e1478ee9&t=7439ba00-eeea-57fd-ba83-c762626e636b
Context: https://github.com/microsoft/azure-pipelines-tasks/issues/14668

Commercial Linux builds are consistently failing against pull requests
initiated from a fork.  There is some issue related to accessing the
`xamarin-xvs` artifact feed on these machines in this case.  We should
disable these builds for now until we can fix the problem.