### PR TITLE
[NET6] Remove as much AppDomain use as possible

### DIFF
--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -110,9 +110,6 @@ namespace xamarin::android::internal
 		};
 
 	private:
-		static constexpr char MONO_ANDROID_ASSEMBLY_NAME[] = "Mono.Android";
-		static constexpr char JAVA_INTEROP_ASSEMBLY_NAME[] = "Java.Interop";
-
 		static constexpr size_t SMALL_STRING_PARSE_BUFFER_LEN = 50;
 		static constexpr bool is_running_on_desktop =
 #if ANDROID
@@ -176,7 +173,11 @@ namespace xamarin::android::internal
 			return counters;
 		}
 
+#if defined (NET6)
+		void propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrowable javaException);
+#else // def NET6
 		void propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException);
+#endif // ndef NET6
 
 		// The reason we don't use the C++ overload feature here is that there appears to be an issue in clang++ that
 		// comes with the Android NDK. The issue is that for calls like:
@@ -226,7 +227,12 @@ namespace xamarin::android::internal
 		void create_xdg_directory (jstring_wrapper& home, size_t home_len, const char *relativePath, size_t relative_path_len, const char *environmentVariableName);
 		void create_xdg_directories_and_environment (jstring_wrapper &homeDir);
 		void disable_external_signal_handlers ();
+		void lookup_bridge_info (MonoClass *klass, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
+#if defined (NET6)
+		void lookup_bridge_info (MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
+#else // def NET6
 		void lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
+#endif // ndef NET6
 		void load_assembly (MonoDomain *domain, jstring_wrapper &assembly);
 #if defined (NET6)
 		void load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jstring_wrapper &assembly);
@@ -236,10 +242,12 @@ namespace xamarin::android::internal
 		void set_debug_options ();
 		void parse_gdb_options ();
 		void mono_runtime_init (dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& runtime_args);
-#if !defined (NET6)
+#if defined (NET6)
+		void init_android_runtime (JNIEnv *env, jclass runtimeClass, jobject loader);
+#else //def NET6
+		void init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader);
 		void setup_bundled_app (const char *dso_name);
 #endif // ndef NET6
-		void init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader);
 		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode);
 
 		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value)
@@ -252,7 +260,11 @@ namespace xamarin::android::internal
 			set_environment_variable_for_directory (name, value, false, 0);
 		}
 
+#if defined (NET6)
+		MonoClass* get_android_runtime_class ();
+#else // def NET6
 		MonoClass* get_android_runtime_class (MonoDomain *domain);
+#endif
 		MonoDomain*	create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool is_root_domain);
 		MonoDomain* create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
 		                                          jstring_array_wrapper &assemblies, jobjectArray assembliesBytes, jstring_array_wrapper &assembliesPaths,

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -1116,7 +1116,7 @@ OSBridge::add_monodroid_domain (MonoDomain *domain)
 	 * use GC API to allocate memory and thus can't be called from within the GC callback as it causes a deadlock
 	 * (the routine allocating the memory waits for the GC round to complete first)
 	 */
-	MonoClass *jnienv = utils.monodroid_get_class_from_name (domain, "Mono.Android", "Android.Runtime", "JNIEnv");;
+	MonoClass *jnienv = utils.monodroid_get_class_from_name (domain, SharedConstants::MONO_ANDROID_ASSEMBLY_NAME, SharedConstants::ANDROID_RUNTIME_NS_NAME, SharedConstants::JNIENV_CLASS_NAME);;
 	node->domain = domain;
 	node->bridge_processing_field = mono_class_get_field_from_name (jnienv, const_cast<char*> ("BridgeProcessing"));
 	node->jnienv_vtable = mono_class_vtable (domain, jnienv);
@@ -1125,6 +1125,7 @@ OSBridge::add_monodroid_domain (MonoDomain *domain)
 	domains_list = node;
 }
 
+#if !defined (NET6) && !defined (ANDROID)
 void
 OSBridge::remove_monodroid_domain (MonoDomain *domain)
 {
@@ -1164,3 +1165,4 @@ OSBridge::on_destroy_contexts ()
 	if (!domains_list)
 		osBridge.clear_mono_java_gc_bridge_info ();
 }
+#endif // ndef NET6 && ndef ANDROID

--- a/src/monodroid/jni/osbridge.hh
+++ b/src/monodroid/jni/osbridge.hh
@@ -117,7 +117,9 @@ namespace xamarin::android::internal
 		void initialize_on_onload (JavaVM *vm, JNIEnv *env);
 		void initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass);
 		void add_monodroid_domain (MonoDomain *domain);
+#if !defined (NET6)
 		void remove_monodroid_domain (MonoDomain *domain);
+#endif // ndef NET6
 		void on_destroy_contexts ();
 
 	private:

--- a/src/monodroid/jni/shared-constants.hh
+++ b/src/monodroid/jni/shared-constants.hh
@@ -15,6 +15,13 @@ namespace xamarin::android::internal
 	class SharedConstants
 	{
 	public:
+		static constexpr char MONO_ANDROID_ASSEMBLY_NAME[] = "Mono.Android";
+		static constexpr char JAVA_INTEROP_ASSEMBLY_NAME[] = "Java.Interop";
+
+		static constexpr char ANDROID_RUNTIME_NS_NAME[] = "Android.Runtime";
+		static constexpr char JNIENV_CLASS_NAME[] = "JNIEnv";
+		static constexpr char ANDROID_ENVIRONMENT_CLASS_NAME[] = "AndroidEnvironment";
+
 #if defined (NET6)
 		static constexpr char RUNTIME_CONFIG_BLOB_NAME[] = "rc.bin";
 #endif // def NET6

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -33,9 +33,9 @@ init ()
 	if (AndroidEnvironment_NotifyTimeZoneChanged)
 		return;
 
-	Mono_Android_dll                          = utils.monodroid_load_assembly (mono_domain_get (), "Mono.Android");
+	Mono_Android_dll                          = utils.monodroid_load_assembly (mono_domain_get (), SharedConstants::MONO_ANDROID_ASSEMBLY_NAME);
 	Mono_Android_image                        = mono_assembly_get_image (Mono_Android_dll);
-	AndroidEnvironment                        = mono_class_from_name (Mono_Android_image,  "Android.Runtime",  "AndroidEnvironment");
+	AndroidEnvironment                        = mono_class_from_name (Mono_Android_image,  SharedConstants::ANDROID_RUNTIME_NS_NAME, SharedConstants::ANDROID_ENVIRONMENT_CLASS_NAME);
 	AndroidEnvironment_NotifyTimeZoneChanged  = mono_class_get_method_from_name (AndroidEnvironment, "NotifyTimeZoneChanged", 0);
 
 	if (AndroidEnvironment_NotifyTimeZoneChanged == nullptr) {

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -218,6 +218,7 @@ Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
 	return assm;
 }
 
+#if !defined (NET6)
 MonoObject *
 Util::monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
@@ -271,14 +272,17 @@ Util::monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendl
 
 	return mono_domain_from_appdomain (appdomain);
 }
+#endif // ndef NET6
 
 MonoClass*
-Util::monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type)
+Util::monodroid_get_class_from_name ([[maybe_unused]] MonoDomain *domain, const char* assembly, const char *_namespace, const char *type)
 {
+#if !defined (NET6)
 	MonoDomain *current = mono_domain_get ();
 
 	if (domain != current)
 		mono_domain_set (domain, FALSE);
+#endif // ndef NET6
 
 	MonoClass *result;
 	MonoAssemblyName *aname = mono_assembly_name_new (assembly);
@@ -289,14 +293,17 @@ Util::monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, c
 	} else
 		result = nullptr;
 
+#if !defined (NET6)
 	if (domain != current)
 		mono_domain_set (current, FALSE);
+#endif // ndef NET6
 
 	mono_assembly_name_free (aname);
 
 	return result;
 }
 
+#if !defined (NET6)
 MonoClass*
 Util::monodroid_get_class_from_image (MonoDomain *domain, MonoImage *image, const char *_namespace, const char *type)
 {
@@ -312,6 +319,7 @@ Util::monodroid_get_class_from_image (MonoDomain *domain, MonoImage *image, cons
 
 	return result;
 }
+#endif // ndef NET6
 
 jclass
 Util::get_class_from_runtime_field (JNIEnv *env, jclass runtime, const char *name, bool make_gref)

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -87,11 +87,14 @@ namespace xamarin::android
 		MonoAssembly    *monodroid_load_assembly (MonoDomain *domain, const char *basename);
 #if defined (NET6)
 		MonoAssembly    *monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const char *basename);
-#endif
+#else // def NET6
 		MonoObject      *monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
+#endif // ndef NET6
 		MonoClass       *monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type);
+#if !defined (NET6)
 		MonoDomain      *monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendly_name, int shadow_copy, const char *shadow_directories);
 		MonoClass       *monodroid_get_class_from_image (MonoDomain *domain, MonoImage* image, const char *_namespace, const char *type);
+#endif
 		int              send_uninterrupted (int fd, void *buf, size_t len);
 		ssize_t          recv_uninterrupted (int fd, void *buf, size_t len);
 		jclass           get_class_from_runtime_field (JNIEnv *env, jclass runtime, const char *name, bool make_gref = false);
@@ -103,7 +106,9 @@ namespace xamarin::android
 
 	private:
 		//char *monodroid_strdup_printf (const char *format, va_list vargs);
+#if !defined (NET6)
 		void  monodroid_property_set (MonoDomain *domain, MonoProperty *property, void *obj, void **params, MonoObject **exc);
+#endif // ndef NET6
 
 		template<typename IdxType>
 		void package_hash_to_hex (IdxType idx);


### PR DESCRIPTION
NET6+ no longer supports multiple AppDomains, there's always only a
single "root" AppDomain.  This allows us to drop bits of code which deal
with obtaining and setting the current AppDomain in various context.

This commit removes almost all uses of AppDomains from the native
Xamarin.Android runtime.  Unfortunately, it requires sometimes messy use
of the C++ preprocessor, but wherever it is possible and not overly
ugly, I try to separate the NET6 and "legacy" code completely, for
easier and less noisy future removal of the latter.