### PR TITLE
[build] fix typo in paths of test .apk files

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -788,7 +788,7 @@ stages:
         testName: Mono.Android.NET_Tests
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration).xml
-        artifactSource: bin/Test$(XA.Build.Configuration)/net6-android/Mono.Android.NET_Tests-Signed.apk
+        artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-Default
         useDotNet: true
 
@@ -800,7 +800,7 @@ stages:
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Aab.xml
         extraBuildArgs: /p:TestsFlavor=Aab /p:AndroidPackageFormat=aab
         packageType: Aab
-        artifactSource: bin/Test$(XA.Build.Configuration)/net6-android/Mono.Android.NET_Tests-Signed.aab
+        artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: net6-Aab
         useDotNet: true
 
@@ -811,7 +811,7 @@ stages:
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Interpreter.xml
         extraBuildArgs: /p:TestsFlavor=Interpreter /p:UseInterpreter=True
-        artifactSource: bin/Test$(XA.Build.Configuration)/net6-android/Mono.Android.NET_Tests-Signed.apk
+        artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-Interpreter
         useDotNet: true
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4831106&view=logs&j=5ded96ba-e325-5baf-fde0-f1868aa3be52&t=cfd7d899-a506-54ab-8689-bd03e4a79419&l=14

Test phases on our .NET 6 Preview 5 release branch can fail with:

    cp: bin/TestRelease/net6-android/Mono.Android.NET_Tests-Signed.apk: No such file or directory

Partially backports da536fcf.

Fix `azure-pipelines.yaml` so that if (when) the
`Mono.Android.NET_Tests` unit tests fail, the corresponding `.apk`
or `.aab` file is uploaded for our later investigation; see also
commit af7f7f5, which contained a "typo" such that .NET 6 packages
*weren't* uploaded on unit test failure, as they used the wrong
target framework identifier in the path.