### PR TITLE
[ci] Install credential provider when signing

### DIFF
--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -3,6 +3,12 @@ parameters:
   condition: succeeded()
 
 steps:
+- task: NuGetAuthenticate@0
+  displayName: authenticate with azure artifacts
+  inputs:
+    forceReinstallCredentialProvider: true
+  condition: ${{ parameters.condition }}
+
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml
   parameters:


### PR DESCRIPTION
Context:  https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4803805&view=logs&j=3ce66085-846b-53dd-5323-3e00eb12b9a6&t=c7de918a-2762-5750-800e-a440a28cd7e6

We've been seeing some .NET 6 .msi signing attempts fail when installing
the MicroBuild signing tooling with the following:

    ##[error]The path 'Microsoft.NuGet.CredentialProvider.zip' either does not exist or is not a valid file system path.

Installing the NuGet credential provider will hopefully address this.