### PR TITLE
[Xamarin.Android.Build.Tasks] Quote Aot Paths (again)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -391,7 +391,6 @@ namespace Xamarin.Android.Tasks
 						if (ldName.IndexOf ('-') >= 0) {
 							ldName = ldName.Substring (ldName.LastIndexOf ("-") + 1);
 						}
-						ldName=$"\\\"{ldName}\\\"";
 					}
 				} else {
 					ldName = "ld";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -304,7 +304,7 @@ namespace Xamarin.Android.Tasks
 					outdir = Path.Combine (AotOutputDirectory, "arm64-v8a");
 					mtriple = "aarch64-linux-android";
 					arch = AndroidTargetArch.Arm64;
-					break;			
+					break;
 
 				case "x86":
 					aotCompiler = Path.Combine (sdkBinDirectory, "cross-x86");
@@ -366,21 +366,21 @@ namespace Xamarin.Android.Tasks
 
 					var libs = new List<string>();
 					if (NdkUtil.UsingClangNDK) {
-						libs.Add ($"-L{toolchainLibDir}");
-						libs.Add ($"-L{androidLibPath}");
+						libs.Add ($"-L{toolchainLibDir.TrimEnd ('\\')}");
+						libs.Add ($"-L{androidLibPath.TrimEnd ('\\')}");
 
 						if (arch == AndroidTargetArch.Arm) {
 							// Needed for -lunwind to work
 							string compilerLibDir = Path.Combine (toolchainPath, "..", "sysroot", "usr", "lib", NdkUtil.GetArchDirName (arch));
-							libs.Add ($"-L{compilerLibDir}");
+							libs.Add ($"-L{compilerLibDir.TrimEnd ('\\')}");
 						}
 					}
 
-					libs.Add ($"\\\"{Path.Combine (toolchainLibDir, "libgcc.a")}\\\"");
-					libs.Add ($"\\\"{Path.Combine (androidLibPath, "libc.so")}\\\"");
-					libs.Add ($"\\\"{Path.Combine (androidLibPath, "libm.so")}\\\"");
+					libs.Add (Path.Combine (toolchainLibDir, "libgcc.a"));
+					libs.Add (Path.Combine (androidLibPath, "libc.so"));
+					libs.Add (Path.Combine (androidLibPath, "libm.so"));
 
-					ldFlags = string.Join(";", libs);
+					ldFlags = $"\\\"{string.Join("\\\";\\\"", libs)}\\\"";
 				}
 
 				string ldName = String.Empty;
@@ -391,6 +391,7 @@ namespace Xamarin.Android.Tasks
 						if (ldName.IndexOf ('-') >= 0) {
 							ldName = ldName.Substring (ldName.LastIndexOf ("-") + 1);
 						}
+						ldName=$"\\\"{ldName}\\\"";
 					}
 				} else {
 					ldName = "ld";
@@ -466,7 +467,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 		}
-			
+
 		bool RunAotCompiler (string assembliesPath, string aotCompiler, string aotOptions, string assembly, string responseFile)
 		{
 			var stdout_completed = new ManualResetEvent (false);
@@ -487,7 +488,7 @@ namespace Xamarin.Android.Tasks
 				WindowStyle=ProcessWindowStyle.Hidden,
 				WorkingDirectory = WorkingDirectory,
 			};
-			
+
 			// we do not want options to be provided out of band to the cross compilers
 			psi.EnvironmentVariables ["MONO_ENV_OPTIONS"] = String.Empty;
 			// the C code cannot parse all the license details, including the activation code that tell us which license level is allowed

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
+using Xamarin.Android.Build;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -14,6 +15,41 @@ namespace Xamarin.Android.Build.Tests
 	[Parallelizable (ParallelScope.Children)]
 	public class AotTests : BaseTest
 	{
+		public string SdkWithSpacesPath {
+			get {
+				return Path.Combine (Root, "temp", string.Format ("SDK Ümläüts"));
+			}
+		}
+
+		[OneTimeSetUp]
+		public void Setup ()
+		{
+			if (!IsWindows)
+				return;
+
+			var sdkPath = AndroidSdkPath;
+			var ndkPath = AndroidNdkPath;
+
+			var symSdkPath = Path.Combine (SdkWithSpacesPath, "sdk");
+			var symNdkPath = Path.Combine (SdkWithSpacesPath, "ndk");
+
+			SymbolicLink.Create (symSdkPath, sdkPath);
+			SymbolicLink.Create (symNdkPath, ndkPath);
+
+			Environment.SetEnvironmentVariable ("TEST_ANDROID_SDK_PATH", symSdkPath);
+			Environment.SetEnvironmentVariable ("TEST_ANDROID_NDK_PATH", symNdkPath);
+		}
+
+		[OneTimeTearDown]
+		public void TearDown ()
+		{
+			if (!IsWindows)
+				return;
+			Environment.SetEnvironmentVariable ("TEST_ANDROID_SDK_PATH", "");
+			Environment.SetEnvironmentVariable ("TEST_ANDROID_NDK_PATH", "");
+			Directory.Delete (SdkWithSpacesPath, recursive: true);
+		}
+
 		[Test, Category ("SmokeTests")]
 		public void BuildBasicApplicationReleaseProfiledAot ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Compile Remove="DebuggingTasksTests.cs" Condition="!Exists('$(XAInstallPrefix)xbuild\Xamarin\Android\Xamarin.Android.Build.Debugging.Tasks.dll')" />
     <Compile Remove="Expected\**" />
+    <Compile Include="..\..\..\..\tools\xabuild\SymbolicLink.cs" />
     <Content Include="Expected\GenerateDesignerFileExpected.cs">
       <Link>..\Expected\GenerateDesignerFileExpected.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -22,7 +22,9 @@ namespace Xamarin.ProjectTools
 
 		public static string GetAndroidSdkPath ()
 		{
-			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+			var sdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_SDK_PATH");
+			if (String.IsNullOrEmpty (sdkPath))
+				sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
 			if (String.IsNullOrEmpty (sdkPath))
 				sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
 			if (String.IsNullOrEmpty (sdkPath))
@@ -34,7 +36,9 @@ namespace Xamarin.ProjectTools
 
 		public static string GetAndroidNdkPath ()
 		{
-			var ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
+			var ndkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_NDK_PATH");
+			if (String.IsNullOrEmpty (ndkPath))
+				ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
 			if (String.IsNullOrEmpty (ndkPath))
 				ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
 			if (String.IsNullOrEmpty (ndkPath))


### PR DESCRIPTION
Fixes #5964

In commit accc846e we missed a few paths which might need to be quoted in order to handle
spaces in the paths. As a result users are seeing errors like the one below.

```
2021-05-28T22:15:09.3191452Z   [aot-compiler stdout] Executing the native linker: "C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE" -Bsymbolic -shared -o obj\Release\110\aot\armeabi-v7a\libaot-Xamarin.AndroidX.CardView.dll.so.tmp "obj\Release\110\aot\armeabi-v7a\Xamarin.AndroidX.CardView.dll\temp-llvm.o" obj\Release\110\aot\armeabi-v7a\Xamarin.AndroidX.CardView.dll\temp.s.o -LC:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\arm-linux-androideabi\4.9.x -LC:\Program Files (x86)\Android\android-sdk\ndk-bundle\platforms\android-21\arch-arm\usr\lib -LC:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\..\sysroot\usr\lib\arm-linux-androideabi "C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\arm-linux-androideabi\4.9.x\libgcc.a" "C:\Program Files (x86)\Android\android-sdk\ndk-bundle\platforms\android-21\arch-arm\usr\lib\libc.so" "C:\Program Files (x86)\Android\android-sdk\ndk-bundle\platforms\android-21\arch-arm\usr\lib\libm.so"
2021-05-28T22:15:09.3195848Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open Files: No such file or directory
2021-05-28T22:15:09.3197593Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\arm-linux-androideabi\4.9.x: No such file or directory
2021-05-28T22:15:09.3199375Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open Files: No such file or directory
2021-05-28T22:15:09.3200935Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open (x86)\Android\android-sdk\ndk-bundle\platforms\android-21\arch-arm\usr\lib: No such file or directory
2021-05-28T22:15:09.3202549Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open Files: No such file or directory
2021-05-28T22:15:09.3204244Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot open (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\..\sysroot\usr\lib\arm-linux-androideabi: No such file or directory
2021-05-28T22:15:09.3205865Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot find -lunwind
2021-05-28T22:15:09.3207138Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot find -lcompiler_rt-extras
2021-05-28T22:15:09.3208785Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot find -lgcc_real
2021-05-28T22:15:09.3210086Z   [aot-compiler stderr] C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\arm-linux-androideabi-ld.EXE: error: cannot find -ldl
```

So lets quote ALL the things. Also update the Aot Unit tests to use Sdk/Ndk paths with spaces in them. We do this 
by creating a symlink to the existing Sdk/Ndk directories in the Unit Test temp directory.
This highlighted a bug in the MacOS ndk were the `aarch64-linux-android21-clang` script would return the following
error

```
usage: dirname path
```

This is because the bash script on MacOS does not support paths with spaces... very similar to many of the .bat files
on Windows. So for now we are disabling the use of Sdk/Ndk paths with spaces on non windows platforms until a 
fix can be found. These changes should allow windows users to use Aot again though since its mostly windows users
who have the Sdk/Ndk directories in locations where spaces are in the path.
