### PR TITLE
[build] set proper settings for NuGet.org

### DIFF
--- a/build-tools/create-packs/Directory.Build.props
+++ b/build-tools/create-packs/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageType>DotnetPlatform</PackageType>
-    <Authors>Microsoft</Authors>
     <OutputPath>$(BootstrapOutputDirectory)nuget-unsigned\</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -5,6 +5,7 @@
     <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <Import Project="License.targets" />
   <Import Project="..\..\build-tools\installers\create-installers.targets" />
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
@@ -14,24 +15,6 @@
   <PropertyGroup>
     <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0\</_MonoAndroidNETOutputDir>
   </PropertyGroup>
-
-  <!-- LICENSE setup -->
-  <PropertyGroup>
-    <NuGetLicense Condition="Exists('$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt')">$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt</NuGetLicense>
-    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)LICENSE</NuGetLicense>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-  </PropertyGroup>
-  <Target Name="_GetLicense">
-    <!-- NuGet doesn't have a way to change the filename of License.txt, so copy it -->
-    <Copy
-        SourceFiles="$(NuGetLicense)"
-        DestinationFiles="$(IntermediateOutputPath)$(PackageLicenseFile)"
-        SkipUnchangedFiles="true"
-    />
-    <ItemGroup>
-      <_PackageFiles Include="$(IntermediateOutputPath)$(PackageLicenseFile)" PackagePath="\" />
-    </ItemGroup>
-  </Target>
 
   <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
   <!-- TODO: Generate PlatformManifest.txt files? -->

--- a/build-tools/create-packs/License.targets
+++ b/build-tools/create-packs/License.targets
@@ -1,0 +1,23 @@
+<!-- Ownership and LICENSE settings for .nupkg's -->
+<Project>
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/xamarin/xamarin-android</PackageProjectUrl>
+    <NuGetLicense Condition="Exists('$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt')">$(XamarinAndroidSourcePath)external\monodroid\tools\scripts\License.txt</NuGetLicense>
+    <NuGetLicense Condition=" '$(NuGetLicense)' == '' ">$(XamarinAndroidSourcePath)LICENSE</NuGetLicense>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <BeforePack>_GetLicense;$(BeforePack)</BeforePack>
+  </PropertyGroup>
+  <Target Name="_GetLicense">
+    <!-- NuGet doesn't have a way to change the filename of License.txt, so copy it -->
+    <Copy
+        SourceFiles="$(NuGetLicense)"
+        DestinationFiles="$(IntermediateOutputPath)$(PackageLicenseFile)"
+        SkipUnchangedFiles="true"
+    />
+    <ItemGroup>
+      <_PackageFiles Include="$(IntermediateOutputPath)$(PackageLicenseFile)" PackagePath="\" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
+++ b/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
@@ -5,7 +5,6 @@
     <PackageType>Template</PackageType>
     <PackageId>Microsoft.Android.Templates</PackageId>
     <Title>.NET Android Templates</Title>
-    <Authors>Microsoft</Authors>
     <Description>Templates for Android platforms.</Description>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -16,6 +15,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\create-packs\License.targets" />
 
   <ItemGroup>
     <Content Include="**\*" Exclude="**\bin\**;**\obj\**" />


### PR DESCRIPTION
Microsoft has rules for submitting signed NuGet packages with the
namespace `Microsoft.*` under the Microsoft + Xamarin organizations.

Some of these rules include:

* Package must be signed.
* Must include a license.
* `$(Authors)` should be `Microsoft`
* `$(PackageProjectUrl)` can't be blank.
* `$(Copyright)` must *exactly* say `© Microsoft Corporation. All rights reserved.`

If any of these are wrong, you'll get errors during `nuget push` such as:

    Response status code does not indicate success:
    400 (The package is not compliant with metadata requirements for Microsoft packages on NuGet.org.
    Go to https://aka.ms/Microsoft-NuGet-Compliance for more information.
    Policy violations: The package metadata is missing required ProjectUrl.).

We used a script to fix up these values and resign for .NET 6 Preview
4. This was painful but got us by for the current release.

Going forward, we should just fill out these values for .NET 6 .nupkg
files.