### PR TITLE
[Xamarin.Android.Build.Tasks] Build should update designtime/Resource.designer.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string NetResgenOutputFile { get; set; }
 
+		public string DesignTimeOutputFile { get; set; }
+
 		public string JavaResgenInputFile { get; set; }
 
 		public string RTxtFile { get; set; }
@@ -173,6 +175,12 @@ namespace Xamarin.Android.Tasks
 			// Write out our Resources.Designer.cs file
 
 			WriteFile (NetResgenOutputFile, resources, language, isCSharp, aliases);
+
+			// During a regular build, write the designtime/Resource.designer.cs file as well
+
+			if (!string.IsNullOrEmpty (DesignTimeOutputFile) && Files.CopyIfChanged (NetResgenOutputFile, DesignTimeOutputFile)) {
+				Log.LogDebugMessage ($"Writing to: {DesignTimeOutputFile}");
+			}
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -112,9 +112,7 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=true" }),
 						"first build failed");
 					var designTimeDesigner = Path.Combine (intermediateOutputPath, "designtime", "Resource.designer.cs");
-					if (useManagedParser) {
-						FileAssert.Exists (designTimeDesigner, $"{designTimeDesigner} should have been created.");
-					}
+					FileAssert.Exists (designTimeDesigner, $"{designTimeDesigner} should have been created.");
 					WaitFor (1000);
 					b.Target = "Build";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=false" }), "second build failed");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1195,6 +1195,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition="'$(_AndroidResourceDesignerFile)' != ''"
 		ContinueOnError="$(DesignTimeBuild)"
 		NetResgenOutputFile="$(_AndroidResourceDesignerFile)"
+		DesignTimeOutputFile="$(_AndroidManagedResourceDesignerFile)"
 		JavaResgenInputFile="$(_GeneratedPrimaryJavaResgenFile)"
 		RTxtFile="$(IntermediateOutputPath)R.txt"
 		Namespace="$(AndroidResgenNamespace)"


### PR DESCRIPTION
When testing .NET 6 in the latest Internal Preview builds of Visual
Studio, we are now in a place where the Android designer is working
and rendering layouts.

Unfortunately if you add a new `android:id="@+id/foo"`, Intellisense
does not update to show that `Resource.Id.foo` is available.

After enabling build logging with `Project System Tools`:

https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools

I found the following is happening:

* I hit Ctrl+S to save the `.xml` file
* `UpdateGeneratedFiles` runs, which updates
  `obj/Debug/*/designtime/Resource.designer.cs`. This runs in a
  design-time context where we use the `ManagedResourceParser`, it
  uses an `R.txt` if found on disk. In this case, it is an old `R.txt`
  from a previous build.
* `UpdateAndroidResources` runs, which updates `R.txt` and
  `obj/Debug/*/Resource.designer.cs`. It runs in a context where we
  run `aapt2` instead of the `ManagedResourceParser`.

Unfortunately, at this point the `designtime/Resource.designer.cs` is
out of date and does not have the new `android:id` available.

This problem seems to happen in "legacy" Xamarin.Android as well.
However, doing a regular build appears to update Intellisense. I think
developers are currently doing a regular build here, which is not
ideal? While in .NET 6, doing a `Build` does *not* update the
Intellisense. The only way I could get .NET 6 to update was to force a
design-time build by changing a random setting in `Project Options`.

To solve the issue, we can make both `UpdateAndroidResources` and
regular `Build` update the `designtime/Resource.designer.cs` file.
These files should stay in sync if we have the proper values from
`aapt2` anyway. I think this will solve the problem in .NET 6 as well
as improve the experience in "legacy" Xamarin.Android.

Down the road, I think we should rethink how design-time builds work,
in general here.

I updated some tests around this scenario to be sure the
`designtime/Resource.designer.cs` get updated with the same contents.