### PR TITLE
[Mono.Android] Make protected constants interfaces public.

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1643,6 +1643,10 @@
   <attr api-since="31" path="/api/package[@name='android.location']/*[@name='LocationManager']/method[@name='addTestProvider']/parameter[@name='powerUsage']" name="name">powerRequirement</attr>
   <attr api-since="31" path="/api/package[@name='java.math']/*[@name='RoundingMode']/method[@name='valueOf']/parameter[@name='rm']" name="name">mode</attr>
 
+  <!-- These interfaces contain constants users need to reference, but the interfaces are protected, nested in a sealed type. -->
+  <!-- C# won't let you access protected types in a sealed type, so make them public so they can be used by user code. -->
+  <attr api-since="30" path="/api/package[@name='android.provider']/interface[contains(@name, 'Contract.') and contains(@name, 'Columns') and @visibility='protected']" name="visibility">public</attr>
+
   <!--
     ***********************************************************************
     THE FOLLOWING LINES MUST BE CREATED FOR ANY NEW PLATFORM THAT IS ADDED.


### PR DESCRIPTION
Fixes #5868.

These interfaces contain constants that we are pointing users to now that we can support them via DIM.  However in Java they are `protected` interfaces in `sealed` classes.  C# prevents users from accessing `protected` types inside a `sealed` type, so users can't actually use these members.

This commit uses `metadata` to make these interfaces `public` so their members can be used.
```
Android.Provider.CalendarContract/IAttendeesColumns
Android.Provider.CalendarContract/ICalendarAlertsColumns
Android.Provider.CalendarContract/ICalendarCacheColumns
Android.Provider.CalendarContract/ICalendarColumns
Android.Provider.CalendarContract/ICalendarSyncColumns
Android.Provider.CalendarContract/IColorsColumns
Android.Provider.CalendarContract/IEventDaysColumns
Android.Provider.CalendarContract/IEventsColumns
Android.Provider.CalendarContract/IExtendedPropertiesColumns
Android.Provider.CalendarContract/IRemindersColumns
Android.Provider.CalendarContract/ISyncColumns
Android.Provider.ContactsContract/IBaseSyncColumns
Android.Provider.ContactsContract/CommonDataKinds/ICommonColumns
Android.Provider.ContactsContract/IContactNameColumns
Android.Provider.ContactsContract/IContactOptionsColumns
Android.Provider.ContactsContract/IContactStatusColumns
Android.Provider.ContactsContract/IDataColumns
Android.Provider.ContactsContract/IDataUsageStatColumns
Android.Provider.ContactsContract/IDeletedContactsColumns
Android.Provider.ContactsContract/IGroupsColumns
Android.Provider.ContactsContract/IPhoneLookupColumns
Android.Provider.ContactsContract/IPresenceColumns
Android.Provider.ContactsContract/IRawContactsColumns
Android.Provider.ContactsContract/ISettingsColumns
Android.Provider.ContactsContract/IStatusColumns
Android.Provider.ContactsContract/IStreamItemPhotosColumns
Android.Provider.ContactsContract/IStreamItemsColumns
Android.Provider.ContactsContract/ISyncColumns
```

