### PR TITLE
[One .NET] move WorkloadManifest.* files to /data/ folder

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -108,11 +108,19 @@
     </ItemGroup>
     <PropertyGroup>
       <_WLPackVersion>@(_WLManifest->'%(Filename)'->Replace('Microsoft.NET.Workload.Android.', ''))</_WLPackVersion>
+      <_SdkManifestsFolder>$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\</_SdkManifestsFolder>
     </PropertyGroup>
     <Unzip
         SourceFiles="@(_WLManifest)"
-        DestinationFolder="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android"
+        DestinationFolder="$(_SdkManifestsFolder)temp"
     />
+    <!-- The .nupkg contains the files under /data/, so we need to move them -->
+    <ItemGroup>
+      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\LICENSE" />
+      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\data\*" />
+    </ItemGroup>
+    <Move SourceFiles="@(_WLExtractedFiles)" DestinationFolder="$(_SdkManifestsFolder)Microsoft.NET.Workload.Android" />
+    <RemoveDir Directories="$(_SdkManifestsFolder)temp\" />
     <Unzip
         SourceFiles="@(_WLPacks)"
         DestinationFolder="$(DotNetPreviewPath)packs\$([System.String]::Copy('%(_WLPacks.Filename)').Replace('.$(_WLPackVersion)', ''))\$(_WLPackVersion)"

--- a/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Workload.Android.proj
@@ -37,8 +37,8 @@ workload manifest pack containing information about the various Microsoft.Androi
     </ReplaceFileContents>
 
     <ItemGroup>
-      <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Workload.Android\WorkloadManifest.targets" PackagePath="\" />
-      <_PackageFiles Include="$(WorkloadManifestJsonPath)" PackagePath="\" />
+      <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Workload.Android\WorkloadManifest.targets" PackagePath="data" />
+      <_PackageFiles Include="$(WorkloadManifestJsonPath)" PackagePath="data" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/pull/188/files#diff-8fcaa29d8e6f00b34b3cb1830d93f33e75f04424780a66a3c658c7021048e74fR125

The future `dotnet workload install` commands will be expecting that
the `.nupkg` for a workload will contain:

* `data/WorkloadManifest.json`
* `data/WorkloadManifest.targets`

This was done so that we don't interfere with NuGet's spec for layout
of a `.nupkg` file. You are allowed to put whatever you like in a
`/data/` folder.

The layout on disk in `C:\Program Files\dotnet`, etc. is unchanged, so
we don't need any changes to our installers, etc.

Future changes in other repos:

* Will need to update xamarin-macios:

https://github.com/xamarin/xamarin-macios/tree/main/dotnet/package

* Will need to update where dotnet/maui provisions workloads:

https://github.com/dotnet/maui/blob/397f90a2dd85a9fde265b0806f46961eaef9299c/src/DotNet/DotNet.csproj#L70

* maui-check will need changes as well:

https://github.com/Redth/dotnet-maui-check