### PR TITLE
[Xamarin.Android.Build.Tasks] fix ArgumentException in GenerateCompressedAssembliesNativeSourceFiles

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -47,7 +47,9 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 
-				if (assemblies.ContainsKey (assembly.ItemSpec)) {
+				var assemblyKey = CompressedAssemblyInfo.GetDictionaryKey (assembly);
+				if (assemblies.ContainsKey (assemblyKey)) {
+					Log.LogDebugMessage ($"Skipping duplicate assembly: {assembly.ItemSpec}");
 					continue;
 				}
 
@@ -57,8 +59,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 
-				assemblies.Add (CompressedAssemblyInfo.GetDictionaryKey (assembly),
-					new CompressedAssemblyInfo (checked((uint)fi.Length)));
+				assemblies.Add (assemblyKey, new CompressedAssemblyInfo (checked((uint)fi.Length)));
 			}
 
 			uint index = 0;


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=41853&view=logs&j=9cf5f8f4-c6e1-5b84-8b95-5f96f5b2da57&t=837f1816-7880-57fc-23bc-a709d74f8097&l=22687

dotnet/maui is hitting a build error, such as:

    error XAGCANSF7004: System.ArgumentException: An entry with the same key already exists.
    error XAGCANSF7004:    at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
    error XAGCANSF7004:    at System.Collections.Generic.TreeSet`1.AddIfNotPresent(T item)
    error XAGCANSF7004:    at System.Collections.Generic.SortedDictionary`2.Add(TKey key, TValue value)
    error XAGCANSF7004:    at Xamarin.Android.Tasks.GenerateCompressedAssembliesNativeSourceFiles.GenerateCompressedAssemblySources()
    error XAGCANSF7004:    at Xamarin.Android.Tasks.GenerateCompressedAssembliesNativeSourceFiles.RunTask()
    error XAGCANSF7004:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17

We believe there is somehow a duplicate assembly, but hard to tell
what is happening exactly from the `.binlog`.

Reviewing the `<GenerateCompressedAssembliesNativeSourceFiles/>`
MSBuild task, it appears the `ContainsKey()` check is not using the
correct key for the dictionary.

I fixed this issue and added a `LogDebugMessage()` call, so we can
figure out what is happening upstream in dotnet/maui.