### PR TITLE
Bump to cmdline-tools 4.0, fix lint errors

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -159,8 +159,8 @@
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
     <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
-    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">1.0</CommandLineToolsFolder>
-    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">6200805_latest</CommandLineToolsVersion>
+    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">4.0</CommandLineToolsFolder>
+    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">7302050_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
     <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">7033400</EmulatorVersion>
     <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">30.3.5</EmulatorPkgRevision>

--- a/Configuration.props
+++ b/Configuration.props
@@ -155,6 +155,7 @@
   <PropertyGroup>
     <AdbToolPath Condition=" '$(AdbToolPath)' == '' ">$(AndroidSdkFullPath)\platform-tools\</AdbToolPath>
     <AdbToolExe Condition=" '$(AdbToolExe)' == '' ">adb</AdbToolExe>
+    <AvdManagerHome Condition=" '$(AvdManagerHome)' == '' ">$(AndroidToolchainDirectory)</AvdManagerHome>
     <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' ">avdmanager</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Threading;
-
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -11,180 +9,147 @@ using Xamarin.Android.BuildTools.PrepTasks;
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
-	public class CreateAndroidEmulator : Task
+	public class CreateAndroidEmulator : ToolTask
 	{
 		public                  string          SdkVersion      {get; set;}
 		public                  string          AndroidAbi      {get; set;}
 		public                  string          AndroidSdkHome  {get; set;}
 		public                  string          JavaSdkHome     {get; set;}
 
-		public                  string          ToolPath        {get; set;}
-		public                  string          ToolExe         {get; set;}
-
 		public                  string          TargetId        {get; set;}
 
 		public                  string          ImageName           {get; set;} = "XamarinAndroidTestRunner64";
+		public                  string          DeviceName          {get; set;} = "pixel_4";
 
 		public                  string          DataPartitionSizeMB {get; set;} = "2048";
 		public                  string          RamSizeMB           {get; set;} = "2048";
 
+		protected override string ToolName => "avdmanager";
 
 		public override bool Execute ()
 		{
-			if (string.IsNullOrEmpty (TargetId) && !string.IsNullOrEmpty (SdkVersion)) {
-				TargetId    = "system-images;android-" + SdkVersion + ";default;" + AndroidAbi;
+			var dirs = string.IsNullOrEmpty (ToolPath)
+				? null
+				: new [] { ToolPath };
+			var path = Which.GetProgramLocation (ToolExe ?? ToolName, out var filename, dirs);
+			if (path == null) {
+				Log.LogError ($"Could not find `avdmanager`. Please set the `{nameof (CreateAndroidEmulator)}.{nameof (ToolPath)}` property appropriately.");
+				return false;
 			}
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (CreateAndroidEmulator)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidAbi)}: {AndroidAbi}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdkHome)}: {AndroidSdkHome}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (JavaSdkHome)}: {JavaSdkHome}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (ImageName)}: {ImageName}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (SdkVersion)}: {SdkVersion}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (TargetId)}: {TargetId}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (ToolExe)}: {ToolExe}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (ToolPath)}: {ToolPath}");
+			ToolExe = filename;
 
-			Run (GetAndroidPath ());
+			if (string.IsNullOrEmpty (TargetId) && !string.IsNullOrEmpty (SdkVersion)) {
+				TargetId = "system-images;android-" + SdkVersion + ";default;" + AndroidAbi;
+			}
+
+			base.Execute ();
+
+			if (Log.HasLoggedErrors)
+				return false;
+
+			var configPaths = new [] {
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".android", "avd", $"{ImageName}.avd", "config.ini"),
+				Path.Combine (AndroidSdkHome, ".android", "avd", $"{ImageName}.avd", "config.ini")
+			};
+
+			foreach (var configPath in configPaths) {
+				if (File.Exists (configPath)) {
+					Log.LogMessage ($"Config file for AVD '{ImageName}' found at {configPath}");
+					WriteConfigFile (configPath);
+					return !Log.HasLoggedErrors;
+				}
+			}
+
+			Log.LogWarning ($"AVD '{ImageName}' will use default emulator settings (memory and data partition size)");
 
 			return !Log.HasLoggedErrors;
 		}
 
-		string GetAndroidPath ()
+		void WriteConfigFile (string configPath)
 		{
-			if (string.IsNullOrEmpty (ToolExe))
-				ToolExe = "avdmanager";
-
-			var dirs = string.IsNullOrEmpty (ToolPath)
-				? null
-				: new [] { ToolPath };
-			string filename;
-			var path = Which.GetProgramLocation (ToolExe, out filename, dirs);
-			if (path == null) {
-				Log.LogError ($"Could not find `avdmanager`. Please set the `{nameof (CreateAndroidEmulator)}.{nameof (ToolPath)}` property appropriately.");
-				return null;
-			}
-			return path;
-		}
-
-		void Run (string android)
-		{
-			if (android == null)
-				return;
-
-			var arguments   = $"create avd --abi {AndroidAbi} -f -n {ImageName} --package \"{TargetId}\"";
-			Exec (android, arguments);
-
-			string configPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".android", "avd", $"{ImageName}.avd", "config.ini");
-			if (!File.Exists (configPath)) {
-				Log.LogWarning ($"Config file for AVD '{ImageName}' not found at {configPath}");
-				Log.LogWarning ($"AVD '{ImageName}' will use default emulator settings (memory and data partition size)");
-				return;
-			}
-
-			ulong diskSize;
-			if (!UInt64.TryParse (DataPartitionSizeMB, out diskSize))
+			if (!ulong.TryParse (DataPartitionSizeMB, out var diskSize))
 				Log.LogError ($"Invalid data partition size '{DataPartitionSizeMB}' - must be a positive integer value expressing size in megabytes");
 
-			ulong ramSize;
-			if (!UInt64.TryParse (RamSizeMB, out ramSize))
+			if (!ulong.TryParse (RamSizeMB, out var ramSize))
 				Log.LogError ($"Invalid RAM size '{RamSizeMB}' - must be a positive integer value expressing size in megabytes");
 
 			if (Log.HasLoggedErrors)
 				return;
 
-			File.AppendAllLines (configPath, new string[] {
-				$"disk.dataPartition.size={diskSize}M",
-				$"hw.ramSize={ramSize}"
-			});
-		}
-
-		StreamWriter stdin;
-
-		void Exec (string android, string arguments, DataReceivedEventHandler stderr = null)
-		{
-			Log.LogMessage (MessageImportance.Low, $"Tool {android} execution started with arguments: {arguments}");
-			var psi = new ProcessStartInfo () {
-				FileName                = android,
-				Arguments               = arguments,
-				UseShellExecute         = false,
-				RedirectStandardInput   = true,
-				RedirectStandardOutput  = false,
-				RedirectStandardError   = true,
-				CreateNoWindow          = true,
-				WindowStyle             = ProcessWindowStyle.Hidden,
-			};
-			Log.LogMessage (MessageImportance.Low, $"Environment variables being passed to the tool:");
-			if (!string.IsNullOrEmpty (AndroidSdkHome)) {
-				psi.EnvironmentVariables ["ANDROID_SDK_HOME"] = AndroidSdkHome;
-				Log.LogMessage (MessageImportance.Low, $"\tANDROID_SDK_HOME=\"{AndroidSdkHome}\"");
-			}
-			if (!string.IsNullOrEmpty (JavaSdkHome)) {
-				psi.EnvironmentVariables ["JAVA_HOME"] = JavaSdkHome;
-				Log.LogMessage (MessageImportance.Low, $"\tJAVA_HOME=\"{JavaSdkHome}\"");
-			}
-
-			var stderr_completed = new ManualResetEvent (false);
-
-			var p = new Process () {
-				StartInfo   = psi,
+			var values = new [] {
+				new ConfigValue {
+					Key = "disk.dataPartition.size=",
+					Value = diskSize,
+					Suffix = "M",
+				},
+				new ConfigValue {
+					Key = "hw.ramSize=",
+					Value = ramSize,
+				}
 			};
 
-			stderr  = stderr ?? DefaultErrorHandler;
-			p.ErrorDataReceived     += stderr;
-			p.ErrorDataReceived     += (sender, e) => {
-				if (e.Data == null)
-					stderr_completed.Set ();
-			};
-
-			using (p) {
-				p.StartInfo = psi;
-				p.Start ();
-				p.BeginErrorReadLine ();
-				stdin = p.StandardInput;
-
-				// Relying on HasExited is racy, but we have no choice here since we need to tell
-				// avdmanager that we want to proceed in creation of the AVD by answering its question
-				// on whether to create a custom hardware profile with "Enter"...
-				while (!p.HasExited) {
-					try {
-						stdin.WriteLine ();
-					} catch (IOException ex) {
-						Log.LogWarning ($"Failed to write the {android} process stdin. The process has probably already exited. {ex.Message}");
+			var lines = new List<string> ();
+			using (var reader = File.OpenText (configPath)) {
+				while (!reader.EndOfStream) {
+					var line = reader.ReadLine ();
+					foreach (var value in values) {
+						if (line == value.ToString ()) {
+							value.Set = true;
+							Log.LogMessage (MessageImportance.Low, $"Value already present: {line}");
+						} else if (line.StartsWith (value.Key, StringComparison.OrdinalIgnoreCase)) {
+							continue;
+						}
 					}
-
-					// Exit early if `true` is returned. It is possible that even though the process
-					// exited, the `HasExited` property will still return `false` and thus trigger
-					// exception from writing stdin of the process which has just exited. This
-					// doesn't remove the race but makes it slightly less probable
-					if (p.WaitForExit (1000))
-						break;
-				}
-
-				// We need to call the parameter-less WaitForExit only if any of the standard
-				// streams have been redirected (see
-				// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.7.2#System_Diagnostics_Process_WaitForExit)
-				//
-				p.WaitForExit ();
-				stderr_completed.WaitOne (TimeSpan.FromSeconds (60));
-				if (p.ExitCode != 0) {
-					Log.LogError ($"Process `{android}` exited with value {p.ExitCode}.");
+					lines.Add (line);
 				}
 			}
-		}
 
-		bool inWarning = false;
-
-		void DefaultErrorHandler (object sender, DataReceivedEventArgs e)
-		{
-			if (string.IsNullOrEmpty (e.Data)) {
-				inWarning = false;
+			var append = values.Where (v => !v.Set);
+			if (!append.Any ()) {
+				Log.LogMessage (MessageImportance.Low, $"Skip writing file: {configPath}");
 				return;
 			}
-			if (e.Data.StartsWith ("Warning:", StringComparison.Ordinal) || inWarning) {
-				Log.LogMessage ($"{e.Data}");
-				inWarning = true;
-			} else {
-				Log.LogError ($"{e.Data}");
+
+			lines.AddRange (append.Select (v => v.ToString ()));
+			File.WriteAllLines (configPath, lines);
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			var cmd = new CommandLineBuilder ();
+			cmd.AppendSwitch ("create avd");
+			cmd.AppendSwitchIfNotNull ("--abi ", AndroidAbi);
+			cmd.AppendSwitch ("--force");
+			cmd.AppendSwitchIfNotNull ("--name ", ImageName);
+			cmd.AppendSwitchIfNotNull ("--package ", TargetId);
+			cmd.AppendSwitchIfNotNull ("--device ", DeviceName);
+			return cmd.ToString ();
+		}
+
+		protected override string GenerateFullPathToTool () => Path.Combine (ToolPath, ToolExe);
+
+		class ConfigValue
+		{
+			/// <summary>
+			/// Key including the `=` symbol
+			/// </summary>
+			public string Key { get; set; }
+
+			public ulong Value { get; set; }
+
+			/// <summary>
+			/// Set to true if the file contains this value
+			/// </summary>
+			public bool Set { get; set; }
+
+			/// <summary>
+			/// Optional suffix such as `M`
+			/// </summary>
+			public string Suffix { get; set; } = "";
+
+			public override string ToString ()
+			{
+				return $"{Key}{Value}{Suffix}";
 			}
 		}
 	}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -17,7 +17,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Output]
 		public                  int             EmulatorProcessId       {get; set;}
 
-		public                  string          AndroidSdkHome  {get; set;}
+		/// <summary>
+		/// Specifies $ANDROID_SDK_HOME. This is not the path to the Android SDK, but a root folder that contains the `.android` folder.
+		/// </summary>
+		[Required]
+		public                  string          AvdManagerHome  {get; set;}
 		public                  string          Port            {get; set;}
 		public                  string          ImageName       {get; set;} = "XamarinAndroidTestRunner64";
 		public			string		Arguments	{get; set;}
@@ -26,11 +30,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public override bool Execute ()
 		{
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (StartAndroidEmulator)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdkHome)}: {AndroidSdkHome}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (ImageName)}: {ImageName}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (Port)}: {Port}");
-
 			Run (GetEmulatorPath ());
 
 			if (!string.IsNullOrEmpty (Port)) {
@@ -79,10 +78,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			var p = new Process () {
 				StartInfo = psi,
 			};
-			if (!string.IsNullOrEmpty (AndroidSdkHome)) {
-				psi.EnvironmentVariables ["ANDROID_HOME"] = AndroidSdkHome;
-				Log.LogMessage (MessageImportance.Low, $"\tANDROID_HOME=\"{AndroidSdkHome}\"");
-			}
+			psi.EnvironmentVariables ["ANDROID_SDK_HOME"] = AvdManagerHome;
+			Log.LogMessage (MessageImportance.Low, $"\tANDROID_SDK_HOME=\"{AvdManagerHome}\"");
 
 			var sawError        = new AutoResetEvent (false);
 

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -52,7 +52,7 @@
     <CreateAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         AndroidAbi="$(TestAvdAbi)"
-        AndroidSdkHome="$(AndroidSdkDirectory)"
+        AvdManagerHome="$(AvdManagerHome)"
         JavaSdkHome="$(JavaSdkDirectory)"
         SdkVersion="$(TestAvdApiLevel)"
         TargetId="$(SdkManagerImageName)"
@@ -64,7 +64,7 @@
     />
     <StartAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "
-        AndroidSdkHome="$(AndroidSdkDirectory)"
+        AvdManagerHome="$(AvdManagerHome)"
         Arguments="$(TestEmulatorArguments)"
         ImageName="$(TestAvdName)"
         Port="$(_AdbEmulatorPort)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -185,6 +185,10 @@ namespace Xamarin.Android.Tasks
 			// MonoPackageManager.java causes this warning to be emitted.
 			// This is by design so we can safely ignore this.
 			{ "ObsoleteSdkInt", new Version (26, 1, 1) },
+			// In cmdline-tools/4.0 and LintVersion=4.2.0 we started seeing errors such as:
+			// obj/Debug/android/AndroidManifest.xml(12,89): error XA0103: MainActivity must extend android.app.Activity [Instantiatable]
+			// obj/Debug/android/AndroidManifest.xml(18,28): error XA0103: MonoRuntimeProvider must extend android.content.ContentProvider [Instantiatable]
+			{ "Instantiatable", new Version (4, 2, 0) },
 		};
 
 		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)", RegexOptions.Compiled);


### PR DESCRIPTION
Context: https://dl-ssl.google.com/android/repository/repository2-1.xml

We were seeing some lint-related MSBuild tests fail with:

    Lint
        Parameters
            ToolPath = /Users/runner/Library/Android/sdk/cmdline-tools/latest/bin
        ...
        LintVersion: 4.2.0
        Environment Variables passed to tool:
        JAVA_HOME=/Users/runner/Library/Android/jdk-11/
        ...
        Errors
            obj/Debug/android/AndroidManifest.xml(12,89): error XA0103:  MainActivity must extend android.app.Activity [Instantiatable] [/Users/runner/work/1/s/bin/TestRelease/temp/CheckLintConfigMerging/UnnamedProject.csproj]
            obj/Debug/android/AndroidManifest.xml(18,28): error XA0103:  MonoRuntimeProvider must extend android.content.ContentProvider [Instantiatable] [/Users/runner/work/1/s/bin/TestRelease/temp/CheckLintConfigMerging/UnnamedProject.csproj]
        2 errors, 3 warnings
        The command exited with code -1.

We suspect the Hosted Agent pool was updated to install
`cmdline-tools` 4.0 in ~/Library/Android/sdk/cmdline-tools/latest and
cause this problem:

https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#android

After updating locally to `cmdline-tools` 4.0 I can reproduce the issue.

I also updated the `<Lint/>` MSBuild task to ignore the
`Instantiatable` error for now.

After this change, emulators failed to start:

    Task CreateAndroidEmulator
    ...
    build-tools/scripts/TestApks.targets(52,5): Config file for AVD 'XamarinAndroidTestRunner29-x86_64' not found at /Users/runner/.android/avd/XamarinAndroidTestRunner29-x86_64.avd/config.ini [/Users/runner/work/1/s/tests/Mono.Android-Tests/Mono.Android-Tests.csproj]
    build-tools/scripts/TestApks.targets(52,5): AVD 'XamarinAndroidTestRunner29-x86_64' will use default emulator settings (memory and data partition size) [/Users/runner/work/1/s/tests/Mono.Android-Tests/Mono.Android-Tests.csproj]
    ...
    Task StartAndroidEmulator
    ...
    build-tools/scripts/TestApks.targets(65,5): Emulator failed to start: emulator: ERROR: Unknown AVD name [XamarinAndroidTestRunner29-x86_64], use -list-avds to see valid list. [/Users/runner/work/1/s/tests/Mono.Android-Tests/Mono.Android-Tests.csproj]

It appears the code in the `<CreateAndroidEmulator/>` MSBuild task
that attempts to pass `\n` to stdin is no longer working?

`avdmanager` prompts with:

    Do you wish to create a custom hardware profile? [no]

I found that if you pass `--device pixel_4`, for example, then
`avdmanager` does not prompt at all. I think we should select a
default device, so we don't have to work with stdin at all.

I converted `<CreateAndroidEmulator/>` to a regular `ToolTask` and
passed `--device`. The command appears to work properly now.