### PR TITLE
[build] Copy templates to lowercase path on Linux

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -128,7 +128,7 @@
     <MakeDir Directories="$(DotNetPreviewPath)template-packs" />
     <!-- Copy template packs to lowercase destination when running on Linux -->
     <Copy Condition="'$(HostOS)' != 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFolder="$(DotNetPreviewPath)template-packs" />
-    <Copy Condition="'$(HostOS)' == 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
+    <Copy Condition="'$(HostOS)' == 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)%(Extension)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
     <ItemGroup>
       <_UnixExecutables Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.*\*\tools\$(HostOS)\**\*.*" />
       <_FilesToTouch Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -126,7 +126,9 @@
         DestinationFolder="$(DotNetPreviewPath)packs\$([System.String]::Copy('%(_WLPacks.Filename)').Replace('.$(_WLPackVersion)', ''))\$(_WLPackVersion)"
     />
     <MakeDir Directories="$(DotNetPreviewPath)template-packs" />
-    <Copy SourceFiles="@(_WLTemplates)" DestinationFolder="$(DotNetPreviewPath)template-packs" />
+    <!-- Copy template packs to lowercase destination when running on Linux -->
+    <Copy Condition="'$(HostOS)' != 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFolder="$(DotNetPreviewPath)template-packs" />
+    <Copy Condition="'$(HostOS)' == 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
     <ItemGroup>
       <_UnixExecutables Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.*\*\tools\$(HostOS)\**\*.*" />
       <_FilesToTouch Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -126,9 +126,8 @@
         DestinationFolder="$(DotNetPreviewPath)packs\$([System.String]::Copy('%(_WLPacks.Filename)').Replace('.$(_WLPackVersion)', ''))\$(_WLPackVersion)"
     />
     <MakeDir Directories="$(DotNetPreviewPath)template-packs" />
-    <!-- Copy template packs to lowercase destination when running on Linux -->
-    <Copy Condition="'$(HostOS)' != 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFolder="$(DotNetPreviewPath)template-packs" />
-    <Copy Condition="'$(HostOS)' == 'Linux'" SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)%(Extension)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
+    <!-- TODO: Workaround Linux casing issue and copy template packs to lowercase destination -->
+    <Copy SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)%(Extension)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
     <ItemGroup>
       <_UnixExecutables Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.*\*\tools\$(HostOS)\**\*.*" />
       <_FilesToTouch Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**" />


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/16946

Copy our template workload pack to a lowercase destination so that it
can be detected and used when building and testing on Linux.