### PR TITLE
[ci] Use macOS 11 for Android Designer tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1056,7 +1056,7 @@ stages:
   - job: designer_integration_mac
     displayName: macOS
     pool:
-      vmImage: $(HostedMacImage)
+      vmImage: internal-macos-11
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1128,7 +1128,9 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
 
   # Check - "Xamarin.Android (Designer Tests Windows)"
+  # TODO: Enable once Windows test issues are fixed.
   - job: designer_integration_win
+    condition: false
     displayName: Windows
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 120


### PR DESCRIPTION
We've been having an issue with Android Designer test dependency
provisioning on macOS:

    Xamarin.Provisioning.ProvisioningException: Failed to provision /Applications/Xcode_12.5.0.app
    ---> Xamarin.Provisioning.ProvisioningException: This Xcode version requires macOS ≥ 11.0 (currently running on 10.15.7)

We should be able to remedy this by moving to the same macOS Big Sur
pool that the Designer build is using.

The Windows tests have also been failing for a while, and this problem
is [not unique to our pipeline][0].  We should disable these tests for
now until the issue is addressed.

[0]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4894821&view=logs&jobId=2f037848-d60e-57a4-8d19-387778a8302c&j=2f037848-d60e-57a4-8d19-387778a8302c&t=fbc84e65-28e6-5146-ccec-20ffda77f75c