### PR TITLE
[One .NET] use AssemblyMetadataAttribute for IsTrimmable

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -111,7 +111,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         RuntimePackNamePatterns="Microsoft.Android.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
         Profile="Android"
-        IsTrimmable="true"
     />
   </ItemGroup>
 </Project>

--- a/src/Mono.Android.Export/Properties/AssemblyInfo.cs
+++ b/src/Mono.Android.Export/Properties/AssemblyInfo.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Xamarin Inc.")]
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Mono.Android/Properties/AssemblyInfo.cs.in
+++ b/src/Mono.Android/Properties/AssemblyInfo.cs.in
@@ -16,6 +16,7 @@ using System.Runtime.CompilerServices;
 // FIXME: Probably need to add Copyright 2009-2011 Novell Inc.
 // [assembly: AssemblyCopyright ("Copyright 2011-2014 Xamarin Inc.")]
 [assembly: AssemblyCompany ("Microsoft Corporation")]
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.Color))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.ColorConverter))]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5638

Going forward in .NET 6, we shouldn't use the `%(IsTrimmable)`
metadata anymore, but use the following C# attribute in each assembly
instead:

    [assembly: AssemblyMetadata ("IsTrimmable", "True")]

Similar changes on the iOS side here:

https://github.com/xamarin/xamarin-macios/commit/289053b1e3bdf3b8c3cc3839384811f6018bba48

Bump to xamarin/java.interop/main@df4c5e7c

Changes: https://github.com/xamarin/java.interop/compare/f9faaaba...df4c5e7c

This adds `AssemblyMetadataAttribute` for `Java.Interop.dll`.