### PR TITLE
[One .NET] fixes for System.* PackageReference

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -33,6 +33,13 @@ _ResolveAssemblies MSBuild target.
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
       DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish"
       Returns="@(ResolvedFileToPublish)">
+      <ItemGroup>
+        <ResolvedFileToPublish
+            Condition=" '%(ResolvedFileToPublish.RuntimeIdentifier)' == '' "
+            Update="@(ResolvedFileToPublish)"
+            RuntimeIdentifier="$(RuntimeIdentifier)"
+        />
+      </ItemGroup>
   </Target>
 
   <Target Name="_FixupIntermediateAssembly" Condition=" '$(_OuterIntermediateAssembly)' != '' ">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -367,7 +367,11 @@ namespace Xamarin.Android.Build.Tests
 					"https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json"
 				},
 				PackageReferences = {
-					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.2.0.7-net6preview01" }
+					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.2.0.7-net6preview01" },
+					new Package { Id = "Microsoft.AspNetCore.Components.WebView", Version = "6.0.0-preview.5.21301.17" },
+					new Package { Id = "Microsoft.Extensions.FileProviders.Embedded", Version = "6.0.0-preview.6.21306.3" },
+					new Package { Id = "Microsoft.JSInterop", Version = "6.0.0-preview.6.21306.3" },
+					new Package { Id = "System.Text.Json", Version = "6.0.0-preview.7.21323.3" },
 				},
 				Sources = {
 					new BuildItem ("EmbeddedResource", "Foo.resx") {


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/1309#issuecomment-866364091

dotnet/maui projects are failing to build after adding new ASP.NET
assemblies for BlazorWebView:

    error XABLD7024: System.IO.IOException: The process cannot access the file 'D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\obj\Release\net6.0-android\android\lz4\System.Runtime.CompilerServices.Unsafe.dll.lz4' because it is being used by another process. [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Xamarin.Android.Tasks.AssemblyCompression.Compress(AssemblyData data, String outputDirectory) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Xamarin.Android.Tasks.BuildApk.<AddAssemblies>g__CompressAssembly|142_1(ITaskItem assembly, <>c__DisplayClass142_0& ) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Xamarin.Android.Tasks.BuildApk.AddAssemblies(ZipArchiveEx apk, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo) [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Xamarin.Android.Tasks.BuildApk.RunTask() [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]
    error XABLD7024:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/builder/azdo/_work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17 [D:\a\1\s\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj]

Which appears to be due to a duplicate assembly:

    Task GenerateCompressedAssembliesNativeSourceFiles
    ...
    Skipping duplicate assembly: obj\Release\net6.0-android\android-x86\linked\System.Runtime.CompilerServices.Unsafe.dll

If you go earlier in the log:

    Task ProcessAssemblies
    ...
    Android ABI not found for: obj\Release\net6.0-android\android-arm64\linked\System.Runtime.CompilerServices.Unsafe.dll
    Android ABI not found for: obj\Release\net6.0-android\android-x86\linked\System.Runtime.CompilerServices.Unsafe.dll

This is happening because `%(RuntimeIdentifier)` is blank?

I could reproduce this in a test, but only after adding a complicated
set of `@(PackageReference)` to an app project.

I believe what is happening is:

* We have a `@(PackageReference)` to a System.* assembly that is also
  in the Mono runtime packs: `Microsoft.NETCore.App.Runtime.*`
* If the `@(PackageReference)` version is *newer* than
  `Microsoft.NETCore.App.Runtime.*`, then it will be preferred over
  the other.

In this case, `%(RuntimeIdentifier)` is blank on the
`@(PackageReference)`. It appears to only be set by runtime packs.

Solution:

* Set `@(ResolvedFileToPublish.RuntimeIdentifier)` to
  `$(RuntimeIdentifier)` if it is blank.

This solved all my warning messages and my test case now compiles.