### PR TITLE
[debugger] Pass timeout parameter to debugger on mono

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -668,11 +668,12 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 			loglevel = options.loglevel;
 
 		char *debug_arg = utils.monodroid_strdup_printf (
-			"--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1",
+			"--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1,timeout=%ld",
 			loglevel,
 			options.host,
 			options.sdb_port,
-			options.server ? "server=y," : ""
+			options.server ? "server=y," : "",
+			options.timeout_time
 		);
 
 		char *debug_options [2] = {


### PR DESCRIPTION
Pass timeout parameter to debugger on mono, this is necessary to start android app using icordebug.