### PR TITLE
[One .NET] exclude libxamarin-debug-app-helper.so from Release builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessNativeLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessNativeLibraries.cs
@@ -57,6 +57,10 @@ namespace Xamarin.Android.Tasks
 							continue;
 						library.SetMetadata ("ArchiveFileName", "libmonodroid.so");
 					}
+				} else if (fileName == "libxamarin-debug-app-helper") {
+					// libxamarin-debug-app-helper.so is only needed for Debug builds
+					if (!IncludeDebugSymbols)
+						continue;
 				}
 				output.Add (library);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -62,20 +62,17 @@
       "Size": 3588112
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 347016
-    },
-    "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37104
+      "Size": 346992
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 2405
+      "Size": 2289
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2278
+      "Size": 2162
     }
   },
-  "PackageSize": 2828142
+  "PackageSize": 2815764
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -1856,7 +1856,7 @@
       "Size": 433196
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 142528
+      "Size": 142776
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776168
@@ -1871,10 +1871,7 @@
       "Size": 3588112
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 347016
-    },
-    "lib/arm64-v8a/libxamarin-debug-app-helper.so": {
-      "Size": 37104
+      "Size": 346992
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
       "Size": 6
@@ -1991,14 +1988,14 @@
       "Size": 339
     },
     "META-INF/ANDROIDD.SF": {
-      "Size": 80343
+      "Size": 80227
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 80216
+      "Size": 80100
     }
   },
-  "PackageSize": 8623661
+  "PackageSize": 8611283
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5855

Currently, in .NET 6, any `.so` file in our runtime pack is included
in apps by default. This is the nature of how native libraries coming
from NuGet packages work. They just get added based on the file path
and `$(RuntimeIdentifier)` of the project.

We already have a special case for `libmono-android.release.so` and
`libmono-android.debug.so` that uses `$(AndroidIncludeDebugSymbols)`
as a way to know which native library is needed.

We can do the same thing here and exclude
`libxamarin-debug-app-helper.so`, which should only be included in
`Debug` builds.

This saves ~37K for all Release apps:

    -37,104 lib/arm64-v8a/libxamarin-debug-app-helper.so *1