### PR TITLE
[ci] Use new 1ES Hosted win2019 Pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -42,7 +42,7 @@ variables:
   DotNet6Version: 6.0.100-preview.3.21202.5
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: Xamarin-Android-Win2019
+  VSEngWinVS2019: android-win-2019
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
@@ -171,8 +171,6 @@ stages:
 
     - template: yaml-templates\clean.yaml
 
-    - template: yaml-templates\update-vs.yaml
-
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)
       displayName: set JI_JAVA_HOME
@@ -292,8 +290,6 @@ stages:
     - template: yaml-templates\kill-processes.yaml
 
     - template: yaml-templates\clean.yaml
-
-    - template: yaml-templates\update-vs.yaml
 
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -26,7 +26,6 @@ jobs:
 
     - template: setup-test-environment.yaml
       parameters:
-        updateVS: true
         jdkTestFolder: ${{ parameters.jdkTestFolder }}
 
     - task: DownloadPipelineArtifact@1


### PR DESCRIPTION
Context: https://www.1eswiki.com/wiki/1ES_hosted_AzureDevOps_Agents

We've been tasked with migrating away from our scale set agent pools to
a new 1ES service.  There are a couple of benefits to using 1ES agent
pools.  We should now be able to use customizable versions of the
[Microsoft-hosted agent images][0] which come preloaded with some of our
dependencies.  These images are also updated regularly which should
hopefully reduce maintenance costs.  Overall, the process for creating,
updating, and rolling out image changes to our scale set agent pools
should now be dramatically simplified over [the existing workflow][1].

Visual Studio update steps have been removed as these images should stay
up to date with the latest stable VS, similar to the Microsoft-hosted
images.

The new Azure Resource for this pool can be found [here][2].

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml
[1]: https://github.com/xamarin/monodroid/wiki/Azure-Pipelines-and-DevOps#windows-scale-set-agent-pool-management
[2]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourceGroups/devdiv-vm-scale-sets/providers/Microsoft.CloudTest/hostedpools/android-win-2019/overview
