### PR TITLE
[Mono.Android] Bind API-S Beta 1.

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-28_r04",   apiLevel: "28", pkgRevision: "4"),
 				new AndroidPlatformComponent ("platform-29_r01",   apiLevel: "29", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-S_r03",    apiLevel: "S",  pkgRevision: "3"),
+				new AndroidPlatformComponent ("platform-S_r04",    apiLevel: "S",  pkgRevision: "4"),
 
 				new AndroidToolchainComponent ("sources-30_r01",   destDir: Path.Combine ("platforms", $"android-30", "src"), pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1650,6 +1650,7 @@
   <attr api-since="31" path="/api/package[@name='android.net.ipsec.ike']" name="managedName">Android.Net.IpSec.Ike</attr>
   <attr api-since="31" path="/api/package[@name='android.net.ipsec.ike.exceptions']" name="managedName">Android.Net.IpSec.Ike.Exceptions</attr>
   <attr api-since="31" path="/api/package[@name='android.view.displayhash']" name="managedName">Android.Views.DisplayHash</attr>
+  <attr api-since="31" path="/api/package[@name='android.view.translation']" name="managedName">Android.Views.Translation</attr>
 
   <!-- These interfaces contain constants users need to reference, but the interfaces are protected, nested in a sealed type. -->
   <!-- C# won't let you access protected types in a sealed type, so make them public so they can be used by user code. -->


### PR DESCRIPTION
Context: https://developer.android.com/about/versions/12/overview
Context: https://android-developers.googleblog.com/search/label/Android12

Android 12 [Beta 1 has been released][0].

  * [API diff vs. Developer Preview 3][1]
  * [API diff vs. API-30][2]

Google's documented [timeline for Android 12][3] is unchanged
vs. commit 11c30ac:

  * May: Beta 1
  * June-July: Beta 2, Beta 3
  * August: Beta 4
    This contains the final APIs and official SDK.

[0]: https://android-developers.googleblog.com/search/label/Android12
[1]: https://developer.android.com/sdk/api_diff/s-beta1-incr/changes
[2]: https://developer.android.com/sdk/api_diff/s-beta1/changes
[3]: https://developer.android.com/about/versions/12/overview#timeline