### PR TITLE
Bump to xamarin/monodroid/main@1f2ce156

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@76c04cd15eca7afc269a6d26296e9d2db6f79be2
+xamarin/monodroid:main@1f2ce156245ef1bf63ec8014882d283b3224216b
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -297,6 +297,10 @@ namespace Xamarin.Android.Build.Tests
 					nativeLib,
 				},
 			};
+			if (Builder.UseDotNet) {
+				//NOTE: in .NET 6 by default an x86_64 emulator would fall back to x86 if we don't set this.
+				proj.SetAndroidSupportedAbis (DeviceAbi);
+			}
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Install (proj), "install should have succeeded. 0");


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/76c04cd1...1f2ce156

* [tools/msbuild] Missing translations for XA0135
* Bump to xamarin/xamarin-android@032d840, xamarin/androidtools@355d015
* [build] fix dotnet tool install command
* [tools/fastdev] Rework Unix timestamp calculation code in xamarin.find
* [tools/fastdev] Add error checking when writing data to disk.
* [tools/msbuild] <GetPrimaryCpuAbi/> selects backup RIDs for .NET 6
* Bump android-sdk-installer to use Mono.Unix
* [tools/msbuild] only run _GetPrimaryCpuAbi for Fast Dev

Other changes:

* `InstantRunNativeLibrary` will need to set the ABI in the `.csproj`
  in order for the test to pass on .NET 6. It's use of
  `BaseTest.DeviceAbi` would not match for an x86_64 emulator.