### PR TITLE
[xaprepare] fix workload install on Linux

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -96,7 +96,7 @@ namespace Xamarin.Android.Prepare
 			// Copy the WorkloadManifest.* files from the latest Microsoft.NET.Workload.Mono.ToolChain listed in package-download.proj
 			var destination = Path.Combine (dotnetPath, "sdk-manifests",
 				context.Properties.GetRequiredValue (KnownProperties.DotNetPreviewVersionBand),
-				"Microsoft.NET.Workload.Mono.ToolChain"
+				"microsoft.net.workload.mono.toolchain"
 			);
 			foreach (var file in Directory.GetFiles (Configurables.Paths.MicrosoftNETWorkloadMonoToolChainDir, "WorkloadManifest.*")) {
 				Utilities.CopyFileToDir (file, destination);


### PR DESCRIPTION
Currently, `make prepare` fails on Linux with:

    System.Exception: Duplicate workload manifest microsoft.net.workload.mono.toolchain
        at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.RefreshWorkloadManifests() in Microsoft.DotNet.TemplateLocator.dll:token 0x600006c+0x6c
        at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver..ctor(IWorkloadManifestProvider manifestProvider, String[] dotnetRootPaths, String[] currentRuntimeIdentifiers) in Microsoft.DotNet.TemplateLocator.dll:token 0x600006b+0x31
        at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.Create(IWorkloadManifestProvider manifestProvider, String dotnetRootPath, String sdkVersion) in Microsoft.DotNet.TemplateLocator.dll:token 0x6000068+0x8a
        at Microsoft.DotNet.Workloads.Workload.Install.WorkloadInstallCommand..ctor(ParseResult parseResult, IReporter reporter, IWorkloadResolver workloadResolver, IInstaller workloadInstaller, INuGetPackageDownloader nugetPackageDownloader, IWorkloadManifestUpdater workloadManifestUpdater, String dotnetDir, String userHome, String tempDirPath, String version) in dotnet.dll:token 0x60001f2+0x17f
        at Microsoft.DotNet.Workloads.Workload.WorkloadCommand.<get_SubCommands>b__9_0(ParseResult appliedOption) in dotnet.dll:token 0x6000152+0x0
        at Microsoft.DotNet.Cli.DotNetTopLevelCommandBase.RunCommand(String[] args) in dotnet.dll:token 0x600090f+0x44
        at Microsoft.DotNet.Workloads.Workload.WorkloadCommand.Run(String[] args) in dotnet.dll:token 0x6000150+0x6
        at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, TimeSpan startupTime, ITelemetry telemetryClient) in dotnet.dll:token 0x6000978+0x2e8
        at Microsoft.DotNet.Cli.Program.Main(String[] args) in dotnet.dll:token 0x6000976+0x6f

Which is the result of:

    $ ls -la ~/android-toolchain/dotnet/sdk-manifests/6.0.100/
    total 36
    drwxr-xr-- 9 codespace codespace 4096 Jun  9 13:25 .
    drwxr-xr-x 3 codespace codespace 4096 Jun  9 13:25 ..
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.sdk.android
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.sdk.ios
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.sdk.maccatalyst
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.sdk.macos
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.sdk.tvos
    drwxr-xr-- 2 codespace codespace 4096 Jun  9 13:25 microsoft.net.workload.mono.toolchain
    drwxr-xr-x 2 codespace codespace 4096 Jun  9 13:25 Microsoft.NET.Workload.Mono.ToolChain

Our code in `Step_InstallDotNetPreview.cs` needs to use a lowercase
path for `microsoft.net.workload.mono.toolchain`

After doing this, the build was able to get past this point.