### PR TITLE
[xaprepare] Don't throw when reading git blame headers without value

### DIFF
--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
@@ -66,8 +66,15 @@ namespace Xamarin.Android.Prepare
 			void StoreHeader (string line)
 			{
 				string[] parts = line.Split (FieldSeparator, 2, StringSplitOptions.RemoveEmptyEntries);
-				if (parts.Length != 2)
-					throw new InvalidOperationException ($"Unexpected commit header format (wrong number of fields): {line}");
+				if (parts.Length != 2) {
+					if (parts.Length == 0) { // should be "impossible"
+						return;
+					}
+
+					var newParts = new string[] { parts [0], String.Empty };
+					Log.Instance.Warning ($"Unexpected commit header format (wrong number of fields): {line}");
+					Log.Instance.Warning ("Using empty string for the header value");
+				}
 
 				if (IsHeaderName ("author")) {
 					Author = parts [1];


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5867

Note: I cannot reproduce it locally, `git blame -p` output doesn't have
any `boundary` headers here

Be more flexible when parsing `git blame -p` output by accepting headers
without values.