### PR TITLE
[ci] Enable Linux stage for PR builds from forks

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -431,11 +431,9 @@ stages:
     - template: yaml-templates\fail-on-issue.yaml
 
 # Check - "Xamarin.Android (Linux Build and Smoke Test)"
-# TODO: Azure artifact authentication is not working against PR builds from forks.
 - stage: linux_build_test
   displayName: Linux
   dependsOn: []
-  condition: ne(variables['System.PullRequest.IsFork'], 'true')
   jobs:
   - job: linux_build_test
     displayName: Build and Smoke Test


### PR DESCRIPTION
I was checking a different pipelines settings and stumbled on a new
PR build setting:

    Make fork builds have the same permissions as regular builds

I've enabled this and it seems to have fixed our Azure artifact auth
issues on Linux.