### PR TITLE
Bump to xamarin/Java.Interop/main@2573dc8c

### DIFF
--- a/Documentation/release-notes/5945.md
+++ b/Documentation/release-notes/5945.md
@@ -1,0 +1,7 @@
+#### Bindings projects
+
+- [GitHub Issue #835](https://github.com/xamarin/java.interop/issues/835):
+  Don't throw an `IndexOutOfRangeException` if a Java type ends with `.` or `$`.
+
+- [GitHub Issue #5821](https://github.com/xamarin/xamarin-android/issues/5921)
+  Don't throw a `NullReferenceException` when binding constructs involving Java generics in return types.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/835
Fixes: https://github.com/xamarin/xamarin-android/issues/5921

Context: https://github.com/xamarin/xamarin-android/issues/5894

Changes: http://github.com/xamarin/Java.Interop/compare/12e670a8560f69581d3a3adf0a9d91e8ce8c9afa...2573dc8c84fd4eb68e75bcae73912c26f4942356

  * xamarin/Java.Interop@2573dc8c: [Java.Interop.Tools.*] IMetadataResolver not TypeDefinitionCache (#842)
  * xamarin/Java.Interop@412e974b: Revert "[generator] Disable [SupportedOSPlatform] until .NET 5/6. (#781)" (#841)
  * xamarin/Java.Interop@23baf0bc: [Java.Interop] Fix NRT warnings introduced by targeting 'net6.0' (#840)
  * xamarin/Java.Interop@131c1496: [generator] Fix NRE from return type not consistently set (#834)
  * xamarin/Java.Interop@100fffc1: [generator] Ensure "global::" is prepended to generic return casts. (#838)
  * xamarin/Java.Interop@9b89e90e: [generator] Ignore types without names (#837)
  * xamarin/Java.Interop@0e01fb5d: [Java.Interop.Tools.JavaSource] Merge @return block values (#836)