### PR TITLE
[One .NET] define UnixFilePermissions.xml

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateUnixFilePermissions.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateUnixFilePermissions.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	/// <summary>
+	/// Creates data/UnixFilePermissions.xml
+	/// NOTE: not currently intended to run on Windows
+	/// </summary>
+	public class GenerateUnixFilePermissions : Task
+	{
+		[Required]
+		public string Output { get; set; }
+
+		public string PackagePath { get; set; } = "";
+
+		public ITaskItem [] Files { get; set; }
+
+		public override bool Execute ()
+		{
+			var settings = new XmlWriterSettings {
+				OmitXmlDeclaration = true,
+				Indent = true,
+			};
+
+			/*
+			 <FileList>
+			   <File Path="tools/Darwin/aapt2" Permission="755" />
+			 </FileList>
+			*/
+
+			using var xml = XmlWriter.Create (Output, settings);
+			xml.WriteStartElement ("FileList");
+			if (Files != null) {
+				var files =
+					from f in Files
+					let path = f.GetMetadata ("RelativePath")
+					let permission = f.GetMetadata ("Permission")
+					where !string.IsNullOrEmpty (path) && !string.IsNullOrEmpty (permission)
+					orderby path
+					select (path, permission);
+				foreach (var (path, permission) in files) {
+					xml.WriteStartElement ("File");
+					xml.WriteAttributeString ("Path", Path.Combine (PackagePath, path));
+					xml.WriteAttributeString ("Permission", permission);
+					xml.WriteEndElement ();
+				}
+			}
+			xml.WriteEndDocument ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -8,6 +8,8 @@ core workload SDK packs imported by WorkloadManifest.targets.
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
 
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateUnixFilePermissions" />
+
   <PropertyGroup>
     <PackageId>Microsoft.Android.Sdk.$(HostOS)</PackageId>
     <Description>C# Tools and Bindings for the Android SDK</Description>
@@ -52,6 +54,13 @@ core workload SDK packs imported by WorkloadManifest.targets.
         DestinationFiles="@(AndroidSdkBuildTools->'$(ToolsSourceDir)%(RelativePath)')"
     />
 
+    <GenerateUnixFilePermissions
+        Condition=" '$(HostOS)' != 'Windows' "
+        Output="$(IntermediateOutputPath)UnixFilePermissions.xml"
+        PackagePath="tools"
+        Files="@(AndroidSdkBuildTools)"
+    />
+
     <ItemGroup>
       <!-- Microsoft.Android.Sdk.ILLink output -->
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.dll" PackagePath="tools" />
@@ -65,6 +74,7 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" PackagePath="Sdk" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" PackagePath="PreserveLists" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\**" PackagePath="targets" />
+      <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <None Include="$(MSBuildThisFileDirectory)SignList.xml" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -337,6 +337,7 @@
       <CodeSign>True</CodeSign>
       <HardenRuntime>True</HardenRuntime>
       <EntitlementsPath>$(DefaultRuntimeEntitlementsPath)</EntitlementsPath>
+      <Permission>755</Permission>
     </_MSBuildFilesUnixSignAndHarden>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -352,12 +353,12 @@
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\mono" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" Permission="755" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" Permission="755" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" ExcludeFromAndroidNETSdk="true" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\mono" ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)"    ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)"  ExcludeFromAndroidNETSdk="true" />


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/16894

There is currently a workaround in place, so that executables inside a
.NET workload have the right permissions:

https://github.com/dotnet/sdk/pull/17299/files

A new `data/UnixFilePermissions.xml` file will be required to define
permissions such as:

    <FileList>
      <File Path="tools/Darwin/aapt2" Permission="755" />
    </FileList>

I am putting this in place before the changes to `dotnet workload
install` actually land.

We also found these files should be *removed* from our .NET workload
packs:

* `aprofutil`
* `mono`
* `mono-symbolicate`