### PR TITLE
[One .NET] improve detection of "Android" assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -192,6 +192,7 @@ namespace Xamarin.Android.Build.Tests
 			FileAssert.Exists (resource_designer_cs);
 			var resource_designer_text = File.ReadAllText (resource_designer_cs);
 			StringAssert.Contains ("public const int MyLayout", resource_designer_text);
+			StringAssert.Contains ("global::LibraryB.Resource.Drawable.IMALLCAPS = global::AppA.Resource.Drawable.IMALLCAPS", resource_designer_text);
 		}
 
 		[Test]


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/603

When building the .NET MAUI workload, I found the following scenario
was broken:

* `Microsoft.Maui.dll` uses `Microsoft.Maui.Resource.Layout.navigationlayout`
in order to use an Android layout.
* A sample app's `Resource.designer.cs` did not contain a line such as:

```csharp
global::Microsoft.Maui.Resource.Layout.navigationlayout = global::MyMauiSampleApp.Resource.Layout.navigationlayout
```

This resulted in a crash at runtime such as:

    UNHANDLED EXCEPTION:
    Android.Runtime.JavaProxyThrowable: Exception of type 'Android.Runtime.JavaProxyThrowable' was thrown.
      --- End of managed Android.Runtime.JavaProxyThrowable stack trace ---
    android.runtime.JavaProxyThrowable: System.InvalidCastException: Unable to convert instance of type 'Android.Widget.FrameLayout' to type 'Microsoft.Maui.NavigationLayout'.
       at Java.Interop.JavaObjectExtensions.CastClass(IJavaObject instance, Type resultType) in Mono.Android.dll:token 0x601fd17+0x5d
       at Java.Interop.JavaObjectExtensions._JavaCast[NavigationLayout](IJavaObject instance) in Mono.Android.dll:token 0x601fd16+0x52
       at Java.Interop.JavaObjectExtensions.JavaCast[NavigationLayout](IJavaObject instance) in Mono.Android.dll:token 0x601fd15+0x0
       at Android.Runtime.Extensions.JavaCast[NavigationLayout](IJavaObject instance) in Mono.Android.dll:token 0x6017c34+0x0
       at Microsoft.Maui.Controls.Handlers.NavigationPageHandler.CreateNativeView() in Microsoft.Maui.Controls.dll:token 0x6001b35+0x2c
       at Microsoft.Maui.Handlers.ViewHandler`2[[Microsoft.Maui.Controls.NavigationPage, Microsoft.Maui.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[Android.Views.View, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065]].SetVirtualView(IView view) in Microsoft.Maui.dll:token 0x6000545+0x7f
       at Microsoft.Maui.HandlerExtensions.ToNative(IView view, IMauiContext context) in Microsoft.Maui.dll:token 0x6000161+0xb3
       at Microsoft.Maui.MauiAppCompatActivity.OnCreate(Bundle savedInstanceState) in Microsoft.Maui.dll:token 0x6000176+0xbd
       at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_savedInstanceState) in Mono.Android.dll:token 0x60150a7+0xf

See: https://github.com/dotnet/maui/blob/bd49fa4acd728c3c5cef7d6cd335216a284a2b4d/src/Controls/src/Core/Handlers/NavigationPage/NavigationPageHandler.Android.cs#L60

This being due to C# using the wrong integer value to retrieve the
layout.

The reason the `Resource.designer.cs` was not correct, was due to the
`Microsoft.Maui.dll` assembly not being included in
`@(_MonoAndroidReferencePath)`.

This occurred because it has the `%(FrameworkReferenceName)` metadata:

    C:\Program Files\dotnet\packs\Microsoft.Maui.Core.Ref.android\0.0.1-alpha1\ref/net6.0-android30.0/Microsoft.Maui.dll
        FrameworkReferenceName = Microsoft.Maui.Core

The `<FilterAssemblies/>` MSBuild task currently filters out any
`%(FrameworkReferenceName)` assemblies. This was originally done so
we'd skip BCL assemblies.

We also have additional information we can use to properly classify an
"Android" assembly. So the new list of fallbacks are:

* Skip `%(FrameworkReferenceName)` equals `Microsoft.Android` as we
  don't need to process `Mono.Android.dll` or `Java.Interop.dll`.
* Skip `%(FrameworkReferenceName)` starts with `Microsoft.NETCore.`
* `@(ProjectReference)` items have `%(TargetPlatformIdentifier)` equal
  to `android`. Check this earlier as it is much quicker than
  inspecting assembly files.
* `[assembly:TargetPlatformAttribute("android30")]` is now present in
  any `net6.0-android` assembly. Look for this additional attribute.
* Any existing fallbacks left in place.

Down the road we should also build a .NET MAUI project in this repo.
This will be easier to accomplish when the .NET MAUI workload is
available.