### PR TITLE
[build] temporarily require Mono 6.12.0.137

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -95,7 +95,7 @@
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/144/b4a385816ed4f1398d0184c38f19f560e868fd80/MonoFramework-MDK-6.12.0.137.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
     <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.12.0.137</MonoRequiredMinimumVersion>
-    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.12.99</MonoRequiredMaximumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">$(MonoRequiredMinimumVersion)</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' And '$(RunningOnCI)' == 'true' ">False</IgnoreMaxMonoVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\sdks\out\android-sources\external\linker\src</LinkerSourceDirectory>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6014

We are occasionally seeing test failures with many forms of:

    Could not load file or assembly 'Microsoft.NET.StringTools, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.

This seems to be caused by Mono 6.12.0.145 installed on some of the
build machines.

We can undo this change when #6014 goes in.