### PR TITLE
Ignore interfaces when generating JavaCallableWrappers

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -328,6 +328,11 @@ namespace Xamarin.Android.Tasks
 
 			bool ok = true;
 			foreach (var t in javaTypes) {
+				if (t.IsInterface) {
+					// Interfaces are in typemap but they shouldn't have JCW generated for them
+					continue;
+				}
+
 				using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 					try {
 						var jti = new JavaCallableWrapperGenerator (t, Log.LogWarning, cache) {

--- a/src/monodroid/jni/build-info.hh
+++ b/src/monodroid/jni/build-info.hh
@@ -8,6 +8,7 @@
 namespace xamarin::android::internal
 {
 #define STRINGIFY(_val_) #_val_
+#define API_STRING(_api_) STRINGIFY(_api_)
 #define VERSION_STRING(_major_, _minor_, _build_) STRINGIFY(_major_) "." STRINGIFY(_minor_) "." STRINGIFY(_build_)
 
 	class BuildInfo final
@@ -50,7 +51,7 @@ namespace xamarin::android::internal
 
 		static constexpr char ndk_api_level[] =
 #if defined (__ANDROID_API__)
-			STRINGIFY(__ANDROID_API__);
+			API_STRING(__ANDROID_API__);
 #else // def __ANDROID_API__
 			"";
 #endif // ndef __ANDROID_API__


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/commit/ebd7d76161ac60ce7ad3bfee87789f08a333ae78
Context: https://github.com/xamarin/java.interop/commit/f9faaaba0ca2f3721ea1de33fd793edeae059474

With `Java.Interop` Java type scanner now including Java interfaces in
the returned set of types, we need to ignore interfaces when generating
JCWs.