### PR TITLE
[tests] delete workload manifest folder from main

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -150,6 +150,7 @@
     <ItemGroup>
       <_PackFilesToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.Android.Workload\**\*.*" />
       <_PackFilesToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Workload.Android\**\*.*" />
+      <_PackFilesToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\Microsoft.NET.Sdk.Android\**\*.*" />
       <_PackFilesToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android*\**\*.*" />
       <_PackFilesToDelete Include="$(DotNetPreviewPath)template-packs\Microsoft.Android.Templates.*.nupkg" />
     </ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4728381&view=ms.vss-test-web.build-test-results-tab&runId=21435278&resultId=100052&paneView=attachments

Since 5400522d, if a previous CI machine runs a build from `main`
followed by `release/6.0.1xx-preview4`, it could encounter the error:

    UnnamedProject.csproj: warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. An item with the same key has already been added. Key: microsoft-android-sdk-full
    Microsoft.NET.Sdk.ImportWorkloads.props(14,3): warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. An item with the same key has already been added. Key: microsoft-android-sdk-full
    Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4236: The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found.

This could happen if both directories exist:

    dotnet/sdk-manifest/6.0.100/Microsoft.NET.Workload.Android
    dotnet/sdk-manifest/6.0.100/Microsoft.NET.Sdk.Android

Which would define the same Android workload twice.

There might be a more comprehensive solution here going forward, but
this should at least fix builds on our release branch for .NET 6
Preview 4.