### PR TITLE
[Xamarin.Android.Build.Tasks] Add Warning for NUnitLite

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3994,12 +3994,12 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		[Category ("DotNetIgnore")] // OpenTK not even shipped for .net 6.
-		public void XA4313 ()
+		[Category ("DotNetIgnore")]
+		public void XA4313 ([Values ("OpenTK-1.0", "Xamarin.Android.NUnitLite")] string reference)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				References = {
-					new BuildItem.Reference ("OpenTK-1.0")
+					new BuildItem.Reference (reference)
 				},
 			};
 			using (var builder = CreateApkBuilder ()) {
@@ -4017,6 +4017,17 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Legacy_OpenTK);
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void NUnitLiteNugetWorks ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Legacy_NUnitLite);
 			using (var builder = CreateApkBuilder ()) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -555,6 +555,11 @@ namespace Xamarin.ProjectTools
 			Version = "0.0.1-alpha",
 			TargetFramework = "MonoAndroid10",
 		};
+		public static Package Xamarin_Legacy_NUnitLite = new Package {
+			Id = "Xamarin.Legacy.NUnitLite",
+			Version = "0.0.1-alpha",
+			TargetFramework = "MonoAndroid10",
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -238,7 +238,7 @@ projects. .NET 5 projects will not import this file.
         Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
         Code="XA4313"
         ResourceName="XA4313"
-        FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLit"
+        FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLite"
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -234,6 +234,12 @@ projects. .NET 5 projects will not import this file.
         ResourceName="XA4313"
         FormatArguments="OpenTK-1.0;Xamarin.Legacy.OpenTK"
     />
+    <AndroidWarning
+        Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
+        Code="XA4313"
+        ResourceName="XA4313"
+        FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLit"
+    />
   </Target>
 
   <Target Name="_GetReferenceAssemblyPaths">


### PR DESCRIPTION
Xamarin.Android.NUnitLite has been deprecated. So lets add a Warning
like we did for OpenTK to give users a heads up.