### PR TITLE
[xaprepare] pass WorkingDirectory to dotnet workload install

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Android.Prepare
 			}
 
 			// Install the microsoft-net-runtime-android workload
-			if (!Utilities.RunCommand (dotnetTool, new [] { "workload", "install", "microsoft-net-runtime-android", "--skip-manifest-update", "--verbosity", "diag" })) {
+			if (!Utilities.RunCommand (dotnetTool, BuildPaths.XamarinAndroidSourceRoot, ignoreEmptyArguments: false, new [] { "workload", "install", "microsoft-net-runtime-android", "--skip-manifest-update", "--verbosity", "diag" })) {
 				Log.ErrorLine ($"dotnet workload install failed.");
 				return false;
 			}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4825895&view=logs&j=afc75dd9-ea98-591e-f4f4-0b6212ccdfde&t=a18fc855-de22-5374-28de-d604f6803bd2&s=af72edbe-9d58-52b1-91f1-857d7e391cf0

In 0150bbbc, I missed that the designer tests phases fail with:

    Workload installation failed: One or more errors occurred. (microsoft.net.runtime.runtimeconfigparser.task::6.0.0-preview.6.21274.1 is not found in NuGet feeds https://api.nuget.org/v3/index.json",)

I believe the command isn't finding the `NuGet.config` file in the
root of the xamarin-android repo, and so we're missing this source:

    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />

We need to set the `WorkingDirectory` of the process, so it finds the
appropriate `NuGet.config` file.

I would use the `--configfile` or `--add-source` switch instead, but
these switches are not implemented yet for the `dotnet workload
install` command.