### PR TITLE
[One .NET] remove EnableWorkloadResolver.sentinel

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
@@ -24,9 +24,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public string DotNetPath { get; set; }
 
 		[Required]
-		public string DotNetVersion { get; set; }
-
-		[Required]
 		public string MSIVersion { get; set; }
 
 		public override bool Execute ()
@@ -44,37 +41,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				// Components
 				componentWriter.WriteStartElement ("ComponentGroup");
 				componentWriter.WriteAttributeString ("Id", "ProductComponents");
-				componentWriter.WriteStartElement ("ComponentRef");
-				componentWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
-				componentWriter.WriteEndElement (); // </ComponentRef>
 
 				// dotnet
 				packWriter.WriteStartElement ("Directory");
 				packWriter.WriteAttributeString ("Id", "dotnet");
 				packWriter.WriteAttributeString ("Name", "dotnet");
-
-				// sdk
-				packWriter.WriteStartElement ("Directory");
-				packWriter.WriteAttributeString ("Id", "sdk");
-				packWriter.WriteAttributeString ("Name", "sdk");
-
-				// DOTNETVERSION
-				packWriter.WriteStartElement ("Directory");
-				packWriter.WriteAttributeString ("Id", "DOTNETVERSION");
-				packWriter.WriteAttributeString ("Name", DotNetVersion);
-				packWriter.WriteAttributeString ("FileSource", Path.Combine (DotNetPath, "sdk", DotNetVersion));
-
-				// EnableWorkloadResolver
-				packWriter.WriteStartElement ("Component");
-				packWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
-				packWriter.WriteStartElement ("File");
-				packWriter.WriteAttributeString ("Id", "EnableWorkloadResolver");
-				packWriter.WriteAttributeString ("Name", "EnableWorkloadResolver.sentinel");
-				packWriter.WriteAttributeString ("KeyPath", "yes");
-				packWriter.WriteEndElement (); // </File>
-				packWriter.WriteEndElement (); // </Component>
-				packWriter.WriteEndElement (); // </Directory> DOTNETVERSION
-				packWriter.WriteEndElement (); // </Directory> sdk
 
 				// sdk-manifests
 				var sdk_manifests_root = Path.Combine (DotNetPath, "sdk-manifests");

--- a/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
+++ b/build-tools/create-dotnet-msi/create-dotnet-msi.csproj
@@ -74,7 +74,6 @@
         Template="$(_WixTemplate)"
         DestinationFile="$(_WixFile)"
         DotNetPath="$(DotNetPreviewPath)"
-        DotNetVersion="$(MicrosoftDotnetSdkInternalPackageVersion)"
         MSIVersion="$(AndroidMSIVersion)"
     />
     <ItemGroup>

--- a/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
+++ b/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
@@ -38,7 +38,6 @@
       <DotNetPayloadDir>$(PayloadDir)\usr\local\share\dotnet\</DotNetPayloadDir>
     </PropertyGroup>
     <ItemGroup>
-      <_FilesToCopy Include="$(DotNetPreviewPath)\sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\EnableWorkloadResolver.sentinel" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Sdk.Android\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Ref\**\*" />
       <_FilesToCopy Include="$(DotNetPreviewPath)\packs\Microsoft.Android.Sdk.Darwin\**\*" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -13,7 +13,6 @@
 
   <PropertyGroup>
     <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0\</_MonoAndroidNETOutputDir>
-    <_WorkloadResolverFlagFile>$(DotNetPreviewPath)sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\EnableWorkloadResolver.sentinel</_WorkloadResolverFlagFile>
   </PropertyGroup>
 
   <!-- LICENSE setup -->
@@ -133,11 +132,6 @@
     />
     <!-- Some files had timestamps in the future -->
     <Touch Files="@(_FilesToTouch)" />
-    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName ($(_WorkloadResolverFlagFile)))" />
-    <Touch
-        Files="$(_WorkloadResolverFlagFile)"
-        AlwaysCreate="true"
-    />
   </Target>
 
   <Target Name="DeleteExtractedWorkloadPacks" >
@@ -148,7 +142,6 @@
       <_PackFilesToDelete Include="$(DotNetPreviewPath)template-packs\Microsoft.Android.Templates.*.nupkg" />
     </ItemGroup>
     <RemoveDir Directories="%(_PackFilesToDelete.RootDir)%(_PackFilesToDelete.Directory)" />
-    <Delete Files="$(_WorkloadResolverFlagFile)" />
   </Target>
 
   <Target Name="PushManifestToBuildAssetRegistry" >


### PR DESCRIPTION
This feature flag is now on by default in .NET 6.0.100-preview.4.21253.14 and higher.

We should stop generating `EnableWorkloadResolver.sentinel`, as it strongly ties our installers to a specific version of the .NET SDK.