### PR TITLE
[One .NET] $(AndroidEnablePreloadAssemblies)=False by default (#5790)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3938,7 +3938,11 @@ namespace UnnamedProject
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var environment = b.Output.GetIntermediaryPath (Path.Combine ("__environment__.txt"));
 				FileAssert.Exists (environment);
-				Assert.AreEqual ($"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}", File.ReadAllText (environment).Trim ());
+				if (Builder.UseDotNet) {
+					Assert.AreEqual ($"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}{Environment.NewLine}mono.enable_assembly_preload=0", File.ReadAllText (environment).Trim ());
+				} else {
+					Assert.AreEqual ($"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}", File.ReadAllText (environment).Trim ());
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -291,7 +291,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
 
 	<!-- If true it will cause all the assemblies in the apk to be preloaded on startup time -->
-        <_AndroidEnablePreloadAssembliesDefault>True</_AndroidEnablePreloadAssembliesDefault>
+	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' == 'true' ">False</_AndroidEnablePreloadAssembliesDefault>
+	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' != 'true' ">True</_AndroidEnablePreloadAssembliesDefault>
 	<AndroidEnablePreloadAssemblies Condition=" '$(AndroidEnablePreloadAssemblies)' == '' ">$(_AndroidEnablePreloadAssembliesDefault)</AndroidEnablePreloadAssemblies>
 	<_NativeAssemblySourceDir>$(IntermediateOutputPath)android\</_NativeAssemblySourceDir>
 	<_AndroidUseNewTypemaps>True</_AndroidUseNewTypemaps>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5838
Context: e0da1f152de84c4cc39983f2fda775ec98c08250

Partially reverts 522d7fb61f3669d85d077ba4f2889dbe8c9c8ac3 which
reverted d13d0f972a4eb663251b2a6b5a934c59a6789db1

The [`$(AndroidEnablePreloadAssemblies)`][0] property controls
whether or not *all* `.dll` files contained within a `.apk` are
loaded during process startup.  *Not* doing so reduces process
startup times, which is desirable, but this also caused certain
Xamarin.Forms apps to fail to run as they previously had, as
not loading all assemblies during startup broke their
Dependency Injection infrastructure.

For .NET 6, we feel we have *some* "wiggle-room" to change default
semantics, so for .NET 6 projects set the default value of
`$(AndroidEnablePreloadAssemblies)` to False, so that assemblies are
*not* pre-loaded during process startup.

`$(AndroidEnablePreloadAssemblies)` can be set to True within the
app's `.csproj` file to return to "legacy" semantics.  This will
cause all assemblies to be loaded during startup, with a
commensurate increase in app startup overheads.

[0]: https://docs.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-properties#androidenablepreloadassemblies