### PR TITLE
[One .NET] dotnet workload install android or android-aot

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1397,10 +1397,9 @@ stages:
     - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
       - group: Publish-Build-Assets
     steps:
-    - checkout: self
-      submodules: recursive
-
-    - template: yaml-templates/use-dot-net.yaml
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1291,19 +1291,12 @@ stages:
     workspace:
       clean: all
     steps:
-    - checkout: self
-      submodules: recursive
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
 
     - checkout: release_scripts
       clean: true
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        remove_dotnet: true
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNetCoreVersion)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -75,12 +75,6 @@
       DependsOnTargets="DeleteExtractedWorkloadPacks" >
     <ItemGroup>
       <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.NET.Sdk.Android.Manifest-*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.$(HostOS).*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Sdk.BundleTool.*.nupkg" />
-      <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.*.nupkg" />
-      <_WLTemplates Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Templates.*.nupkg" />
-      <!-- Runtime packs are not yet supported by workloads -->
-      <!-- <_WLPacks Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Runtime.*.nupkg" /> -->
     </ItemGroup>
     <PropertyGroup>
       <_WLPackVersion>@(_WLManifest->'%(Filename)'->Replace('Microsoft.NET.Sdk.Android.Manifest-$(DotNetPreviewVersionBand).', ''))</_WLPackVersion>
@@ -97,24 +91,29 @@
     </ItemGroup>
     <Move SourceFiles="@(_WLExtractedFiles)" DestinationFolder="$(_SdkManifestsFolder)microsoft.net.sdk.android" />
     <RemoveDir Directories="$(_SdkManifestsFolder)temp\" />
-    <Unzip
-        SourceFiles="@(_WLPacks)"
-        DestinationFolder="$(DotNetPreviewPath)packs\$([System.String]::Copy('%(_WLPacks.Filename)').Replace('.$(_WLPackVersion)', ''))\$(_WLPackVersion)"
-    />
-    <MakeDir Directories="$(DotNetPreviewPath)template-packs" />
-    <!-- TODO: Workaround Linux casing issue and copy template packs to lowercase destination -->
-    <Copy SourceFiles="@(_WLTemplates)" DestinationFiles="@(_WLTemplates->'%(Filename)%(Extension)'->ToLower()->'$(DotNetPreviewPath)template-packs\%(Identity)')" />
-    <ItemGroup>
-      <_UnixExecutables Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.*\*\tools\$(HostOS)\**\*.*" />
-      <_FilesToTouch Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.android\**" />
-      <_FilesToTouch Include="$(DotNetPreviewPath)packs\$([System.String]::Copy('%(_WLPacks.Filename)').Replace('.$(_WLPackVersion)', ''))\$(_WLPackVersion)\**" />
-    </ItemGroup>
+
+    <!-- dotnet workload install android-aot -->
+    <PropertyGroup>
+      <_NuGetConfig>$(AndroidToolchainCacheDirectory)\NuGet.config</_NuGetConfig>
+      <_NuGetContent>
+<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$(OutputPath)" />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+]]>
+      </_NuGetContent>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_NuGetConfig)" Lines="$(_NuGetContent)" Overwrite="true" />
     <Exec
-        Condition=" '$(HostOS)' == 'Darwin' or '$(HostOS)' == 'Linux' "
-        Command="chmod +x &quot;%(_UnixExecutables.Identity)&quot;"
+        WorkingDirectory="$(AndroidToolchainCacheDirectory)"
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-aot --skip-manifest-update --verbosity diag"
     />
-    <!-- Some files had timestamps in the future -->
-    <Touch Files="@(_FilesToTouch)" />
+    <Delete Files="$(_NuGetConfig)" />
   </Target>
 
   <Target Name="DeleteExtractedWorkloadPacks" >

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -94,7 +94,8 @@
 
     <!-- dotnet workload install android-aot -->
     <PropertyGroup>
-      <_NuGetConfig>$(AndroidToolchainCacheDirectory)\NuGet.config</_NuGetConfig>
+      <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
+      <_NuGetConfig>$(_TempDirectory)\NuGet.config</_NuGetConfig>
       <_NuGetContent>
 <![CDATA[
 <?xml version="1.0" encoding="utf-8"?>
@@ -110,10 +111,10 @@
     </PropertyGroup>
     <WriteLinesToFile File="$(_NuGetConfig)" Lines="$(_NuGetContent)" Overwrite="true" />
     <Exec
-        WorkingDirectory="$(AndroidToolchainCacheDirectory)"
-        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-aot --skip-manifest-update --verbosity diag"
+        WorkingDirectory="$(_TempDirectory)"
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-aot --skip-manifest-update --verbosity diag --temp-dir &quot;$(_TempDirectory)&quot;"
     />
-    <Delete Files="$(_NuGetConfig)" />
+    <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
 
   <Target Name="DeleteExtractedWorkloadPacks" >

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -68,6 +68,12 @@ namespace Xamarin.Android.Prepare
 				}
 			}
 
+			// Delete the metadata folder, which contains old workload data
+			var metadataPath = Path.Combine (dotnetPath, "metadata");
+			if (Directory.Exists (metadataPath)) {
+				Utilities.DeleteDirectory (metadataPath);
+			}
+
 			if (File.Exists (dotnetTool)) {
 				if (!TestDotNetSdk (dotnetTool)) {
 					Log.WarningLine ($"Attempt to run `dotnet --version` failed, reinstalling the SDK.");

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -1,15 +1,23 @@
 {
   "version": "@WORKLOAD_VERSION@",
   "workloads": {
-    "microsoft-android-sdk-full": {
-      "description": "Android SDK",
+    "android": {
+      "description": "Microsoft Android SDK for .NET",
       "packs": [
         "Microsoft.Android.Sdk",
         "Microsoft.Android.Sdk.BundleTool",
         "Microsoft.Android.Ref",
+        "Microsoft.Android.Runtime.android-arm",
+        "Microsoft.Android.Runtime.android-arm64",
+        "Microsoft.Android.Runtime.android-x86",
+        "Microsoft.Android.Runtime.android-x64",
         "Microsoft.Android.Templates"
       ],
       "extends" : [ "microsoft-net-runtime-android" ]
+    },
+    "android-aot": {
+      "description": "Microsoft Android SDK for .NET with AOT support",
+      "extends" : [ "android", "microsoft-net-runtime-android-aot" ]
     }
   },
   "packs": {
@@ -29,6 +37,22 @@
       "version": "@WORKLOAD_VERSION@"
     },
     "Microsoft.Android.Ref": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.android-arm": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.android-arm64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.android-x86": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/tree/ef4518bf502ffa6760625c4cb53fa0cb015bc6d1/src/Workload#net-maui-workload-ids

Right now to install the Android workload you would run:

    dotnet workload install microsoft-android-sdk-full

Let's shorten this to be:

    dotnet workload install android

We can also create a new workload that extends `android`, and includes
AOT support:

    dotnet workload install android-aot

To test this behavior on our CI, I reworked the `ExtractWorkloadPacks`
to run `dotnet workload install` commands. This should give us more
confidence that our workload can be installed -- and our MSBuild tests
will consume the installed workload.

Other changes:

* Added our `Microsoft.Android.Runtime.*` packs to the
  `WorkloadManifest.json`. This was mostly omitted by mistake;
  however, runtime packs aren't resolved either due to:
  https://github.com/dotnet/sdk/issues/14044

* Call `setup-test-environment.yaml` in `dotnet_create_msi` job

* Delete `dotnet/metadata` folder in `Step_InstallDotNetPreview`