### PR TITLE
[One .NET] Make apk size checks more lenient

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -279,9 +279,7 @@ stages:
         testResultsFiles: TestResult-*.xml
         testRunTitle: Java Interop Tests - Windows Build Tree
 
-    - script: dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g
-      displayName: install apkdiff dotnet tool
-      continueOnError: true
+    - template: yaml-templates\install-apkdiff.yaml
 
     # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
     # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
@@ -403,9 +401,7 @@ stages:
         testResultsFiles: TestResult-*.xml
         testRunTitle: Java Interop Tests - Windows Dotnet Build
 
-    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
-      displayName: install apkdiff dotnet tool
-      continueOnError: true
+    - template: yaml-templates\install-apkdiff.yaml
 
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
@@ -503,9 +499,7 @@ stages:
         artifactName: nuget-linux-unsigned
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
-    - script: dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g
-      displayName: install apkdiff dotnet tool
-      continueOnError: true
+    - template: yaml-templates/install-apkdiff.yaml
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
@@ -549,10 +543,6 @@ stages:
     - script: make prepare V=1 CONFIGURATION=$(ApkTestConfiguration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
-
-    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
-      displayName: install apkdiff dotnet tool
-      continueOnError: true
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -804,10 +794,6 @@ stages:
     - script: make prepare V=1 CONFIGURATION=$(XA.Build.Configuration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
-
-    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
-      displayName: install apkdiff dotnet tool
-      continueOnError: true
 
     - task: MSBuild@1
       displayName: create nuget.config for Mono.Android.NET_Tests

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -279,7 +279,7 @@ stages:
         testResultsFiles: TestResult-*.xml
         testRunTitle: Java Interop Tests - Windows Build Tree
 
-    - script: dotnet tool update apkdiff -g
+    - script: dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g
       displayName: install apkdiff dotnet tool
       continueOnError: true
 
@@ -403,7 +403,7 @@ stages:
         testResultsFiles: TestResult-*.xml
         testRunTitle: Java Interop Tests - Windows Dotnet Build
 
-    - script: 'dotnet tool update apkdiff -g'
+    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
       displayName: install apkdiff dotnet tool
       continueOnError: true
 
@@ -503,7 +503,7 @@ stages:
         artifactName: nuget-linux-unsigned
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
-    - script: dotnet tool update apkdiff -g
+    - script: dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g
       displayName: install apkdiff dotnet tool
       continueOnError: true
 
@@ -550,7 +550,7 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
 
-    - script: 'dotnet tool update apkdiff -g'
+    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
       displayName: install apkdiff dotnet tool
       continueOnError: true
 
@@ -805,7 +805,7 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
 
-    - script: 'dotnet tool update apkdiff -g'
+    - script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
       displayName: install apkdiff dotnet tool
       continueOnError: true
 

--- a/build-tools/automation/yaml-templates/install-apkdiff.yaml
+++ b/build-tools/automation/yaml-templates/install-apkdiff.yaml
@@ -1,0 +1,10 @@
+parameters:
+  version: '0.0.13'
+  condition: succeeded()
+  continueOnError: true
+
+steps:
+- script: dotnet tool update apkdiff --version ${{ parameters.version }} --add-source https://api.nuget.org/v3/index.json -g
+  displayName: install apkdiff ${{ parameters.version }}
+  condition: ${{ parameters.condition }}
+  continueOnError: ${{ parameters.continueOnError }}

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -31,7 +31,7 @@ jobs:
     - task: CmdLine@2
       displayName: install apkdiff dotnet tool
       inputs:
-        script: 'dotnet tool update apkdiff -g'
+        script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
       continueOnError: true
 
     - template: run-nunit-tests.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -28,12 +28,6 @@ jobs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - task: CmdLine@2
-      displayName: install apkdiff dotnet tool
-      inputs:
-        script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
-      continueOnError: true
-
     - template: run-nunit-tests.yaml
       parameters:
         useDotNet: ${{ eq(parameters.target_framework, 'netcoreapp3.1') }}

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -34,12 +34,6 @@ jobs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
 
-    - task: CmdLine@2
-      displayName: install apkdiff dotnet tool
-      inputs:
-        script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
-      continueOnError: true
-
     # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
     # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
     - template: run-nunit-tests.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     - task: CmdLine@2
       displayName: install apkdiff dotnet tool
       inputs:
-        script: 'dotnet tool update apkdiff -g'
+        script: 'dotnet tool update apkdiff --version 0.0.13 --add-source https://api.nuget.org/v3/index.json -g'
       continueOnError: true
 
     # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -88,3 +88,5 @@ steps:
   inputs:
     projects: ${{ parameters.xaSourcePath }}/build-tools/create-packs/Microsoft.Android.Sdk.proj
     arguments: -t:ExtractWorkloadPacks -c ${{ parameters.configuration }} -v:n -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog
+
+- template: install-apkdiff.yaml

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -102,10 +102,17 @@ namespace Xamarin.Android.Build.Tests
 
 				const int ApkSizeThreshold = 5 * 1024;
 				const int AssemblySizeThreshold = 5 * 1024;
+				const int ApkPercentChangeThreshold = 3;
+				const int FilePercentChangeThreshold = 5;
+				var regressionCheckArgs = $"--test-apk-size-regression={ApkSizeThreshold} --test-assembly-size-regression={AssemblySizeThreshold}";
+				// Make .NET 6 checks more lenient during previews. Report if any files increase by more than 5% or if the package size increases by more than 3%
+				if (Builder.UseDotNet) {
+					regressionCheckArgs = $"--test-apk-percentage-regression=\"{ApkPercentChangeThreshold}\" --test-content-percentage-regression=\"{FilePercentChangeThreshold}\"";
+				}
 				var apkFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + "-Signed.apk");
 				var apkDescPath = Path.Combine (Root, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);
-				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression --test-apk-size-regression={ApkSizeThreshold} --test-assembly-size-regression={AssemblySizeThreshold} {apkDescReferencePath} {apkFile}");
+				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression {regressionCheckArgs} {apkDescReferencePath} {apkFile}");
 				Assert.IsTrue (code == 0, $"apkdiff regression test failed with exit code: {code}\ncontext: https://github.com/xamarin/xamarin-android/blob/main/Documentation/project-docs/ApkSizeRegressionChecks.md\nstdOut: {stdOut}\nstdErr: {stdErr}");
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/radekdoulik/apkdiff/pull/2

New percentage changed based checks have been added to apkdiff to allow
for greater flexibility when determining whether or not a size change
is problematic.  The .NET 6 .apk content and size checks have been
updated to use percentage based comparisons, and as a result have been
made more lenient.  This should reduce the amount of times we need to
manually update .apkdesc files.  These checks can be tightened as we get
closer to a stable release.