### PR TITLE
[tests] stop using bintray URLs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -135,7 +135,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
 			proj.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\android-crop-1.0.1.aar") {
-				WebContent = "https://jcenter.bintray.com/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
+				WebContent = "https://repo1.maven.org/maven2/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
 			});
 			proj.MetadataXml = @"
 				<metadata>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3299,10 +3299,6 @@ public class MyReceiver : BroadcastReceiver
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "gson-2.7.jar") {
 				WebContent = "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar"
 			});
-			//Twitter SDK https://bintray.com/twitteross/twitterkit/twitter-core/3.3.0
-			proj.OtherBuildItems.Add (new BuildItem ("AndroidAarLibrary", "twitter-core-3.3.0.aar") {
-				WebContent = "https://dl.bintray.com/twitteross/twitterkit/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
-			});
 			/* The source is simple:
 			 *
 				public class Lambda

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -225,7 +225,7 @@ namespace UnnamedProject
 				WebContent = $"https://repo1.maven.org/maven2/com/google/code/gson/gson/2.7/{jar}"
 			});
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidAarLibrary ("android-crop-1.0.1.aar") {
-				WebContent = "https://jcenter.bintray.com/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
+				WebContent = "https://repo1.maven.org/maven2/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
 			});
 			// Each NuGet package and AAR file are in libraryprojectimports.cache, AndroidJavaSource is not
 			int libraryProjectImportsJars = 14;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -838,7 +838,7 @@ namespace Lib2
 
 				// Add a new AAR file to the project
 				var aar = new AndroidItem.AndroidAarLibrary ("Jars\\android-crop-1.0.1.aar") {
-					WebContent = "https://jcenter.bintray.com/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
+					WebContent = "https://repo1.maven.org/maven2/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
 				};
 				proj.OtherBuildItems.Add (aar);
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4690182&view=ms.vss-test-web.build-test-results-tab

The `BuildTest.Desugar()` test is failing on CI with:

    System.Net.WebException : The remote server returned an error: (403) Forbidden.

Even using the latest URLs here, the download gives me a login prompt
in the browser:

    https://mvnrepository.com/artifact/com.twitter.sdk.android/twitter-core/3.3.0
    https://repo.spring.io/libs-release/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar

I just removed the usage of this `.aar` file in the `Desugar()` test,
since there seem to be sufficient `.aar` files used in the test.

I also updated a few other URLs that were using `bintray.com`, because
they may eventually stop working.