### PR TITLE
[Xamarin.Android.Build.Tasks] Allow package to be defined with AndroidManifestPlaceholders

### DIFF
--- a/Documentation/release-notes/5951.md
+++ b/Documentation/release-notes/5951.md
@@ -1,0 +1,5 @@
+#### Application build and deployment
+
+- [GitHub Issue #5851](https://github.com/xamarin/xamarin-android/issues/5851):
+  Add support for using `AndroidManifestPlaceholders` to set the `package`
+  value in the `AndroidManifest.xml`.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -1,21 +1,21 @@
-// 
+//
 // GetAndroidPackageName.cs
-//  
+//
 // Author:
 //       Jonathan Pobst <monkey@jpobst.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc. (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,8 +23,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
+using System;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
@@ -41,6 +42,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AssemblyName { get; set; }
 
+		public string [] ManifestPlaceholders { get; set; }
+
 		[Output]
 		public string PackageName { get; set; }
 
@@ -54,6 +57,7 @@ namespace Xamarin.Android.Tasks
 				if (reader.MoveToContent () == XmlNodeType.Element) {
 					var package = reader.GetAttribute ("package");
 					if (!string.IsNullOrEmpty (package)) {
+						package = ManifestDocument.ReplacePlaceholders (ManifestPlaceholders, package);
 						PackageName = AndroidAppManifest.CanonicalizePackageName (package);
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -509,6 +509,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <GetAndroidPackageName
       ManifestFile="$(_AndroidManifestAbs)"
       AssemblyName="$(AssemblyName)"
+      ManifestPlaceholders="$(AndroidManifestPlaceholders)"
       PackageName="$(_AndroidPackage)">
     <Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />
   </GetAndroidPackageName>
@@ -904,6 +905,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
 		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
 		<_PropertyCacheItems Include="AndroidSupportedAbis=$(AndroidSupportedAbis)" />
+		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"


### PR DESCRIPTION
Fixes #5951
  Related: commit b423ff6.
  
  Our current `AndroidManifestPlaceholders` implementation would allow users
  to change any part of the manifest with the exception of the `package`
  element on the `manifest` itself. What was actually happening was the
  `package` was being changed but it was happening after  the
  `GetAndroidPackageName` had already been called. So the internal MSBuild
  property `$(_AndroidPackage)` did not reflect the desired value.
  
  So lets update `GetAndroidPackageName` to use the `AndroidManifestPlaceholders`.
  Note: This will only effect the `$(_AndroidPackage)` value when the
  manifest is being used. If the user is using the `GenerateApplicationManifest`
  option, the `$(_AndroidPackage)` will be controlled from the `$(ApplicationId)`
  MSBuild property.