### PR TITLE
Preload System.Security.Cryptography.Native.OpenSsl on startup

### DIFF
--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -82,6 +82,10 @@ public class MonoPackageManager {
 				if (!BuildConfig.DotNetRuntime) {
 					// .net5+ APKs don't contain `libmono-native.so`
 					System.loadLibrary("mono-native");
+				} else {
+					// for .net6 we temporarily need to load the SSL DSO
+					// see: https://github.com/dotnet/runtime/issues/51274#issuecomment-832963657
+					System.loadLibrary("System.Security.Cryptography.Native.OpenSsl");
 				}
 
 				System.loadLibrary("monodroid");


### PR DESCRIPTION
Work around for https://github.com/dotnet/runtime/issues/51274 which
will be removed before NET6 release.