### PR TITLE
[NET6] Enable support for AssemblyLoadContext

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <limits>
+#include <functional>
 #include <mono/metadata/object.h>
 #include <mono/metadata/assembly.h>
 
@@ -50,7 +51,10 @@ namespace xamarin::android::internal {
 #endif
 		const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid);
 
-		void install_preload_hooks ();
+		void install_preload_hooks_for_appdomains ();
+#if defined (NET6)
+		void install_preload_hooks_for_alc ();
+#endif // def NET6
 		MonoReflectionType* typemap_java_to_managed (MonoString *java_type);
 
 		/* returns current number of *all* assemblies found from all invocations */
@@ -93,11 +97,12 @@ namespace xamarin::android::internal {
 		MonoReflectionType* typemap_java_to_managed (const char *java_type_name);
 		size_t register_from (const char *apk_file, monodroid_should_register should_register);
 		void gather_bundled_assemblies_from_apk (const char* apk, monodroid_should_register should_register);
-#if defined (NET6) && defined (NET6_ALC_WORKS)
+#if defined (NET6)
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, MonoAssemblyLoadContextGCHandle alc_gchandle, MonoError *error);
-#else // def NET6 && def NET6_ALC_WORKS
+#endif // def NET6
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, bool ref_only);
-#endif // !(def NET6 && def NET6_ALC_WORKS)
+		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, std::function<MonoImage*(char*, uint32_t, const char*)> loader, bool ref_only);
+
 #if defined (DEBUG) || !defined (ANDROID)
 		template<typename H>
 		bool typemap_read_header (int dir_fd, const char *file_type, const char *dir_path, const char *file_path, uint32_t expected_magic, H &header, size_t &file_size, int &fd);
@@ -111,12 +116,12 @@ namespace xamarin::android::internal {
 		bool register_debug_symbols_for_assembly (const char *entry_name, MonoBundledAssembly *assembly, const mono_byte *debug_contents, int debug_size);
 
 		static md_mmap_info md_mmap_apk_file (int fd, uint32_t offset, uint32_t size, const char* filename, const char* apk);
-#if defined (NET6) && defined (NET6_ALC_WORKS)
-		static MonoAssembly* open_from_bundles (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, void *user_data, MonoError *error);
-#else // def NET6 && def NET6_ALC_WORKS
 		static MonoAssembly* open_from_bundles_full (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
+#if defined (NET6)
+		static MonoAssembly* open_from_bundles (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, void *user_data, MonoError *error);
+#else // def NET6
 		static MonoAssembly* open_from_bundles_refonly (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
-#endif // !(def NET6 && def NET6_ALC_WORKS)
+#endif // ndef NET6
 		static void get_assembly_data (const MonoBundledAssembly *e, char*& assembly_data, uint32_t& assembly_data_size);
 
 		void zip_load_entries (int fd, const char *apk_name, monodroid_should_register should_register);

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -173,6 +173,24 @@ Util::monodroid_store_package_name (const char *name)
 	log_info (LOG_DEFAULT, "Generated hash 0x%s for package name %s", package_property_suffix, name);
 }
 
+#if defined (NET6)
+MonoAssembly*
+Util::monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const char *basename)
+{
+	MonoImageOpenStatus  status;
+	MonoAssemblyName    *aname = mono_assembly_name_new (basename);
+	MonoAssembly        *assm = mono_assembly_load_full_alc (alc_handle, aname, nullptr, &status);
+
+	mono_assembly_name_free (aname);
+
+	if (assm == nullptr || status != MonoImageOpenStatus::MONO_IMAGE_OK) {
+		log_fatal (LOG_DEFAULT, "Unable to find assembly '%s'.", basename);
+		exit (FATAL_EXIT_MISSING_ASSEMBLY);
+	}
+	return assm;
+}
+#endif // def NET6
+
 MonoAssembly *
 Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
 {

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -39,6 +39,10 @@ constexpr int FALSE = 0;
 #include "basic-utilities.hh"
 #endif
 
+#if defined (NET6)
+#include <mono/metadata/mono-private-unstable.h>
+#endif // def NET6
+
 #include "java-interop-util.h"
 #include "logger.hh"
 
@@ -81,6 +85,9 @@ namespace xamarin::android
 		int              monodroid_getpagesize ();
 		void             monodroid_store_package_name (const char *name);
 		MonoAssembly    *monodroid_load_assembly (MonoDomain *domain, const char *basename);
+#if defined (NET6)
+		MonoAssembly    *monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const char *basename);
+#endif
 		MonoObject      *monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
 		MonoClass       *monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type);
 		MonoDomain      *monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendly_name, int shadow_copy, const char *shadow_directories);


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext?view=net-5.0
    
dotnet 6 removes support for AppDomains (technically, there still exists
a single AppDomain, but creation of new ones is no longer possible),
replacing them (in a way) with AssemblyLoadContext, which enables scoped
loading of managed assemblies.

Part of the change is the new set of MonoVM functions we need to call in
order to load an assembly into either the default AssemblyLoadContext
(early in the startup process) or into the application-created context
later on during application run time.  MonoVM also adds new preload
hooks which work with the `ALC` instead of the older AppDomains.

This commit adds support for `ALC` preload callbacks and the new
assembly load functions.