### PR TITLE
[build] add dotnet/runtime dependency through dotnet/installer

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -359,27 +359,6 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		string _bundledPreviewRuntimePackVersion;
-		public string BundledPreviewRuntimePackVersion {
-			get {
-				if (string.IsNullOrEmpty (_bundledPreviewRuntimePackVersion)) {
-					var dotnetPath = Properties.GetRequiredValue (KnownProperties.DotNetPreviewPath);
-					dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
-					var dotnetPreviewVersion = Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion);
-					var bundledVersionsPath = Path.Combine (dotnetPath, "sdk", dotnetPreviewVersion, "Microsoft.NETCoreSdk.BundledVersions.props");
-					if (!File.Exists (bundledVersionsPath))
-						throw new FileNotFoundException ("Could not find Microsoft.NETCoreSdk.BundledVersions.props.", bundledVersionsPath);
-
-					var version = XDocument.Load (bundledVersionsPath).Descendants ().FirstOrDefault (p => p.Name == "BundledNETCoreAppPackageVersion")?.Value ?? string.Empty;
-					if (string.IsNullOrEmpty (version))
-						throw new InvalidOperationException ($"Unable to locate $(BundledNETCoreAppPackageVersion) in {bundledVersionsPath}.");
-
-					_bundledPreviewRuntimePackVersion = version;
-				}
-				return _bundledPreviewRuntimePackVersion;
-			}
-		}
-
 		/// <summary>
 		///   Do not install mingw-w64 with brew on MacOS, default false
 		/// </summary>

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Android.Prepare
 		public const string CommandLineToolsFolder              = nameof (CommandLineToolsFolder);
 		public const string DotNetPreviewPath                   = "DotNetPreviewPath";
 		public const string MicrosoftDotnetSdkInternalPackageVersion = "MicrosoftDotnetSdkInternalPackageVersion";
+		public const string MicrosoftNETCoreAppRefPackageVersion = "MicrosoftNETCoreAppRefPackageVersion";
 		public const string EmulatorVersion                     = "EmulatorVersion";
 		public const string EmulatorPkgRevision                 = "EmulatorPkgRevision";
 		public const string HostOS                              = "HostOS";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -26,6 +26,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.CommandLineToolsVersion,             StripQuotes ("@CommandLineToolsVersion@"));
 			properties.Add (KnownProperties.DotNetPreviewPath,                   StripQuotes (@"@DotNetPreviewPath@"));
 			properties.Add (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion, StripQuotes ("@MicrosoftDotnetSdkInternalPackageVersion@"));
+			properties.Add (KnownProperties.MicrosoftNETCoreAppRefPackageVersion, StripQuotes ("@MicrosoftNETCoreAppRefPackageVersion@"));
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));
 			properties.Add (KnownProperties.EmulatorPkgRevision,                 StripQuotes ("@EmulatorPkgRevision@"));
 			properties.Add (KnownProperties.HostOS,                              StripQuotes ("@HostOS@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -411,7 +411,7 @@ namespace Xamarin.Android.Prepare
 				return Path.Combine (
 					XAPackagesDir,
 					$"microsoft.netcore.app.runtime.mono.android-{androidTarget}",
-					ctx.BundledPreviewRuntimePackVersion,
+					ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNETCoreAppRefPackageVersion),
 					"runtimes",
 					$"android-{androidTarget}"
 				);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -88,8 +88,7 @@ namespace Xamarin.Android.Prepare
 			// Install runtime packs associated with the SDK previously installed.
 			var packageDownloadProj = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "build-tools", "xaprepare", "xaprepare", "package-download.proj");
 			var logPath = Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{context.BuildTimeStamp}-download-runtime-packs.binlog");
-			return Utilities.RunCommand (dotnetTool, new string [] { "restore", $"-p:DotNetRuntimePacksVersion={context.BundledPreviewRuntimePackVersion}",
-				ProcessRunner.QuoteArgument (packageDownloadProj), ProcessRunner.QuoteArgument ($"-bl:{logPath}") });
+			return Utilities.RunCommand (dotnetTool, new string [] { "restore", ProcessRunner.QuoteArgument (packageDownloadProj), ProcessRunner.QuoteArgument ($"-bl:{logPath}") });
 		}
 
 		async Task<bool> InstallDotNetAsync (Context context, string dotnetPath, string version, bool runtimeOnly = false)

--- a/build-tools/xaprepare/xaprepare/package-download.proj
+++ b/build-tools/xaprepare/xaprepare/package-download.proj
@@ -3,16 +3,16 @@
 package-download.proj
 
 Downloads .NET runtime packs using the version specified in $(DotNetRuntimePacksVersion) if set.
-Otherwise, the $(BundledNETCoreAppPackageVersion) version specified in the Microsoft.NET.Sdk that
-is building/restoring this project will be used.  $(BundledNETCoreAppPackageVersion) is set in 
-dotnet\sdk\$(MicrosoftDotnetSdkInternalPackageVersion)\Microsoft.NETCoreSdk.BundledVersions.props
+Otherwise, $(MicrosoftNETCoreAppRefPackageVersion) from eng/Versions.props will be used.
 ***********************************************************************************************
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../../../Configuration.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' " >$(BundledNETCoreAppPackageVersion)</DotNetRuntimePacksVersion>
+    <DotNetRuntimePacksVersion Condition=" '$(DotNetRuntimePacksVersion)' == '' " >$(MicrosoftNETCoreAppRefPackageVersion)</DotNetRuntimePacksVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -60,6 +60,7 @@
       <Replacement Include="@CommandLineToolsVersion@=$(CommandLineToolsVersion)" />
       <Replacement Include="@DotNetPreviewPath@=$(DotNetPreviewPath)" />
       <Replacement Include="@MicrosoftDotnetSdkInternalPackageVersion@=$(MicrosoftDotnetSdkInternalPackageVersion)" />
+      <Replacement Include="@MicrosoftNETCoreAppRefPackageVersion@=$(MicrosoftNETCoreAppRefPackageVersion)" />
       <Replacement Include="@EmulatorVersion@=$(EmulatorVersion)" />
       <Replacement Include="@EmulatorPkgRevision@=$(EmulatorPkgRevision)" />
       <Replacement Include="@HostOS@=$(HostOS)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,6 +8,10 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>7a5c445a69359415b7ff18b91cd24472ef9509ff</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.5.21265.5" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>64303750a9198a49f596bcc3aa13de804e421579</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20181.7">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,7 @@
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-preview.5.21264.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.20181.7</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.5.21265.5</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Trim all characters after first `-` or `+` is encountered. -->


### PR DESCRIPTION
Context: https://github.com/dotnet/installer/blob/f442964a34125c76240b1bf2d2c53fdb00d53e41/eng/Version.Details.xml#L20-L23

We can start tracking dotnet/runtime as a "coherent dependency" of
dotnet/installer. This is a bit simpler than manually parsing:

    dotnet\sdk\*\Microsoft.NETCoreSdk.BundledVersions.props

The benefit of doing this, is when maestro comes along to bump
dotnet/installer, we'll get a diff for dotnet/runtime as well.

We can also start using the `$(MicrosoftNETCoreAppRefPackageVersion)`
MSBuild property throughout our build as needed. We'll need to do this
if we want to provision `Microsoft.NET.Workload.Mono.ToolChain` to a
specific version.

An example if we updated things *now*:

    > darc update-dependencies --channel ".NET 6"
    Looking up latest build of https://github.com/dotnet/installer on .NET 6
    Looking up latest build of https://github.com/dotnet/arcade on .NET 6
    Updating 'Microsoft.Dotnet.Sdk.Internal': '6.0.100-preview.5.21266.3' => '6.0.100-preview.6.21269.6' (from build '20210519.6' of 'https://github.com/dotnet/installer')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Updating 'Microsoft.NET.ILLink.Tasks': '6.0.100-preview.5.21264.1' => '6.0.100-preview.5.21268.2' to ensure coherency with Microsoft.Dotnet.Sdk.Internal@6.0.100-preview.6.21269.6
    Updating 'Microsoft.NETCore.App.Ref': '6.0.0-preview.5.21265.5' => '6.0.0-preview.6.21269.1' to ensure coherency with Microsoft.Dotnet.Sdk.Internal@6.0.100-preview.6.21269.6
    Local dependencies updated from channel '.NET 6'.