### PR TITLE
[One .NET] clean up default ILLink MSBuild properties

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -50,9 +50,9 @@
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and ('$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full') ">true</PublishTrimmed>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>
-    <TrimMode Condition=" '$(PublishTrimmed)' == 'true' and '$(TrimMode)' == '' ">link</TrimMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
+    <TrimmerDefaultAction Condition=" '$(TrimmerDefaultAction)' == '' and '$(AndroidLinkMode)' == 'Full' ">link</TrimmerDefaultAction>
     <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x86</RuntimeIdentifiers>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -18,12 +18,6 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition="'$(VSAndroidDesigner)' != ''"
           Value="$(VSAndroidDesigner)"
           Trim="true" />
-      <!-- Mark all assemblies to be linked for AndroidLinkMode=Full -->
-      <ResolvedFileToPublish
-          Update="@(ResolvedFileToPublish)"
-          Condition=" '$(AndroidLinkMode)' == 'Full' and '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.AssetType)' != 'native' "
-          TrimMode="link"
-      />
       <!-- TODO: remove setting the trim mode here, once the support packages are updated to NET6 and compatability packages not needed -->
       <ResolvedFileToPublish
           Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.AndroidX.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Android.Support.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Google.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.GooglePlayServices.')) ) ">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5856

In .NET 6 Preview 4, we can adjust some of our defaults for ILLink:

This can be completely removed, it is the default now:

    <TrimMode Condition=" '$(PublishTrimmed)' == 'true' and '$(TrimMode)' == '' ">link</TrimMode>

There is a new feature that has the same behavior as
`AndroidLinkMode=full`:

    <TrimmerDefaultAction Condition=" '$(TrimmerDefaultAction)' == '' and '$(AndroidLinkMode)' == 'Full' ">link</TrimmerDefaultAction>

This allows us to remove where we were manually setting
`%(TrimMode)=link` on the `@(ResolvedFileToPublish)` item group.

In a future PR, we should add an additional default to emit warning
for `TrimmerDefaultAction=link` or `AndroidLinkMode=Full`:

    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' and '$(TrimmerDefaultAction)' != 'link' ">true</SuppressTrimAnalysisWarnings>

I don't think we should enable this yet, because it causes warnings in
`Mono.Android.dll` and `Java.Interop.dll`, so this won't complete #5856.

If you also set `TrimmerSingleWarn=false`, we can see several warnings
we will eventually need to address:

    ILLink warning IL2072: Java.Interop.JniRuntime.SetMarshalMemberBuilder(JniRuntime.CreationOptions): '#0' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Object System.Activator::CreateInstance(System.Type)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2026: Java.Interop.JniRuntime.SetMarshalMemberBuilder(JniRuntime.CreationOptions): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    ILLink warning IL2067: Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type,JniNativeMethodRegistrationArguments): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethods(Type)'. The parameter 'marshalType' of method 'Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type,JniNativeMethodRegistrationArguments)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2072: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType,Type,String): '#0' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Reflection.MethodInfo System.Reflection.RuntimeReflectionExtensions::GetRuntimeMethod(System.Type,System.String,System.Type[])'. The return value of method 'System.Type.GetNestedType(String,BindingFlags)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType,Type,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicNestedTypes' in call to 'System.Type.GetNestedType(String,BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType,Type,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2060: Java.Interop.JniRuntime.JniValueManager.GetObjectArrayMarshaler(Type): Call to 'System.Reflection.MethodInfo System.Reflection.MethodInfo::MakeGenericMethod(System.Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
    ILLink warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): '#0' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Object System.Activator::CreateInstance(System.Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): '#0' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Object System.Activator::CreateInstance(System.Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2057: Java.Interop.ManagedPeer.Construct(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr,IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2075: Java.Interop.ManagedPeer.Construct(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr,IntPtr): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Type.GetConstructor(Type[])'. The return value of method 'System.Type.GetType(String,Boolean)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2057: Java.Interop.ManagedPeer.GetParameterTypes(String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2057: Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2075: Android.Runtime.AndroidTypeManager.CreateDynamicCallback(MethodInfo): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2026: Android.Runtime.AndroidTypeManager.CreateDynamicCallback(MethodInfo): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    ILLink warning IL2057: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2072: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String): 'target' argument does not satisfy 'All' in call to 'System.Delegate.CreateDelegate(Type,Type,String)'. The return value of method 'System.Type System.Type::get_BaseType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2072: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String): 'target' argument does not satisfy 'All' in call to 'System.Delegate.CreateDelegate(Type,Type,String)'. The return value of method 'System.Type.GetType(String,Boolean)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter 'type' of method 'Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2067: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String): 'target' argument does not satisfy 'All' in call to 'System.Delegate.CreateDelegate(Type,Type,String)'. The parameter 'type' of method 'Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType,Type,String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Java.Interop.JavaConvert.GetJniHandleConverterForType(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String,BindingFlags)'. The parameter 't' of method 'Java.Interop.JavaConvert.GetJniHandleConverterForType(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2055: Java.Interop.JavaObjectExtensions.GetHelperType(Type,String): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    ILLink warning IL2026: Java.Interop.JavaObjectExtensions.GetHelperType(Type,String): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    ILLink warning IL2026: Java.Interop.JavaObjectExtensions.GetHelperType(Type,String): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    ILLink warning IL2057: Android.Runtime.JNIEnv.RegisterJniNatives(IntPtr,Int32,IntPtr,IntPtr,Int32): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2026: Android.Runtime.ResourceIdManager.GetResourceTypeFromAssembly(Assembly): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    ILLink warning IL2075: Android.Runtime.ResourceIdManager.UpdateIdValues(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'Android.Runtime.ResourceIdManager.GetResourceTypeFromAssembly(Assembly)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Java.Interop.TypeManager.CreateProxy(Type,IntPtr,JniHandleOwnership): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructor(BindingFlags,Binder,Type[],ParameterModifier[])'. The parameter 'type' of method 'Java.Interop.TypeManager.CreateProxy(Type,IntPtr,JniHandleOwnership)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2070: Java.Interop.TypeManager.CreateProxy(Type,IntPtr,JniHandleOwnership): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructor(BindingFlags,Binder,Type[],ParameterModifier[])'. The parameter 'type' of method 'Java.Interop.TypeManager.CreateProxy(Type,IntPtr,JniHandleOwnership)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink warning IL2057: Java.Interop.TypeManager.GetParameterTypes(String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2057: Java.Interop.TypeManager.n_Activate(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr,IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String,Boolean)'. It's not possible to guarantee the availability of the target type.
    ILLink warning IL2075: Java.Interop.TypeManager.n_Activate(IntPtr,IntPtr,IntPtr,IntPtr,IntPtr,IntPtr): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Type.GetConstructor(Type[])'. The return value of method 'System.Type.GetType(String,Boolean)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

I looked into fixing a few, and we will need to compile
`Java.Interop.dll` against at least .NET 5 to solve these issues. We
are getting close to being able to do that.

Also tracked by: https://github.com/xamarin/xamarin-android/issues/5652