### PR TITLE
[One .NET] add @(SdkSupportedTargetPlatformIdentifier)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
@@ -3,4 +3,8 @@
       Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
   <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.BundleTool"
       Condition=" '$(AndroidPackageFormat)' == 'aab' " />
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+    <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/16208/files
Context: https://gist.github.com/sfoslund/12e1daff114bccc8a29ebb441bc461a5#detecting-installed-platforms
Fixes: https://github.com/xamarin/xamarin-android/issues/5941

The VS ProjectSystem needs a way to know during MSBuild evaluation
which platforms are supported by a workload.

If we add the item group:

    <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />

This enables the IDE to know that Android is supported.

I will make a future change in xamarin/xamarin-macios for this.