### PR TITLE
[One .NET] enable C# bindings for @(AndroidLibrary)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -83,10 +83,13 @@ This item group populates the Build Action drop-down in IDEs.
     <ItemGroup Condition=" '$(AndroidApplication)' != 'true' ">
       <EmbeddedNativeLibrary Include="@(AndroidNativeLibrary)" />
     </ItemGroup>
+    <!-- Any .NET 6 project -->
+    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
+      <LibraryProjectZip  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
+    </ItemGroup>
     <!-- .NET 6 class libraries-->
     <ItemGroup Condition=" '$(AndroidApplication)' != 'true' and '$(UsingAndroidNETSdk)' == 'true' ">
       <AndroidAarLibrary  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' != 'true' " />
-      <LibraryProjectZip  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
       <AndroidJavaLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
       <EmbeddedJar        Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
       <!-- .aar files should be copied to $(OutputPath) in .NET 6-->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -380,6 +380,15 @@ namespace Xamarin.Android.Build.Tests
 					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
 						TextContent = () => InlineData.ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
 					},
+					new AndroidItem.TransformFile ("Transforms.xml") {
+						// Remove two methods that introduced warnings:
+						// Com.Balysv.Material.Drawable.Menu.MaterialMenuView.cs(214,30): warning CS0114: 'MaterialMenuView.OnRestoreInstanceState(IParcelable)' hides inherited member 'View.OnRestoreInstanceState(IParcelable?)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+						// Com.Balysv.Material.Drawable.Menu.MaterialMenuView.cs(244,56): warning CS0114: 'MaterialMenuView.OnSaveInstanceState()' hides inherited member 'View.OnSaveInstanceState()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+						TextContent = () => "<metadata><remove-node path=\"/api/package[@name='com.balysv.material.drawable.menu']/class[@name='MaterialMenuView']/method[@name='onRestoreInstanceState']\" /><remove-node path=\"/api/package[@name='com.balysv.material.drawable.menu']/class[@name='MaterialMenuView']/method[@name='onSaveInstanceState']\" /></metadata>",
+					},
+					new AndroidItem.AndroidLibrary ("material-menu-1.1.0.aar") {
+						WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
+					},
 				}
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": AndroidX.AppCompat.App.AppCompatActivity");
@@ -425,8 +434,9 @@ namespace Xamarin.Android.Build.Tests
 			FileAssert.Exists (assemblyPath);
 			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
 				var typeName = "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest";
-				var type = assembly.MainModule.GetType (typeName);
-				Assert.IsNotNull (type, $"{assemblyPath} should contain {typeName}");
+				Assert.IsNotNull (assembly.MainModule.GetType (typeName), $"{assemblyPath} should contain {typeName}");
+				typeName = "Com.Balysv.Material.Drawable.Menu.MaterialMenuView";
+				Assert.IsNotNull (assembly.MainModule.GetType (typeName), $"{assemblyPath} should contain {typeName}");
 			}
 
 			var rids = runtimeIdentifiers.Split (';');


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/1475

A .NET 6 application project was failing to include C# bindings for
`.aar` files, but `.jar` files were working.

The workaround was to include:

    <LibraryProjectZip Include="myjavalibrary.aar" />

We had a test that checked this behavior for `.jar` files, but not
`.aar` files.

After reproducing the behavior in a test, I found the
`_CategorizeAndroidLibraries` MSBuild target did not automatically
setup the `@(LibraryProjectZip)` item group in .NET 6 application
projects. `@(AndroidAarLibrary)` *was* being setup, which explained
why the Java code made it to `classes.dex`, but C# bindings were
missing.

Updated the `_CategorizeAndroidLibraries` MSBuild target for this case.