### PR TITLE
[One .NET] set env var automatically for $(UseInterpreter)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3929,17 +3929,21 @@ namespace UnnamedProject
 		public void PackageNamingPolicy ([Values ("LowercaseMD5", "LowercaseCrc64")] string packageNamingPolicy)
 		{
 			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("UseInterpreter", "true");
 			proj.SetProperty ("AndroidPackageNamingPolicy", packageNamingPolicy);
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var environment = b.Output.GetIntermediaryPath (Path.Combine ("__environment__.txt"));
 				FileAssert.Exists (environment);
+				var values = new List<string> {
+					$"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}"
+				};
 				if (Builder.UseDotNet) {
-					Assert.AreEqual ($"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}{Environment.NewLine}mono.enable_assembly_preload=0", File.ReadAllText (environment).Trim ());
-				} else {
-					Assert.AreEqual ($"__XA_PACKAGE_NAMING_POLICY__={packageNamingPolicy}", File.ReadAllText (environment).Trim ());
+					values.Add ("mono.enable_assembly_preload=0");
+					values.Add ("DOTNET_MODIFIABLE_ASSEMBLIES=Debug");
 				}
+				Assert.AreEqual (string.Join (Environment.NewLine, values), File.ReadAllText (environment).Trim ());
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1513,6 +1513,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <_GeneratedAndroidEnvironment Include="__XA_PACKAGE_NAMING_POLICY__=$(AndroidPackageNamingPolicy)" />
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
+    <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(UsingAndroidNETSdk)' == 'true' and '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
   </ItemGroup>
   <WriteLinesToFile
       File="$(IntermediateOutputPath)__environment__.txt"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6016
Context: https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp1/Android/AndroidEnvironment.txt

Currently, the the .NET MAUI project template includes a
`@(AndroidEnvironment)` file for "Hot Reload" scenarios. Let's setup
this value by default so it will not be needed.