### PR TITLE
Bump LibZipSharp to 2.0.0-alpha7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>2.0.0-alpha6</LibZipSharpVersion>
+    <LibZipSharpVersion>2.0.0-alpha7</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>


### PR DESCRIPTION
Context: https://github.com/xamarin/LibZipSharp/commit/fcb9323d9d95b06051f67d8d73ba371a4029722d
Context: https://libzip.org/news/release-1.8.0.html

2.0.0-alpha7 changes:

  * bump libzip version to 1.8.0
  * add support for ZSTD compression
  * properly hide all the native library symbols except for the libzip ones