### PR TITLE
try to use jdk 11 for device tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1037,7 +1037,7 @@ stages:
     parameters:
       job_name: mac_msbuilddevice_tests
       job_suffix: Legacy
-      jdkTestFolder: $(XA.Jdk8.Folder)
+      jdkTestFolder: $(XA.Jdk11.Folder)
 
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
   - template: yaml-templates/run-msbuild-device-tests.yaml


### PR DESCRIPTION

Since 5da92bd we are seeing the on device tests fail with the following error.

    error JAVAC0000: java.lang.AssertionError: annotationType() :  unrecognized Attribute name MODULE (class com.sun.tools.javac.util.SharedNameTable$NameImpl)

This suggests that AP 31 requires JDK 11 in order to compile.
So lets bump the version which we use for the on device tests for now,
until we can figure out what do actually do.