### PR TITLE
[One .NET] fix for non-existent .dll/.pdb files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Tasks
 			var symbols = new Dictionary<string, ITaskItem> ();
 
 			if (ResolvedSymbols != null) {
-				foreach (var symbol in ResolvedSymbols) {
+				foreach (var symbol in ResolvedSymbols.Where (Filter)) {
 					symbols [symbol.ItemSpec] = symbol;
 				}
 			}
@@ -124,10 +124,10 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		bool Filter (ITaskItem assembly)
+		bool Filter (ITaskItem item)
 		{
-			if (!File.Exists (assembly.ItemSpec)) {
-				Log.LogDebugMessage ($"Skipping non-existent dependency '{assembly.ItemSpec}'.");
+			if (!File.Exists (item.ItemSpec)) {
+				Log.LogDebugMessage ($"Skipping non-existent file '{item.ItemSpec}'.");
 				return false;
 			}
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -626,6 +626,15 @@ public abstract class Foo<TVirtualView, TNativeView> : AbstractViewHandler<TVirt
 			appBuilder.AssertTargetIsSkipped ("CoreCompile");
 		}
 
+		[Test]
+		public void SignAndroidPackage ()
+		{
+			var proj = new XASdkProject ();
+			var builder = CreateDotNetBuilder (proj);
+			var parameters = new [] { "BuildingInsideVisualStudio=true" };
+			Assert.IsTrue (builder.Build ("SignAndroidPackage", parameters), $"{proj.ProjectName} should succeed");
+		}
+
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)
 		{
 			if (string.IsNullOrEmpty (relativeProjectDir)) {


### PR DESCRIPTION
In .NET 6 if you run:

    dotnet build HelloAndroid -t:SignAndroidPackage -p:BuildingInsideVisualStudio=true

You'll hit the error:

    Microsoft.Android.Sdk.AssemblyResolution.targets(136,5): error MSB4096:
    The item "obj\Debug\net6.0-android\UnnamedProject.pdb" in item list "ResolvedSymbols" does not define a value for metadata "DestinationSubPath".  In order to use this metadata, either qualify it by specifying %(ResolvedSymbols.DestinationSubPath), or ensure that all items in this list define a value for this metadata.

I could reproduce this problem in a test.

This file doesn't actually exist, as you can see in the log:

    Skipping non-existent dependency 'obj\Debug\net6.0-android\UnnamedProject.dll'.

In this scenario, we're using an optimization when building inside the
IDE. In this case:

* IDE runs `Build`
* IDE runs `Install`

On the second install, we make sure that `Build` doesn't run again.
This avoids MSBuild calculating the `Inputs` and `Outputs` of many
targets.

See: https://github.com/xamarin/xamarin-android/commit/76fb90e03194d5999c4da3b0146da40eca257295

To solve the problem, we simply need to run the same `File.Exists()`
check on the symbol files in the `<ProcessAssemblies/>` MSBuild task.