### PR TITLE
[xaprepare] better cleanup past .NET 6 installs

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -24,9 +24,26 @@ namespace Xamarin.Android.Prepare
 			// Delete any custom Microsoft.Android packs that may have been installed by test runs. Other ref/runtime packs will be ignored.
 			var packsPath = Path.Combine (dotnetPath, "packs");
 			if (Directory.Exists (packsPath)) {
-				foreach (var packToRemove in Directory.EnumerateDirectories (packsPath).Where (p => new DirectoryInfo (p).Name.Contains ("Android"))) {
-					Log.StatusLine ($"Removing Android pack: {packToRemove}");
-					Utilities.DeleteDirectory (packToRemove);
+				foreach (var packToRemove in Directory.EnumerateDirectories (packsPath)) {
+					var info = new DirectoryInfo (packToRemove);
+					if (info.Name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
+						Log.StatusLine ($"Removing Android pack: {packToRemove}");
+						Utilities.DeleteDirectory (packToRemove);
+					}
+				}
+			}
+
+			// Delete Workload manifests, such as sdk-manifests/6.0.100/Microsoft.NET.Sdk.Android
+			var sdkManifestsPath = Path.Combine (dotnetPath, "sdk-manifests");
+			if (Directory.Exists (sdkManifestsPath)) {
+				foreach (var versionBand in Directory.EnumerateDirectories (sdkManifestsPath)) {
+					foreach (var workloadManifestDirectory in Directory.EnumerateDirectories (versionBand)) {
+						var info = new DirectoryInfo (workloadManifestDirectory);
+						if (info.Name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
+							Log.StatusLine ($"Removing Android manifest directory: {workloadManifestDirectory}");
+							Utilities.DeleteDirectory (workloadManifestDirectory);
+						}
+					}
 				}
 			}
 
@@ -36,6 +53,18 @@ namespace Xamarin.Android.Prepare
 				foreach (var sdkToRemove in Directory.EnumerateDirectories (sdkPath).Where (s => new DirectoryInfo (s).Name != dotnetPreviewVersion)) {
 					Log.StatusLine ($"Removing out of date SDK: {sdkToRemove}");
 					Utilities.DeleteDirectory (sdkToRemove);
+				}
+			}
+
+			// Delete Android template-packs
+			var templatePacksPath = Path.Combine (dotnetPath, "template-packs");
+			if (Directory.Exists (templatePacksPath)) {
+				foreach (var templateToRemove in Directory.EnumerateFiles (templatePacksPath)) {
+					var name = Path.GetFileName (templateToRemove);
+					if (name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
+						Log.StatusLine ($"Removing Android template: {templateToRemove}");
+						Utilities.DeleteFile (templateToRemove);
+					}
 				}
 			}
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4728381&view=ms.vss-test-web.build-test-results-tab&runId=21435278&resultId=100052&paneView=attachments

CI on some of our release branches is failing with errors such as:

    UnnamedProject.csproj: warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. An item with the same key has already been added. Key: microsoft-android-sdk-full
    Microsoft.NET.Sdk.ImportWorkloads.props(14,3): warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. An item with the same key has already been added. Key: microsoft-android-sdk-full
    Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4236: The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found.

This could happen if both directories exist:

    dotnet/sdk-manifest/6.0.100/Microsoft.NET.Workload.Android
    dotnet/sdk-manifest/6.0.100/Microsoft.NET.Sdk.Android

Which would define the same Android workload twice.

xaprepare was setup to clean certain folders in
`$(AndroidToolchainDirectory)\dotnet`, but also needs to delete:

* `sdk-manifests/6.0.100/*Android*`
* `template-packs/*Android*`

I also changed some of the string comparisons to use
`StringComparison.OrdinalIgnoreCase`.