### PR TITLE
[aapt2] Use the aapt2 from `build-tools_r$(XABuildToolsVersion)-{os}.zip`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -115,8 +115,11 @@
       For some reason, the URL for platform-tools/build-tools 30.0.2 is prefixed with what appears to be a GIT commit hash or some other checksum...
       Linux packages don't have any prefix, but this forces us to have *some* mechanism to handle this...
     -->
-    <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">5a6ceea22103d8dec989aefcef309949c0c42f1d.</XABuildToolsPackagePrefix>
-    <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">efbaa277338195608aa4e3dbd43927e97f60218c.</XABuildToolsPackagePrefix>
+    <XABuildToolsPackagePrefixMacOS>5a6ceea22103d8dec989aefcef309949c0c42f1d.</XABuildToolsPackagePrefixMacOS>
+    <XABuildToolsPackagePrefixWindows>efbaa277338195608aa4e3dbd43927e97f60218c.</XABuildToolsPackagePrefixWindows>
+    <XABuildToolsPackagePrefixLinux></XABuildToolsPackagePrefixLinux>
+    <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildToolsPackagePrefixMacOS)</XABuildToolsPackagePrefix>
+    <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
     <XABuildToolsVersion>30.0.2</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">30.0.2</XABuildToolsFolder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">b2be9c80582174e645d3736daa0d44d8610b38a8.</XAPlatformToolsPackagePrefix>

--- a/Documentation/release-notes/5888.md
+++ b/Documentation/release-notes/5888.md
@@ -1,0 +1,46 @@
+#### Application build and deployment
+
+- [GitHub PR #5888](https://github.com/xamarin/xamarin-android/pull/5888):
+  [aapt2] Use the aapt2 from build-tools_r$(XABuildToolsVersion)-{os}.zip.
+  Due to issues with the `aapt2` builds from maven, we are now sourcing
+  the version of `aapt2` we ship from the SDK build-tools on our build machines.
+
+  If you are experiencing endless builds or `aapt2` crashes during a build you
+  can try using `aapt2` from maven.
+
+  1. Windows users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-windows.jar
+
+    macOS users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-osx.jar
+
+  2. Extract the `aapt2-*.jar` file into a "well-known" directory; this location will be used in step (3):
+     * Windows:
+
+        cd %USERPROFILE%
+        mkdir xa-tools
+        cd xa-tools
+        jar xf %USERPROFILE%\Downloads\aapt2-4.0.0-6051327-windows.jar
+
+     * macOS:
+
+        cd
+        mkdir xa-tools
+        cd xa-tools
+        jar xf ~/Downloads/aapt2-4.0.0-6051327-osx.jar
+
+  3. In the same directory as your App's `.csproj`, add or update `Directory.Build.props` to contain:
+
+    ```xml
+    <Project>
+
+      <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+        <Aapt2ToolPath>$(USERPROFILE)\xa-tools</Aapt2ToolPath>
+        <Aapt2ToolExe>aapt2.exe</Aapt2ToolExe>
+      </PropertyGroup>
+
+      <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+        <Aapt2ToolPath>$(HOME)\xa-tools</Aapt2ToolPath>
+        <Aapt2ToolExe>aapt2</Aapt2ToolExe>
+      </PropertyGroup>
+
+    </Project>
+    ```

--- a/Documentation/release-notes/5888.md
+++ b/Documentation/release-notes/5888.md
@@ -1,31 +1,34 @@
 #### Application build and deployment
 
 - [GitHub PR #5888](https://github.com/xamarin/xamarin-android/pull/5888):
-  [aapt2] Use the aapt2 from build-tools_r$(XABuildToolsVersion)-{os}.zip.
+  Use the aapt2 from the Android SDK Build-tools package.
   Due to issues with the `aapt2` builds from maven, we are now sourcing
   the version of `aapt2` we ship from the SDK build-tools on our build machines.
 
   If you are experiencing endless builds or `aapt2` crashes during a build you
-  can try using `aapt2` from maven.
+  can try using the `aapt2` from maven which was used in previous releases.
 
-  1. Windows users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-windows.jar
+  1. Download the `aapt2` package:
 
-    macOS users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-osx.jar
+      * Windows users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-windows.jar
 
-  2. Extract the `aapt2-*.jar` file into a "well-known" directory; this location will be used in step (3):
-     * Windows:
+      * macOS users, download: https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/4.0.0-6051327/aapt2-4.0.0-6051327-osx.jar
 
-        cd %USERPROFILE%
-        mkdir xa-tools
-        cd xa-tools
-        jar xf %USERPROFILE%\Downloads\aapt2-4.0.0-6051327-windows.jar
+  2. Extract the `aapt2-*.jar` file into a "well-known" directory; this location will be used in the next step:
 
-     * macOS:
+      * Windows:
 
-        cd
-        mkdir xa-tools
-        cd xa-tools
-        jar xf ~/Downloads/aapt2-4.0.0-6051327-osx.jar
+            cd %USERPROFILE%
+            mkdir xa-tools
+            cd xa-tools
+            jar xf %USERPROFILE%\Downloads\aapt2-4.0.0-6051327-windows.jar
+
+      * macOS:
+
+            cd
+            mkdir xa-tools
+            cd xa-tools
+            jar xf ~/Downloads/aapt2-4.0.0-6051327-osx.jar
 
   3. In the same directory as your App's `.csproj`, add or update `Directory.Build.props` to contain:
 

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -344,6 +344,11 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public bool MonoArchiveDownloaded { get; set; }
 
+		// <summary>
+		///   Set by <see cref="Step_Get_Android_BuildTools"/> if the archive has been downloaded and validated.
+		/// </summary>
+		public bool BuildToolsArchiveDownloaded { get; set; }
+
 		/// <summary>
 		///   Determines whether or not we are running on a hosted azure pipelines agent.
 		///   These agents have certain limitations, the most pressing being the amount of available storage.

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -49,6 +49,9 @@ namespace Xamarin.Android.Prepare
 		public const string RemapAssemblyRefToolExecutable      = "RemapAssemblyRefToolExecutable";
 		public const string XABuildToolsFolder                  = "XABuildToolsFolder";
 		public const string XABuildToolsVersion                 = "XABuildToolsVersion";
+		public const string XABuildToolsPackagePrefixMacOS      = "XABuildToolsPackagePrefixMacOS";
+		public const string XABuildToolsPackagePrefixWindows    = "XABuildToolsPackagePrefixWindows";
+		public const string XABuildToolsPackagePrefixLinux      = "XABuildToolsPackagePrefixLinux";
 		public const string XABuildToolsPackagePrefix           = "XABuildToolsPackagePrefix";
 		public const string XABinRelativeInstallPrefix          = "XABinRelativeInstallPrefix";
 		public const string XAInstallPrefix                     = "XAInstallPrefix";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -53,6 +53,9 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.RemapAssemblyRefToolExecutable,      StripQuotes (@"@RemapAssemblyRefToolExecutable@"));
 			properties.Add (KnownProperties.XABuildToolsFolder,                  StripQuotes (@"@XABuildToolsFolder@"));
 			properties.Add (KnownProperties.XABuildToolsVersion,                 StripQuotes ("@XABuildToolsVersion@"));
+			properties.Add (KnownProperties.XABuildToolsPackagePrefixMacOS,      StripQuotes ("@XABuildToolsPackagePrefixMacOS@"));
+			properties.Add (KnownProperties.XABuildToolsPackagePrefixWindows,    StripQuotes ("@XABuildToolsPackagePrefixWindows@"));
+			properties.Add (KnownProperties.XABuildToolsPackagePrefixLinux,      StripQuotes ("@XABuildToolsPackagePrefixLinux@"));
 			properties.Add (KnownProperties.XABuildToolsPackagePrefix,           StripQuotes ("@XABuildToolsPackagePrefix@"));
 			properties.Add (KnownProperties.XABinRelativeInstallPrefix,          StripQuotes (@"@XABinRelativeInstallPrefix@"));
 			properties.Add (KnownProperties.XAInstallPrefix,                     StripQuotes (@"@XAInstallPrefix@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -394,6 +394,7 @@ namespace Xamarin.Android.Prepare
 			public static string WindowsBinutilsInstallDir           => GetCachedPath (ref windowsBinutilsInstallDir,           () => Path.Combine (InstallMSBuildDir, "ndk"));
 			public static string HostBinutilsInstallDir              => GetCachedPath (ref hostBinutilsInstallDir,              () => Path.Combine (InstallMSBuildDir, ctx.Properties.GetRequiredValue (KnownProperties.HostOS), "ndk"));
 			public static string BinutilsCacheDir                    => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
+			public static string AndroidBuildToolsCacheDir           => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
 
 			// not really configurables, merely convenience aliases for more frequently used paths that come from properties
 			public static string XAInstallPrefix                => ctx.Properties.GetRequiredValue (KnownProperties.XAInstallPrefix);

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Android.Prepare
 			// directory where the NDK binutils are installed
 			Steps.Add (new Step_InstallGNUBinutils ());
 			Steps.Add (new Step_GenerateCGManifest ());
+			Steps.Add (new Step_Get_Android_BuildTools ());
 
 			AddRequiredOSSpecificSteps (false);
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Net;
+
+namespace Xamarin.Android.Prepare
+{
+	partial class Step_Get_Android_BuildTools : StepWithDownloadProgress
+	{
+		List<(string package, string prefix)> packages = new List<(string package, string prefix)>();
+
+		public Step_Get_Android_BuildTools ()
+			: base ("Downloading build-tools archive")
+		{
+			string XABuildToolsVersion     = Context.Instance.Properties [KnownProperties.XABuildToolsVersion];
+			string XABuildToolsPackagePrefixMacOS = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixMacOS] ?? string.Empty;
+			string XABuildToolsPackagePrefixWindows = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixWindows] ?? string.Empty;
+			string XABuildToolsPackagePrefixLinux = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixLinux] ?? string.Empty;
+
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-macosx.zip", prefix: XABuildToolsPackagePrefixMacOS));
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-windows.zip", prefix: XABuildToolsPackagePrefixWindows));
+			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-linux.zip", prefix: XABuildToolsPackagePrefixLinux));
+		}
+
+		protected override async Task<bool> Execute (Context context)
+		{
+			bool success = true;
+			foreach (var package in packages) {
+				success &= await DownloadBuildToolsPackage (context, package.prefix + package.package, package.package);
+				if (!success) {
+					Log.InfoLine ($"build-tools package '{package.package}' not present");
+					return false;
+				}
+			}
+
+			context.BuildToolsArchiveDownloaded = success;
+			return true;
+		}
+
+		async Task<bool> DownloadBuildToolsPackage (Context context, string packageName, string localPackageName)
+		{
+			string localArchivePath = Path.Combine (Configurables.Paths.AndroidBuildToolsCacheDir, localPackageName);
+			Uri url = new Uri (AndroidToolchain.AndroidUri, packageName);
+
+			if (Utilities.FileExists (localArchivePath)) {
+				Log.StatusLine ($"build-tools already downloaded ({localArchivePath})");
+				return true;
+			}
+
+			Log.StatusLine ($"Downloading {packageName} from ", url.ToString (), tailColor: ConsoleColor.White);
+ 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (url);
+			if (!success) {
+				if (status == HttpStatusCode.NotFound)
+					Log.ErrorLine ("build-tools URL not found");
+				else
+					Log.ErrorLine ("Failed to obtain build-tools size. HTTP status code: {status} ({(int)status})");
+				return false;
+			}
+			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
+			Log.StatusLine ($"  {context.Characters.Link} {url}", ConsoleColor.White);
+			await Download (context, url, localArchivePath, "build-tools", Path.GetFileName (localArchivePath), downloadStatus);
+
+			if (!File.Exists (localArchivePath)) {
+				Log.ErrorLine ($"Download of build-tools from {url} failed");
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -86,6 +86,9 @@
       <Replacement Include="@RemapAssemblyRefToolExecutable@=$(RemapAssemblyRefToolExecutable)" />
       <Replacement Include="@XABuildToolsFolder@=$(XABuildToolsFolder)" />
       <Replacement Include="@XABuildToolsVersion@=$(XABuildToolsVersion)" />
+      <Replacement Include="@XABuildToolsPackagePrefixMacOS@=$(XABuildToolsPackagePrefixMacOS)" />
+      <Replacement Include="@XABuildToolsPackagePrefixWindows@=$(XABuildToolsPackagePrefixWindows)" />
+      <Replacement Include="@XABuildToolsPackagePrefixLinux@=$(XABuildToolsPackagePrefixLinux)" />
       <Replacement Include="@XABuildToolsPackagePrefix@=$(XABuildToolsPackagePrefix)" />
       <Replacement Include="@XAPlatformToolsVersion@=$(XAPlatformToolsVersion)" />
       <Replacement Include="@XAInstallPrefix@=$(XAInstallPrefix)" />

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -7,44 +7,36 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_Aapt2Download Include="aapt2-$(Aapt2Version)-osx.zip">
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-macosx.zip">
       <Platform>osx</Platform>
       <HostOS>Darwin</HostOS>
-    </_Aapt2Download>
-    <_Aapt2Download Include="aapt2-$(Aapt2Version)-linux.zip">
+      <FilesToExtract>aapt2</FilesToExtract>
+    </_BuildTools>
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-linux.zip">
       <Platform>linux</Platform>
       <HostOS>Linux</HostOS>
-    </_Aapt2Download>
-    <_Aapt2Download Include="aapt2-$(Aapt2Version)-windows.zip">
+      <FilesToExtract>aapt2</FilesToExtract>
+    </_BuildTools>
+    <_BuildTools Include="build-tools_r$(XABuildToolsVersion)-windows.zip">
       <Platform>windows</Platform>
       <HostOS></HostOS>
-    </_Aapt2Download>
+      <FilesToExtract>aapt2.exe</FilesToExtract>
+    </_BuildTools>
   </ItemGroup>
 
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
 
-  <Target Name="_DownloadAapt2" BeforeTargets="Build">
-    <ItemGroup>
-      <_DownloadUrl Include="%(_Aapt2Download.Identity)">
-        <Platform>%(_Aapt2Download.Platform)</Platform>
-        <HostOS>%(_Aapt2Download.HostOS)</HostOS>
-        <Url>https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/$(Aapt2Version)/aapt2-$(Aapt2Version)-%(_Aapt2Download.Platform).jar</Url>
-      </_DownloadUrl>
-    </ItemGroup>
-
-    <DownloadUri
-        SourceUris="%(_DownloadUrl.Url)"
-        DestinationFiles="@(_DownloadUrl->'$(AndroidToolchainCacheDirectory)\%(Filename)%(Extension)')"
-    />
+  <Target Name="_ExtractAapt2" BeforeTargets="Build">
     <UnzipDirectoryChildren
-        NoSubdirectory="True"
-        SourceFiles="$(AndroidToolchainCacheDirectory)\%(_DownloadUrl.Filename)%(_DownloadUrl.Extension)"
-        DestinationFolder="$(_Destination)%(_DownloadUrl.HostOS)"
+        NoSubdirectory="False"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)"
+        DestinationFolder="$(_Destination)%(_BuildTools.HostOS)"
+        FilesToExtract="%(_BuildTools.FilesToExtract)"
     />
   </Target>
 
   <Target Name="_CleanAapt2" BeforeTargets="Clean">
-    <Delete Files="@(_Aapt2Download->'$(_Destination)\%(HostOS)')" />
+    <Delete Files="@(_BuildTools->'$(_Destination)\%(HostOS)')" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1288832
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1287930

Commit c9e2d754 had to revert the version of `aapt2` we were shipping
due to issues with older PC's. Specifically a certain type of AMD
processor the AMD Phenom II. That commit simply reverted back to the last
known working version.

This made us think about if getting `aapt2` from maven was the best
idea. We are not 100% sure if the builds on maven even match those
being shipped in the google sdk. So the idea now is to use the one that
google ships with its sdk. However since we will control which version
of the build tools we want to ship we will not be relying on the one
from the users SDK folder. This will make sure we always ship a known
working version of `aapt2` with our product.

The `XABuildToolsVersion` value will be sourced from [Configuration.props](https://github.com/xamarin/xamarin-android/blob/main/Configuration.props#L120).
the `os` value will be `windows`, `linux` or `macosx`.
At the time of this commit the `XABuildToolsVersion` value was 30.0.2.