### PR TITLE
Revert "[One .NET] remove NuGet workarounds"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -21,6 +21,8 @@ This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
   <Import Project="Microsoft.Android.Sdk.Application.targets" Condition=" '$(AndroidApplication)' == 'true' " />
   <Import Project="Microsoft.Android.Sdk.AssemblyResolution.targets" />
   <Import Project="Microsoft.Android.Sdk.ILLink.targets" />
+  <!-- Only import this in VS 2019 16.x -->
+  <Import Project="Microsoft.Android.Sdk.NuGet.targets" Condition=" '$(MSBuildRuntimeType)' == 'Full' and '$(MSBuildVersion)' &lt; '17.0' " />
   <Import Project="Microsoft.Android.Sdk.ProjectCapabilities.targets" />
   <Import Project="Microsoft.Android.Sdk.Publish.targets" />
   <Import Project="Microsoft.Android.Sdk.RuntimeConfig.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets
@@ -1,0 +1,53 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.NuGet.targets
+
+This file contains *temporary* workarounds for NuGet. This is required for Visual Studio 16.x.
+
+Not needed for versions of MSBuild that contain: https://github.com/NuGet/NuGet.Client/commit/10274281c37e9dd3626938757f7e947d649b821b
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Xamarin.Android.Tasks.FixupNuGetReferences" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
+  <PropertyGroup>
+    <_AndroidPlatformVersion>$(TargetPlatformVersion)</_AndroidPlatformVersion>
+    <_AndroidPlatformVersion Condition=" !$(_AndroidPlatformVersion.EndsWith ('.0')) ">$(_AndroidPlatformVersion).0</_AndroidPlatformVersion>
+    <!-- Clear $(AssetTargetFallback), so only $(PackageTargetFallback) is used. -->
+    <AssetTargetFallback></AssetTargetFallback>
+    <!--
+      Use $(PackageTargetFallback), even though it is deprecated.
+      It doesn't suffer from: https://github.com/NuGet/docs.microsoft.com-nuget/issues/1955
+    -->
+    <PackageTargetFallback>
+      net6.0-android$(_AndroidPlatformVersion);
+      monoandroid12.0;
+      monoandroid11.0;
+      monoandroid10.0;
+      monoandroid90;
+      monoandroid81;
+      monoandroid80;
+      monoandroid70;
+      monoandroid60;
+      monoandroid50;
+      $(PackageTargetFallback);
+    </PackageTargetFallback>
+  </PropertyGroup>
+
+  <Target Name="_FixupNuGetReferences" AfterTargets="ResolvePackageAssets">
+    <FixupNuGetReferences
+        PackageTargetFallback="$(PackageTargetFallback)"
+        CopyLocalItems="@(RuntimeCopyLocalItems)">
+      <Output TaskParameter="AssembliesToRemove" ItemName="_AssembliesToRemove" />
+      <Output TaskParameter="AssembliesToAdd"    ItemName="Reference" />
+    </FixupNuGetReferences>
+    <ItemGroup>
+      <RuntimeCopyLocalItems          Remove="@(_AssembliesToRemove)" />
+      <ResolvedCompileFileDefinitions Remove="@(_AssembliesToRemove)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FixupNuGetReferences.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// This task contains *temporary* workarounds for NuGet in .NET 5.
+	/// </summary>
+	public class FixupNuGetReferences : AndroidTask
+	{
+		public override string TaskPrefix => "FNR";
+
+		[Required]
+		public string [] PackageTargetFallback { get; set; }
+
+		public ITaskItem [] CopyLocalItems { get; set; }
+
+		[Output]
+		public string [] AssembliesToAdd { get; set; }
+
+		[Output]
+		public ITaskItem [] AssembliesToRemove { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (CopyLocalItems == null || CopyLocalItems.Length == 0)
+				return true;
+
+			var assembliesToAdd     = new Dictionary<string, string> ();
+			var assembliesToRemove  = new List<ITaskItem> ();
+			var fallbackDirectories = new HashSet<string> ();
+
+			foreach (var item in CopyLocalItems) {
+				var directory = Path.GetDirectoryName (item.ItemSpec);
+				var directoryName = Path.GetFileName (directory);
+				Log.LogDebugMessage ($"{directoryName} -> {item.ItemSpec}");
+				if (directoryName.StartsWith ("netstandard2", StringComparison.OrdinalIgnoreCase)) {
+					var parent = Directory.GetParent (directory);
+					foreach (var nugetDirectory in parent.EnumerateDirectories ()) {
+						var name = Path.GetFileName (nugetDirectory.Name);
+						foreach (var fallback in PackageTargetFallback) {
+							if (!string.Equals (name, fallback, StringComparison.OrdinalIgnoreCase))
+								continue;
+							var fallbackDirectory = Path.Combine (parent.FullName, name);
+							fallbackDirectories.Add (fallbackDirectory);
+
+							// Remove the netstandard assembly, if there is a platform-specific one
+							var path = Path.Combine (fallbackDirectory, Path.GetFileName (item.ItemSpec));
+							if (File.Exists (path)) {
+								Log.LogDebugMessage ($"Removing: {item.ItemSpec}");
+								assembliesToRemove.Add (item);
+							}
+						}
+					}
+				}
+			}
+
+			// Look for any platform-specific assemblies
+			foreach (var directory in fallbackDirectories) {
+				foreach (var assembly in Directory.GetFiles (directory, "*.dll")) {
+					var assemblyName = Path.GetFileName (assembly);
+					if (!assembliesToAdd.ContainsKey (assemblyName)) {
+						Log.LogDebugMessage ($"Adding: {assembly}");
+						assembliesToAdd.Add (assemblyName, assembly);
+					}
+				}
+			}
+
+			AssembliesToAdd = assembliesToAdd.Values.ToArray ();
+			AssembliesToRemove = assembliesToRemove.ToArray ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/1322#issuecomment-861603825

This conditionally reverts commit ca51adbc.

There is a change in NuGet that is currently needed by the .NET 6
Android workload:

https://github.com/NuGet/NuGet.Client/commit/10274281c37e9dd3626938757f7e947d649b821b

This change is not present in VS 16.10 or VS 16.11:

https://github.com/dotnet/msbuild/blob/vs16.11/eng/Version.Details.xml

If we want Visual Studio 2019 on Windows to continue working for .NET
6 projects, then we can't actually remove our NuGet workarounds.

I put the workarounds back, but then are now conditionally imported:

    <Import Project="Microsoft.Android.Sdk.NuGet.targets" Condition=" '$(MSBuildRuntimeType)' == 'Full' and '$(MSBuildVersion)' &lt; '17.0' " />

So if you use `dotnet build` or Visual Studio 2022, these will not be
used. This way we can keep VS 2019 working for some period of time.