### PR TITLE
[monodroid] MonoVM initialization without pointer parsing

### DIFF
--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -38,9 +38,6 @@
 
 #include <mono/jit/mono-private-unstable.h>
 #include <mono/metadata/mono-private-unstable.h>
-
-// This should be defined in the public Mono headers
-typedef void * (*PInvokeOverrideFn) (const char *libraryName, const char *entrypointName);
 #endif
 
 namespace xamarin::android::internal
@@ -307,6 +304,7 @@ namespace xamarin::android::internal
 		static std::mutex             pinvoke_map_write_lock;
 		static pinvoke_api_map        xa_pinvoke_map;
 		static pinvoke_library_map    other_pinvoke_map;
+		static MonoCoreRuntimeProperties monovm_core_properties;
 #else // def NET6
 		static std::mutex   api_init_lock;
 		static void        *api_dso_handle;

--- a/src/monodroid/jni/monovm-properties.hh
+++ b/src/monodroid/jni/monovm-properties.hh
@@ -9,35 +9,42 @@ namespace xamarin::android::internal
 {
 	class MonoVMProperties final
 	{
-		constexpr static size_t PROPERTY_COUNT = 1;
-
-		constexpr static char PINVOKE_OVERRIDE_KEY[] = "PINVOKE_OVERRIDE";
-		constexpr static size_t PINVOKE_OVERRIDE_INDEX = 0;
+		constexpr static size_t PROPERTY_COUNT = 0;
 
 		using property_array = const char*[PROPERTY_COUNT];
 
 	public:
-		explicit MonoVMProperties (PInvokeOverrideFn pinvoke_override_cb)
+		explicit MonoVMProperties ()
 		{
 			static_assert (PROPERTY_COUNT == N_PROPERTY_KEYS);
 			static_assert (PROPERTY_COUNT == N_PROPERTY_VALUES);
-
-			snprintf (ptr_str, sizeof(ptr_str), "%p", pinvoke_override_cb);
 		}
 
 		int property_count () const
 		{
-			return _property_count;
+			if constexpr (PROPERTY_COUNT != 0) {
+				return _property_count;
+			} else {
+				return 0;
+			}
 		}
 
 		const char* const* property_keys () const
 		{
-			return _property_keys;
+			if constexpr (PROPERTY_COUNT != 0) {
+				return _property_keys;
+			} else {
+				return nullptr;
+			}
 		}
 
 		const char* const* property_values () const
 		{
-			return _property_values;
+			if constexpr (PROPERTY_COUNT != 0) {
+				return _property_values;
+			} else {
+				return nullptr;
+			}
 		}
 
 	private:
@@ -51,18 +58,13 @@ namespace xamarin::android::internal
 		}
 
 	private:
-		property_array _property_keys = {
-			PINVOKE_OVERRIDE_KEY,
-		};
+		property_array _property_keys = {};
 		constexpr static size_t N_PROPERTY_KEYS = sizeof(_property_keys) / sizeof(const char*);
 
-		property_array _property_values = {
-			ptr_str,
-		};
+		property_array _property_values = {};
 		constexpr static size_t N_PROPERTY_VALUES = sizeof(_property_values) / sizeof(const char*);
 
-		int _property_count = 1;
-		char ptr_str[20];
+		int _property_count = 0;
 	};
 }
 #endif // def NET6


### PR DESCRIPTION
Context: 0cd890bdf7fb0255f11d8c14e3de69c9e2691117

0cd890bd added code to initialize NET6 MonoVM using its new
`monovm_initialize` API which accepts a number of key-value string
properties, parsed by the runtime in order to configure various areas of
the VM.  One of these properties is `PINVOKE_OVERRIDE`, a new way to
resolve p/invoke calls which, at the time of 0cd890bd, required
converting pointer to a callback function to a string, which would then
be parsed by `monovm_initialize` back into a pointer.

This commit removes the need for parsing by using new MonoVM
initialization function, `monovm_initialize_preparsed`, which takes a
typesafe struct of runtime initialization arguments, including a "real"
pointer to the `PINVOKE_OVERRIDE` callback function.

The new initialization routine still accepts the key-value properties
but, at this point, we pass no additional properties using this
mechanism (the class that handles them is kept around since it is
possible we'll use it once `runtimeconfig.json` support lands)