### PR TITLE
[tests] remove SingleThreadedAttribute

### DIFF
--- a/tests/MSBuildDeviceIntegration/AssemblyInfo.cs
+++ b/tests/MSBuildDeviceIntegration/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using NUnit.Framework;
+
+[assembly: NonParallelizable]

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -12,7 +12,8 @@ using System.Collections.Generic;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Category ("UsesDevices")]
+	[TestFixture]
+	[Category ("UsesDevice")]
 	public class DebuggingTest : DeviceTest {
 		[TearDown]
 		public void ClearDebugProperties ()

--- a/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
@@ -7,7 +7,6 @@ using Xamarin.Tools.Zip;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[NonParallelizable] //These tests deploy to devices
 	[Category ("DotNetIgnore")] // .csproj files are legacy projects that won't build under dotnet
 	public class DeleteBinObjTest : DeviceTest
 	{

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -16,11 +16,10 @@ using NUnit.Framework.Interfaces;
 using Xamarin.ProjectTools;
 using System.Xml.XPath;
 
-[assembly: NonParallelizable]
-
 namespace Xamarin.Android.Build.Tests
 {
-	[SingleThreaded, Category ("UsesDevice")]
+	[TestFixture]
+	[Category ("UsesDevice")]
 	public class DeploymentTest : DeviceTest {
 
 		static ProjectBuilder builder;
@@ -230,25 +229,25 @@ namespace Xamarin.Android.Build.Tests
 			return tests.Where (p => tests.IndexOf (p) % NODE_COUNT == node).ToArray ();
 		}
 
-		[Test, NonParallelizable]
+		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 0 })]
 		[Category ("TimeZoneInfo")]
 		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode1 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
-		[Test, NonParallelizable]
+		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 1 })]
 		[Category ("TimeZoneInfo")]
 		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode2 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
-		[Test, NonParallelizable]
+		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 2 })]
 		[Category ("TimeZoneInfo")]
 		[Retry (2)]
 		public void CheckTimeZoneInfoIsCorrectNode3 (string timeZone) => CheckTimeZoneInfoIsCorrect (timeZone);
 
-		[Test, NonParallelizable]
+		[Test]
 		[TestCaseSource (nameof (GetTimeZoneTestCases), new object [] { 3 })]
 		[Category ("TimeZoneInfo")]
 		[Retry (2)]

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -7,8 +7,8 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[SingleThreaded]
-	[Category ("UsesDevices")]
+	[TestFixture]
+	[Category ("UsesDevice")]
 	public class InstallAndRunTests : DeviceTest
 	{
 		static ProjectBuilder builder;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -12,7 +12,6 @@ using System.Globalization;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[NonParallelizable] //These tests deploy to devices
 	[Category ("Commercial"), Category ("UsesDevice")]
 	public class InstallTests : DeviceTest
 	{

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -7,8 +7,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[NonParallelizable] //These tests deploy to devices
-	[Category ("Commercial"), Category ("UsesDevices")]
+	[Category ("Commercial"), Category ("UsesDevice")]
 	public class InstantRunTest : DeviceTest
 	{
 		[Test]

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -11,7 +11,7 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[NonParallelizable]
+	[TestFixture]
 	[Category ("UsesDevice")]
 	public class MonoAndroidExportTest : DeviceTest {
 #pragma warning disable 414

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -10,7 +10,7 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[TestFixture, NonParallelizable]
+	[TestFixture]
 	public class PerformanceTest : DeviceTest
 	{
 		const int Retry = 2;

--- a/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[NonParallelizable] //These tests deploy to devices
 	[Category ("Commercial"), Category ("UsesDevice")]
 	public class SystemApplicationTests : DeviceTest
 	{

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -12,8 +12,8 @@ using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[NonParallelizable]
-	[Category ("UsesDevices"), Category ("SmokeTests"), Category ("DotNetIgnore")] // These don't need to run under `dotnet test`
+	[TestFixture]
+	[Category ("UsesDevice"), Category ("SmokeTests"), Category ("DotNetIgnore")] // These don't need to run under `dotnet test`
 	public class XASdkDeployTests : DeviceTest
 	{
 		static object [] DotNetInstallAndRunSource = new object [] {


### PR DESCRIPTION
We occasionally hit test failures in the
`InstallAndRunTests.InterpreterEnabled` test. Running the test locally
by itself seems to work fine.

Then I noticed the class was decorated with the `[SingleThreaded]`
attribute and not `[NonParallelizable]`. `[SingleThreaded]`'s summary
says:

> Marks a test fixture as requiring all child tests to be run on the
> same thread as the OneTimeSetUp and OneTimeTearDown. A flag in the
> NUnit.Framework.Internal.TestExecutionContext is set forcing all
> child tests to be run sequentially on the current thread. Any
> NUnit.Framework.ParallelScope setting is ignored.

How is this test class not failing *more* often than it is? I found
that we set an assembly-level attribute in `DeploymentTest.cs`:

    [assembly: NonParallelizable]

But from the description of `[SingleThreaded]`, it seems like this
setting would be ignored.

To (hopefully) make things better:

* Move `[assembly: NonParallelizable]` to an easier to find
  `AssemblyInfo.cs` file.
* Remove all usage of `[NonParallelizable]` in other files in the
  `MSBuildDeviceIntegration` project.
* Remove all usage of `[SingleThreaded]`.
* Fix a couple places we had a `UsesDevices` category, as `UsesDevice`
  appears to be the category used more often.
* Add `[TestFixture]` in a few places that it was missing.