### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Assembly Ordering in PackageManager

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -93,8 +93,9 @@ namespace Xamarin.Android.Tasks
 				.Concat (MonoAndroidHelper.GetFrameworkAssembliesToTreatAsUserAssemblies (ResolvedAssemblies))
 				.ToList ();
 			var mainFileName = Path.GetFileName (MainAssembly);
+			var mainAssembly = new List<ITaskItem> () { new TaskItem (mainFileName) };
 			Func<string,string,bool> fileNameEq = (a,b) => a.Equals (b, StringComparison.OrdinalIgnoreCase);
-			assemblies = assemblies.Where (a => fileNameEq (a.ItemSpec, mainFileName)).Concat (assemblies.Where (a => !fileNameEq (a.ItemSpec, mainFileName))).ToList ();
+			assemblies = mainAssembly.Concat (assemblies.Where (a => !fileNameEq (Path.GetFileName (a.ItemSpec), mainFileName))).ToList ();
 
 			using (var pkgmgr = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				pkgmgr.WriteLine ("package mono;");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -323,7 +323,7 @@ namespace UnnamedProject
 				var packageManagerPath = Path.Combine (Root, appb.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "mono", "MonoPackageManager_Resources.java");
 				var before = GetAssembliesFromPackageManager (packageManagerPath);
 				if (!Builder.UseDotNet) {
-					Assert.AreEqual ("", before, $"After first `{appb.Target}`, assemblies list would be empty.");
+					Assert.AreEqual ("\"App1.dll\",", before, $"After first `{appb.Target}`, assemblies list should only have main App dll.");
 				}
 
 				// NuGet restore, either with /t:Restore in a separate MSBuild call or /restore in a single call

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/CheckPackageManagerAssemblyOrder.java
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/CheckPackageManagerAssemblyOrder.java
@@ -1,0 +1,10 @@
+package mono;
+public class MonoPackageManager_Resources {
+	public static String[] Assemblies = new String[]{
+		/* We need to ensure that "HelloAndroid.dll" comes first in this list. */
+		"HelloAndroid.dll",
+		"Xamarin.AndroidX.SavedState.dll",
+	};
+	public static String[] Dependencies = new String[]{
+	};
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Category ("Node-2")]
+	public class GeneratePackageManagerJavaTests : BaseTest
+	{
+		[Test]
+		public void CheckPackageManagerAssemblyOrder ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new [] {
+				new ApiInfo { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1",  Stable = true },
+				new ApiInfo { Id = "28", Level = 28, Name = "Pie", FrameworkVersion = "v9.0",  Stable = true },
+			});
+			MonoAndroidHelper.RefreshSupportedVersions (new [] {
+				Path.Combine (referencePath, "MonoAndroid"),
+			});
+
+			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"), $@"<?xml version='1.0' ?><manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.microsoft.net6.helloandroid' android:versionCode='1' />");
+
+			var task = new GeneratePackageManagerJava {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				ResolvedUserAssemblies = new ITaskItem []  {
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/Xamarin.AndroidX.SavedState.dll"),
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/HelloAndroid.dll"),
+				},
+				ResolvedAssemblies = new ITaskItem []  {
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/Xamarin.AndroidX.SavedState.dll"),
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/HelloAndroid.dll"),
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/System.Console.dll"),
+					new TaskItem ("obj/Release/net6.0-android/android-arm/linked/System.Linq.dll"),
+				},
+				OutputDirectory = Path.Combine(path, "src", "mono"),
+				EnvironmentOutputDirectory = Path.Combine (path, "env"),
+				MainAssembly = "obj/Release/net6.0-android/android-arm/linked/HelloAndroid.dll",
+				TargetFrameworkVersion = "v6.0",
+				Manifest = Path.Combine (path, "AndroidManifest.xml"),
+				IsBundledApplication = false,
+				SupportedAbis = new string [] { "x86" , "arm64-v8a" },
+				AndroidPackageName = "com.microsoft.net6.helloandroid",
+				EnablePreloadAssembliesDefault = false,
+				InstantRunEnabled = false,
+			};
+			Assert.IsTrue (task.Execute (), "Task should have executed.");
+			AssertFileContentsMatch (Path.Combine (Root, "Expected", "CheckPackageManagerAssemblyOrder.java"), Path.Combine(path, "src", "mono", "MonoPackageManager_Resources.java"));
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Xamarin.Android.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -45,7 +46,9 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (CheckPackageManagerAssemblyOrderChecks))]
 		public void CheckPackageManagerAssemblyOrder (string[] resolvedUserAssemblies, string[] resolvedAssemblies)
 		{
-			var path = Path.Combine (Root, "temp", TestName);
+			// avoid a PathTooLongException because using the TestName will include ALL the arguments.
+			var testHash = Files.HashString (string.Join ("", resolvedUserAssemblies) + string.Join ("", resolvedAssemblies));
+			var path = Path.Combine (Root, "temp", $"CheckPackageManagerAssemblyOrder{testHash}");
 			Directory.CreateDirectory (path);
 
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new [] {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -41,6 +41,10 @@
       <Link>..\Expected\GenerateDesignerFileWithLibraryReferenceExpected.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Expected\CheckPackageManagerAssemblyOrder.java">
+      <Link>..\Expected\CheckPackageManagerAssemblyOrder.java</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context:

  * https://discord.com/channels/732297728826277939/732297965019988138/859449393472471082
  * ...through...
  * https://discord.com/channels/732297728826277939/732297965019988138/859454102999400488

The ordering of `MonoPackageManager_Resources.Assemblies` is very important to process startup, e.g. see 9c043786, wherein we decide that we *must* preload the *first* assembly listed within `MonoPackageManager_Resources.Assemblies`, as that's The One that has the correct resource IDs.

The problem is threefold:

 1. The order of `@(_ResolvedUserAssemblies)` is poorly defined/undefined.
 2. `@(_ResolvedUserAssemblies)` contains *paths* which includes directory names.
 3. The observed ordering of `@(_ResolvedUserAssemblies)` *differs* between "legacy" MSBuild and `dotnet build`.

See also: https://github.com/xamarin/xamarin-android/blob/52d6880e74337db3fa245ea82b2a02b5016efece/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs#L95-L109

The code in `GeneratePackageManagerJava.cs` line 97 was *always* faulty: `assemblies` contains *paths*, not filenames, and thus `fileNameEq (a.ItemSpec, mainFileName)` will *always* return false (e.g. `a.ItemSpec` would be `obj/Debug/whatever/MainAssembly.dll`, while `mainFileName` will be `MainAssembly.dll`, which will never be equal).

It Just Happened™ to work on Legacy because `@(_ResolvedUserAssemblies)` *always* contained the main/"app" assembly as the first assembly.  This isn't the case on .NET 6 `dotnet build`.

The "giveaway" is the contents of `MonoPackageManager_Resources`:

```java
public class MonoPackageManager_Resources {
        public static String[] Assemblies = new String[]{
                /* We need to ensure that "HelloAndroid.dll" comes first in this list. */
                "Xamarin.AndroidX.Activity.dll",
                // …
        };
}
```

`HelloAndroid.dll` isn't `Xamarin.AndroidX.Activity.dll`.

So let's rework the `GeneratePackageManagerJava` to force the issue and always put the `MainAssembly` first in the list.
We also upgrade the filter to use the filenames rather then the entire path when checking for the main assembly. 

Unit tests have also been added to ensure that the output is what we expect.