### PR TITLE
[One .NET] extend the microsoft-net-runtime-android workload

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Android.Prepare
 		public const string CommandLineToolsVersion             = nameof (CommandLineToolsVersion);
 		public const string CommandLineToolsFolder              = nameof (CommandLineToolsFolder);
 		public const string DotNetPreviewPath                   = "DotNetPreviewPath";
+		public const string DotNetPreviewVersionBand            = nameof (DotNetPreviewVersionBand);
 		public const string MicrosoftDotnetSdkInternalPackageVersion = "MicrosoftDotnetSdkInternalPackageVersion";
 		public const string MicrosoftNETCoreAppRefPackageVersion = "MicrosoftNETCoreAppRefPackageVersion";
 		public const string EmulatorVersion                     = "EmulatorVersion";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -25,6 +25,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.CommandLineToolsFolder,              StripQuotes ("@CommandLineToolsFolder@"));
 			properties.Add (KnownProperties.CommandLineToolsVersion,             StripQuotes ("@CommandLineToolsVersion@"));
 			properties.Add (KnownProperties.DotNetPreviewPath,                   StripQuotes (@"@DotNetPreviewPath@"));
+			properties.Add (KnownProperties.DotNetPreviewVersionBand,            StripQuotes (@"@DotNetPreviewVersionBand@"));
 			properties.Add (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion, StripQuotes ("@MicrosoftDotnetSdkInternalPackageVersion@"));
 			properties.Add (KnownProperties.MicrosoftNETCoreAppRefPackageVersion, StripQuotes ("@MicrosoftNETCoreAppRefPackageVersion@"));
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -380,6 +380,13 @@ namespace Xamarin.Android.Prepare
 			public static string NetcoreAppRuntimeAndroidX86         => GetCachedPath (ref netcoreAppRuntimeAndroidX86, () => GetNetcoreAppRuntimePath (ctx, "x86"));
 			public static string NetcoreAppRuntimeAndroidX86_64      => GetCachedPath (ref netcoreAppRuntimeAndroidX86_64, () => GetNetcoreAppRuntimePath (ctx, "x64"));
 
+			public static string MicrosoftNETWorkloadMonoToolChainDir => Path.Combine (
+				XAPackagesDir,
+				$"microsoft.net.workload.mono.toolchain.manifest-{ctx.Properties.GetRequiredValue (KnownProperties.DotNetPreviewVersionBand)}",
+				ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNETCoreAppRefPackageVersion),
+				"data"
+			);
+
 			// CMake
 			public static string CmakeMSBuildPropsName               = "cmake-config.props";
 			public static string CmakeShellScriptsPropsName          = "cmake-config.sh";

--- a/build-tools/xaprepare/xaprepare/package-download.proj
+++ b/build-tools/xaprepare/xaprepare/package-download.proj
@@ -20,6 +20,7 @@ Otherwise, $(MicrosoftNETCoreAppRefPackageVersion) from eng/Versions.props will 
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x86" Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x64" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(DotNetPreviewVersionBand)" Version="[$(DotNetRuntimePacksVersion)]" />
   </ItemGroup>
 
 </Project>

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -59,6 +59,7 @@
       <Replacement Include="@CommandLineToolsFolder@=$(CommandLineToolsFolder)" />
       <Replacement Include="@CommandLineToolsVersion@=$(CommandLineToolsVersion)" />
       <Replacement Include="@DotNetPreviewPath@=$(DotNetPreviewPath)" />
+      <Replacement Include="@DotNetPreviewVersionBand@=$(DotNetPreviewVersionBand)" />
       <Replacement Include="@MicrosoftDotnetSdkInternalPackageVersion@=$(MicrosoftDotnetSdkInternalPackageVersion)" />
       <Replacement Include="@MicrosoftNETCoreAppRefPackageVersion@=$(MicrosoftNETCoreAppRefPackageVersion)" />
       <Replacement Include="@EmulatorVersion@=$(EmulatorVersion)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -8,7 +8,8 @@
         "Microsoft.Android.Sdk.BundleTool",
         "Microsoft.Android.Ref",
         "Microsoft.Android.Templates"
-      ]
+      ],
+      "extends" : [ "microsoft-net-runtime-android" ]
     }
   },
   "packs": {


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/d43e88620fe574045f026a4ebce50f7a8541347a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in

In order to start using packs from the `microsoft-net-runtime-android`
workload, we need to:

1. Add `Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100` to
   `package-download.proj`.

2. Copy `WorkloadManifest.*` files from:

```
Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100/data/
```

To:

    ~/android-toolchain/dotnet/sdk-manifests/6.0.100/Microsoft.NET.Workload.Mono.ToolChain/

So we get the latest `WorkloadManifest.json` based on the version
defined in `$(MicrosoftNETCoreAppRefPackageVersion)`.

3. `xaprepare` should run:

```
~/android-toolchain/dotnet/dotnet workload install microsoft-net-runtime-android --skip-manifest-update --verbosity diag
```

So the packs are installed for local development and CI.

4. Our workload should "extend" `microsoft-net-runtime-android`. This
   would make sure these packs are installed on user's machines.