### PR TITLE
[Mono.Android] Obsolete [LinkerSafe]

### DIFF
--- a/src/Mono.Android/Android/LinkerSafeAttribute.cs
+++ b/src/Mono.Android/Android/LinkerSafeAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace Android
 {
+#if NETCOREAPP
+	[Obsolete ("For .NET 6+, please use: [assembly: global::System.Reflection.AssemblyMetadata(\"IsTrimmable\", \"True\")]")]
+#endif  // NETCOREAPP
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public sealed class LinkerSafeAttribute : Attribute
 	{


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5639

Context: https://github.com/mono/linker/blob/84338086c5f36f4847b85242b1c8c2d3ea7177ac/docs/design/trimmed-assemblies.md#assemblymetadataistrimmable-true

The `Android.LinkerSafeAttribute` custom attribute is beening
replaced by the [`System.Reflection.AssemblyMetadataAttribute`][0]
custom attribute, with a `Key` of `"IsTrimmable"` and a
`Value` of `"True"`:

	// Old-and-busted
	[assembly: Android.LinkerSafe]

	// New hotness:
	[assembly: global::System.Reflection.AssemblyMetadata("IsTrimmable", "True")]

`AssemblyMetadataAttribute` is more portable, part of
.NET Standard 1.0 and above, with linker support in .NET 5+.
It should thus be preferred over `Android.LinkerSafeAttribute`.

[0]: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblymetadataattribute?view=net-5.0