### PR TITLE
[ci] Use new 1ES Hosted Ubuntu Pools

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -163,7 +163,7 @@ stages:
   jobs:
   - job: linux_build_package
     displayName: Linux Build
-    pool: Xamarin-Android-Ubuntu-Public
+    pool: android-public-ubuntu-vmss
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -172,36 +172,7 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - template: yaml-templates/use-dot-net.yaml
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNetCoreVersion)
-
-    - task: NuGetToolInstaller@1
-      displayName: 'Use NuGet 5.x'
-      inputs:
-        versionSpec: 5.x
-
-    - script: >
-        sudo apt remove -y --purge --auto-remove mono-devel &&
-        sudo apt install -y gnupg ca-certificates &&
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
-        (echo "deb https://download.mono-project.com/repo/ubuntu preview-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list) &&
-        sudo apt update &&
-        sudo apt install -y mono-devel
-      displayName: install mono preview
-
-    - script: >
-        sudo apt remove -y --purge --auto-remove cmake &&
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&
-        sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&
-        sudo apt-get update &&
-        sudo apt install -y cmake
-      displayName: install updated version of cmake
-
-    - script: echo "##vso[task.setvariable variable=PATH]$PATH:$HOME/android-toolchain/$(XA.Jdk11.Folder)/bin"
-      displayName: append jdk tools to PATH
+    - template: yaml-templates/setup-ubuntu.yaml
 
     - script: make jenkins V=1 PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make jenkins

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -401,7 +401,7 @@ stages:
   jobs:
   - job: linux_build_test
     displayName: Build and Smoke Test
-    pool: Xamarin-Android-Ubuntu20.04
+    pool: android-devdiv-ubuntu-vmss
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 2
     workspace:
@@ -421,29 +421,12 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: delete external xamarin-android submodule
 
-    - template: yaml-templates/use-dot-net.yaml
-
-    - template: yaml-templates/use-dot-net.yaml
-      parameters:
-        version: $(DotNetCoreVersion)
+    - template: yaml-templates/setup-ubuntu.yaml
 
     - task: NuGetAuthenticate@0
       displayName: authenticate with azure artifacts
       inputs:
         forceReinstallCredentialProvider: true
-
-    - script: >
-        sudo apt remove -y --purge --auto-remove mono-complete &&
-        sudo apt remove -y --purge --auto-remove mono-devel &&
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
-        echo "deb https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list &&
-        sudo apt update &&
-        sudo apt install -y mono-devel
-      displayName: install mono preview
-
-    - task: NuGetToolInstaller@0
-      inputs:
-        versionSpec: 5.x
 
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android

--- a/build-tools/automation/yaml-templates/setup-ubuntu.yaml
+++ b/build-tools/automation/yaml-templates/setup-ubuntu.yaml
@@ -1,0 +1,24 @@
+steps:
+- template: use-dot-net.yaml
+
+- template: use-dot-net.yaml
+  parameters:
+    version: $(DotNetCoreVersion)
+
+- script: sudo rm /etc/apt/sources.list.d/treasure-data.list || true
+  displayName: remove invalid treasure-data source
+
+- script: >
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
+    echo "deb https://download.mono-project.com/repo/ubuntu preview-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-preview.list &&
+    sudo apt update &&
+    sudo apt install -y --no-install-recommends mono-complete nuget msbuild
+  displayName: install mono preview
+
+- task: NuGetToolInstaller@1
+  displayName: Use NuGet 5.x
+  inputs:
+    versionSpec: 5.x
+
+- script: echo "##vso[task.setvariable variable=XDG_CONFIG_HOME]$HOME/.config"
+  displayName: update XDG_CONFIG_HOME

--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -22,6 +22,7 @@ override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/aapt2.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libwinpthread-1.dll
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libZipSharpNative.dll
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/runtimes/*/libMono.Unix.so
 
 	dh_install
 
@@ -40,7 +41,9 @@ override_dh_clideps:
 		--exclude-moduleref=libfam.so.0 \
 		--exclude-moduleref=libgamin-1.so.0 \
 		--exclude-moduleref=libmono-btls-shared \
+		--exclude-moduleref=libZipSharpNative \
 		--exclude-moduleref=lzo.dll \
+		--exclude-moduleref=Microsoft.VisualStudio.Setup.Configuration.Native.dll \
 		--exclude-moduleref=mscoree.dll \
 		--exclude-moduleref=mscorwks.dll \
 		--exclude-moduleref=msvcrt \


### PR DESCRIPTION
Context: https://www.1eswiki.com/wiki/1ES_hosted_AzureDevOps_Agents

We've been tasked with migrating away from our scale set agent pools to
a new 1ES service.  There are a couple of benefits to using 1ES agent
pools.  We should now be able to use customizable versions of the
[Microsoft-hosted agent images][0] which come preloaded with some of our
dependencies.  These images are also updated regularly which should
hopefully reduce maintenance costs.  Overall, the process for creating,
updating, and rolling out image changes to our scale set agent pools
should now be dramatically simplified over [the existing workflow][1].

Our internal and OSS Linux builds will now use the same Ubuntu 20.04
base image, so setup tasks can be shared.  A couple of workarounds
have been added to avoid some open issues in these new images.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml
[1]: https://github.com/xamarin/monodroid/wiki/Azure-Pipelines-and-DevOps#windows-scale-set-agent-pool-management