### PR TITLE
[ci] Fix smoke and emulator test issues

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -112,6 +112,18 @@
           ]
         },
         {
+          "label": "prepare-sample-under-dotnet",
+          "type": "shell",
+          "command": "dotnet build --no-restore tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj -c ${input:configuration} -t:GenerateNuGetConfig -p:AndroidNETTestConfigOutputDir=${workspaceRoot}/samples",
+          "group": {
+              "kind": "build",
+              "isDefault": true
+          },
+          "problemMatcher": [
+              "$msCompile"
+          ]
+        },
+        {
           "label": "build-sample-under-dotnet",
           "type": "shell",
           "command": "${env:HOME}/android-toolchain/dotnet/dotnet build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          SdkVersion      {get; set;}
 		public                  string          AndroidAbi      {get; set;}
 		/// <summary>
-		/// Specifies $ANDROID_SDK_HOME. This is not the path to the Android SDK, but a root folder that contains the `.android` folder.
+		/// Specifies $ANDROID_PREFS_ROOT. This is not the path to the Android SDK, but a root folder that contains the `.android` folder.
 		/// </summary>
 		[Required]
 		public                  string          AvdManagerHome  {get; set;}
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			}
 
 			var env = new List<string> ();
-			env.Add ($"ANDROID_SDK_HOME={AvdManagerHome}");
+			env.Add ($"ANDROID_PREFS_ROOT={AvdManagerHome}");
 			if (!string.IsNullOrEmpty (JavaSdkHome)) {
 				env.Add ($"JAVA_HOME={JavaSdkHome}");
 			}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -12,12 +13,16 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 {
 	public class RunAndroidEmulatorCheckBootTimes : Task
 	{
+		public string AndroidSdkDirectory { get; set; }
+		public string AvdManagerHome { get; set; }
 		public string CheckBootTimesPath { get; set; }
 		public string DeviceName { get; set; } = "XamarinAndroidTestRunner64";
 
 		public override bool Execute ()
 		{
 			Log.LogMessage (MessageImportance.High, $"Task {nameof (RunAndroidEmulatorCheckBootTimes)}");
+			Log.LogMessage (MessageImportance.High, $"     {nameof (AndroidSdkDirectory)}: {AndroidSdkDirectory}");
+			Log.LogMessage (MessageImportance.High, $"     {nameof (AvdManagerHome)}: {AvdManagerHome}");
 			Log.LogMessage (MessageImportance.High, $"     {nameof (CheckBootTimesPath)}: {CheckBootTimesPath}");
 			Log.LogMessage (MessageImportance.High, $"     {nameof (DeviceName)}: {DeviceName}");
 
@@ -32,9 +37,16 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			var timeoutInMS = (int) TimeSpan.FromMinutes (15).TotalMilliseconds;
 			bool finishAsExpected = false;
 			bool processTimedOut = false;
+			var args = new StringBuilder ($"--devicename {DeviceName} --verbose");
+			if (!string.IsNullOrWhiteSpace (AndroidSdkDirectory)) {
+				args.Append ($" --sdkpath \"{AndroidSdkDirectory.TrimEnd ('\\')}\"");
+			}
+			if (!string.IsNullOrWhiteSpace (AvdManagerHome)) {
+				args.Append ($" --avdhome \"{AvdManagerHome.TrimEnd ('\\')}\"");
+			}
 			var success = RunProcess (
 				fileInfo.FullName,
-				$"--devicename {DeviceName} --verbose",
+				args.ToString (),
 				timeoutInMS,
 				(string data, ManualResetEvent mre) => {
 					Log.LogMessage (MessageImportance.High, $"CheckBootTimes ({DateTime.UtcNow}): {data}");

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  int             EmulatorProcessId       {get; set;}
 
 		/// <summary>
-		/// Specifies $ANDROID_SDK_HOME. This is not the path to the Android SDK, but a root folder that contains the `.android` folder.
+		/// Specifies $ANDROID_PREFS_ROOT. This is not the path to the Android SDK, but a root folder that contains the `.android` folder.
 		/// </summary>
 		[Required]
 		public                  string          AvdManagerHome  {get; set;}
@@ -78,8 +78,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			var p = new Process () {
 				StartInfo = psi,
 			};
-			psi.EnvironmentVariables ["ANDROID_SDK_HOME"] = AvdManagerHome;
-			Log.LogMessage (MessageImportance.Low, $"\tANDROID_SDK_HOME=\"{AvdManagerHome}\"");
+			psi.EnvironmentVariables ["ANDROID_PREFS_ROOT"] = AvdManagerHome;
+			Log.LogMessage (MessageImportance.Low, $"\tANDROID_PREFS_ROOT=\"{AvdManagerHome}\"");
 
 			var sawError        = new AutoResetEvent (false);
 

--- a/build-tools/check-boot-times/Program.cs
+++ b/build-tools/check-boot-times/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Diagnostics;
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tools
 	{
 		static string sdkPath;
 		static string adbPath;
+		static string avdHome;
 		static string avdManagerPath;
 		static string emulatorPath;
 		static string sdkManagerPath;
@@ -40,15 +41,20 @@ namespace Xamarin.Android.Tools
 				{
 					    Argument = new Argument<string>(),
 				},
+				new Option ("--avdhome", "Parent folder of emulator preferences (`.android`) and nested `avd` folder.")
+				{
+					Argument = new Argument<string> (),
+				},
 			};
 
 			rootCommand.Name = "CheckBootTimes";
 			rootCommand.Description = "Collect Android Emulator boot times.";
-			rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(async (bool verbose, int? executiontimes, string sdkpath, string devicename) => {
+			rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(async (bool verbose, int? executiontimes, string sdkpath, string devicename, string avdhome) => {
 				showVerbose = verbose;
 				executionTimes = executiontimes.HasValue ? executiontimes.Value : 1;
 				sdkPath = sdkpath;
 				deviceName = devicename;
+				avdHome = avdhome;
 
 				Console.WriteLine ($"Testing emulator startup times for {executionTimes} execution(s). This may take several minutes.");
 
@@ -349,14 +355,12 @@ namespace Xamarin.Android.Tools
 
 		static bool UpdateVirtualDevice ()
 		{
-			var homePath = GetHomePath ();
-			var vdPath = Path.Combine (homePath, $".android/avd/{deviceName}.avd/config.ini");
+			var homePath = string.IsNullOrWhiteSpace (avdHome) ? GetHomePath () : avdHome;
+			var vdPath = Path.Combine (homePath, ".android", "avd", $"{deviceName}.avd", "config.ini");
 
 			if (!File.Exists (vdPath)) {
 				return false;
 			}
-
-			var sdkPath = new FileInfo (emulatorPath).Directory.Parent.FullName;
 
 			var content = "skin.name=pixel_2" + Environment.NewLine;
 			content += "skin.dynamic=yes" + Environment.NewLine;
@@ -396,6 +400,10 @@ namespace Xamarin.Android.Tools
 					process.StartInfo.RedirectStandardOutput = true;
 					process.StartInfo.RedirectStandardError = true;
 					process.EnableRaisingEvents = true;
+					process.StartInfo.EnvironmentVariables ["ANDROID_SDK_ROOT"] = sdkPath;
+					if (!string.IsNullOrWhiteSpace (avdHome)) {
+						process.StartInfo.EnvironmentVariables ["ANDROID_PREFS_ROOT"] = avdHome;
+					}
 
 					var mre = new ManualResetEvent (false /* -> nonsignaled */);
 
@@ -508,6 +516,14 @@ namespace Xamarin.Android.Tools
 				}
 			}
 
+			if (string.IsNullOrWhiteSpace (sdkPath) || !Directory.Exists (sdkPath)) {
+				sdkPath = new FileInfo (emulatorPath).Directory.Parent.FullName;
+			}
+
+			Console.WriteLine ($"Using ANDROID_SDK_ROOT: '{sdkPath}'");
+			if (!string.IsNullOrWhiteSpace (avdHome)) {
+				Console.WriteLine ($"Using ANDROID_PREFS_ROOT: '{avdHome}'");
+			}
 			Console.WriteLine ($"Running adb from: '{adbPath}'");
 			Console.WriteLine ($"Running avdmanager from: '{avdManagerPath}'");
 			Console.WriteLine ($"Running emulator from: '{emulatorPath}'");
@@ -528,22 +544,22 @@ namespace Xamarin.Android.Tools
 					if (!string.IsNullOrWhiteSpace (sdkPath)) {
 						potentialLocations.AddRange (new []{
 							$"{sdkPath}/platform-tools",
-							$"{sdkPath}/cmdline-tools/1.0/bin",
+							$"{sdkPath}/cmdline-tools/4.0/bin",
 							$"{sdkPath}/cmdline-tools/latest/bin",
 							$"{sdkPath}/emulator",
 						});
 					} else {
 						potentialLocations.AddRange (new []{
 							"AppData/Local/Android/Sdk/platform-tools",
-							"AppData/Local/Android/Sdk/cmdline-tools/1.0/bin",
+							"AppData/Local/Android/Sdk/cmdline-tools/4.0/bin",
 							"AppData/Local/Android/Sdk/cmdline-tools/latest/bin",
 							"AppData/Local/Android/Sdk/emulator",
 							"Library/Android/sdk/platform-tools",
-							"Library/Android/sdk/cmdline-tools/1.0/bin",
+							"Library/Android/sdk/cmdline-tools/4.0/bin",
 							"Library/Android/sdk/cmdline-tools/latest/bin",
 							"Library/Android/sdk/emulator",
 							"android-toolchain/sdk/platform-tools",
-							"android-toolchain/sdk/cmdline-tools/1.0/bin",
+							"android-toolchain/sdk/cmdline-tools/4.0/bin",
 							"android-toolchain/sdk/cmdline-tools/latest/bin",
 							"android-toolchain/sdk/emulator",
 						});
@@ -551,7 +567,7 @@ namespace Xamarin.Android.Tools
 						if (RunningOnWindowsEnvironment) {
 							potentialLocations.AddRange (new []{
 								"C:/Program Files (x86)/Android/android-sdk/platform-tools",
-								"C:/Program Files (x86)/Android/android-sdk/cmdline-tools/1.0/bin",
+								"C:/Program Files (x86)/Android/android-sdk/cmdline-tools/4.0/bin",
 								"C:/Program Files (x86)/Android/android-sdk/cmdline-tools/latest/bin",
 								"C:/Program Files (x86)/Android/android-sdk/emulator",
 							});

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -346,6 +346,8 @@
   <Target Name="CheckBootTimes"
       DependsOnTargets="AcquireAndroidTarget;ReleaseAndroidTarget">
     <RunAndroidEmulatorCheckBootTimes
+        AndroidSdkDirectory="$(AndroidSdkDirectory)"
+        AvdManagerHome="$(AvdManagerHome)"
         DeviceName="$(TestAvdName)"
         CheckBootTimesPath="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\check-boot-times.exe"
     />

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,1 @@
+nuget.config

--- a/samples/NuGet.config
+++ b/samples/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local-xa" value="../bin/BuildDebug/nuget-unsigned" />
-  </packageSources>
-  <disabledPackageSources />
-</configuration>

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Android.Build.Tests
 				"AndroidAttachDebugger=True",
 			}), "Project should have run.");
 			WaitForPermissionActivity (Path.Combine (Root, dotnet.ProjectDirectory, "permission-logcat.log"));
-			Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, dotnet.ProjectDirectory, "logcat.log")), "Activity should have started");
+			Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, dotnet.ProjectDirectory, "logcat.log"), 120), "Activity should have started");
 			// we need to give a bit of time for the debug server to start up.
 			WaitFor (2000);
 			session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5944
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4791430&view=logs&jobId=9e58dffc-b78a-5028-45f4-4d99f4c2da6c

The TestBinaryDeserialization test has been disabled for .NET 6 as it
is no longer supported due to security reasons.

The "Run check-boot-times" test has seemingly been failing since commit
92efdccb6, which introduced a new version of avdmanager and changed the
path where our AVD files are stored.  The corresponding task and tool
have been fixed to know about this new AVD home location.  The create
and start Android emulator tasks have also been updated for uniformity.
All of these tasks now set [`$(ANDROID_PREFS_ROOT)`][0] rather than the
now deprecated `$(ANDROID_SDK_HOME)` variable.

I have also seen some intermittent test failures on various PR builds in
some of our InstallAndRun emulator tests, and I have bumped the timeout
for those tests.  The RunWithInterpreterEnabled test has been reworked
a bit to ensure that the required logging properties are set.

The nuget.config file that was added to the samples folder in commit
4201dc18 has been removed, as it cause problems with release builds.  A
new vscode task has been added to generate the config file as needed
for local testing instead.

[0]: https://developer.android.com/studio/command-line/variables.html