### PR TITLE
[ci] Enable CI for Maestro bot PRs

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -16,27 +16,32 @@ namespace Xamarin.Android.Prepare
 		{
 			Log.StatusLine ("Determining test jobs to run...");
 
+			var runAllTestsLoggingCommand = "##vso[task.setvariable variable=TestAreas;isOutput=true]MSBuild,MSBuildDevice,BCL,Designer";
+
 			string commitRevision = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION");
 			string commitMessage = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSIONMESSAGE");
 			if (string.IsNullOrEmpty (commitRevision) || string.IsNullOrEmpty (commitMessage)) {
-				Log.ErrorLine ("One or more source version variable values were empty:");
-				Log.ErrorLine ($"BUILD_SOURCEVERSION='{commitRevision}' BUILD_SOURCEVERSIONMESSAGE='{commitMessage}'.");
-				return false;
+				Log.WarningLine ("One or more source version variable values were empty:");
+				Log.WarningLine ($"BUILD_SOURCEVERSION='{commitRevision}' BUILD_SOURCEVERSIONMESSAGE='{commitMessage}'.");
+				Log.MessageLine (runAllTestsLoggingCommand);
+				return true;
 			}
 
-			// Assume we're building a merge commit as part of an Azure Pipelines PR build. Otherwise, this step will fail.
+			// Assume we're building a merge commit as part of an Azure Pipelines PR build. Otherwise, run all tests.
 			//  Example: Merge 0b66502c8b9f33cbb8d21b2dab7c100629aec081 into 0bef8aa5cd74d83d77c4e2b3f63975a0deb804b3
 			var commitMessagePieces = commitMessage.Split (new string [] { " " }, StringSplitOptions.RemoveEmptyEntries);
 			if (string.IsNullOrEmpty (commitMessagePieces [3])) {
-				Log.ErrorLine ($"Unable to parse merge commit message from: '{commitMessage}'.");
-				return false;
+				Log.WarningLine ($"Unable to parse merge commit message from: '{commitMessage}'.");
+				Log.MessageLine (runAllTestsLoggingCommand);
+				return true;
 			}
 
 			var git = new GitRunner (context);
 			var filesChanged = await git.RunCommandForOutputAsync (BuildPaths.XamarinAndroidSourceRoot, "diff", "--name-only", commitRevision, commitMessagePieces [3]);
 			if (filesChanged == null || filesChanged.Count < 1) {
-				Log.ErrorLine ($"Unable to determine if any files were changed in this PR.");
-				return false;
+				Log.WarningLine ($"Unable to determine if any files were changed in this PR.");
+				Log.MessageLine (runAllTestsLoggingCommand);
+				return true;
 			}
 
 			var testAreas = new HashSet<string> ();


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5830

We'd like to have our PR builds and tests run automatically against
dependency bump PRs created by the dotnet Maestro bot.  To do this, I've
overridden the CI triggers in the Xamarin.Android-PR pipeline to include
branches that begin with `darc-*`.

These branches will now trigger a build automatically, but it will be
building an individual commit and not a merge commit.  The xaprepare
tool has been updated to enable all test jobs in these cases.