### PR TITLE
[readme] Add 16.10 download links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Link   |
 |-----------------|--------|
-| **Commercial Xamarin.Android 11.2 (d16-9) Preview** for Windows+Visual Studio 2019 Preview  | [Download][commercial-d16-9-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.2 (d16-9) Preview** for macOS                               | [Download][commercial-d16-9-macOS-x86_64]   |
-| **Commercial Xamarin.Android 11.1 (d16-8)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-8-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.1 (d16-8)** for macOS                                       | [Download][commercial-d16-8-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.3 (d16-10)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-10-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.3 (d16-10)** for macOS                                      | [Download][commercial-d16-10-macOS-x86_64]   |
 | **OSS Xamarin.Android 11.1.99 (master)** for Ubuntu\*                                       | [![OSS Linux/Ubuntu x86_64][oss-ubuntu-x86_64-icon]][oss-ubuntu-x86_64-status] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
@@ -36,6 +34,10 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Link   |
 |-----------------|--------|
+| **Commercial Xamarin.Android 11.2 (d16-9)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-9-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.2 (d16-9)** for macOS                                       | [Download][commercial-d16-9-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.1 (d16-8)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-8-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.1 (d16-8)** for macOS                                       | [Download][commercial-d16-8-macOS-x86_64]   |
 | **Commercial Xamarin.Android 11.0 (d16-7)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-7-Windows-x86_64] |
 | **Commercial Xamarin.Android 11.0 (d16-7)** for macOS                                       | [Download][commercial-d16-7-macOS-x86_64]   |
 | **Commercial Xamarin.Android 10.3 (d16-6)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-6-Windows-x86_64] |
@@ -79,6 +81,8 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d16-8-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-8-macos
 [commercial-d16-9-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-9-windows
 [commercial-d16-9-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-9-macos
+[commercial-d16-10-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-10-windows
+[commercial-d16-10-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-10-macos
 
 # Contributing
 


### PR DESCRIPTION
Links currently point to `xamarin.android-11.3.0.4`.