### PR TITLE
Branching for d16-11; Bump $(ProductVersion) to 11.4.0

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@76c04cd15eca7afc269a6d26296e9d2db6f79be2
+xamarin/monodroid:d16-11@fab2d0b3e5205cb97d03e7a33a367245dbd211aa
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = main
+    branch = d16-11
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git
@@ -46,4 +46,4 @@
 [submodule "external/xamarin-android-tools"]
     path = external/xamarin-android-tools
     url = https://github.com/xamarin/xamarin-android-tools
-    branch = main
+    branch = d16-11

--- a/Configuration.props
+++ b/Configuration.props
@@ -95,7 +95,7 @@
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/144/b4a385816ed4f1398d0184c38f19f560e868fd80/MonoFramework-MDK-6.12.0.137.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
     <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.12.0.137</MonoRequiredMinimumVersion>
-    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.12.99</MonoRequiredMaximumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.12.0.137</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' And '$(RunningOnCI)' == 'true' ">False</IgnoreMaxMonoVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\sdks\out\android-sources\external\linker\src</LinkerSourceDirectory>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductVersion>11.3.99</ProductVersion>
+    <ProductVersion>11.4.0</ProductVersion>
     <!-- NuGet package version numbers. See Documentation/guides/OneDotNet.md.
          Rules:
          * Major/Minor match Android stable API level, such as 30.0 for API 30.

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1073,13 +1073,14 @@ stages:
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'main' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
-        $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
-        if ("$(Build.Reason)" -eq "PullRequest") {
-            $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
-        }
-        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
-            $branchName = "main"
-        }
+        $branchName = "d16-10"
+        # $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        # if ("$(Build.Reason)" -eq "PullRequest") {
+        #     $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
+        # }
+        # if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
+        #     $branchName = "main"
+        # }
         Set-Location -Path $(System.DefaultWorkingDirectory)/UITools
         git checkout $branchName
         git submodule update -q --init --recursive

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1073,14 +1073,18 @@ stages:
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'main' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
-        $branchName = "d16-10"
-        # $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
-        # if ("$(Build.Reason)" -eq "PullRequest") {
-        #     $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
-        # }
-        # if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
-        #     $branchName = "main"
-        # }
+        $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        if ("$(Build.Reason)" -eq "PullRequest") {
+            $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
+        }
+        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
+            $branchName = "main"
+        }
+        if ("$branchName" -eq "d16-11") {
+            # Building UITools/d16-11 on macOS results in 930+ CS0246 errors around AppKit.
+            # Use d16-10 branch instead.
+            $branchName = "d16-10"
+        }
         Set-Location -Path $(System.DefaultWorkingDirectory)/UITools
         git checkout $branchName
         git submodule update -q --init --recursive


### PR DESCRIPTION
Xamarin.Android v11.4.0 will be shipped as part of
Visual Studio 2019 16.11 Preview 3 and subsequent releases.

Changes: https://github.com/xamarin/monodroid/compare/76c04cd15eca7afc269a6d26296e9d2db6f79be2...fab2d0b3e5205cb97d03e7a33a367245dbd211aa

  * xamarin/monodroid@fab2d0b3e: Branching for d16-11. (#1209)