### PR TITLE
[tests] fix for DotNetNew tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -644,6 +644,7 @@ public abstract class Foo<TVirtualView, TNativeView> : AbstractViewHandler<TVirt
 			}
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] =
 				FullProjectDirectory = Path.Combine (Root, relativeProjectDir);
+			new XASdkProject ().CopyNuGetConfig (relativeProjectDir);
 			return new DotNetCLI (Path.Combine (FullProjectDirectory, $"{TestName}.csproj"));
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -420,6 +420,7 @@ $@"<Project>
 			var repoNuGetConfig = Path.Combine (XABuildPaths.TopDirectory, "NuGet.config");
 			var projNugetConfig = Path.Combine (Root, relativeDirectory, "NuGet.config");
 			if (File.Exists (repoNuGetConfig) && !File.Exists (projNugetConfig)) {
+				Directory.CreateDirectory (Path.GetDirectoryName (projNugetConfig));
 				File.Copy (repoNuGetConfig, projNugetConfig, overwrite: true);
 				// Write additional sources to NuGet.config if needed
 				if (ExtraNuGetConfigSources != null) {


### PR DESCRIPTION
If you run the `DotNetNew` tests by themselves, they fail because a
`NuGet.config` file is not generated that contains:

     <add key="testsource1" value="C:\src\xamarin-android\bin\BuildDebug\nuget-unsigned" />

...and so it isn't able to locate any of the
`Microsoft.Android.Runtime.*` packs without this.

We have two `CreateDotNetBuilder()` methods in this test, and they now
generate the `NuGet.config` file in the same way.

I also fixed a place that `Directory.CreateDirectory()` was needed.