### PR TITLE
[ci] Uninstall apkdiff before installation

### DIFF
--- a/build-tools/automation/yaml-templates/install-apkdiff.yaml
+++ b/build-tools/automation/yaml-templates/install-apkdiff.yaml
@@ -4,6 +4,11 @@ parameters:
   continueOnError: true
 
 steps:
+- powershell: dotnet tool uninstall apkdiff -g
+  displayName: uninstall apkdiff
+  ignoreLASTEXITCODE: true
+  condition: ${{ parameters.condition }}
+
 - script: dotnet tool update apkdiff --version ${{ parameters.version }} --add-source https://api.nuget.org/v3/index.json -g
   displayName: install apkdiff ${{ parameters.version }}
   condition: ${{ parameters.condition }}


### PR DESCRIPTION
We've been running into issues trying to install an older version of
apkdiff on various machines after bumping the version in a PR.  Avoid
this by always attempting to uninstall apkdiff first.  The uninstall
exit code is ignored as uninstall attempts will error if the tool is not
already installed.