### PR TITLE
Try to detect when the emulator is not working

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@d111a7aac3b0a4c386da11fd2c02b9418ee6f259
+xamarin/monodroid:main@a0e1eb4d9907ad0b89191586bbb125ecf5607090
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@a0e1eb4d9907ad0b89191586bbb125ecf5607090
+xamarin/monodroid:main@33e542fac95f1ac4e56d3965d2f336a1d6a5f98e
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@36536006a74d9fa9b08b14301f73b2e7da93d75d
+xamarin/monodroid:main@d111a7aac3b0a4c386da11fd2c02b9418ee6f259
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\TestApks.targets" />
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -22,11 +22,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[SetUpFixture]
 		public class SetUp {
-			public static bool HasDevices {
-				get;
-				private set;
-			}
-
 			public static string DeviceAbi {
 				get;
 				private set;
@@ -66,7 +61,7 @@ namespace Xamarin.Android.Build.Tests
 			{
 				try {
 					DeviceSdkVersion = GetSdkVersion ();
-					if (HasDevices = DeviceSdkVersion != -1) {
+					if (DeviceSdkVersion != -1) {
 						if (DeviceSdkVersion >= 21)
 							DeviceAbi = RunAdbCommand ("shell getprop ro.product.cpu.abilist64").Trim ();
 
@@ -84,8 +79,7 @@ namespace Xamarin.Android.Build.Tests
 
 			int GetSdkVersion ()
 			{
-				var adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
-				var command = $"{adbTarget} shell getprop ro.build.version.sdk";
+				var command = $"shell getprop ro.build.version.sdk";
 				var result = RunAdbCommand (command);
 				if (result.Contains ("*")) {
 					// Run the command again, we likely got:
@@ -123,29 +117,6 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 		}
-
-		protected bool HasDevices => SetUp.HasDevices;
-
-		/// <summary>
-		/// Checks if there is a device available
-		/// * Defaults to Assert.Fail ()
-		/// </summary>
-		public void AssertHasDevices (bool fail = true)
-		{
-			if (!HasDevices) {
-				var message = "This test requires an attached device or emulator.";
-				if (fail) {
-					Assert.Fail (message);
-				} else {
-					Assert.Ignore (message);
-				}
-			}
-		}
-
-		protected string DeviceAbi => SetUp.DeviceAbi;
-
-		protected int DeviceSdkVersion => SetUp.DeviceSdkVersion;
-
 		protected bool IsWindows => TestEnvironment.IsWindows;
 
 		protected bool IsMacOS => TestEnvironment.IsMacOS;
@@ -232,6 +203,20 @@ namespace Xamarin.Android.Build.Tests
 			pause.WaitOne(milliseconds);
 		}
 
+		protected static void WaitFor (TimeSpan timeSpan, Func<bool> func, int intervalInMS = 10)
+		{
+			var pause = new ManualResetEvent (false);
+			TimeSpan total = timeSpan;
+			TimeSpan interval = TimeSpan.FromMilliseconds (intervalInMS);
+			while (total.TotalMilliseconds > 0) {
+				pause.WaitOne (interval);
+				total = total.Subtract (interval);
+				if (func ()) {
+					break;
+				}
+			}
+		}
+
 		protected static string RunAdbCommand (string command, bool ignoreErrors = true, int timeout = 30)
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
@@ -261,7 +246,7 @@ namespace Xamarin.Android.Build.Tests
 			return stdOutput + stdError;
 		}
 
-		protected static (int code, string stdOutput, string stdError) RunProcessWithExitCode (string exe, string args)
+		protected static (int code, string stdOutput, string stdError) RunProcessWithExitCode (string exe, string args, int timeoutInSeconds = 30)
 		{
 			TestContext.Out.WriteLine ($"{nameof(RunProcess)}: {exe} {args}");
 			var info = new ProcessStartInfo (exe, args) {
@@ -287,7 +272,7 @@ namespace Xamarin.Android.Build.Tests
 				proc.BeginOutputReadLine ();
 				proc.BeginErrorReadLine ();
 
-				if (!proc.WaitForExit ((int)TimeSpan.FromSeconds (30).TotalMilliseconds)) {
+				if (!proc.WaitForExit ((int)TimeSpan.FromSeconds (timeoutInSeconds).TotalMilliseconds)) {
 					proc.Kill ();
 					TestContext.Out.WriteLine ($"{nameof (RunProcess)} timed out: {exe} {args}");
 					return (-1, null, null); //Don't try to read stdout/stderr

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -17,12 +17,49 @@ namespace Xamarin.Android.Build.Tests
 	{
 		public const string GuestUserName = "guest1";
 
+		protected bool HasDevices {
+			get {
+				string output = RunAdbCommand ("shell echo OK");
+				return output.Contains ("OK");
+			}
+		}
+
+		/// <summary>
+		/// Checks if there is a device available
+		/// * Defaults to Assert.Fail ()
+		/// </summary>
+		public void AssertHasDevices (bool fail = true)
+		{
+			if (!HasDevices) {
+				var message = "This test requires an attached device or emulator.";
+				if (fail) {
+					Assert.Fail (message);
+				} else {
+					Assert.Ignore (message);
+				}
+			}
+		}
+
+		protected string DeviceAbi => SetUp.DeviceAbi;
+
+		protected int DeviceSdkVersion => SetUp.DeviceSdkVersion;
+
 		[OneTimeSetUp]
 		public void DeviceSetup ()
 		{
 			SetAdbLogcatBufferSize (64);
 			RunAdbCommand ("logcat -c");
 			CreateGuestUser (GuestUserName);
+		}
+
+		[SetUp]
+		public void CheckDevice ()
+		{
+			if (!HasDevices) {
+				// something went wrong with the emulator.
+				// lets restart it.
+				RestartDevice (Path.Combine (Root, "Emulator.csproj"));
+			}
 		}
 
 		[TearDown]
@@ -61,6 +98,16 @@ namespace Xamarin.Android.Build.Tests
 			}
  		}
 
+		public static void RestartDevice (string project)
+		{
+			TestContext.Out.WriteLine ($"Trying to restart Emulator");
+			// shell out to msbuild and start the emulator again
+			using (var builder = new Builder ()) {
+				var out1 = RunProcessWithExitCode (builder.BuildTool, $"{project} /restore /t:AcquireAndroidTarget", timeoutInSeconds: 120);
+				TestContext.Out.WriteLine ($"{out1}");
+			}
+		}
+
 		protected static void RunAdbInput (string command, params object [] args)
 		{
 			RunAdbCommand ($"shell {command} {string.Join (" ", args)}");
@@ -93,20 +140,6 @@ namespace Xamarin.Android.Build.Tests
 			WaitFor (timeout ?? TimeSpan.FromMinutes (1), func);
 			stopwatch.Stop ();
 			return stopwatch.Elapsed;
-		}
-
-		protected void WaitFor (TimeSpan timeSpan, Func<bool> func)
-		{
-			var pause = new ManualResetEvent (false);
-			TimeSpan total = timeSpan;
-			TimeSpan interval = TimeSpan.FromMilliseconds (10);
-			while (total.TotalMilliseconds > 0) {
-				pause.WaitOne (interval);
-				total = total.Subtract (interval);
-				if (func ()) {
-					break;
-				}
-			}
 		}
 
 		protected static bool MonitorAdbLogcat (Func<string, bool> action, string logcatFilePath, int timeout = 15)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -45,6 +45,10 @@
       <Link>..\Expected\CheckPackageManagerAssemblyOrder.java</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Emulator.csproj">
+      <Link>..\Emulator.csproj</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[Category ("Node-2")]
-	public class BundleToolTests : BaseTest
+	public class BundleToolTests : DeviceTest
 	{
 		static readonly string [] Abis = new [] { "armeabi-v7a", "arm64-v8a", "x86" };
 		XamarinAndroidLibraryProject lib;


### PR DESCRIPTION
We have seen in the past issues where the emulator seems to disappear during Unit testing. 
I don't have access to the error message which we got since those old builds have since been removed. 

Our existing setup checked that we had a running emulator when the test fixture was started. So this check
only happened once. If anything happens to the emulator after that check the unit tests would still think
that is was running. Also there is no recovery mechanism. All the code to start the emulator is handled by 
the pipelines build scripts and the `AcquireAndroidTarget`. 

So we need to rethink this a bit. The pipelines will still call `AcquireAndroidTarget` to start up the emulator 
before all the tests. But we need to introduce some additional checks to make sure the emulator is functioning
and has not crashed during the test run. The introduction of a new `CheckDevice` method which will run
BEFORE every device test will do a simple `echo OK` to the adb shell. This will allow us to check to see if 
the emulator is responding. If that fails there is a new `RestartDevice` method which will make use of the 
`AcquireAndroidTarget` to make sure the emulator starts up.  It does this by making use of a simple
`Emulator.csproj` which is just there to import the appropriate targets. We can then use the existing unit
test `Builder` infrastructure to run the required target and start the emulator. 

This may well increase our build times since we need to do the additional checks per unit test, but should
make the overall system more reliable. 