### PR TITLE
[One .NET] include .pdb files from <ProjectReference/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Xamarin.ProjectTools;
@@ -31,6 +32,7 @@ namespace Xamarin.Android.Build.Tests
 	}
 
 	public static class StringAssertEx {
+		[DebuggerHidden]
 		public static void DoesNotContain (string text, IEnumerable<string> collection, string message = null)
 		{
 			foreach (var line in collection) {
@@ -41,6 +43,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[DebuggerHidden]
 		public static void Contains (string text, IEnumerable<string> collection, string message = null)
 		{
 			foreach (var line in collection) {
@@ -59,11 +62,13 @@ namespace Xamarin.Android.Build.Tests
 			return regex.Match (string.Join ("\n", collection)).Success;
 		}
 
+		[DebuggerHidden]
 		public static void ContainsRegex (string pattern, IEnumerable<string> collection, string message = null, RegexOptions additionalOptions = 0)
 		{
 			Assert.IsTrue (ContainsRegex (pattern, collection, additionalOptions), message);
 		}
 
+		[DebuggerHidden]
 		public static void DoesNotContainRegex (string pattern, IEnumerable<string> collection, string message = null, RegexOptions additionalOptions = 0)
 		{
 			Assert.IsFalse (ContainsRegex (pattern, collection, additionalOptions), message);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -63,7 +63,7 @@ namespace Xamarin.ProjectTools
 				TextContent = MainPageXaml,
 			});
 			Sources.Add (new BuildItem.Source ("MainPage.xaml.cs") {
-				TextContent = () => ProcessSourceTemplate (MainPage_xaml_cs),
+				TextContent = () => ProcessSourceTemplate (MainPage),
 			});
 			OtherBuildItems.Add (new BuildItem ("EmbeddedResource", "App.xaml") {
 				TextContent = () => ProcessSourceTemplate (App_xaml),
@@ -73,7 +73,10 @@ namespace Xamarin.ProjectTools
 			});
 
 			MainActivity = default_main_activity_cs;
+			MainPage = MainPage_xaml_cs;
 		}
+
+		public string MainPage { get; set; }
 
 		protected virtual string MainPageXaml () => ProcessSourceTemplate (MainPage_xaml);
 	}


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1300734

Break points are currently not working for .NET 6 projects inside
`<ProjectReference/>` from the main Android application. It turns out
that `@(ResolvePublishList)` does not contain `.pdb` files for
referenced projects?

I could reproduce this in our existing
`ApplicationRunsWithDebuggerAndBreaks` test. I added a class library
and an additional break point to make sure the break point works.

To actually solve the issue, I added a `File.Exists()` check to look
for `.pdb` files on disk and add them -- as there appears to be no way
to find the files from MSBuild item groups from the dotnet/sdk.

I also added an assertion that the `.pdb` files are deployed.

I added `[DebuggerHidden]` to a couple assertion helper methods, too.
This way when the assertions fail, VS will break inside the test that
failed instead of these methods.