### PR TITLE
[Mono.Android] Bind API-S Beta 2.

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-28_r04",   apiLevel: "28", pkgRevision: "4"),
 				new AndroidPlatformComponent ("platform-29_r01",   apiLevel: "29", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-S_r04",    apiLevel: "S",  pkgRevision: "4"),
+				new AndroidPlatformComponent ("platform-S_r05",    apiLevel: "S",  pkgRevision: "5"),
 
 				new AndroidToolchainComponent ("sources-30_r01",   destDir: Path.Combine ("platforms", $"android-30", "src"), pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 


### PR DESCRIPTION
Context: https://developer.android.com/about/versions/12/overview
Context: https://android-developers.googleblog.com/search/label/Android12

Android 12 [Beta 2 has been released][0].

  * [API diff vs. Beta 1][1]
  * [API diff vs. API-30][2]

Google's documented [timeline for Android 12][3] is unchanged
vs. commit 11c30ac:

  * May: Beta 1
  * June-July: Beta 2, Beta 3
  * August: Beta 4
    This contains the final APIs and official SDK.

[0]: https://android-developers.googleblog.com/2021/06/android-12-beta-2-update.html
[1]: https://developer.android.com/sdk/api_diff/s-beta2-incr/changes
[2]: https://developer.android.com/sdk/api_diff/s-beta2/changes
[3]: https://developer.android.com/about/versions/12/overview#timeline