### PR TITLE
[azdo] fix release branch triggers

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -15,7 +15,7 @@ schedules:
     include:
     - main
     - d16-9
-    - 6.0.*
+    - release/*
 
 # External sources, scripts, tests, and yaml template files.
 resources:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -5,7 +5,7 @@ name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 trigger:
 - main
 - d16-*
-- 6.0.*
+- release/*
 
 pr:
   autoCancel: false
@@ -13,7 +13,7 @@ pr:
     include:
     - main
     - d16-*
-    - 6.0.*
+    - release/*
 
 # Global variables
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -5,7 +5,7 @@ name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 trigger:
   - main
   - d16-*
-  - 6.0.*
+  - release/*
 
 # External sources, scripts, tests, and yaml template files.
 resources:


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/598#issuecomment-820609077

In 8ca43359, I messed up, and we used the wrong branch name
`6.0.1xx-preview3`, which should have been prefixed with `release/`.

Replace 8ca43359, in favor of `release/*`, so we can follow .NET 6
branch naming such as `release/6.0.1xx-preview4`.