### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for `android:useEmbeddedDex`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -172,10 +172,11 @@ namespace Xamarin.Android.Tasks
 				apk.FixupWindowsPathSeparators ((a, b) => Log.LogDebugMessage ($"Fixing up malformed entry `{a}` -> `{b}`"));
 
 				// Add classes.dx
+				CompressionMethod dexCompressionMethod = GetCompressionMethod (".dex");
 				foreach (var dex in DalvikClasses) {
 					string apkName = dex.GetMetadata ("ApkName");
 					string dexPath = string.IsNullOrWhiteSpace (apkName) ? Path.GetFileName (dex.ItemSpec) : apkName;
-					AddFileToArchiveIfNewer (apk, dex.ItemSpec, DalvikPath + dexPath);
+					AddFileToArchiveIfNewer (apk, dex.ItemSpec, DalvikPath + dexPath, compressionMethod: dexCompressionMethod);
 				}
 
 				if (EmbedAssemblies && !BundleAssemblies)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -32,6 +32,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] UsesLibraries { get; set; }
 
+		[Output]
+		public bool UseEmbeddedDex { get; set; } = false;
+
 		public override bool RunTask ()
 		{
 			var androidNs = AndroidAppManifest.AndroidXNamespace;
@@ -42,6 +45,11 @@ namespace Xamarin.Android.Tasks
 				string text = app.Attribute (androidNs + "extractNativeLibs")?.Value;
 				if (bool.TryParse (text, out bool value)) {
 					EmbeddedDSOsEnabled = !value;
+				}
+
+				text = app.Attribute (androidNs + "useEmbeddedDex")?.Value;
+				if (bool.TryParse (text, out value)) {
+					UseEmbeddedDex = value;
 				}
 
 				var libraries = new List<ITaskItem> ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1505,9 +1505,11 @@ because xbuild doesn't support framework reference assemblies.
       AndroidApiLevel="$(_AndroidApiLevel)">
     <Output TaskParameter="EmbeddedDSOsEnabled" PropertyName="_EmbeddedDSOsEnabled" />
     <Output TaskParameter="UsesLibraries"       ItemName="AndroidExternalJavaLibrary" />
+    <Output TaskParameter="UseEmbeddedDex"      PropertyName="_UseEmbeddedDex" />
   </ReadAndroidManifest>
   <PropertyGroup>
     <AndroidStoreUncompressedFileExtensions Condition=" '$(_EmbeddedDSOsEnabled)' == 'True' ">.so;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
+    <AndroidStoreUncompressedFileExtensions Condition=" '$(_UseEmbeddedDex)' == 'True' ">.dex;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>
   </PropertyGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DX.targets
@@ -93,7 +93,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         UseDx="$(UseDx)"
         MultiDexEnabled="$(AndroidEnableMultiDex)"
         MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
-        JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp)"
+        JavaLibrariesToCompile="@(_JavaLibrariesToCompileForApp);@(_InstantRunJavaReference)"
         AlternativeJarFiles="@(_AlternativeJarForAppDx)"
     />
     <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void ApplicationRunsWithoutDebugger ([Values (false, true)] bool isRelease, [Values (false, true)] bool extractNativeLibs)
+		public void ApplicationRunsWithoutDebugger ([Values (false, true)] bool isRelease, [Values (false, true)] bool extractNativeLibs, [Values (false, true)] bool useEmbeddedDex)
 		{
 			AssertHasDevices ();
 
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
-				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs.ToString ().ToLowerInvariant ()}\" ");
+				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs.ToString ().ToLowerInvariant ()}\" android:useEmbeddedDex=\"{useEmbeddedDex.ToString ().ToLowerInvariant ()}\" ");
 				Assert.True (b.Install (proj), "Project should have installed.");
 				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				AssertExtractNativeLibs (manifest, extractNativeLibs);


### PR DESCRIPTION
Fixes #5925
Context https://developer.android.com/topic/security/dex

Android 10 introduced a new attribute for the application element in the
AndroidManifest.xml, `android:useEmbeddedDex`. This allows the .dex files
to be run directly from the apk, rather than unpacked. This new attribute
does require that the .dex files be STORED in the apk rather than
COMPRESSED. Otherwise you get the following error

    Failure [INSTALL_FAILED_INVALID_APK: Some dex are not uncompressed and aligned correctly

So lets update BuildApk to use the `GetCompressionMethod` method to figure
out if we need to compress the .dex files. We can then update the `ReadAndroidManifest`
task to check for the new attribute and update the `AndroidStoreUncompressedFileExtensions`
ItemGroup accordingly.

Also added unit tests.