### PR TITLE
[build] fix nightly CI builds

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -34,6 +34,7 @@ resources:
 variables:
   RunningOnCI: true
   XA.Build.Configuration: Release
+  XA.Jdk11.Folder: jdk-11
   XA.Jdk8.Folder: jdk-1.8
   NuGetArtifactName: nuget-unsigned
   InstallerArtifactName: installers-unsigned


### PR DESCRIPTION
The nightly TimeZone and System App tests are failing with:

    error XA0030: Building with JDK version `14.0.2` is not supported. Please install JDK version `11.0`.
    See https://aka.ms/xamarin/jdk9-errors

Earlier in the log:

    JI_JAVA_HOME = /Users/runner/Library/Android/
    ...
    warning XA5300: An exception occurred while validating the Java SDK installation in '/Users/runner/Library/Android/' that was found while searching the paths from '$JI_JAVA_HOME'.
    Ensure that the Android section of the Visual Studio options has a valid Java SDK directory configured.
    To use a custom SDK path for a command line build, set the 'JavaSdkDirectory' MSBuild property to the custom path.
    Exception: Could not find required file `jar` within `/Users/runner/Library/Android/`; is this a valid JDK?
        Parameter name: homePath

It turns out that `JI_JAVA_HOME` isn't quite right because of
`setup-test-environment.yaml`'s default value for `jdkTestFolder`:

    jdkTestFolder: $(XA.Jdk11.Folder)

`azure-pipelines-nightly.yaml` doesn't set `$(XA.Jdk11.Folder)`, and
so `$JI_JAVA_HOME` would have an incorrect path:

    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/${{ parameters.jdkTestFolder }}"
      displayName: set JI_JAVA_HOME
      condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))

Things were only working before, because xamarin-android-tools *used*
to be able to locate the old Microsoft OpenJDK 1.8 and that code was
removed.