### PR TITLE
[Xamarin.Android.Build.Tasks] Add OpenTK/NUnitLite Error for .net 6

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -22,6 +22,7 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CleanIntermediateIfNeeded;
       _CheckProjectItems;
       _CheckForContent;
+      _CheckForObsoleteFrameworkAssemblies;
       _ValidateAndroidPackageProperties;
       AddLibraryJarsToBind;
       $(BuildDependsOn);
@@ -87,6 +88,7 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CleanIntermediateIfNeeded;
       _AddAndroidDefines;
       _CheckForContent;
+      _CheckForObsoleteFrameworkAssemblies;
       _RemoveLegacyDesigner;
       _ValidateAndroidPackageProperties;
       AddLibraryJarsToBind;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3998,7 +3998,6 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		[Category ("DotNetIgnore")]
 		public void XA4313 ([Values ("OpenTK-1.0", "Xamarin.Android.NUnitLite")] string reference)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -4006,11 +4005,13 @@ namespace UnnamedProject
 					new BuildItem.Reference (reference)
 				},
 			};
+			bool shouldSucceed = !Builder.UseDotNet;
+			string expectedText = shouldSucceed ? "succeeded" : "failed";
 			using (var builder = CreateApkBuilder ()) {
 				builder.ThrowOnBuildFailure = false;
-				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				Assert.AreEqual (shouldSucceed, builder.Build (proj), $"Build should have {expectedText}.");
 				string error = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build succeeded."))
+						.SkipWhile (x => !x.StartsWith ($"Build {expectedText}.", StringComparison.OrdinalIgnoreCase))
 						.FirstOrDefault (x => x.Contains ("warning XA4313"));
 				Assert.IsNotNull (error, "Build should have failed with XA4313.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4006,14 +4006,15 @@ namespace UnnamedProject
 				},
 			};
 			bool shouldSucceed = !Builder.UseDotNet;
-			string expectedText = shouldSucceed ? "succeeded" : "failed";
+			string expectedText = shouldSucceed ? "succeeded" : "FAILED";
+			string warnOrError = shouldSucceed ? "warning" : "error";
 			using (var builder = CreateApkBuilder ()) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (shouldSucceed, builder.Build (proj), $"Build should have {expectedText}.");
 				string error = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ($"Build {expectedText}.", StringComparison.OrdinalIgnoreCase))
-						.FirstOrDefault (x => x.Contains ("warning XA4313"));
-				Assert.IsNotNull (error, "Build should have failed with XA4313.");
+						.SkipWhile (x => !x.StartsWith ($"Build {expectedText}."))
+						.FirstOrDefault (x => x.Contains ($"{warnOrError} XA4313"));
+				Assert.IsNotNull (error, $"Build should have {expectedText} with XA4313 {warnOrError}.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -779,19 +779,23 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CheckForObsoleteFrameworkAssemblies">
+  <PropertyGroup>
+    <_TreatErrorAsWarning Condition="'$(UsingAndroidNETSdk)' != 'true' " >True</_TreatErrorAsWarning>
+    <_TreatErrorAsWarning Condition=" '$(_TreatErrorAsWarning)' == ''">False</_TreatErrorAsWarning>
+  </PropertyGroup>
   <AndroidError
     Condition=" '%(Reference.Identity)' == 'OpenTK-1.0' "
     Code="XA4313"
     ResourceName="XA4313"
     FormatArguments="OpenTK-1.0;Xamarin.Legacy.OpenTK"
-    ContinueOnError=" '$(UsingAndroidNETSdk)' != 'true' "
+    ContinueOnError="$(_TreatErrorAsWarning)"
   />
   <AndroidError
     Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
     Code="XA4313"
     ResourceName="XA4313"
     FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLite"
-    ContinueOnError=" '$(UsingAndroidNETSdk)' != 'true' "
+    ContinueOnError="$(_TreatErrorAsWarning)"
   />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -778,6 +778,23 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 </Target>
 
+<Target Name="_CheckForObsoleteFrameworkAssemblies">
+  <AndroidError
+    Condition=" '%(Reference.Identity)' == 'OpenTK-1.0' "
+    Code="XA4313"
+    ResourceName="XA4313"
+    FormatArguments="OpenTK-1.0;Xamarin.Legacy.OpenTK"
+    ContinueOnError=" '$(UsingAndroidNETSdk)' != 'true' "
+  />
+  <AndroidError
+    Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
+    Code="XA4313"
+    ResourceName="XA4313"
+    FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLite"
+    ContinueOnError=" '$(UsingAndroidNETSdk)' != 'true' "
+  />
+</Target>
+
 <Target Name="_CheckDuplicateJavaLibraries" DependsOnTargets="_GetLibraryImports">
   <CheckDuplicateJavaLibraries
     JavaSourceFiles="@(AndroidJavaSource)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -227,21 +227,6 @@ projects. .NET 5 projects will not import this file.
     <Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/>
   </Target>
 
-  <Target Name="_CheckForObsoleteFrameworkAssemblies">
-    <AndroidWarning
-        Condition=" '%(Reference.Identity)' == 'OpenTK-1.0' "
-        Code="XA4313"
-        ResourceName="XA4313"
-        FormatArguments="OpenTK-1.0;Xamarin.Legacy.OpenTK"
-    />
-    <AndroidWarning
-        Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
-        Code="XA4313"
-        ResourceName="XA4313"
-        FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLite"
-    />
-  </Target>
-
   <Target Name="_GetReferenceAssemblyPaths">
     <GetReferenceAssemblyPaths
         TargetFrameworkMoniker="$(TargetFrameworkIdentifier),Version=v1.0"


### PR DESCRIPTION
Rework of commit 064babf6 to raise an error under .net 6 if the user tries to
use OpenTK or NUnitLite. We can do this by using the `AndroidError`
task to raise the error. Under legacy projects we use the `ContinueOnError`
Task property to control if the output is a warning or not. Under .net 6
it will be an error, under legacy it will be a warning.

Update the existing unit test to handle the new errors/warnings and
let it run under .net 6.