### PR TITLE
[xaprepare] Add a missing line to fix for issue 5867

### DIFF
--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Android.Prepare
 					}
 
 					var newParts = new string[] { parts [0], String.Empty };
+					parts = newParts;
 					Log.Instance.Warning ($"Unexpected commit header format (wrong number of fields): {line}");
 					Log.Instance.Warning ("Using empty string for the header value");
 				}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5867
Context: 40fdecbd5d4877a0ac28045ecd6832604970ecc3

Assign new array to the old one so that IndexOutOfRangeException
isn't thrown later on in the code.