### PR TITLE
[Xamarin.Android.Build.Tasks] fix warning with $(UseInterpreter)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -455,9 +455,10 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
-		public void DotNetBuildXamarinForms ()
+		public void DotNetBuildXamarinForms ([Values (true, false)] bool useInterpreter)
 		{
 			var proj = new XamarinFormsXASdkProject ();
+			proj.SetProperty ("UseInterpreter", useInterpreter.ToString ());
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build (), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -190,7 +190,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidAotMode Condition=" '$(AndroidUseInterpreter)' != 'False' ">Interpreter</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' ">None</AndroidAotMode>
-	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' ">True</AotAssemblies>
+	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' And '$(AndroidAotMode)' != 'Interpreter' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
 
 	<AndroidUseDebugRuntime


### PR DESCRIPTION
We currently emit a warning when `$(UseInterpreter)` is true:

    warning XA0119: Using fast deployment and AOT at the same time is not recommended. Use fast deployment for Debug configurations and AOT for Release configurations. [C:\src\xamarin-android\bin\TestDebug\temp\DotNetBuildXamarinFormsTrue\UnnamedProject.csproj]

It turns out that we were setting `$(AotAssemblies)` to true when the
interpreter was used.

Since `$(UseInterpreter)` on Android is meant for Debug & "Hot Reload"
scenarios, we definitely don't want this setting to enable AOT!

Luckily enabling AOT doesn't do anything yet in .NET 6, because it is
not implemented yet. I also suspect enabling the interpreter is not
used much (if at all) in "legacy" Xamarin.Android.

I updated a .NET 6 test so it sets `$(UseInterpreter)` and verifies
there are no build warnings.