### PR TITLE
[One .NET] enable WebSocketTests

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
+++ b/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
@@ -9,7 +9,7 @@ namespace System.NetTests
 	[TestFixture]
 	public class WebSocketTests
 	{
-		[Test, Category ("InetAccess"), Category ("DotNetIgnore")] // https://github.com/xamarin/xamarin-android/issues/5801
+		[Test, Category ("InetAccess")]
 		public void TestSocketConnection()
 		{
 			string testMessage = "This is a test!";


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5801

Web sockets appear to be working in .NET 6 Preview 5 and higher. I
think we can simply enable these tests now.