### PR TITLE
Bump to xamarin/java.interop/main@4d0cba64

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -19,12 +19,15 @@ steps:
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
-- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/${{ parameters.jdkTestFolder }}"
+- script: |
+    echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/${{ parameters.jdkTestFolder }}"
+    echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]$HOME/Library/Android/dotnet/dotnet"
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: |
     echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\${{ parameters.jdkTestFolder }}
+    echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]%USERPROFILE%\android-toolchain\dotnet\dotnet.exe
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -31,7 +31,7 @@ by projects that use the Microsoft.Android framework in .NET 5.
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-netcoreapp3.1\ref\Java.Interop.dll" />
+      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net6.0\ref\Java.Interop.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.Export.dll" />
       <FrameworkListFileClass Include="@(_AndroidRefPackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />

--- a/build-tools/xaprepare/xaprepare/Resources/JdkInfo.Windows.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/JdkInfo.Windows.props.in
@@ -16,5 +16,6 @@
     <JavaCPath Condition=" '$(JavaCPath)' == '' ">@javac@</JavaCPath>
     <JarPath Condition=" '$(JarPath)' == '' ">@jar@</JarPath>
     <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">@javahome@</JavaSdkDirectory>
+    <DotnetToolPath Condition=" '$(DotnetToolPath)' == '' ">@dotnet@</DotnetToolPath>
   </PropertyGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Windows.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Android.Prepare
 			string jdkJvmPath = Path.Combine (javaSdkDirectory, "jre", "bin", "server", "jvm.dll");
 			string jdkIncludePathShared = Path.Combine (javaSdkDirectory, "include");
 			string jdkIncludePathOS = Path.Combine (jdkIncludePathShared, "win32");
+			var dotnetPath = context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewPath);
+			var dotnetTool = Path.Combine (dotnetPath, "dotnet");
 
 			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
 				{ "@JdkJvmPath@",           jdkJvmPath },
@@ -24,6 +26,7 @@ namespace Xamarin.Android.Prepare
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },
 				{ "@javahome@",             context.OS.JavaHome },
+				{ "@dotnet@",               dotnetTool },
 			};
 
 			var step = new GeneratedPlaceholdersFile (

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Unix.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Android.Prepare
 		async Task<bool> ExecuteOSSpecific (Context context)
 		{
 			string javaInteropDir = context.Properties.GetRequiredValue (KnownProperties.JavaInteropFullPath);
+			var dotnetPath = context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewPath);
+			var dotnetTool = Path.Combine (dotnetPath, "dotnet");
+
 			Log.StatusLine ();
 			var make = new MakeRunner (context) {
 				NoParallelJobs = true
@@ -23,6 +26,7 @@ namespace Xamarin.Android.Prepare
 					$"JI_JAVA_HOME={context.OS.JavaHome}",
 					$"JAVA_HOME={context.OS.JavaHome}",
 					$"JI_MAX_JDK={Configurables.Defaults.MaxJDKVersion}",
+					$"DOTNET_TOOL_PATH={dotnetTool}"
 				}
 			);
 			if (!result)
@@ -36,6 +40,7 @@ namespace Xamarin.Android.Prepare
 					$"bin/Build{context.Configuration}/JdkInfo.props",
 					$"CONFIGURATION={context.Configuration}",
 					$"JI_MAX_JDK={Configurables.Defaults.MaxJDKVersion}",
+					$"DOTNET_TOOL_PATH={dotnetTool}"
 				}
 			);
 			return result;

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=netcoreapp3.1" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
 
     <Compile Include="..\Xamarin.Android.Build.Tasks\obj\$(Configuration)\Profile.g.cs" Link="Profile.g.cs" />
 

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -119,6 +119,7 @@ namespace Xamarin.Android.Build
 				xml.Load (reader);
 
 			var toolsets = xml.SelectSingleNode ("configuration/msbuildToolsets/toolset");
+			SetProperty (toolsets, "XABuild", "true"); // Enables MSBuild .targets to check for xabuild
 			SetProperty (toolsets, "VsInstallRoot", paths.VsInstallRoot);
 			SetProperty (toolsets, "MSBuildToolsPath", paths.MSBuildBin);
 			SetProperty (toolsets, "MSBuildToolsPath32", paths.MSBuildBin);


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/df4c5e7c...4d0cba64

Other changes are required here to enable Java.Interop to target `net6.0`.