### PR TITLE
[One .NET] fix $(PackageTargetFallback) and $(TargetPlatformVersion)

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Globalization;
 using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework;
@@ -61,7 +62,7 @@ Specifies the supported Android platform versions for this SDK.
 				writer.WriteEndElement (); // </TargetPlatformSupported>
 				writer.WriteStartElement ("TargetPlatformVersion");
 				writer.WriteAttributeString ("Condition", " '$(TargetPlatformVersion)' == '' ");
-				writer.WriteString (versions.MaxStableVersion.ApiLevel.ToString ());
+				writer.WriteString (versions.MaxStableVersion.ApiLevel.ToString ("0.0", CultureInfo.InvariantCulture));
 				writer.WriteEndElement (); // </TargetPlatformVersion>
 				writer.WriteEndElement (); // </PropertyGroup>
 
@@ -70,7 +71,7 @@ Specifies the supported Android platform versions for this SDK.
 						.Where (v => v.ApiLevel >= MinimumApiLevel)
 						.OrderBy (v => v.ApiLevel)) {
 					writer.WriteStartElement ("AndroidSdkSupportedTargetPlatformVersion");
-					writer.WriteAttributeString ("Include", version.ApiLevel.ToString ());
+					writer.WriteAttributeString ("Include", version.ApiLevel.ToString ("0.0", CultureInfo.InvariantCulture));
 					writer.WriteEndElement (); // </AndroidSdkSupportedTargetPlatformVersion>
 				}
 				writer.WriteStartElement ("SdkSupportedTargetPlatformVersion");

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
@@ -12,6 +12,8 @@ This file contains *temporary* workarounds for NuGet in .NET 5.
   <UsingTask TaskName="Xamarin.Android.Tasks.FixupNuGetReferences" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <PropertyGroup>
+    <_AndroidPlatformVersion>$(TargetPlatformVersion)</_AndroidPlatformVersion>
+    <_AndroidPlatformVersion Condition=" !$(_AndroidPlatformVersion.EndsWith ('.0')) ">$(_AndroidPlatformVersion).0</_AndroidPlatformVersion>
     <!-- Clear $(AssetTargetFallback), so only $(PackageTargetFallback) is used. -->
     <AssetTargetFallback></AssetTargetFallback>
     <!--
@@ -19,7 +21,7 @@ This file contains *temporary* workarounds for NuGet in .NET 5.
       It doesn't suffer from: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955
     -->
     <PackageTargetFallback>
-      net6.0-android$(TargetPlatformVersion).0;
+      net6.0-android$(_AndroidPlatformVersion);
       monoandroid12.0;
       monoandroid11.0;
       monoandroid10.0;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+				b.AssertHasNoWarnings ();
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: end of file not at end of a line"),
 					"Should not get a warning from the <CompileNativeAssembly/> task.");
 				var lockFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, ".__lock");
@@ -195,7 +195,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("AndroidEnableMultiDex", "true");
 			using (var b = CreateDllBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");
+				b.AssertHasNoWarnings ();
 
 				// $(AndroidEnableMultiDex) should not add android-support-multidex.jar!
 				if (Builder.UseDotNet) {
@@ -4070,10 +4070,7 @@ namespace UnnamedProject
 
 				StringAssertEx.Contains ("error XA4310", builder.LastBuildOutput, "Error should be XA4310");
 				StringAssertEx.Contains ("`DoesNotExist`", builder.LastBuildOutput, "Error should include the name of the nonexistent file");
-				if (!Builder.UseDotNet) {
-					// ILLink produces lots of warnings in .NET 5+
-					StringAssertEx.Contains ("0 Warning(s)", builder.LastBuildOutput, "Should have no MSBuild warnings.");
-				}
+				builder.AssertHasNoWarnings ();
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -396,12 +396,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 				Assert.IsTrue (b.Build (proj), "First build failed");
-				if (!Builder.UseDotNet) {
-					// In .NET 5+, there are ILLink warnings
-					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
-							"First build should not contain warnings!  Contains\n" +
-							string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
-				}
+				b.AssertHasNoWarnings ();
 
 				//Make sure the APKs are signed
 				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {
@@ -425,12 +420,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 				item.TextContent = () => proj.StringsXml.Replace ("${PROJECT_NAME}", "Foo");
 				item.Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "Second build failed");
-				if (!Builder.UseDotNet) {
-					// In .NET 5+, there are ILLink warnings
-					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
-						"Second build should not contain warnings!  Contains\n" +
-						string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
-				}
+				b.AssertHasNoWarnings ();
 
 				//Make sure the APKs are signed
 				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
@@ -89,5 +89,17 @@ namespace Xamarin.Android.Build.Tests
 				Assert.AreEqual (contents, actual, $"{archivePath} should contain {contents}");
 			}
 		}
+
+		[DebuggerHidden]
+		public static void AssertHasNoWarnings (this ProjectBuilder builder)
+		{
+			Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, " 0 Warning(s)"), $"{builder.BuildLogFile} should have no MSBuild warnings.");
+		}
+
+		[DebuggerHidden]
+		public static void AssertHasNoWarnings (this DotNetCLI dotnet)
+		{
+			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), $"{dotnet.BuildLogFile} should have no MSBuild warnings.");
+		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5819

A project using Maui and `TargetFramework=net6.0-android` can hit the
warning:

    warning CA1416: This call site is reachable on all platforms. 'Class1' is only supported on: 'android' 30.0 and later.

I found the project had:

    TargetPlatformVersion = 30

Projects that emit no warnings have `TargetPlatformVersion = 30.0`.

Update the `<GenerateSupportedPlatforms/>` MSBuild task to always
append `.0`:

    version.ApiLevel.ToString ("0.0", CultureInfo.InvariantCulture)

This solves the warning, but we still get an error in other projects
in the solution:

    error CS1061: 'Class1<TVirtualView, TNativeView>' does not contain a definition for 'Context' and no accessible extension method 'Context' accepting a first argument of type 'Class1<TVirtualView, TNativeView>' could be found (are you missing a using directive or an assembly reference?)

The build used:

    ~\.nuget\packages\microsoft.maui.core\6.0.100-preview.3.269\lib\netstandard2.1\Microsoft.Maui.dll

Instead of:

    ~\.nuget\packages\microsoft.maui.core\6.0.100-preview.3.269\lib\net6.0-android30.0\Microsoft.Maui.dll

I found this project uses `TargetFramework=net6.0-android30.0`, which
resulted in a weird value for `$(PackageTargetFallback)`:

    PackageTargetFallback =
        net6.0-android30.0.0;
        monoandroid12.0;
        monoandroid11.0;
        monoandroid10.0;
        monoandroid90;
        monoandroid81;
        monoandroid80;
        monoandroid70;
        monoandroid60;
        monoandroid50;

To fix this, I conditionally added the `.0` and the project builds
successfully.

We will hopefully be able to remove usage of
`$(PackageTargetFallback)` soon, as it was a workaround until NuGet
has official support for .NET 6 & MonoAndroid target frameworks.

I added a new test that covers these cases. I also added a new
`AssertHasNoWarnings()` extension method to simplify checking for
warnings. I also updated a couple tests that no longer emit warnings.