### PR TITLE
Bump to xamarin/monodroid/main@76c04cd1

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@ff633623e2c5793e765b7e498c7ea3f9dd7cbe88
+xamarin/monodroid:main@76c04cd15eca7afc269a6d26296e9d2db6f79be2
 mono/mono:2020-02@b4a385816ed4f1398d0184c38f19f560e868fd80

--- a/Documentation/release-notes/5860.md
+++ b/Documentation/release-notes/5860.md
@@ -1,0 +1,8 @@
+#### Application build and deployment
+
+- [GitHub Issue #5863](https://github.com/xamarin/xamarin-android/issues/5863):
+  Setting the `AndroidFastDeploymentType` MSBuild property to `Assemblies:Dexes`
+  may result in an MSB3680 error "The source file "obj/Debug/androidx/jl/classes.dex" does not exist".
+- [GitHub PR #5860](https://github.com/xamarin/xamarin-android/pull/5860):
+  Improve Fast Deployment error reporting so that more error conditions get more unique
+  and actionable error messages.


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/ff633623e2c5793e765b7e498c7ea3f9dd7cbe88...76c04cd15eca7afc269a6d26296e9d2db6f79be2

  * xamarin/monodroid@76c04cd15 [tools/msbuild] [MSB3680] The source file "obj/Debug/androidx/jl/classes.dex" does not exist (#1197)
  * xamarin/monodroid@ed584c775 [tools/msbuild] Improve FastDeploy error messages (#1190)
  * xamarin/monodroid@74294dca0 Bump to xamarin/androidtools/main@47ec118f (#1195)
