### PR TITLE
[One .NET] normalize case for $(TargetPlatformIdentifier)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <MicrosoftAndroidSdkTargetsImported>true</MicrosoftAndroidSdkTargetsImported>
+    <!-- Normalize casing -->
+    <TargetPlatformIdentifier>Android</TargetPlatformIdentifier>
     <_XamarinAndroidBuildTasksAssembly>..\tools\Xamarin.Android.Build.Tasks.dll</_XamarinAndroidBuildTasksAssembly>
     <UsingAndroidNETSdk>true</UsingAndroidNETSdk>
     <!-- Enable nuget package conflict resolution -->


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/blob/1a79ddc4dc8df38f645d2b5517cdfa330747511e/accepted/2020/net5/net5.md#valid-platforms
Context: https://github.com/xamarin/xamarin-macios/commit/e35bb9c47913fc8ef6c23a89a73e219f75daa448

The spec for `$(TargetPlatformIdentifier)` mentions that each workload
should normalize the casing.

xamarin-macios already does this for `iOS`, `macOS`, `tvOS`, etc. We
should normalize to `Android`.

The place I set this is only imported by `WorkloadManifest.targets`
when MSBuild's case insensitive string comparison matches:

    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk"
      Condition=" '$(TargetPlatformIdentifier)' == 'android' " />

So we can simply set this early on in our .NET 6 `.targets`:

    <TargetPlatformIdentifier>Android</TargetPlatformIdentifier>