### PR TITLE
Update VSCode Support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,11 @@
 {
     "recommendations": [
-      "ms-vscode.csharp",
+      "ms-dotnettools.csharp",
       "ms-vscode.cpptools",
       "ms-vscode.mono-debug",
-      "wghats.vscode-nxunit-test-adapter",
       "visualstudioexptteam.vscodeintellicode",
       "streetsidesoftware.code-spell-checker",
+      "wghats.vscode-nxunit-test-adapter",
+      "derivitec-ltd.vscode-dotnet-adapter",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "nxunitExplorer.nunit": "build-tools/scripts/nunit3-console",
     "nxunitExplorer.modules": [
         "bin/TestDebug/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll",
         "bin/TestDebug/net472/Xamarin.Android.Build.Tests.dll",
         "bin/TestRelease/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll",
     ],
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "dotnetCoreExplorer.searchpatterns": "bin/Test{Debug,Release}/**/net6.0/{Xamarin.Android.Build.Tests,MSBuildDeviceIntegration}.dll",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,18 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Build All Xamarin.Android",
+            "type": "shell",
+            "windows":{ "command": ".\\build.cmd ${input:buildtype}"},
+            "linux":{"command": "./build.sh ${input:buildtype}"},
+            "osx":{"command": "./build.sh ${input:buildtype}"},
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
+            "problemMatcher": ["$msCompile", "$gcc"]
+        },
+        {
             "label": "Build Xamarin.Android Build Tasks",
             "type": "shell",
             "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Build /p:Configuration=${input:configuration}",
@@ -198,6 +210,19 @@
             "Install",
             "SignAndroidPackage",
             "Clean"
+        ]
+      },
+      {
+        "id": "buildtype",
+        "type": "pickString",
+        "default": "Prepare",
+        "description": "Select Build Stage to Run.",
+        "options": [
+            "Prepare",
+            "PrepareExternal",
+            "Build",
+            "Pack",
+            "Everything",
         ]
       },
     ]

--- a/Documentation/guides/vscode-support.md
+++ b/Documentation/guides/vscode-support.md
@@ -1,82 +1,88 @@
 # VSCode Support
 
-Xamarin.Android itself can be developed within VSCode. There is
-a workspace included in the repo `Xamarin.Android.code-workspace`.
+Xamarin.Android itself can be developed within
+[Visual Studio Code (VSCode)](https://code.visualstudio.com/).
+There is a workspace included in the repo `Xamarin.Android.code-workspace`.
 The required extensions should be installed when you open the
 workspace.
 
 ## Building Xamarin.Android
 
-Open the `Xamarin.Android.code-workspace` in vscode. Then use the
+Open the `Xamarin.Android.code-workspace` in VSCode. Then use the
 Build Command Pallette (Ctrl+Shift+B in Windows, Cmd+Shift+B on Mac)
 to list the available build commands.
 
-Select "Build All Xamarin.Android". You will then be presented with a
-list of options.
+Select **Build All Xamarin.Android**. You will then be presented with a
+list of options:
 
-* Prepare - Installs the required Dependencies.
-* PrepareExternal - Installs the required Commercial Dependencies (Xamarin Team Members Only)
-* Build - Build Xamarin. Android.
-* Pack - Create the Nuget Packages.
-* Everything - Calls Prepare, Build and Pack.
+* `Prepare` - Installs the required Dependencies.
+* `PrepareExternal` - Installs the required Commercial Dependencies (Xamarin Team Members Only)
+* `Build` - Build Xamarin.Android.
+* `Pack` - Create the NuGet Packages.
+* `Everything` - Calls Prepare, Build and Pack.
 
 The normal order is `Prepare`, `Build` then `Pack`. This will result in
 a usable copy of Xamarin.Android. You can now use it to build apps
 and run the unit tests.
 
-Note: PrepareExternal is for internal Xamarin Team members only, this sets up
+Note: `PrepareExternal` is for internal Xamarin Team members only, this sets up
 the commercial parts of the repository. Trying to use this command when you
 do not have access to the required repositories will result in a failure.
 
 ## Running/Debugging Unit Tests
 
-Xamarin.Android Legacy uses the `wghats.vscode-nxunit-test-adapter` extension
+Xamarin.Android Legacy uses the
+[wghats.vscode-nxunit-test-adapter](https://marketplace.visualstudio.com/items?itemName=wghats.vscode-nxunit-test-adapter) extension
 to allow you to run and debug unit tests. This extension should be installed
 automatically.
 
-We also use `derivitec-ltd.vscode-dotnet-adapter` to run the tests under
-`dotnet`. These two extensions have pretty much the same functionality.
+We also use the
+[derivitec-ltd.vscode-dotnet-adapter](https://marketplace.visualstudio.com/items?itemName=derivitec-ltd.vscode-dotnet-adapter) extension
+to run the tests under `dotnet`. These two extensions have pretty much the same functionality.
 
 ### wghats.vscode-nxunit-test-adapter
 
 In order to run or debug the tests you will need to set a path
 to the `nunit-console.exe` file. This is will be located in your
-global nuget cache, usually  in `$HOME/.nuget`.
+global nuget cache, usually  in `$HOME/.nuget` or `%USERPROFILE%/.nuget`.
 
 The setting you need to set is `nxunitExplorer.nunit`. This will need
-to be done in your `Preferences->Settings` in VSCode. This will save
+to be done in your **Preferences** > **Settings** in VSCode. This will save
 the setting globally so it will be available when ever you open
 Xamarin.Android.
 
-Alternatively you can add something like the following to the `Xamarin.Android.code-workspace`.
+Alternatively you can add something like the following to the `Xamarin.Android.code-workspace`:
 
-MacOS Setting
+macOS or Linux Setting:
+
 ```json
 "nxunitExplorer.nunit": "%HOME%/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe"
 ```
 
-Windows Setting
+Windows Setting:
+
 ```json
 "nxunitExplorer.nunit": "%USERPROFILE%/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe"
 ```
 
-The path will change depending on where your nuget cache is and depending on which
-Nunit version is being used. Note you can use environment variables in this path.
-However you need to use *Windows* style environment variables (`%var%`) rather
-than *nix based ones ($var) because of the way the `nxunit-explorer` parses the
+The path will change depending on where your NuGet cache is and depending on which
+NUnit version is being used. You can use environment variables in this path.
+However you need to use *Windows* style environment variable syntax (`%var%`) rather
+than \*nix based syntax (`$var`) because of the way the `nxunit-explorer` parses the
 settings.
 
 Once that is setup you can to go the `Testing` tab in VSCode and browse/run/debug
 the unit tests.
 
-Note: There is a slight problem with the nxunitExplorer in that it does not escape
+Note: There is a slight problem with `nxunitExplorer` in that it does not escape
 the names of the unit tests it runs. As a result the unit tests which contain
 arguments do not run within VSCode. However a work around is to run the top
 level fixture rather than the single test.
 
 Alternatively you can download the patched executable from [here](https://github.com/dellis1972/vscode-nxunit-test-adapter/releases/tag/Patch2) and replace
 your `testrun` files with these. This will allow you to run and debug all the
-tests. The upstream pull request is [PR15](prash-wghats/vscode-nxunit-test-adapter#15)
+tests. The upstream pull request is
+[prash-wghats/vscode-nxunit-test-adapter#15](https://github.com/prash-wghats/vscode-nxunit-test-adapter/pull/15).
 
 ### derivitec-ltd.vscode-dotnet-adapter
 
@@ -95,7 +101,7 @@ sample applications `HelloWorld` and `VSAndroidApp`. You can select the
 In order to use the `Debug Sample Under DotNet` you will need to have built
 Xamarin.Android for .net 6 using the `Pack` command mentioned earlier.
 See the [windows documentation](../building/windows/instructions.md) or
-[*nix documentation](../building/unix/instructions.md) for additional details
+[\*nix documentation](../building/unix/instructions.md) for additional details
 on working with .net 6.
 
 When you select a `Debug` config and click the run button you will be asked
@@ -115,7 +121,7 @@ in `.vscode/tasks.json`.
     "options": [
         "samples/HelloWorld/HelloWorld.csproj",
         "samples/HelloWorld/HelloWorld.DotNet.csproj",
-        "samples/VSAndroidApp/VSAndroidApp.csproj",
+        "samples/VSAndroidApp/VSAndroidApp.csproj"
     ]
 },
 ```

--- a/Documentation/guides/vscode-support.md
+++ b/Documentation/guides/vscode-support.md
@@ -1,0 +1,127 @@
+# VSCode Support
+
+Xamarin.Android itself can be developed within VSCode. There is
+a workspace included in the repo `Xamarin.Android.code-workspace`.
+The required extensions should be installed when you open the
+workspace.
+
+## Building Xamarin.Android
+
+Open the `Xamarin.Android.code-workspace` in vscode. Then use the
+Build Command Pallette (Ctrl+Shift+B in Windows, Cmd+Shift+B on Mac)
+to list the available build commands.
+
+Select "Build All Xamarin.Android". You will then be presented with a
+list of options.
+
+* Prepare - Installs the required Dependencies.
+* PrepareExternal - Installs the required Commercial Dependencies (Xamarin Team Members Only)
+* Build - Build Xamarin. Android.
+* Pack - Create the Nuget Packages.
+* Everything - Calls Prepare, Build and Pack.
+
+The normal order is `Prepare`, `Build` then `Pack`. This will result in
+a usable copy of Xamarin.Android. You can now use it to build apps
+and run the unit tests.
+
+Note: PrepareExternal is for internal Xamarin Team members only, this sets up
+the commercial parts of the repository. Trying to use this command when you
+do not have access to the required repositories will result in a failure.
+
+## Running/Debugging Unit Tests
+
+Xamarin.Android Legacy uses the `wghats.vscode-nxunit-test-adapter` extension
+to allow you to run and debug unit tests. This extension should be installed
+automatically.
+
+We also use `derivitec-ltd.vscode-dotnet-adapter` to run the tests under
+`dotnet`. These two extensions have pretty much the same functionality.
+
+### wghats.vscode-nxunit-test-adapter
+
+In order to run or debug the tests you will need to set a path
+to the `nunit-console.exe` file. This is will be located in your
+global nuget cache, usually  in `$HOME/.nuget`.
+
+The setting you need to set is `nxunitExplorer.nunit`. This will need
+to be done in your `Preferences->Settings` in VSCode. This will save
+the setting globally so it will be available when ever you open
+Xamarin.Android.
+
+Alternatively you can add something like the following to the `Xamarin.Android.code-workspace`.
+
+MacOS Setting
+```json
+"nxunitExplorer.nunit": "%HOME%/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe"
+```
+
+Windows Setting
+```json
+"nxunitExplorer.nunit": "%USERPROFILE%/.nuget/packages/nunit.consolerunner/3.11.1/tools/nunit3-console.exe"
+```
+
+The path will change depending on where your nuget cache is and depending on which
+Nunit version is being used. Note you can use environment variables in this path.
+However you need to use *Windows* style environment variables (`%var%`) rather
+than *nix based ones ($var) because of the way the `nxunit-explorer` parses the
+settings.
+
+Once that is setup you can to go the `Testing` tab in VSCode and browse/run/debug
+the unit tests.
+
+Note: There is a slight problem with the nxunitExplorer in that it does not escape
+the names of the unit tests it runs. As a result the unit tests which contain
+arguments do not run within VSCode. However a work around is to run the top
+level fixture rather than the single test.
+
+Alternatively you can download the patched executable from [here](https://github.com/dellis1972/vscode-nxunit-test-adapter/releases/tag/Patch2) and replace
+your `testrun` files with these. This will allow you to run and debug all the
+tests. The upstream pull request is [PR15](prash-wghats/vscode-nxunit-test-adapter#15)
+
+### derivitec-ltd.vscode-dotnet-adapter
+
+This should work out of the box as long as you have `dotnet` installed. This is
+a dependency for Xamarin.Android so it should be installed as soon as you
+build Xamarin.Android.
+
+### Running the Sample
+
+Xamarin.Android provides a few Debug configurations in VSCode to debug the
+sample applications `HelloWorld` and `VSAndroidApp`. You can select the
+`Debug Sample` Run and Debug config to run and debug the samples under
+`mono` or you can use `Debug Sample Under DotNet` to debug this under the
+.net 6 system.
+
+In order to use the `Debug Sample Under DotNet` you will need to have built
+Xamarin.Android for .net 6 using the `Pack` command mentioned earlier.
+See the [windows documentation](../building/windows/instructions.md) or
+[*nix documentation](../building/unix/instructions.md) for additional details
+on working with .net 6.
+
+When you select a `Debug` config and click the run button you will be asked
+to select the `Configuration` you want to use, followed by the `Project` and
+finally if you want to attach the debugger. If you want to alter the list of
+projects you can select you can change the list for the `project` input section
+in `.vscode/tasks.json`.
+
+```json
+{
+    // Add additional projects here. They will be available in the drop down
+    // in vscode.
+    "id": "project",
+    "type": "pickString",
+    "default": "samples/HelloWorld/HelloWorld.csproj",
+    "description": "Pick the Project you want to build.",
+    "options": [
+        "samples/HelloWorld/HelloWorld.csproj",
+        "samples/HelloWorld/HelloWorld.DotNet.csproj",
+        "samples/VSAndroidApp/VSAndroidApp.csproj",
+    ]
+},
+```
+
+you can add your own projects here and they will run with the Xamarin.Android
+you have built locally.
+
+
+

--- a/Xamarin.Android.code-workspace
+++ b/Xamarin.Android.code-workspace
@@ -4,5 +4,7 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"nxunitExplorer.logpanel": true
+	}
 }

--- a/build-tools/scripts/vswhere.cmd
+++ b/build-tools/scripts/vswhere.cmd
@@ -1,0 +1,2 @@
+@echo off
+CALL "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,33 @@
+@echo off
+
+FOR /F "tokens=1 delims=" %%F IN ('.\build-tools\scripts\vswhere.cmd') DO SET result=%%F
+2>NUL CALL "%result%\Common7\Tools\VsDevCmd.bat"
+IF ERRORLEVEL 1 CALL:FAILED_CASE
+
+2>NUL CALL :%1_CASE
+IF ERRORLEVEL 1 CALL :DEFAULT_CASE
+
+:Prepare_CASE
+    msbuild Xamarin.Android.sln /t:Prepare
+    GOTO END_CASE
+:PrepareExternal_CASE
+    msbuild Xamarin.Android.sln /t:PrepareExternal
+    GOTO END_CASE
+:Build_CASE
+    msbuild Xamarin.Android.sln
+    msbuild tools/xabuild/xabuild.csproj
+    GOTO END_CASE
+:Pack_CASE
+    msbuild Xamarin.Android.sln /t:PackDotNet
+    GOTO END_CASE
+:DEFAULT_CASE
+    msbuild Xamarin.Android.sln /t:Prepare
+    msbuild Xamarin.Android.sln
+    msbuild tools/xabuild/xabuild.csproj
+    msbuild Xamarin.Android.sln /t:PackDotNet
+    GOTO END_CASE
+:FAILED_CASE
+    echo "Failed to find an instance of Visual Studio. Please check it is correctly installed."
+    GOTO END_CASE
+:END_CASE
+    GOTO :EOF

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+if [ -z $1 ]; then
+    make prepare && make jenkins && make pack-dotnet
+else
+    case $1 in
+        Prepare)
+            make prepare
+            break
+        ;;
+        PrepareExternal)
+            make prepare-external-git-dependencies
+            break
+        ;;
+        Build)
+            make jenkins
+            break
+        ;;
+        Pack)
+            make pack-dotnet
+            break
+        ;;
+        Everything)
+            make prepare && make jenkins && make pack-dotnet
+            break
+        ;;
+    esac
+fi


### PR DESCRIPTION
Update the extensions list to use the correct id for the vscode csharp extension.

Remove the `nxunitExplorer.nunit` setting as it was causing the unit tests not to load.
This is because the extension is expecting a CIL image, but we were passing a batch
file. As a result none of the unit tests would load in the IDE.

Add some documentation around using VSCode to run the unit tests and debug the 
sample apps. This includes a link to a patched version of the `testrun.exe` which the 
`nxunit.explorer` extension uses. There is a bug in the extension where tests will 
parameters will NOT run or debug. The link patched version of the files is included 
in the docs. A PR to the upstream extension has also been sent.

Added the `dotnet-adapter` extension which lets us run the tests under a `dotnet`
context.