### PR TITLE
Add support for NDK r23.

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -129,14 +129,14 @@ Added in Xamarin.Android 6.1.
 
 A path to a directory containing
 the Android [binutils][binutils] such as `ld`, the native linker,
-and `as`, the native assembler. These tools are part of the Android
-NDK and are also included in the Xamarin.Android installation.
+and `as`, the native assembler. These tools are included in the
+Xamarin.Android installation.
 
-The default value is `$(MonoAndroidBinDirectory)\ndk\`.
+The default value is `$(MonoAndroidBinDirectory)\binutils\`.
 
 Added in Xamarin.Android 10.0.
 
-[binutils]: https://android.googlesource.com/toolchain/binutils/
+[binutils]: https://github.com/xamarin/xamarin-android-binutils/
 
 ## AndroidBoundExceptionType
 

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -310,18 +310,18 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-strip.exe" />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
@@ -341,18 +341,18 @@
     </_MSBuildFilesUnixSignAndHarden>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" Permission="755" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" Permission="755" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" ExcludeFromAndroidNETSdk="true" />

--- a/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
+++ b/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Android.Prepare
 		public string NDKVersionMajor        { get; private set; } = String.Empty;
 		public string NDKVersionMinor        { get; private set; } = String.Empty;
 		public string NDKVersionMicro        { get; private set; } = String.Empty;
+		public string NDKVersionTag          { get; private set; } = String.Empty;
 		public string NDKMinimumApiAvailable { get; private set; } = String.Empty;
 
 		public string VersionHash            { get; private set; } = String.Empty;
@@ -59,8 +60,7 @@ namespace Xamarin.Android.Prepare
 				string rev = parts [1].Trim ();
 				NDKRevision = rev;
 
-				Version ver;
-				if (!Version.TryParse (rev, out ver)) {
+				if (!Utilities.ParseAndroidPkgRevision (rev, out Version? ver, out string tag)) {
 					Log.ErrorLine ($"Unable to parse NDK revision '{rev}' as a valid version string");
 					return false;
 				}
@@ -68,6 +68,7 @@ namespace Xamarin.Android.Prepare
 				NDKVersionMajor = ver.Major.ToString ();
 				NDKVersionMinor = ver.Minor.ToString ();
 				NDKVersionMicro = ver.Build.ToString ();
+				NDKVersionTag = tag;
 				break;
 			}
 

--- a/build-tools/xaprepare/xaprepare/Application/MonoJitRuntime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoJitRuntime.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Prepare
 			OutputMonoBtlsFilename        = Configurables.Defaults.MonoRuntimeOutputMonoBtlsFilename;
 			OutputMonoPosixHelperFilename = Configurables.Defaults.MonoRuntimeOutputMonoPosixHelperFilename;
 			OutputProfilerFilename        = Configurables.Defaults.MonoRuntimeOutputProfilerFilename;
-			Strip                         = Path.Combine (Configurables.Paths.AndroidToolchainBinDirectory, $"{Configurables.Defaults.AndroidToolchainPrefixes [Name]}-strip");
+			Strip                         = Path.Combine (Configurables.Paths.AndroidToolchainBinDirectory, "llvm-strip");
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -29,6 +29,29 @@ namespace Xamarin.Android.Prepare
 
 		public static readonly Encoding UTF8NoBOM = new UTF8Encoding (false);
 
+		public static bool ParseAndroidPkgRevision (string? v, out Version? version, out string? tag)
+		{
+			string? ver = v?.Trim ();
+			version = null;
+			tag = null;
+			if (String.IsNullOrEmpty (ver))
+				return false;
+
+			if (ver!.IndexOf ('.') < 0)
+				ver = $"{ver}.0";
+
+			int tagIdx = ver.IndexOf ('-');
+			if (tagIdx >= 0) {
+				tag = ver.Substring (tagIdx + 1);
+				ver = ver.Substring (0, tagIdx - 1);
+			}
+
+			if (Version.TryParse (ver, out version))
+				return true;
+
+			return false;
+		}
+
 		public static bool AbiChoiceChanged (Context context)
 		{
 			string cacheFile = Configurables.Paths.MonoRuntimesEnabledAbisCachePath;

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "22b";
-		public const string AndroidNdkPkgRevision = "22.1.7171670";
+		public const string AndroidNdkVersion = "23";
+		public const string AndroidNdkPkgRevision = "23.0.7599858";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -398,8 +398,8 @@ namespace Xamarin.Android.Prepare
 			public static string AndroidToolchainRootDirectory       => GetCachedPath (ref androidToolchainRootDirectory,       () => Path.Combine (AndroidNdkDirectory, "toolchains", "llvm", "prebuilt", NdkToolchainOSTag));
 			public static string AndroidToolchainBinDirectory        => GetCachedPath (ref androidToolchainBinDirectory,        () => Path.Combine (AndroidToolchainRootDirectory, "bin"));
 			public static string AndroidToolchainSysrootLibDirectory => GetCachedPath (ref androidToolchainSysrootLibDirectory, () => Path.Combine (AndroidToolchainRootDirectory, "sysroot", "usr", "lib"));
-			public static string WindowsBinutilsInstallDir           => GetCachedPath (ref windowsBinutilsInstallDir,           () => Path.Combine (InstallMSBuildDir, "ndk"));
-			public static string HostBinutilsInstallDir              => GetCachedPath (ref hostBinutilsInstallDir,              () => Path.Combine (InstallMSBuildDir, ctx.Properties.GetRequiredValue (KnownProperties.HostOS), "ndk"));
+			public static string WindowsBinutilsInstallDir           => GetCachedPath (ref windowsBinutilsInstallDir,           () => Path.Combine (InstallMSBuildDir, "binutils"));
+			public static string HostBinutilsInstallDir              => GetCachedPath (ref hostBinutilsInstallDir,              () => Path.Combine (InstallMSBuildDir, ctx.Properties.GetRequiredValue (KnownProperties.HostOS), "binutils"));
 			public static string BinutilsCacheDir                    => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
 			public static string AndroidBuildToolsCacheDir           => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",                            destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "7", dependencyType: AndroidToolchainComponentType.EmulatorDependency),
-				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
+				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}",         destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
 				new AndroidToolchainComponent ($"{XABuildToolsPackagePrefix}build-tools_r{XABuildToolsVersion}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"commandlinetools-{cltOsTag}-{CommandLineToolsVersion}",
 					destDir: Path.Combine ("cmdline-tools", CommandLineToolsFolder), isMultiVersion: true),

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -307,35 +307,19 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			if (!ParseVersion (pkgRevision, out Version? pkgVer) || pkgVer == null) {
+			if (!Utilities.ParseAndroidPkgRevision (pkgRevision, out Version? pkgVer, out string pkgTag) || pkgVer == null) {
 				Log.DebugLine ($"Failed to parse a valid version from Pkg.Revision ({pkgRevision}) for component '{component.Name}'. Component will be reinstalled.");
 				return false;
 			}
 
-			if (!ParseVersion (component.PkgRevision, out Version? expectedPkgVer) || expectedPkgVer == null)
+			if (!Utilities.ParseAndroidPkgRevision (component.PkgRevision, out Version? expectedPkgVer, out string expectedTag) || expectedPkgVer == null)
 				throw new InvalidOperationException ($"Invalid expected package version for component '{component.Name}': {component.PkgRevision}");
 
-			bool equal = pkgVer == expectedPkgVer;
+			bool equal = (pkgVer == expectedPkgVer) && (pkgTag == expectedTag);
 			if (!equal)
-				Log.DebugLine ($"Installed version of '{component.Name}' ({pkgVer}) is different than the required one ({expectedPkgVer})");
+				Log.DebugLine ($"Installed version of '{component.Name}' ({pkgRevision}) is different than the required one ({component.PkgRevision})");
 
 			return equal;
-		}
-
-		bool ParseVersion (string? v, out Version? version)
-		{
-			string? ver = v?.Trim ();
-			version = null;
-			if (String.IsNullOrEmpty (ver))
-				return false;
-
-			if (ver!.IndexOf ('.') < 0)
-				ver = $"{ver}.0";
-
-			if (Version.TryParse (ver, out version))
-				return true;
-
-			return false;
 		}
 
 		bool IsNdk (AndroidToolchainComponent component)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -312,14 +312,20 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string toolchainLibDir;
-				if (ndk.UsesClang)
-					toolchainLibDir = GetNdkToolchainLibraryDir (ndk, toolchainPath, arch);
-				else
+				if (ndk.UsesClang) {
+					if (ndk.NoBinutils) {
+						toolchainLibDir = String.Empty;
+					} else {
+						toolchainLibDir = GetNdkToolchainLibraryDir (ndk, toolchainPath, arch);
+					}
+				} else
 					toolchainLibDir = GetNdkToolchainLibraryDir (ndk, toolchainPath);
 
 				var libs = new List<string> ();
 				if (ndk.UsesClang) {
-					libs.Add ($"-L{toolchainLibDir.TrimEnd ('\\')}");
+					if (!String.IsNullOrEmpty (toolchainLibDir)) {
+						libs.Add ($"-L{toolchainLibDir.TrimEnd ('\\')}");
+					}
 					libs.Add ($"-L{androidLibPath.TrimEnd ('\\')}");
 
 					if (arch == AndroidTargetArch.Arm) {
@@ -329,7 +335,9 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				libs.Add (Path.Combine (toolchainLibDir, "libgcc.a"));
+				if (!String.IsNullOrEmpty (toolchainLibDir)) {
+					libs.Add (Path.Combine (toolchainLibDir, "libgcc.a"));
+				}
 				libs.Add (Path.Combine (androidLibPath, "libc.so"));
 				libs.Add (Path.Combine (androidLibPath, "libm.so"));
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -1,23 +1,23 @@
-// 
+//
 // ResolveSdksTask.cs
-//  
+//
 // Author:
 //       Michael Hutchinson <mhutchinson@novell.com>
 //       Jonathan Pryor <jonp@xamarin.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc.
 // Copyright (c) 2013 Xamarin Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Tasks
 			}
 			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 			MonoAndroidLibPath  = MonoAndroidHelper.GetOSLibPath () + Path.DirectorySeparatorChar;
-			AndroidBinUtilsPath = MonoAndroidBinPath + "ndk" + Path.DirectorySeparatorChar;
+			AndroidBinUtilsPath = MonoAndroidBinPath + "binutils" + Path.DirectorySeparatorChar;
 
 			var minVersion      = Version.Parse (MinimumSupportedJavaVersion);
 			var maxVersion      = Version.Parse (LatestSupportedJavaVersion);
@@ -139,4 +139,3 @@ namespace Xamarin.Android.Tasks
 		}
 	}
 }
-

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				var ndkDir = AndroidNdkPath;
 				var sdkDir = AndroidSdkPath;
 				NdkTools ndk = NdkTools.Create (ndkDir, log);
+				ndk.OSBinPath = SetUp.OSBinDirectory;
 				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir, AndroidSdkResolver.GetJavaSdkPath ());
 				var platforms = ndk.GetSupportedPlatforms ();
 				Assert.AreNotEqual (0, platforms.Count (), "No platforms found");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -42,6 +42,11 @@ namespace Xamarin.Android.Build.Tests
 				private set;
 			}
 
+			public static string OSBinDirectory {
+				get;
+				private set;
+			}
+
 			static SetUp ()
 			{
 #if NETCOREAPP
@@ -54,6 +59,16 @@ namespace Xamarin.Android.Build.Tests
 					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 					AndroidMSBuildDirectory = builder.AndroidMSBuildDirectory;
 				}
+
+				string osSubdirName;
+				if (TestEnvironment.IsLinux) {
+					osSubdirName = "Linux";
+				} else if (TestEnvironment.IsMacOS) {
+					osSubdirName = "Darwin";
+				} else {
+					osSubdirName = String.Empty;
+				}
+				OSBinDirectory = Path.Combine (AndroidMSBuildDirectory, osSubdirName);
 			}
 
 			[OneTimeSetUp]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -2,25 +2,25 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 2584
+      "Size": 2604
     },
     "assemblies/Java.Interop.dll": {
       "Size": 67759
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 251450
+      "Size": 251399
     },
     "assemblies/mscorlib.dll": {
       "Size": 769324
     },
     "assemblies/System.Core.dll": {
-      "Size": 28186
+      "Size": 28187
     },
     "assemblies/System.dll": {
       "Size": 9171
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2867
+      "Size": 2866
     },
     "classes.dex": {
       "Size": 345208
@@ -32,13 +32,13 @@
       "Size": 707024
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 282936
+      "Size": 286736
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4037584
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65496
+      "Size": 65624
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 20032
@@ -74,5 +74,5 @@
       "Size": 1724
     }
   },
-  "PackageSize": 3978964
+  "PackageSize": 3983060
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -8,7 +8,7 @@
       "Size": 7200
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68711
+      "Size": 68710
     },
     "assemblies/Mono.Android.dll": {
       "Size": 562181
@@ -77,10 +77,10 @@
       "Size": 7050
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7179
+      "Size": 7178
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4859
+      "Size": 4860
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
       "Size": 13574
@@ -122,16 +122,16 @@
       "Size": 707024
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 282936
+      "Size": 281352
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4037584
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
-      "Size": 65496
+      "Size": 65624
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 142104
+      "Size": 140560
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkTools.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkTools.cs
@@ -33,6 +33,8 @@ namespace Xamarin.Android.Tasks
 			{ NdkToolKind.Strip, "strip" },
 		};
 
+		string? osBinPath;
+
 		public NdkVersion Version { get; }
 		public string NdkRootDirectory { get; }
 		public bool UsesClang { get; protected set; }
@@ -47,6 +49,17 @@ namespace Xamarin.Android.Tasks
 
 		protected TaskLoggingHelper? Log { get; }
 
+		public string OSBinPath {
+			get => osBinPath ?? MonoAndroidHelper.GetOSBinPath ();
+			set {
+				if (String.IsNullOrEmpty (value)) {
+					osBinPath = null;
+				} else {
+					osBinPath = value;
+				}
+			}
+		}
+
 		protected NdkTools (string androidNdkPath, NdkVersion version, TaskLoggingHelper? log = null)
 		{
 			if (String.IsNullOrEmpty (androidNdkPath)) {
@@ -58,7 +71,7 @@ namespace Xamarin.Android.Tasks
 			Version = version;
 		}
 
-		public static NdkTools? Create (string androidNdkPath, TaskLoggingHelper? log = null)
+		public static NdkTools? Create (string androidNdkPath, TaskLoggingHelper? log = null, string? osBinPath = null)
 		{
 			if (String.IsNullOrEmpty (androidNdkPath)) {
 				log?.LogCodedError ("XA5104", Properties.Resources.XA5104);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/WithClang.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/WithClang.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Tasks
 
 		public override string GetToolPath (string name, AndroidTargetArch arch, int apiLevel)
 		{
-			return MakeToolPath ($"{GetArchTriple (arch)}-{name}");
+			return MakeToolPath ($"{GetArchTriple (arch)}-{name}", mustExist: false);
 		}
 
 		public override string GetClangDeviceLibraryPath ()
@@ -99,11 +99,11 @@ namespace Xamarin.Android.Tasks
 			return arch == AndroidTargetArch.Arm ? "armv7a-linux-androideabi" : GetArchTriple (arch);
 		}
 
-		protected string MakeToolPath (string toolName)
+		protected string MakeToolPath (string toolName, bool mustExist = true)
 		{
 			string toolPath = Path.Combine (GetToolchainDir (), "bin", toolName);
 
-			return GetExecutablePath (toolPath, mustExist: true)!;
+			return GetExecutablePath (toolPath, mustExist) ?? String.Empty;
 		}
 
 		protected string GetToolchainDir ()

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -279,7 +279,6 @@ endif()
 if(ANDROID)
   add_compile_definitions(HAVE_LZ4)
   add_compile_definitions(PLATFORM_ANDROID)
-  add_compile_definitions(__ANDROID_API__=${ANDROID_NATIVE_API_LEVEL})
 
   if(ANDROID_ABI MATCHES "^(arm64-v8a|x86_64)")
     add_compile_definitions(ANDROID64)

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
@@ -2,25 +2,25 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 3748
+      "Size": 3768
     },
     "assemblies/FormsViewGroup.dll": {
       "Size": 7191
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68687
+      "Size": 68688
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 554849
+      "Size": 560342
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68430
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936191
+      "Size": 936261
     },
     "assemblies/Newtonsoft.Json.dll": {
-      "Size": 317978
+      "Size": 319336
     },
     "assemblies/Plugin.Connectivity.Abstractions.dll": {
       "Size": 3760
@@ -29,31 +29,31 @@
       "Size": 10201
     },
     "assemblies/System.Core.dll": {
-      "Size": 192208
+      "Size": 192206
     },
     "assemblies/System.Data.dll": {
       "Size": 316107
     },
     "assemblies/System.dll": {
-      "Size": 443219
+      "Size": 443196
     },
     "assemblies/System.Drawing.Common.dll": {
       "Size": 16345
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113284
+      "Size": 113285
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 23252
+      "Size": 23251
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193448
+      "Size": 193447
     },
     "assemblies/System.ServiceModel.Internals.dll": {
       "Size": 26590
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592564
+      "Size": 592565
     },
     "assemblies/System.Xml.Linq.dll": {
       "Size": 34368
@@ -113,10 +113,10 @@
       "Size": 471882
     },
     "assemblies/Xamarin.Forms.Performance.Integration.dll": {
-      "Size": 21994
+      "Size": 21996
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114903
+      "Size": 114909
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
       "Size": 367732
@@ -131,7 +131,7 @@
       "Size": 43499
     },
     "classes.dex": {
-      "Size": 2467216
+      "Size": 2499728
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
       "Size": 38632
@@ -140,16 +140,16 @@
       "Size": 870816
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 6709116
+      "Size": 6742720
     },
     "lib/armeabi-v7a/libaot-Mono.Security.dll.so": {
       "Size": 443012
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 8675720
+      "Size": 8676492
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3390724
+      "Size": 3394680
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.Abstractions.dll.so": {
       "Size": 21976
@@ -164,7 +164,7 @@
       "Size": 3262352
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 3963940
+      "Size": 3963520
     },
     "lib/armeabi-v7a/libaot-System.Drawing.Common.dll.so": {
       "Size": 69900
@@ -260,22 +260,22 @@
       "Size": 609712
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
-      "Size": 1113088
+      "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736764
+      "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 216944
+      "Size": 229116
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456716
+      "Size": 4456332
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48652
+      "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 135288
+      "Size": 136376
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
       "Size": 46012
@@ -284,16 +284,16 @@
       "Size": 823996
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 6289704
+      "Size": 6318972
     },
     "lib/x86/libaot-Mono.Security.dll.so": {
       "Size": 413872
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 8035152
+      "Size": 8035916
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3155276
+      "Size": 3159240
     },
     "lib/x86/libaot-Plugin.Connectivity.Abstractions.dll.so": {
       "Size": 25620
@@ -308,7 +308,7 @@
       "Size": 2960556
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 3648832
+      "Size": 3648424
     },
     "lib/x86/libaot-System.Drawing.Common.dll.so": {
       "Size": 73160
@@ -404,22 +404,22 @@
       "Size": 589672
     },
     "lib/x86/libmono-btls-shared.so": {
-      "Size": 1459984
+      "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803736
+      "Size": 803352
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 272240
+      "Size": 297800
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212604
+      "Size": 4212220
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61348
+      "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 133560
+      "Size": 134612
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 36222148
+  "PackageSize": 36295876
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
@@ -2,7 +2,178 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 3748
+      "Size": 3768
+    },
+    "classes.dex": {
+      "Size": 2802888
+    },
+    "lib/armeabi-v7a/libmono-btls-shared.so": {
+      "Size": 1112688
+    },
+    "lib/armeabi-v7a/libmono-native.so": {
+      "Size": 736396
+    },
+    "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
+      "Size": 4276344
+    },
+    "lib/armeabi-v7a/libmonodroid.so": {
+      "Size": 229116
+    },
+    "lib/armeabi-v7a/libmonosgen-2.0.so": {
+      "Size": 4456332
+    },
+    "lib/armeabi-v7a/libxa-internal-api.so": {
+      "Size": 48844
+    },
+    "lib/armeabi-v7a/libxamarin-app.so": {
+      "Size": 110724
+    },
+    "lib/x86/libmono-btls-shared.so": {
+      "Size": 1459584
+    },
+    "lib/x86/libmono-native.so": {
+      "Size": 803352
+    },
+    "lib/x86/libmonodroid_bundle_app.so": {
+      "Size": 4279696
+    },
+    "lib/x86/libmonodroid.so": {
+      "Size": 297800
+    },
+    "lib/x86/libmonosgen-2.0.so": {
+      "Size": 4212220
+    },
+    "lib/x86/libxa-internal-api.so": {
+      "Size": 61112
+    },
+    "lib/x86/libxamarin-app.so": {
+      "Size": 109168
+    },
+    "META-INF/android.arch.core_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata-core.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_viewmodel.version": {
+      "Size": 6
+    },
+    "META-INF/android.support.design_material.version": {
+      "Size": 12
+    },
+    "META-INF/ANDROIDD.RSA": {
+      "Size": 1205
+    },
+    "META-INF/ANDROIDD.SF": {
+      "Size": 103239
+    },
+    "META-INF/androidx.appcompat_appcompat.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.browser_browser.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cardview_cardview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.core_core.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cursoradapter_cursoradapter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.customview_customview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.documentfile_documentfile.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.drawerlayout_drawerlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.fragment_fragment.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.interpolator_interpolator.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-v4.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.loader_loader.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.media_media.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.mediarouter_mediarouter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.palette_palette.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.print_print.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.recyclerview_recyclerview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.transition_transition.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.viewpager_viewpager.version": {
+      "Size": 6
+    },
+    "META-INF/com.google.android.material_material.version": {
+      "Size": 10
+    },
+    "META-INF/MANIFEST.MF": {
+      "Size": 103131
+    },
+    "META-INF/proguard/androidx-annotations.pro": {
+      "Size": 308
+    },
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
     },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
@@ -64,11 +235,11 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
+    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
+      "Size": 2664
     },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
+    "res/animator-v21/design_appbar_state_list_animator.xml": {
+      "Size": 1216
     },
     "res/animator/design_fab_hide_motion_spec.xml": {
       "Size": 796
@@ -78,9 +249,6 @@
     },
     "res/animator/mtrl_btn_state_list_anim.xml": {
       "Size": 2624
-    },
-    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
-      "Size": 2664
     },
     "res/animator/mtrl_btn_unelevated_state_list_anim.xml": {
       "Size": 120
@@ -100,8 +268,38 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
-    "res/animator-v21/design_appbar_state_list_animator.xml": {
-      "Size": 1216
+    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 464
+    },
+    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_btn_colored_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_color_highlight_material.xml": {
+      "Size": 544
+    },
+    "res/color-v23/abc_tint_btn_checkable.xml": {
+      "Size": 624
+    },
+    "res/color-v23/abc_tint_default.xml": {
+      "Size": 1120
+    },
+    "res/color-v23/abc_tint_edittext.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_seek_thumb.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_tint_spinner.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_switch_track.xml": {
+      "Size": 664
+    },
+    "res/color-v23/design_tint_password_toggle.xml": {
+      "Size": 376
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -205,10 +403,10 @@
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
-    "res/color/mtrl_tabs_icon_color_selector.xml": {
+    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
       "Size": 464
     },
-    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
+    "res/color/mtrl_tabs_icon_color_selector.xml": {
       "Size": 464
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
@@ -226,554 +424,11 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 464
-    },
-    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_btn_colored_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_color_highlight_material.xml": {
-      "Size": 544
-    },
-    "res/color-v23/abc_tint_btn_checkable.xml": {
-      "Size": 624
-    },
-    "res/color-v23/abc_tint_default.xml": {
-      "Size": 1120
-    },
-    "res/color-v23/abc_tint_edittext.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_seek_thumb.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_tint_spinner.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_switch_track.xml": {
-      "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
-    },
-    "res/drawable/abc_btn_borderless_material.xml": {
-      "Size": 588
-    },
-    "res/drawable/abc_btn_check_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_colored_material.xml": {
-      "Size": 344
-    },
-    "res/drawable/abc_btn_default_mtrl_shape.xml": {
-      "Size": 932
-    },
-    "res/drawable/abc_btn_radio_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_cab_background_internal_bg.xml": {
-      "Size": 372
-    },
-    "res/drawable/abc_cab_background_top_material.xml": {
-      "Size": 336
-    },
-    "res/drawable/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable/abc_edit_text_material.xml": {
-      "Size": 868
-    },
-    "res/drawable/abc_ic_ab_back_material.xml": {
-      "Size": 692
-    },
-    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
-      "Size": 1000
-    },
-    "res/drawable/abc_ic_clear_material.xml": {
-      "Size": 684
-    },
-    "res/drawable/abc_ic_go_search_api_material.xml": {
-      "Size": 640
-    },
-    "res/drawable/abc_ic_menu_overflow_material.xml": {
-      "Size": 792
-    },
-    "res/drawable/abc_ic_search_api_material.xml": {
-      "Size": 812
-    },
-    "res/drawable/abc_ic_voice_search_api_material.xml": {
-      "Size": 828
-    },
-    "res/drawable/abc_item_background_holo_dark.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_item_background_holo_light.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_list_divider_material.xml": {
-      "Size": 480
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_holo_dark.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_list_selector_holo_light.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_small_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_seekbar_thumb_material.xml": {
-      "Size": 1100
-    },
-    "res/drawable/abc_seekbar_tick_mark_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_seekbar_track_material.xml": {
-      "Size": 1408
-    },
-    "res/drawable/abc_spinner_textfield_background_material.xml": {
-      "Size": 1160
-    },
-    "res/drawable/abc_switch_thumb_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_tab_indicator_material.xml": {
-      "Size": 468
-    },
-    "res/drawable/abc_text_cursor_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_textfield_search_material.xml": {
-      "Size": 756
-    },
-    "res/drawable/abc_vector_test.xml": {
-      "Size": 612
-    },
-    "res/drawable/design_bottom_navigation_item_background.xml": {
-      "Size": 784
-    },
-    "res/drawable/design_fab_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/design_password_eye.xml": {
-      "Size": 464
-    },
-    "res/drawable/design_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/ic_mtrl_chip_checked_black.xml": {
-      "Size": 600
-    },
-    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
-      "Size": 940
-    },
-    "res/drawable/ic_mtrl_chip_close_circle.xml": {
-      "Size": 808
-    },
-    "res/drawable/icon.png": {
-      "Size": 1358
-    },
-    "res/drawable/mr_button_connected_dark.xml": {
-      "Size": 3424
-    },
-    "res/drawable/mr_button_connected_light.xml": {
-      "Size": 3424
-    },
-    "res/drawable/mr_button_connecting_dark.xml": {
-      "Size": 3424
-    },
-    "res/drawable/mr_button_connecting_light.xml": {
-      "Size": 3424
-    },
-    "res/drawable/mr_button_dark.xml": {
-      "Size": 756
-    },
-    "res/drawable/mr_button_light.xml": {
-      "Size": 756
-    },
-    "res/drawable/mr_dialog_close_dark.xml": {
-      "Size": 340
-    },
-    "res/drawable/mr_dialog_close_light.xml": {
-      "Size": 444
-    },
-    "res/drawable/mr_dialog_material_background_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/mr_dialog_material_background_light.xml": {
-      "Size": 484
-    },
-    "res/drawable/mr_group_collapse.xml": {
-      "Size": 1924
-    },
-    "res/drawable/mr_group_expand.xml": {
-      "Size": 1924
-    },
-    "res/drawable/mr_media_pause_dark.xml": {
-      "Size": 340
-    },
-    "res/drawable/mr_media_pause_light.xml": {
-      "Size": 444
-    },
-    "res/drawable/mr_media_play_dark.xml": {
-      "Size": 340
-    },
-    "res/drawable/mr_media_play_light.xml": {
-      "Size": 444
-    },
-    "res/drawable/mr_media_stop_dark.xml": {
-      "Size": 340
-    },
-    "res/drawable/mr_media_stop_light.xml": {
-      "Size": 444
-    },
-    "res/drawable/mr_vol_type_audiotrack_dark.xml": {
-      "Size": 340
-    },
-    "res/drawable/mr_vol_type_audiotrack_light.xml": {
-      "Size": 444
-    },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/mtrl_tabs_default_indicator.xml": {
-      "Size": 628
-    },
-    "res/drawable/navigation_empty_icon.xml": {
-      "Size": 516
-    },
-    "res/drawable/notification_bg.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_bg_low.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_icon_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/notification_tile_bg.xml": {
-      "Size": 304
-    },
-    "res/drawable/tooltip_frame_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/tooltip_frame_light.xml": {
-      "Size": 484
-    },
-    "res/drawable/xamarin_logo.png": {
-      "Size": 9794
-    },
-    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
-      "Size": 372
-    },
-    "res/drawable-v21/$avd_hide_password__0.xml": {
-      "Size": 1176
-    },
-    "res/drawable-v21/$avd_hide_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_hide_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/$avd_show_password__0.xml": {
-      "Size": 1136
-    },
-    "res/drawable-v21/$avd_show_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_show_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/abc_btn_colored_material.xml": {
-      "Size": 1716
-    },
-    "res/drawable-v21/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable-v21/abc_edit_text_material.xml": {
-      "Size": 1172
-    },
-    "res/drawable-v21/abc_list_divider_material.xml": {
-      "Size": 516
-    },
-    "res/drawable-v21/avd_hide_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/avd_show_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/design_password_eye.xml": {
-      "Size": 816
-    },
-    "res/drawable-v21/notification_action_background.xml": {
-      "Size": 1180
-    },
-    "res/drawable-v23/abc_control_background_material.xml": {
-      "Size": 304
-    },
-    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
-      "Size": 267
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
-      "Size": 321
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
-      "Size": 356
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
-      "Size": 754
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
-      "Size": 825
-    },
-    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
-      "Size": 216
-    },
-    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
-      "Size": 173
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 251
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 152
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 139
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 270
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 193
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 364
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 467
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 253
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
-      "Size": 167
-    },
-    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
-      "Size": 222
-    },
-    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
-      "Size": 211
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
-      "Size": 541
-    },
-    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
-      "Size": 776
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
-      "Size": 159
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
-      "Size": 197
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
-      "Size": 194
-    },
-    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 327
-    },
-    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
-      "Size": 395
-    },
-    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 311
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 187
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
-      "Size": 181
-    },
-    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
-    "res/drawable-mdpi-v4/ic_audiotrack_dark.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/ic_audiotrack_light.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/ic_dialog_close_dark.png": {
-      "Size": 168
-    },
-    "res/drawable-mdpi-v4/ic_dialog_close_light.png": {
-      "Size": 164
-    },
-    "res/drawable-mdpi-v4/ic_media_pause_dark.png": {
-      "Size": 90
-    },
-    "res/drawable-mdpi-v4/ic_media_pause_light.png": {
-      "Size": 101
-    },
-    "res/drawable-mdpi-v4/ic_media_play_dark.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/ic_media_play_light.png": {
-      "Size": 208
-    },
-    "res/drawable-mdpi-v4/ic_media_stop_dark.png": {
-      "Size": 90
-    },
-    "res/drawable-mdpi-v4/ic_media_stop_light.png": {
-      "Size": 99
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disabled_dark.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disabled_light.png": {
-      "Size": 301
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disconnected_dark.png": {
-      "Size": 406
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_disconnected_light.png": {
-      "Size": 389
-    },
-    "res/drawable-mdpi-v4/ic_mr_button_grey.png": {
-      "Size": 268
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_dark.png": {
-      "Size": 256
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_dark.png": {
-      "Size": 250
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_light.png": {
-      "Size": 256
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_speaker_light.png": {
-      "Size": 255
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_tv_dark.png": {
-      "Size": 128
-    },
-    "res/drawable-mdpi-v4/ic_vol_type_tv_light.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
-      "Size": 98
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 127
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 253
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 318
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
+      "Size": 540
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -916,11 +571,11 @@
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-hdpi-v4/design_ic_visibility.png": {
-      "Size": 470
-    },
     "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
       "Size": 507
+    },
+    "res/drawable-hdpi-v4/design_ic_visibility.png": {
+      "Size": 470
     },
     "res/drawable-hdpi-v4/ic_audiotrack_dark.png": {
       "Size": 205
@@ -994,11 +649,11 @@
     "res/drawable-hdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 225
     },
-    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
-      "Size": 212
-    },
     "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 225
+    },
+    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
+      "Size": 212
     },
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
@@ -1011,6 +666,330 @@
     },
     "res/drawable-ldrtl-hdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 345
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 127
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 253
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 318
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 178
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 494
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 417
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 260
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 705
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 525
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 325
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 905
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 437
+    },
+    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
+      "Size": 267
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
+      "Size": 321
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
+      "Size": 356
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
+      "Size": 754
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
+      "Size": 825
+    },
+    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
+      "Size": 216
+    },
+    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
+      "Size": 173
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 251
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
+      "Size": 152
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
+      "Size": 139
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
+      "Size": 270
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
+      "Size": 193
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
+      "Size": 364
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
+      "Size": 467
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
+      "Size": 253
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
+      "Size": 167
+    },
+    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
+      "Size": 222
+    },
+    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
+      "Size": 211
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
+      "Size": 541
+    },
+    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
+      "Size": 776
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
+      "Size": 159
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
+      "Size": 197
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
+      "Size": 194
+    },
+    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 327
+    },
+    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
+      "Size": 395
+    },
+    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
+      "Size": 311
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
+      "Size": 187
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
+      "Size": 181
+    },
+    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
+      "Size": 351
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility.png": {
+      "Size": 309
+    },
+    "res/drawable-mdpi-v4/ic_audiotrack_dark.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/ic_audiotrack_light.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/ic_dialog_close_dark.png": {
+      "Size": 168
+    },
+    "res/drawable-mdpi-v4/ic_dialog_close_light.png": {
+      "Size": 164
+    },
+    "res/drawable-mdpi-v4/ic_media_pause_dark.png": {
+      "Size": 90
+    },
+    "res/drawable-mdpi-v4/ic_media_pause_light.png": {
+      "Size": 101
+    },
+    "res/drawable-mdpi-v4/ic_media_play_dark.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/ic_media_play_light.png": {
+      "Size": 208
+    },
+    "res/drawable-mdpi-v4/ic_media_stop_dark.png": {
+      "Size": 90
+    },
+    "res/drawable-mdpi-v4/ic_media_stop_light.png": {
+      "Size": 99
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disabled_dark.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disabled_light.png": {
+      "Size": 301
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disconnected_dark.png": {
+      "Size": 406
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_disconnected_light.png": {
+      "Size": 389
+    },
+    "res/drawable-mdpi-v4/ic_mr_button_grey.png": {
+      "Size": 268
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_dark.png": {
+      "Size": 256
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_dark.png": {
+      "Size": 250
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_group_light.png": {
+      "Size": 256
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_speaker_light.png": {
+      "Size": 255
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_tv_dark.png": {
+      "Size": 128
+    },
+    "res/drawable-mdpi-v4/ic_vol_type_tv_light.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
+      "Size": 98
+    },
+    "res/drawable-v21/$avd_hide_password__0.xml": {
+      "Size": 1176
+    },
+    "res/drawable-v21/$avd_hide_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_hide_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/$avd_show_password__0.xml": {
+      "Size": 1136
+    },
+    "res/drawable-v21/$avd_show_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_show_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/abc_btn_colored_material.xml": {
+      "Size": 1716
+    },
+    "res/drawable-v21/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable-v21/abc_edit_text_material.xml": {
+      "Size": 1172
+    },
+    "res/drawable-v21/abc_list_divider_material.xml": {
+      "Size": 516
+    },
+    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/abc_ratingbar_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/abc_ratingbar_small_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/avd_hide_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/avd_show_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/design_password_eye.xml": {
+      "Size": 816
+    },
+    "res/drawable-v21/notification_action_background.xml": {
+      "Size": 1180
+    },
+    "res/drawable-v23/abc_control_background_material.xml": {
+      "Size": 304
+    },
+    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
+      "Size": 372
     },
     "res/drawable-xhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 280
@@ -1153,11 +1132,11 @@
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
     },
-    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
-      "Size": 593
-    },
     "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
       "Size": 629
+    },
+    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
+      "Size": 593
     },
     "res/drawable-xhdpi-v4/ic_audiotrack_dark.png": {
       "Size": 235
@@ -1603,23 +1582,14 @@
     "res/drawable-xhdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 252
     },
-    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
-      "Size": 221
-    },
     "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 247
     },
+    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
+      "Size": 221
+    },
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 494
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 417
     },
     "res/drawable-xxhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 286
@@ -1762,11 +1732,11 @@
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
-      "Size": 868
-    },
     "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 884
+    },
+    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
+      "Size": 868
     },
     "res/drawable-xxhdpi-v4/ic_audiotrack_dark.png": {
       "Size": 306
@@ -2206,15 +2176,6 @@
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 1647
     },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 260
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 705
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 525
-    },
     "res/drawable-xxxhdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
       "Size": 275
     },
@@ -2293,11 +2254,11 @@
     "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
-      "Size": 1155
-    },
     "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 1201
+    },
+    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
+      "Size": 1155
     },
     "res/drawable-xxxhdpi-v4/ic_group_collapse_00.png": {
       "Size": 253
@@ -2398,20 +2359,233 @@
     "res/drawable-xxxhdpi-v4/ic_mr_button_grey.png": {
       "Size": 879
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 325
+    "res/drawable/abc_btn_borderless_material.xml": {
+      "Size": 588
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 905
+    "res/drawable/abc_btn_check_material.xml": {
+      "Size": 464
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 437
+    "res/drawable/abc_btn_colored_material.xml": {
+      "Size": 344
     },
-    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
-      "Size": 540
+    "res/drawable/abc_btn_default_mtrl_shape.xml": {
+      "Size": 932
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/drawable/abc_btn_radio_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_cab_background_internal_bg.xml": {
+      "Size": 372
+    },
+    "res/drawable/abc_cab_background_top_material.xml": {
+      "Size": 336
+    },
+    "res/drawable/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable/abc_edit_text_material.xml": {
+      "Size": 868
+    },
+    "res/drawable/abc_ic_ab_back_material.xml": {
+      "Size": 692
+    },
+    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
+      "Size": 1000
+    },
+    "res/drawable/abc_ic_clear_material.xml": {
+      "Size": 684
+    },
+    "res/drawable/abc_ic_go_search_api_material.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_ic_menu_overflow_material.xml": {
+      "Size": 792
+    },
+    "res/drawable/abc_ic_search_api_material.xml": {
+      "Size": 812
+    },
+    "res/drawable/abc_ic_voice_search_api_material.xml": {
+      "Size": 828
+    },
+    "res/drawable/abc_item_background_holo_dark.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_item_background_holo_light.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_list_divider_material.xml": {
+      "Size": 480
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_holo_dark.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_list_selector_holo_light.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_ratingbar_indicator_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_small_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_seekbar_thumb_material.xml": {
+      "Size": 1100
+    },
+    "res/drawable/abc_seekbar_tick_mark_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_seekbar_track_material.xml": {
+      "Size": 1408
+    },
+    "res/drawable/abc_spinner_textfield_background_material.xml": {
+      "Size": 1160
+    },
+    "res/drawable/abc_switch_thumb_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_tab_indicator_material.xml": {
+      "Size": 468
+    },
+    "res/drawable/abc_text_cursor_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_textfield_search_material.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_vector_test.xml": {
+      "Size": 612
+    },
+    "res/drawable/design_bottom_navigation_item_background.xml": {
+      "Size": 784
+    },
+    "res/drawable/design_fab_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/design_password_eye.xml": {
+      "Size": 464
+    },
+    "res/drawable/design_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/ic_mtrl_chip_checked_black.xml": {
+      "Size": 600
+    },
+    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
+      "Size": 940
+    },
+    "res/drawable/ic_mtrl_chip_close_circle.xml": {
+      "Size": 808
+    },
+    "res/drawable/icon.png": {
+      "Size": 1358
+    },
+    "res/drawable/mr_button_connected_dark.xml": {
+      "Size": 3424
+    },
+    "res/drawable/mr_button_connected_light.xml": {
+      "Size": 3424
+    },
+    "res/drawable/mr_button_connecting_dark.xml": {
+      "Size": 3424
+    },
+    "res/drawable/mr_button_connecting_light.xml": {
+      "Size": 3424
+    },
+    "res/drawable/mr_button_dark.xml": {
+      "Size": 756
+    },
+    "res/drawable/mr_button_light.xml": {
+      "Size": 756
+    },
+    "res/drawable/mr_dialog_close_dark.xml": {
+      "Size": 340
+    },
+    "res/drawable/mr_dialog_close_light.xml": {
+      "Size": 444
+    },
+    "res/drawable/mr_dialog_material_background_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/mr_dialog_material_background_light.xml": {
+      "Size": 484
+    },
+    "res/drawable/mr_group_collapse.xml": {
+      "Size": 1924
+    },
+    "res/drawable/mr_group_expand.xml": {
+      "Size": 1924
+    },
+    "res/drawable/mr_media_pause_dark.xml": {
+      "Size": 340
+    },
+    "res/drawable/mr_media_pause_light.xml": {
+      "Size": 444
+    },
+    "res/drawable/mr_media_play_dark.xml": {
+      "Size": 340
+    },
+    "res/drawable/mr_media_play_light.xml": {
+      "Size": 444
+    },
+    "res/drawable/mr_media_stop_dark.xml": {
+      "Size": 340
+    },
+    "res/drawable/mr_media_stop_light.xml": {
+      "Size": 444
+    },
+    "res/drawable/mr_vol_type_audiotrack_dark.xml": {
+      "Size": 340
+    },
+    "res/drawable/mr_vol_type_audiotrack_light.xml": {
+      "Size": 444
+    },
+    "res/drawable/mtrl_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/mtrl_tabs_default_indicator.xml": {
+      "Size": 628
+    },
+    "res/drawable/navigation_empty_icon.xml": {
+      "Size": 516
+    },
+    "res/drawable/notification_bg_low.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_bg.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_icon_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/notification_tile_bg.xml": {
+      "Size": 304
+    },
+    "res/drawable/tooltip_frame_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/tooltip_frame_light.xml": {
+      "Size": 484
+    },
+    "res/drawable/xamarin_logo.png": {
+      "Size": 9799
+    },
+    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
+      "Size": 400
     },
     "res/interpolator/mr_fast_out_slow_in.xml": {
       "Size": 400
@@ -2425,20 +2599,143 @@
     "res/interpolator/mtrl_fast_out_slow_in.xml": {
       "Size": 144
     },
-    "res/interpolator/mtrl_linear.xml": {
-      "Size": 132
-    },
     "res/interpolator/mtrl_linear_out_slow_in.xml": {
       "Size": 136
     },
-    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
-      "Size": 400
+    "res/interpolator/mtrl_linear.xml": {
+      "Size": 132
     },
-    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
+      "Size": 520
     },
-    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
+      "Size": 520
+    },
+    "res/layout-v16/notification_template_custom_big.xml": {
+      "Size": 3012
+    },
+    "res/layout-v17/abc_action_mode_close_item_material.xml": {
+      "Size": 840
+    },
+    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1536
+    },
+    "res/layout-v17/abc_alert_dialog_title_material.xml": {
+      "Size": 1516
+    },
+    "res/layout-v17/abc_dialog_title_material.xml": {
+      "Size": 1072
+    },
+    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
+      "Size": 848
+    },
+    "res/layout-v17/abc_search_view.xml": {
+      "Size": 3472
+    },
+    "res/layout-v17/abc_select_dialog_material.xml": {
+      "Size": 976
+    },
+    "res/layout-v17/abc_tooltip.xml": {
+      "Size": 1056
+    },
+    "res/layout-v17/browser_actions_context_menu_page.xml": {
+      "Size": 1660
+    },
+    "res/layout-v17/browser_actions_context_menu_row.xml": {
+      "Size": 1164
+    },
+    "res/layout-v17/design_layout_snackbar_include.xml": {
+      "Size": 1436
+    },
+    "res/layout-v17/mr_cast_group_item.xml": {
+      "Size": 944
+    },
+    "res/layout-v17/mr_cast_group_volume_item.xml": {
+      "Size": 1416
+    },
+    "res/layout-v17/mr_cast_media_metadata.xml": {
+      "Size": 2140
+    },
+    "res/layout-v17/mr_cast_route_item.xml": {
+      "Size": 1804
+    },
+    "res/layout-v17/mr_dialog_header_item.xml": {
+      "Size": 556
+    },
+    "res/layout-v17/mr_picker_dialog.xml": {
+      "Size": 1000
+    },
+    "res/layout-v17/mr_picker_route_item.xml": {
+      "Size": 932
+    },
+    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
+      "Size": 1396
+    },
+    "res/layout-v17/notification_action_tombstone.xml": {
+      "Size": 1332
+    },
+    "res/layout-v17/notification_action.xml": {
+      "Size": 1156
+    },
+    "res/layout-v17/notification_template_big_media_custom.xml": {
+      "Size": 3044
+    },
+    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
+      "Size": 3216
+    },
+    "res/layout-v17/notification_template_big_media_narrow.xml": {
+      "Size": 1824
+    },
+    "res/layout-v17/notification_template_big_media.xml": {
+      "Size": 1696
+    },
+    "res/layout-v17/notification_template_custom_big.xml": {
+      "Size": 3208
+    },
+    "res/layout-v17/notification_template_lines_media.xml": {
+      "Size": 2872
+    },
+    "res/layout-v17/notification_template_media_custom.xml": {
+      "Size": 2756
+    },
+    "res/layout-v17/notification_template_media.xml": {
+      "Size": 1292
+    },
+    "res/layout-v17/select_dialog_multichoice_material.xml": {
+      "Size": 864
+    },
+    "res/layout-v17/select_dialog_singlechoice_material.xml": {
+      "Size": 864
+    },
+    "res/layout-v21/abc_screen_toolbar.xml": {
+      "Size": 1504
+    },
+    "res/layout-v21/notification_action_tombstone.xml": {
+      "Size": 1228
+    },
+    "res/layout-v21/notification_action.xml": {
+      "Size": 1052
+    },
+    "res/layout-v21/notification_template_custom_big.xml": {
+      "Size": 2456
+    },
+    "res/layout-v21/notification_template_icon_group.xml": {
+      "Size": 988
+    },
+    "res/layout-v21/toolbar.xml": {
+      "Size": 496
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
+    "res/layout-v26/abc_screen_toolbar.xml": {
+      "Size": 1560
+    },
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
+    },
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
     },
     "res/layout/abc_action_bar_title_item.xml": {
       "Size": 872
@@ -2458,23 +2755,14 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 748
     },
-    "res/layout-v17/abc_action_mode_close_item_material.xml": {
-      "Size": 840
+    "res/layout/abc_activity_chooser_view_list_item.xml": {
+      "Size": 1304
     },
     "res/layout/abc_activity_chooser_view.xml": {
       "Size": 1684
     },
-    "res/layout/abc_activity_chooser_view_list_item.xml": {
-      "Size": 1304
-    },
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1492
-    },
-    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1536
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
     },
     "res/layout/abc_alert_dialog_material.xml": {
       "Size": 2480
@@ -2482,17 +2770,11 @@
     "res/layout/abc_alert_dialog_title_material.xml": {
       "Size": 1424
     },
-    "res/layout-v17/abc_alert_dialog_title_material.xml": {
-      "Size": 1516
-    },
     "res/layout/abc_cascading_menu_item_layout.xml": {
       "Size": 1868
     },
     "res/layout/abc_dialog_title_material.xml": {
       "Size": 1028
-    },
-    "res/layout-v17/abc_dialog_title_material.xml": {
-      "Size": 1072
     },
     "res/layout/abc_expanded_menu_layout.xml": {
       "Size": 388
@@ -2512,26 +2794,20 @@
     "res/layout/abc_popup_menu_header_item_layout.xml": {
       "Size": 804
     },
-    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
-      "Size": 848
-    },
     "res/layout/abc_popup_menu_item_layout.xml": {
       "Size": 2072
     },
     "res/layout/abc_screen_content_include.xml": {
       "Size": 548
     },
-    "res/layout/abc_screen_simple.xml": {
-      "Size": 832
-    },
     "res/layout/abc_screen_simple_overlay_action_mode.xml": {
       "Size": 792
     },
+    "res/layout/abc_screen_simple.xml": {
+      "Size": 832
+    },
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1452
-    },
-    "res/layout-v21/abc_screen_toolbar.xml": {
-      "Size": 1504
     },
     "res/layout/abc_search_dropdown_item_icons_2line.xml": {
       "Size": 1916
@@ -2539,20 +2815,11 @@
     "res/layout/abc_search_view.xml": {
       "Size": 3428
     },
-    "res/layout-v17/abc_search_view.xml": {
-      "Size": 3472
-    },
     "res/layout/abc_select_dialog_material.xml": {
       "Size": 932
     },
-    "res/layout-v17/abc_select_dialog_material.xml": {
-      "Size": 976
-    },
     "res/layout/abc_tooltip.xml": {
       "Size": 972
-    },
-    "res/layout-v17/abc_tooltip.xml": {
-      "Size": 1056
     },
     "res/layout/bottomtablayout.xml": {
       "Size": 816
@@ -2560,14 +2827,8 @@
     "res/layout/browser_actions_context_menu_page.xml": {
       "Size": 1576
     },
-    "res/layout-v17/browser_actions_context_menu_page.xml": {
-      "Size": 1660
-    },
     "res/layout/browser_actions_context_menu_row.xml": {
       "Size": 1032
-    },
-    "res/layout-v17/browser_actions_context_menu_row.xml": {
-      "Size": 1164
     },
     "res/layout/design_bottom_navigation_item.xml": {
       "Size": 1488
@@ -2575,14 +2836,11 @@
     "res/layout/design_bottom_sheet_dialog.xml": {
       "Size": 1180
     },
-    "res/layout/design_layout_snackbar.xml": {
-      "Size": 520
-    },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1344
     },
-    "res/layout-v17/design_layout_snackbar_include.xml": {
-      "Size": 1436
+    "res/layout/design_layout_snackbar.xml": {
+      "Size": 520
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -2593,9 +2851,6 @@
     "res/layout/design_menu_item_action_area.xml": {
       "Size": 320
     },
-    "res/layout/design_navigation_item.xml": {
-      "Size": 532
-    },
     "res/layout/design_navigation_item_header.xml": {
       "Size": 440
     },
@@ -2605,11 +2860,14 @@
     "res/layout/design_navigation_item_subheader.xml": {
       "Size": 564
     },
-    "res/layout/design_navigation_menu.xml": {
-      "Size": 524
+    "res/layout/design_navigation_item.xml": {
+      "Size": 532
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
+    },
+    "res/layout/design_navigation_menu.xml": {
+      "Size": 524
     },
     "res/layout/design_text_input_password_icon.xml": {
       "Size": 560
@@ -2623,26 +2881,14 @@
     "res/layout/mr_cast_group_item.xml": {
       "Size": 860
     },
-    "res/layout-v17/mr_cast_group_item.xml": {
-      "Size": 944
-    },
     "res/layout/mr_cast_group_volume_item.xml": {
       "Size": 1292
-    },
-    "res/layout-v17/mr_cast_group_volume_item.xml": {
-      "Size": 1416
     },
     "res/layout/mr_cast_media_metadata.xml": {
       "Size": 2056
     },
-    "res/layout-v17/mr_cast_media_metadata.xml": {
-      "Size": 2140
-    },
     "res/layout/mr_cast_route_item.xml": {
       "Size": 1720
-    },
-    "res/layout-v17/mr_cast_route_item.xml": {
-      "Size": 1804
     },
     "res/layout/mr_chooser_dialog.xml": {
       "Size": 1656
@@ -2659,20 +2905,11 @@
     "res/layout/mr_dialog_header_item.xml": {
       "Size": 472
     },
-    "res/layout-v17/mr_dialog_header_item.xml": {
-      "Size": 556
-    },
     "res/layout/mr_picker_dialog.xml": {
       "Size": 960
     },
-    "res/layout-v17/mr_picker_dialog.xml": {
-      "Size": 1000
-    },
     "res/layout/mr_picker_route_item.xml": {
       "Size": 848
-    },
-    "res/layout-v17/mr_picker_route_item.xml": {
-      "Size": 932
     },
     "res/layout/mr_playback_control.xml": {
       "Size": 1548
@@ -2680,26 +2917,17 @@
     "res/layout/mr_volume_control.xml": {
       "Size": 1420
     },
-    "res/layout/mtrl_layout_snackbar.xml": {
-      "Size": 520
-    },
     "res/layout/mtrl_layout_snackbar_include.xml": {
       "Size": 1304
     },
-    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
-      "Size": 1396
-    },
-    "res/layout/notification_action.xml": {
-      "Size": 1092
-    },
-    "res/layout-v17/notification_action.xml": {
-      "Size": 1156
+    "res/layout/mtrl_layout_snackbar.xml": {
+      "Size": 520
     },
     "res/layout/notification_action_tombstone.xml": {
       "Size": 1268
     },
-    "res/layout-v17/notification_action_tombstone.xml": {
-      "Size": 1332
+    "res/layout/notification_action.xml": {
+      "Size": 1092
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -2707,35 +2935,17 @@
     "res/layout/notification_media_cancel_action.xml": {
       "Size": 744
     },
-    "res/layout/notification_template_big_media.xml": {
-      "Size": 1504
-    },
-    "res/layout-v17/notification_template_big_media.xml": {
-      "Size": 1696
-    },
     "res/layout/notification_template_big_media_custom.xml": {
       "Size": 2760
-    },
-    "res/layout-v17/notification_template_big_media_custom.xml": {
-      "Size": 3044
-    },
-    "res/layout/notification_template_big_media_narrow.xml": {
-      "Size": 1564
-    },
-    "res/layout-v17/notification_template_big_media_narrow.xml": {
-      "Size": 1824
     },
     "res/layout/notification_template_big_media_narrow_custom.xml": {
       "Size": 2868
     },
-    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
-      "Size": 3216
+    "res/layout/notification_template_big_media_narrow.xml": {
+      "Size": 1564
     },
-    "res/layout-v16/notification_template_custom_big.xml": {
-      "Size": 3012
-    },
-    "res/layout-v17/notification_template_custom_big.xml": {
-      "Size": 3208
+    "res/layout/notification_template_big_media.xml": {
+      "Size": 1504
     },
     "res/layout/notification_template_icon_group.xml": {
       "Size": 392
@@ -2743,20 +2953,11 @@
     "res/layout/notification_template_lines_media.xml": {
       "Size": 2660
     },
-    "res/layout-v17/notification_template_lines_media.xml": {
-      "Size": 2872
-    },
-    "res/layout/notification_template_media.xml": {
-      "Size": 1200
-    },
-    "res/layout-v17/notification_template_media.xml": {
-      "Size": 1292
-    },
     "res/layout/notification_template_media_custom.xml": {
       "Size": 2528
     },
-    "res/layout-v17/notification_template_media_custom.xml": {
-      "Size": 2756
+    "res/layout/notification_template_media.xml": {
+      "Size": 1200
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -2773,14 +2974,8 @@
     "res/layout/select_dialog_multichoice_material.xml": {
       "Size": 780
     },
-    "res/layout-v17/select_dialog_multichoice_material.xml": {
-      "Size": 864
-    },
     "res/layout/select_dialog_singlechoice_material.xml": {
       "Size": 780
-    },
-    "res/layout-v17/select_dialog_singlechoice_material.xml": {
-      "Size": 864
     },
     "res/layout/shellcontent.xml": {
       "Size": 1140
@@ -2794,204 +2989,9 @@
     "res/layout/toolbar.xml": {
       "Size": 452
     },
-    "res/layout-v21/toolbar.xml": {
-      "Size": 496
-    },
-    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
-      "Size": 520
-    },
-    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 520
-    },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
-    },
-    "res/layout-v21/notification_action.xml": {
-      "Size": 1052
-    },
-    "res/layout-v21/notification_action_tombstone.xml": {
-      "Size": 1228
-    },
-    "res/layout-v21/notification_template_custom_big.xml": {
-      "Size": 2456
-    },
-    "res/layout-v21/notification_template_icon_group.xml": {
-      "Size": 988
-    },
-    "res/layout-v26/abc_screen_toolbar.xml": {
-      "Size": 1560
-    },
     "resources.arsc": {
       "Size": 493672
-    },
-    "classes.dex": {
-      "Size": 2774432
-    },
-    "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 104912
-    },
-    "lib/x86/libxamarin-app.so": {
-      "Size": 104132
-    },
-    "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 216940
-    },
-    "lib/x86/libmonodroid.so": {
-      "Size": 272124
-    },
-    "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48620
-    },
-    "lib/x86/libxa-internal-api.so": {
-      "Size": 61312
-    },
-    "lib/armeabi-v7a/libmono-btls-shared.so": {
-      "Size": 1113088
-    },
-    "lib/x86/libmono-btls-shared.so": {
-      "Size": 1459984
-    },
-    "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456372
-    },
-    "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212484
-    },
-    "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736764
-    },
-    "lib/x86/libmono-native.so": {
-      "Size": 803736
-    },
-    "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
-      "Size": 4272008
-    },
-    "lib/x86/libmonodroid_bundle_app.so": {
-      "Size": 4271648
-    },
-    "META-INF/proguard/androidx-annotations.pro": {
-      "Size": 308
-    },
-    "META-INF/androidx.legacy_legacy-support-v4.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.mediarouter_mediarouter.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cardview_cardview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.appcompat_appcompat.version": {
-      "Size": 6
-    },
-    "META-INF/android.support.design_material.version": {
-      "Size": 12
-    },
-    "META-INF/com.google.android.material_material.version": {
-      "Size": 10
-    },
-    "META-INF/androidx.browser_browser.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.media_media.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.print_print.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cursoradapter_cursoradapter.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.customview_customview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_viewmodel.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.documentfile_documentfile.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.palette_palette.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.transition_transition.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.recyclerview_recyclerview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.interpolator_interpolator.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.fragment_fragment.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.core_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.viewpager_viewpager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.core_core.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata-core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.drawerlayout_drawerlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.loader_loader.version": {
-      "Size": 6
-    },
-    "META-INF/ANDROIDD.SF": {
-      "Size": 103239
-    },
-    "META-INF/ANDROIDD.RSA": {
-      "Size": 1205
-    },
-    "META-INF/MANIFEST.MF": {
-      "Size": 103131
     }
   },
-  "PackageSize": 16173046
+  "PackageSize": 16238582
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
@@ -4,6 +4,300 @@
     "AndroidManifest.xml": {
       "Size": 3748
     },
+    "assemblies/FormsViewGroup.dll": {
+      "Size": 7191
+    },
+    "assemblies/Java.Interop.dll": {
+      "Size": 68688
+    },
+    "assemblies/Mono.Android.dll": {
+      "Size": 555037
+    },
+    "assemblies/Mono.Security.dll": {
+      "Size": 68430
+    },
+    "assemblies/mscorlib.dll": {
+      "Size": 936261
+    },
+    "assemblies/Newtonsoft.Json.dll": {
+      "Size": 319336
+    },
+    "assemblies/Plugin.Connectivity.Abstractions.dll": {
+      "Size": 3760
+    },
+    "assemblies/Plugin.Connectivity.dll": {
+      "Size": 10201
+    },
+    "assemblies/System.Core.dll": {
+      "Size": 192206
+    },
+    "assemblies/System.Data.dll": {
+      "Size": 316107
+    },
+    "assemblies/System.dll": {
+      "Size": 443196
+    },
+    "assemblies/System.Drawing.Common.dll": {
+      "Size": 16345
+    },
+    "assemblies/System.Net.Http.dll": {
+      "Size": 113285
+    },
+    "assemblies/System.Numerics.dll": {
+      "Size": 23251
+    },
+    "assemblies/System.Runtime.Serialization.dll": {
+      "Size": 193447
+    },
+    "assemblies/System.ServiceModel.Internals.dll": {
+      "Size": 26590
+    },
+    "assemblies/System.Xml.dll": {
+      "Size": 592565
+    },
+    "assemblies/System.Xml.Linq.dll": {
+      "Size": 34368
+    },
+    "assemblies/Xamarin.AndroidX.Activity.dll": {
+      "Size": 7686
+    },
+    "assemblies/Xamarin.AndroidX.AppCompat.dll": {
+      "Size": 124577
+    },
+    "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
+      "Size": 6649
+    },
+    "assemblies/Xamarin.AndroidX.CardView.dll": {
+      "Size": 7355
+    },
+    "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
+      "Size": 18262
+    },
+    "assemblies/Xamarin.AndroidX.Core.dll": {
+      "Size": 131922
+    },
+    "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
+      "Size": 15433
+    },
+    "assemblies/Xamarin.AndroidX.Fragment.dll": {
+      "Size": 43119
+    },
+    "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
+      "Size": 6705
+    },
+    "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
+      "Size": 7053
+    },
+    "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
+      "Size": 7185
+    },
+    "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
+      "Size": 4865
+    },
+    "assemblies/Xamarin.AndroidX.Loader.dll": {
+      "Size": 13574
+    },
+    "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
+      "Size": 102425
+    },
+    "assemblies/Xamarin.AndroidX.SavedState.dll": {
+      "Size": 6260
+    },
+    "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
+      "Size": 11260
+    },
+    "assemblies/Xamarin.AndroidX.ViewPager.dll": {
+      "Size": 19420
+    },
+    "assemblies/Xamarin.Forms.Core.dll": {
+      "Size": 471882
+    },
+    "assemblies/Xamarin.Forms.Performance.Integration.dll": {
+      "Size": 21996
+    },
+    "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
+      "Size": 114909
+    },
+    "assemblies/Xamarin.Forms.Platform.Android.dll": {
+      "Size": 367732
+    },
+    "assemblies/Xamarin.Forms.Platform.dll": {
+      "Size": 56584
+    },
+    "assemblies/Xamarin.Forms.Xaml.dll": {
+      "Size": 55027
+    },
+    "assemblies/Xamarin.Google.Android.Material.dll": {
+      "Size": 43499
+    },
+    "classes.dex": {
+      "Size": 2473052
+    },
+    "lib/armeabi-v7a/libmono-btls-shared.so": {
+      "Size": 1112688
+    },
+    "lib/armeabi-v7a/libmono-native.so": {
+      "Size": 736396
+    },
+    "lib/armeabi-v7a/libmonodroid.so": {
+      "Size": 229052
+    },
+    "lib/armeabi-v7a/libmonosgen-2.0.so": {
+      "Size": 4456332
+    },
+    "lib/armeabi-v7a/libxa-internal-api.so": {
+      "Size": 48844
+    },
+    "lib/armeabi-v7a/libxamarin-app.so": {
+      "Size": 136376
+    },
+    "lib/x86/libmono-btls-shared.so": {
+      "Size": 1459584
+    },
+    "lib/x86/libmono-native.so": {
+      "Size": 803352
+    },
+    "lib/x86/libmonodroid.so": {
+      "Size": 297720
+    },
+    "lib/x86/libmonosgen-2.0.so": {
+      "Size": 4212220
+    },
+    "lib/x86/libxa-internal-api.so": {
+      "Size": 61112
+    },
+    "lib/x86/libxamarin-app.so": {
+      "Size": 134612
+    },
+    "META-INF/android.support.design_material.version": {
+      "Size": 12
+    },
+    "META-INF/ANDROIDD.RSA": {
+      "Size": 1205
+    },
+    "META-INF/ANDROIDD.SF": {
+      "Size": 67501
+    },
+    "META-INF/androidx.activity_activity.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.appcompat_appcompat-resources.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.appcompat_appcompat.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.arch.core_core-runtime.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.browser_browser.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cardview_cardview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.core_core.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cursoradapter_cursoradapter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.customview_customview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.documentfile_documentfile.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.drawerlayout_drawerlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.fragment_fragment.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.interpolator_interpolator.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-v4.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.lifecycle_lifecycle-runtime.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.lifecycle_lifecycle-viewmodel.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.loader_loader.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.media_media.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.print_print.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.recyclerview_recyclerview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.savedstate_savedstate.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.transition_transition.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.viewpager_viewpager.version": {
+      "Size": 6
+    },
+    "META-INF/com.google.android.material_material.version": {
+      "Size": 10
+    },
+    "META-INF/MANIFEST.MF": {
+      "Size": 67393
+    },
+    "META-INF/proguard/androidx-annotations.pro": {
+      "Size": 339
+    },
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
+    },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
     },
@@ -100,11 +394,11 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
+    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
+      "Size": 2664
     },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
+    "res/animator-v21/design_appbar_state_list_animator.xml": {
+      "Size": 1216
     },
     "res/animator/design_fab_hide_motion_spec.xml": {
       "Size": 796
@@ -114,9 +408,6 @@
     },
     "res/animator/mtrl_btn_state_list_anim.xml": {
       "Size": 2624
-    },
-    "res/animator-v19/mtrl_btn_state_list_anim.xml": {
-      "Size": 2664
     },
     "res/animator/mtrl_btn_unelevated_state_list_anim.xml": {
       "Size": 120
@@ -136,8 +427,38 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
-    "res/animator-v21/design_appbar_state_list_animator.xml": {
-      "Size": 1216
+    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 464
+    },
+    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_btn_colored_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_color_highlight_material.xml": {
+      "Size": 544
+    },
+    "res/color-v23/abc_tint_btn_checkable.xml": {
+      "Size": 624
+    },
+    "res/color-v23/abc_tint_default.xml": {
+      "Size": 1120
+    },
+    "res/color-v23/abc_tint_edittext.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_seek_thumb.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_tint_spinner.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_switch_track.xml": {
+      "Size": 664
+    },
+    "res/color-v23/design_tint_password_toggle.xml": {
+      "Size": 376
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -241,10 +562,10 @@
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
-    "res/color/mtrl_tabs_icon_color_selector.xml": {
+    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
       "Size": 464
     },
-    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
+    "res/color/mtrl_tabs_icon_color_selector.xml": {
       "Size": 464
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
@@ -262,461 +583,11 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 464
-    },
-    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_btn_colored_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_color_highlight_material.xml": {
-      "Size": 544
-    },
-    "res/color-v23/abc_tint_btn_checkable.xml": {
-      "Size": 624
-    },
-    "res/color-v23/abc_tint_default.xml": {
-      "Size": 1120
-    },
-    "res/color-v23/abc_tint_edittext.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_seek_thumb.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_tint_spinner.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_switch_track.xml": {
-      "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
-    },
-    "res/drawable/abc_btn_borderless_material.xml": {
-      "Size": 588
-    },
-    "res/drawable/abc_btn_check_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_check_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_btn_colored_material.xml": {
-      "Size": 344
-    },
-    "res/drawable/abc_btn_default_mtrl_shape.xml": {
-      "Size": 932
-    },
-    "res/drawable/abc_btn_radio_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_radio_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_cab_background_internal_bg.xml": {
-      "Size": 372
-    },
-    "res/drawable/abc_cab_background_top_material.xml": {
-      "Size": 336
-    },
-    "res/drawable/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable/abc_edit_text_material.xml": {
-      "Size": 868
-    },
-    "res/drawable/abc_ic_ab_back_material.xml": {
-      "Size": 692
-    },
-    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
-      "Size": 1000
-    },
-    "res/drawable/abc_ic_clear_material.xml": {
-      "Size": 684
-    },
-    "res/drawable/abc_ic_go_search_api_material.xml": {
-      "Size": 640
-    },
-    "res/drawable/abc_ic_menu_overflow_material.xml": {
-      "Size": 792
-    },
-    "res/drawable/abc_ic_search_api_material.xml": {
-      "Size": 812
-    },
-    "res/drawable/abc_ic_voice_search_api_material.xml": {
-      "Size": 828
-    },
-    "res/drawable/abc_item_background_holo_dark.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_item_background_holo_light.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_list_divider_material.xml": {
-      "Size": 480
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_holo_dark.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_list_selector_holo_light.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 664
-    },
-    "res/drawable-v21/abc_ratingbar_small_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_seekbar_thumb_material.xml": {
-      "Size": 1100
-    },
-    "res/drawable/abc_seekbar_tick_mark_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_seekbar_track_material.xml": {
-      "Size": 1408
-    },
-    "res/drawable/abc_spinner_textfield_background_material.xml": {
-      "Size": 1160
-    },
-    "res/drawable/abc_switch_thumb_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_tab_indicator_material.xml": {
-      "Size": 468
-    },
-    "res/drawable/abc_text_cursor_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_textfield_search_material.xml": {
-      "Size": 756
-    },
-    "res/drawable/abc_vector_test.xml": {
-      "Size": 612
-    },
-    "res/drawable/btn_checkbox_checked_mtrl.xml": {
-      "Size": 2688
-    },
-    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
-      "Size": 2660
-    },
-    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_radio_off_mtrl.xml": {
-      "Size": 1728
-    },
-    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/btn_radio_on_mtrl.xml": {
-      "Size": 1656
-    },
-    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/design_bottom_navigation_item_background.xml": {
-      "Size": 784
-    },
-    "res/drawable/design_fab_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/design_password_eye.xml": {
-      "Size": 464
-    },
-    "res/drawable/design_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/ic_mtrl_chip_checked_black.xml": {
-      "Size": 600
-    },
-    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
-      "Size": 940
-    },
-    "res/drawable/ic_mtrl_chip_close_circle.xml": {
-      "Size": 808
-    },
-    "res/drawable/icon.png": {
-      "Size": 1358
-    },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/mtrl_tabs_default_indicator.xml": {
-      "Size": 628
-    },
-    "res/drawable/navigation_empty_icon.xml": {
-      "Size": 516
-    },
-    "res/drawable/notification_bg.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_bg_low.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_icon_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/notification_tile_bg.xml": {
-      "Size": 304
-    },
-    "res/drawable/tooltip_frame_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/tooltip_frame_light.xml": {
-      "Size": 484
-    },
-    "res/drawable/xamarin_logo.png": {
-      "Size": 9794
-    },
-    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
-      "Size": 372
-    },
-    "res/drawable-v21/$avd_hide_password__0.xml": {
-      "Size": 1176
-    },
-    "res/drawable-v21/$avd_hide_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_hide_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/$avd_show_password__0.xml": {
-      "Size": 1136
-    },
-    "res/drawable-v21/$avd_show_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_show_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/abc_btn_colored_material.xml": {
-      "Size": 1716
-    },
-    "res/drawable-v21/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable-v21/abc_edit_text_material.xml": {
-      "Size": 1172
-    },
-    "res/drawable-v21/abc_list_divider_material.xml": {
-      "Size": 516
-    },
-    "res/drawable-v21/avd_hide_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/avd_show_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
-      "Size": 264
-    },
-    "res/drawable-v21/design_password_eye.xml": {
-      "Size": 816
-    },
-    "res/drawable-v21/notification_action_background.xml": {
-      "Size": 1180
-    },
-    "res/drawable-v23/abc_control_background_material.xml": {
-      "Size": 304
-    },
-    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
-      "Size": 267
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
-      "Size": 321
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
-      "Size": 356
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
-      "Size": 754
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
-      "Size": 825
-    },
-    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
-      "Size": 216
-    },
-    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
-      "Size": 173
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 251
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 152
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 139
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 270
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 193
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 364
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 467
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 253
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
-      "Size": 167
-    },
-    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
-      "Size": 222
-    },
-    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
-      "Size": 211
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
-      "Size": 541
-    },
-    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
-      "Size": 776
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
-      "Size": 159
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
-      "Size": 197
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
-      "Size": 194
-    },
-    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 327
-    },
-    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
-      "Size": 395
-    },
-    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 311
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 187
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
-      "Size": 181
-    },
-    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
-      "Size": 98
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 127
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 253
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 318
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
+      "Size": 540
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -859,11 +730,11 @@
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-hdpi-v4/design_ic_visibility.png": {
-      "Size": 470
-    },
     "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
       "Size": 507
+    },
+    "res/drawable-hdpi-v4/design_ic_visibility.png": {
+      "Size": 470
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 1358
@@ -874,11 +745,11 @@
     "res/drawable-hdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 225
     },
-    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
-      "Size": 212
-    },
     "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 225
+    },
+    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
+      "Size": 212
     },
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
@@ -891,6 +762,267 @@
     },
     "res/drawable-ldrtl-hdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 345
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 127
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 253
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 318
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 178
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 494
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 417
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 260
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 705
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 525
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 325
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 905
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 437
+    },
+    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
+      "Size": 267
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
+      "Size": 321
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
+      "Size": 356
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
+      "Size": 754
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
+      "Size": 825
+    },
+    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
+      "Size": 216
+    },
+    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
+      "Size": 173
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 251
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
+      "Size": 152
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
+      "Size": 139
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
+      "Size": 270
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
+      "Size": 193
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
+      "Size": 364
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
+      "Size": 467
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
+      "Size": 253
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
+      "Size": 167
+    },
+    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
+      "Size": 222
+    },
+    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
+      "Size": 211
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
+      "Size": 541
+    },
+    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
+      "Size": 776
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
+      "Size": 159
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
+      "Size": 197
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
+      "Size": 194
+    },
+    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 327
+    },
+    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
+      "Size": 395
+    },
+    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
+      "Size": 311
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
+      "Size": 187
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
+      "Size": 181
+    },
+    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
+      "Size": 351
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility.png": {
+      "Size": 309
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
+      "Size": 98
+    },
+    "res/drawable-v21/$avd_hide_password__0.xml": {
+      "Size": 1176
+    },
+    "res/drawable-v21/$avd_hide_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_hide_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/$avd_show_password__0.xml": {
+      "Size": 1136
+    },
+    "res/drawable-v21/$avd_show_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_show_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/abc_btn_colored_material.xml": {
+      "Size": 1716
+    },
+    "res/drawable-v21/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable-v21/abc_edit_text_material.xml": {
+      "Size": 1172
+    },
+    "res/drawable-v21/abc_list_divider_material.xml": {
+      "Size": 516
+    },
+    "res/drawable-v21/abc_ratingbar_indicator_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/abc_ratingbar_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/abc_ratingbar_small_material.xml": {
+      "Size": 704
+    },
+    "res/drawable-v21/avd_hide_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/avd_show_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/design_password_eye.xml": {
+      "Size": 816
+    },
+    "res/drawable-v21/notification_action_background.xml": {
+      "Size": 1180
+    },
+    "res/drawable-v23/abc_control_background_material.xml": {
+      "Size": 304
+    },
+    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
+      "Size": 372
     },
     "res/drawable-xhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 280
@@ -1033,11 +1165,11 @@
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
     },
-    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
-      "Size": 593
-    },
     "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
       "Size": 629
+    },
+    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
+      "Size": 593
     },
     "res/drawable-xhdpi-v4/icon.png": {
       "Size": 1140
@@ -1048,23 +1180,14 @@
     "res/drawable-xhdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 252
     },
-    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
-      "Size": 221
-    },
     "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 247
     },
+    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
+      "Size": 221
+    },
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 494
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 417
     },
     "res/drawable-xxhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 286
@@ -1207,23 +1330,14 @@
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
-      "Size": 868
-    },
     "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 884
     },
+    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
+      "Size": 868
+    },
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 1647
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 260
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 705
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 525
     },
     "res/drawable-xxxhdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
       "Size": 275
@@ -1303,26 +1417,209 @@
     "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
-      "Size": 1155
-    },
     "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 1201
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 325
+    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
+      "Size": 1155
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 905
+    "res/drawable/abc_btn_borderless_material.xml": {
+      "Size": 588
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 437
+    "res/drawable/abc_btn_check_material_anim.xml": {
+      "Size": 816
     },
-    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
-      "Size": 540
+    "res/drawable/abc_btn_check_material.xml": {
+      "Size": 464
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/drawable/abc_btn_colored_material.xml": {
+      "Size": 344
+    },
+    "res/drawable/abc_btn_default_mtrl_shape.xml": {
+      "Size": 932
+    },
+    "res/drawable/abc_btn_radio_material_anim.xml": {
+      "Size": 816
+    },
+    "res/drawable/abc_btn_radio_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_cab_background_internal_bg.xml": {
+      "Size": 372
+    },
+    "res/drawable/abc_cab_background_top_material.xml": {
+      "Size": 336
+    },
+    "res/drawable/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable/abc_edit_text_material.xml": {
+      "Size": 868
+    },
+    "res/drawable/abc_ic_ab_back_material.xml": {
+      "Size": 692
+    },
+    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
+      "Size": 1000
+    },
+    "res/drawable/abc_ic_clear_material.xml": {
+      "Size": 684
+    },
+    "res/drawable/abc_ic_go_search_api_material.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_ic_menu_overflow_material.xml": {
+      "Size": 792
+    },
+    "res/drawable/abc_ic_search_api_material.xml": {
+      "Size": 812
+    },
+    "res/drawable/abc_ic_voice_search_api_material.xml": {
+      "Size": 828
+    },
+    "res/drawable/abc_item_background_holo_dark.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_item_background_holo_light.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_list_divider_material.xml": {
+      "Size": 480
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_holo_dark.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_list_selector_holo_light.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_ratingbar_indicator_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_small_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_seekbar_thumb_material.xml": {
+      "Size": 1100
+    },
+    "res/drawable/abc_seekbar_tick_mark_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_seekbar_track_material.xml": {
+      "Size": 1408
+    },
+    "res/drawable/abc_spinner_textfield_background_material.xml": {
+      "Size": 1160
+    },
+    "res/drawable/abc_switch_thumb_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_tab_indicator_material.xml": {
+      "Size": 468
+    },
+    "res/drawable/abc_text_cursor_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_textfield_search_material.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_vector_test.xml": {
+      "Size": 612
+    },
+    "res/drawable/btn_checkbox_checked_mtrl.xml": {
+      "Size": 2688
+    },
+    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
+      "Size": 2660
+    },
+    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_radio_off_mtrl.xml": {
+      "Size": 1728
+    },
+    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/btn_radio_on_mtrl.xml": {
+      "Size": 1656
+    },
+    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/design_bottom_navigation_item_background.xml": {
+      "Size": 784
+    },
+    "res/drawable/design_fab_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/design_password_eye.xml": {
+      "Size": 464
+    },
+    "res/drawable/design_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/ic_mtrl_chip_checked_black.xml": {
+      "Size": 600
+    },
+    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
+      "Size": 940
+    },
+    "res/drawable/ic_mtrl_chip_close_circle.xml": {
+      "Size": 808
+    },
+    "res/drawable/icon.png": {
+      "Size": 1358
+    },
+    "res/drawable/mtrl_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/mtrl_tabs_default_indicator.xml": {
+      "Size": 628
+    },
+    "res/drawable/navigation_empty_icon.xml": {
+      "Size": 516
+    },
+    "res/drawable/notification_bg_low.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_bg.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_icon_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/notification_tile_bg.xml": {
+      "Size": 304
+    },
+    "res/drawable/tooltip_frame_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/tooltip_frame_light.xml": {
+      "Size": 484
+    },
+    "res/drawable/xamarin_logo.png": {
+      "Size": 9799
+    },
+    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
+      "Size": 400
     },
     "res/interpolator/btn_checkbox_checked_mtrl_animation_interpolator_0.xml": {
       "Size": 316
@@ -1351,20 +1648,125 @@
     "res/interpolator/mtrl_fast_out_slow_in.xml": {
       "Size": 144
     },
-    "res/interpolator/mtrl_linear.xml": {
-      "Size": 132
-    },
     "res/interpolator/mtrl_linear_out_slow_in.xml": {
       "Size": 136
     },
-    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
-      "Size": 400
+    "res/interpolator/mtrl_linear.xml": {
+      "Size": 132
     },
-    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
+      "Size": 528
     },
-    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
+      "Size": 528
+    },
+    "res/layout-v16/notification_template_custom_big.xml": {
+      "Size": 3012
+    },
+    "res/layout-v17/abc_action_mode_close_item_material.xml": {
+      "Size": 840
+    },
+    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1536
+    },
+    "res/layout-v17/abc_alert_dialog_title_material.xml": {
+      "Size": 1560
+    },
+    "res/layout-v17/abc_dialog_title_material.xml": {
+      "Size": 1116
+    },
+    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
+      "Size": 848
+    },
+    "res/layout-v17/abc_search_view.xml": {
+      "Size": 3472
+    },
+    "res/layout-v17/abc_select_dialog_material.xml": {
+      "Size": 1020
+    },
+    "res/layout-v17/abc_tooltip.xml": {
+      "Size": 1056
+    },
+    "res/layout-v17/browser_actions_context_menu_page.xml": {
+      "Size": 1660
+    },
+    "res/layout-v17/browser_actions_context_menu_row.xml": {
+      "Size": 1164
+    },
+    "res/layout-v17/design_layout_snackbar_include.xml": {
+      "Size": 1444
+    },
+    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
+      "Size": 1404
+    },
+    "res/layout-v17/notification_action_tombstone.xml": {
+      "Size": 1332
+    },
+    "res/layout-v17/notification_action.xml": {
+      "Size": 1156
+    },
+    "res/layout-v17/notification_template_big_media_custom.xml": {
+      "Size": 3044
+    },
+    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
+      "Size": 3216
+    },
+    "res/layout-v17/notification_template_big_media_narrow.xml": {
+      "Size": 1824
+    },
+    "res/layout-v17/notification_template_big_media.xml": {
+      "Size": 1696
+    },
+    "res/layout-v17/notification_template_custom_big.xml": {
+      "Size": 3208
+    },
+    "res/layout-v17/notification_template_lines_media.xml": {
+      "Size": 2872
+    },
+    "res/layout-v17/notification_template_media_custom.xml": {
+      "Size": 2756
+    },
+    "res/layout-v17/notification_template_media.xml": {
+      "Size": 1292
+    },
+    "res/layout-v17/select_dialog_multichoice_material.xml": {
+      "Size": 864
+    },
+    "res/layout-v17/select_dialog_singlechoice_material.xml": {
+      "Size": 864
+    },
+    "res/layout-v21/abc_screen_toolbar.xml": {
+      "Size": 1504
+    },
+    "res/layout-v21/fallbacktoolbardonotuse.xml": {
+      "Size": 496
+    },
+    "res/layout-v21/notification_action_tombstone.xml": {
+      "Size": 1228
+    },
+    "res/layout-v21/notification_action.xml": {
+      "Size": 1052
+    },
+    "res/layout-v21/notification_template_custom_big.xml": {
+      "Size": 2456
+    },
+    "res/layout-v21/notification_template_icon_group.xml": {
+      "Size": 988
+    },
+    "res/layout-v21/toolbar.xml": {
+      "Size": 496
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
+    "res/layout-v26/abc_screen_toolbar.xml": {
+      "Size": 1560
+    },
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
+    },
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
     },
     "res/layout/abc_action_bar_title_item.xml": {
       "Size": 872
@@ -1384,23 +1786,14 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 748
     },
-    "res/layout-v17/abc_action_mode_close_item_material.xml": {
-      "Size": 840
+    "res/layout/abc_activity_chooser_view_list_item.xml": {
+      "Size": 1304
     },
     "res/layout/abc_activity_chooser_view.xml": {
       "Size": 1684
     },
-    "res/layout/abc_activity_chooser_view_list_item.xml": {
-      "Size": 1304
-    },
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1492
-    },
-    "res/layout-v17/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1536
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
     },
     "res/layout/abc_alert_dialog_material.xml": {
       "Size": 2476
@@ -1408,17 +1801,11 @@
     "res/layout/abc_alert_dialog_title_material.xml": {
       "Size": 1472
     },
-    "res/layout-v17/abc_alert_dialog_title_material.xml": {
-      "Size": 1560
-    },
     "res/layout/abc_cascading_menu_item_layout.xml": {
       "Size": 1868
     },
     "res/layout/abc_dialog_title_material.xml": {
       "Size": 1072
-    },
-    "res/layout-v17/abc_dialog_title_material.xml": {
-      "Size": 1116
     },
     "res/layout/abc_expanded_menu_layout.xml": {
       "Size": 388
@@ -1438,26 +1825,20 @@
     "res/layout/abc_popup_menu_header_item_layout.xml": {
       "Size": 804
     },
-    "res/layout-v17/abc_popup_menu_header_item_layout.xml": {
-      "Size": 848
-    },
     "res/layout/abc_popup_menu_item_layout.xml": {
       "Size": 2072
     },
     "res/layout/abc_screen_content_include.xml": {
       "Size": 548
     },
-    "res/layout/abc_screen_simple.xml": {
-      "Size": 832
-    },
     "res/layout/abc_screen_simple_overlay_action_mode.xml": {
       "Size": 792
     },
+    "res/layout/abc_screen_simple.xml": {
+      "Size": 832
+    },
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1452
-    },
-    "res/layout-v21/abc_screen_toolbar.xml": {
-      "Size": 1504
     },
     "res/layout/abc_search_dropdown_item_icons_2line.xml": {
       "Size": 1916
@@ -1465,20 +1846,11 @@
     "res/layout/abc_search_view.xml": {
       "Size": 3428
     },
-    "res/layout-v17/abc_search_view.xml": {
-      "Size": 3472
-    },
     "res/layout/abc_select_dialog_material.xml": {
       "Size": 976
     },
-    "res/layout-v17/abc_select_dialog_material.xml": {
-      "Size": 1020
-    },
     "res/layout/abc_tooltip.xml": {
       "Size": 972
-    },
-    "res/layout-v17/abc_tooltip.xml": {
-      "Size": 1056
     },
     "res/layout/bottomtablayout.xml": {
       "Size": 832
@@ -1486,14 +1858,8 @@
     "res/layout/browser_actions_context_menu_page.xml": {
       "Size": 1576
     },
-    "res/layout-v17/browser_actions_context_menu_page.xml": {
-      "Size": 1660
-    },
     "res/layout/browser_actions_context_menu_row.xml": {
       "Size": 1032
-    },
-    "res/layout-v17/browser_actions_context_menu_row.xml": {
-      "Size": 1164
     },
     "res/layout/custom_dialog.xml": {
       "Size": 612
@@ -1504,14 +1870,11 @@
     "res/layout/design_bottom_sheet_dialog.xml": {
       "Size": 1184
     },
-    "res/layout/design_layout_snackbar.xml": {
-      "Size": 528
-    },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1352
     },
-    "res/layout-v17/design_layout_snackbar_include.xml": {
-      "Size": 1444
+    "res/layout/design_layout_snackbar.xml": {
+      "Size": 528
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -1522,9 +1885,6 @@
     "res/layout/design_menu_item_action_area.xml": {
       "Size": 320
     },
-    "res/layout/design_navigation_item.xml": {
-      "Size": 536
-    },
     "res/layout/design_navigation_item_header.xml": {
       "Size": 440
     },
@@ -1534,11 +1894,14 @@
     "res/layout/design_navigation_item_subheader.xml": {
       "Size": 564
     },
-    "res/layout/design_navigation_menu.xml": {
-      "Size": 528
+    "res/layout/design_navigation_item.xml": {
+      "Size": 536
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
+    },
+    "res/layout/design_navigation_menu.xml": {
+      "Size": 528
     },
     "res/layout/design_text_input_password_icon.xml": {
       "Size": 564
@@ -1549,32 +1912,20 @@
     "res/layout/fallbacktoolbardonotuse.xml": {
       "Size": 452
     },
-    "res/layout-v21/fallbacktoolbardonotuse.xml": {
-      "Size": 496
-    },
     "res/layout/flyoutcontent.xml": {
       "Size": 944
-    },
-    "res/layout/mtrl_layout_snackbar.xml": {
-      "Size": 528
     },
     "res/layout/mtrl_layout_snackbar_include.xml": {
       "Size": 1312
     },
-    "res/layout-v17/mtrl_layout_snackbar_include.xml": {
-      "Size": 1404
-    },
-    "res/layout/notification_action.xml": {
-      "Size": 1092
-    },
-    "res/layout-v17/notification_action.xml": {
-      "Size": 1156
+    "res/layout/mtrl_layout_snackbar.xml": {
+      "Size": 528
     },
     "res/layout/notification_action_tombstone.xml": {
       "Size": 1268
     },
-    "res/layout-v17/notification_action_tombstone.xml": {
-      "Size": 1332
+    "res/layout/notification_action.xml": {
+      "Size": 1092
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -1582,35 +1933,17 @@
     "res/layout/notification_media_cancel_action.xml": {
       "Size": 744
     },
-    "res/layout/notification_template_big_media.xml": {
-      "Size": 1504
-    },
-    "res/layout-v17/notification_template_big_media.xml": {
-      "Size": 1696
-    },
     "res/layout/notification_template_big_media_custom.xml": {
       "Size": 2760
-    },
-    "res/layout-v17/notification_template_big_media_custom.xml": {
-      "Size": 3044
-    },
-    "res/layout/notification_template_big_media_narrow.xml": {
-      "Size": 1564
-    },
-    "res/layout-v17/notification_template_big_media_narrow.xml": {
-      "Size": 1824
     },
     "res/layout/notification_template_big_media_narrow_custom.xml": {
       "Size": 2868
     },
-    "res/layout-v17/notification_template_big_media_narrow_custom.xml": {
-      "Size": 3216
+    "res/layout/notification_template_big_media_narrow.xml": {
+      "Size": 1564
     },
-    "res/layout-v16/notification_template_custom_big.xml": {
-      "Size": 3012
-    },
-    "res/layout-v17/notification_template_custom_big.xml": {
-      "Size": 3208
+    "res/layout/notification_template_big_media.xml": {
+      "Size": 1504
     },
     "res/layout/notification_template_icon_group.xml": {
       "Size": 392
@@ -1618,20 +1951,11 @@
     "res/layout/notification_template_lines_media.xml": {
       "Size": 2660
     },
-    "res/layout-v17/notification_template_lines_media.xml": {
-      "Size": 2872
-    },
-    "res/layout/notification_template_media.xml": {
-      "Size": 1200
-    },
-    "res/layout-v17/notification_template_media.xml": {
-      "Size": 1292
-    },
     "res/layout/notification_template_media_custom.xml": {
       "Size": 2528
     },
-    "res/layout-v17/notification_template_media_custom.xml": {
-      "Size": 2756
+    "res/layout/notification_template_media.xml": {
+      "Size": 1200
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -1648,14 +1972,8 @@
     "res/layout/select_dialog_multichoice_material.xml": {
       "Size": 780
     },
-    "res/layout-v17/select_dialog_multichoice_material.xml": {
-      "Size": 864
-    },
     "res/layout/select_dialog_singlechoice_material.xml": {
       "Size": 780
-    },
-    "res/layout-v17/select_dialog_singlechoice_material.xml": {
-      "Size": 864
     },
     "res/layout/shellcontent.xml": {
       "Size": 888
@@ -1669,327 +1987,9 @@
     "res/layout/toolbar.xml": {
       "Size": 452
     },
-    "res/layout-v21/toolbar.xml": {
-      "Size": 496
-    },
-    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
-      "Size": 528
-    },
-    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 528
-    },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
-    },
-    "res/layout-v21/notification_action.xml": {
-      "Size": 1052
-    },
-    "res/layout-v21/notification_action_tombstone.xml": {
-      "Size": 1228
-    },
-    "res/layout-v21/notification_template_custom_big.xml": {
-      "Size": 2456
-    },
-    "res/layout-v21/notification_template_icon_group.xml": {
-      "Size": 988
-    },
-    "res/layout-v26/abc_screen_toolbar.xml": {
-      "Size": 1560
-    },
     "resources.arsc": {
       "Size": 347268
-    },
-    "classes.dex": {
-      "Size": 2467756
-    },
-    "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114906
-    },
-    "assemblies/FormsViewGroup.dll": {
-      "Size": 7191
-    },
-    "assemblies/Newtonsoft.Json.dll": {
-      "Size": 317978
-    },
-    "assemblies/Plugin.Connectivity.Abstractions.dll": {
-      "Size": 3760
-    },
-    "assemblies/Plugin.Connectivity.dll": {
-      "Size": 10201
-    },
-    "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7686
-    },
-    "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124577
-    },
-    "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6649
-    },
-    "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7355
-    },
-    "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18262
-    },
-    "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131922
-    },
-    "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15433
-    },
-    "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43119
-    },
-    "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6705
-    },
-    "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7053
-    },
-    "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7185
-    },
-    "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4865
-    },
-    "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13574
-    },
-    "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102425
-    },
-    "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6260
-    },
-    "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11260
-    },
-    "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19420
-    },
-    "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 471882
-    },
-    "assemblies/Xamarin.Forms.Performance.Integration.dll": {
-      "Size": 22008
-    },
-    "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367732
-    },
-    "assemblies/Xamarin.Forms.Platform.dll": {
-      "Size": 56584
-    },
-    "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55027
-    },
-    "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43499
-    },
-    "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193447
-    },
-    "assemblies/Java.Interop.dll": {
-      "Size": 68623
-    },
-    "assemblies/Mono.Android.dll": {
-      "Size": 554752
-    },
-    "assemblies/mscorlib.dll": {
-      "Size": 936306
-    },
-    "assemblies/System.Core.dll": {
-      "Size": 192208
-    },
-    "assemblies/System.dll": {
-      "Size": 443294
-    },
-    "assemblies/System.Net.Http.dll": {
-      "Size": 113286
-    },
-    "assemblies/System.Xml.dll": {
-      "Size": 592605
-    },
-    "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26592
-    },
-    "assemblies/System.Drawing.Common.dll": {
-      "Size": 16345
-    },
-    "assemblies/System.Data.dll": {
-      "Size": 316116
-    },
-    "assemblies/System.Numerics.dll": {
-      "Size": 23251
-    },
-    "assemblies/System.Xml.Linq.dll": {
-      "Size": 34368
-    },
-    "assemblies/Mono.Security.dll": {
-      "Size": 68489
-    },
-    "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 130176
-    },
-    "lib/x86/libxamarin-app.so": {
-      "Size": 129296
-    },
-    "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 216940
-    },
-    "lib/x86/libmonodroid.so": {
-      "Size": 272124
-    },
-    "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48620
-    },
-    "lib/x86/libxa-internal-api.so": {
-      "Size": 61312
-    },
-    "lib/armeabi-v7a/libmono-btls-shared.so": {
-      "Size": 1113088
-    },
-    "lib/x86/libmono-btls-shared.so": {
-      "Size": 1459984
-    },
-    "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456372
-    },
-    "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212484
-    },
-    "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736764
-    },
-    "lib/x86/libmono-native.so": {
-      "Size": 803736
-    },
-    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.fragment_fragment.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.documentfile_documentfile.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.drawerlayout_drawerlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.loader_loader.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cursoradapter_cursoradapter.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.interpolator_interpolator.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.activity_activity.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.transition_transition.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cardview_cardview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.browser_browser.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.appcompat_appcompat-resources.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.appcompat_appcompat.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.lifecycle_lifecycle-viewmodel.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.savedstate_savedstate.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.arch.core_core-runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.recyclerview_recyclerview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.print_print.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.lifecycle_lifecycle-runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-v4.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.media_media.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.customview_customview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
-      "Size": 6
-    },
-    "META-INF/android.support.design_material.version": {
-      "Size": 12
-    },
-    "META-INF/com.google.android.material_material.version": {
-      "Size": 10
-    },
-    "META-INF/androidx.viewpager_viewpager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.core_core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
-      "Size": 6
-    },
-    "META-INF/proguard/androidx-annotations.pro": {
-      "Size": 339
-    },
-    "META-INF/ANDROIDD.SF": {
-      "Size": 67501
-    },
-    "META-INF/ANDROIDD.RSA": {
-      "Size": 1205
-    },
-    "META-INF/MANIFEST.MF": {
-      "Size": 67393
     }
   },
-  "PackageSize": 12801376
+  "PackageSize": 12854624
 }

--- a/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
@@ -2,7 +2,220 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 2876
+      "Size": 2896
+    },
+    "assemblies/Java.Interop.dll": {
+      "Size": 68160
+    },
+    "assemblies/Mono.Android.dll": {
+      "Size": 330421
+    },
+    "assemblies/Mono.Security.dll": {
+      "Size": 61400
+    },
+    "assemblies/mscorlib.dll": {
+      "Size": 843651
+    },
+    "assemblies/System.Core.dll": {
+      "Size": 33884
+    },
+    "assemblies/System.dll": {
+      "Size": 208052
+    },
+    "assemblies/System.Net.Http.dll": {
+      "Size": 110901
+    },
+    "assemblies/System.Numerics.dll": {
+      "Size": 15656
+    },
+    "assemblies/VSAndroidApp.dll": {
+      "Size": 60901
+    },
+    "assemblies/Xamarin.Android.Arch.Lifecycle.Common.dll": {
+      "Size": 6971
+    },
+    "assemblies/Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll": {
+      "Size": 7017
+    },
+    "assemblies/Xamarin.Android.Arch.Lifecycle.ViewModel.dll": {
+      "Size": 4779
+    },
+    "assemblies/Xamarin.Android.Support.Compat.dll": {
+      "Size": 50728
+    },
+    "assemblies/Xamarin.Android.Support.CoordinaterLayout.dll": {
+      "Size": 17769
+    },
+    "assemblies/Xamarin.Android.Support.Design.dll": {
+      "Size": 28949
+    },
+    "assemblies/Xamarin.Android.Support.DrawerLayout.dll": {
+      "Size": 14618
+    },
+    "assemblies/Xamarin.Android.Support.Fragment.dll": {
+      "Size": 41190
+    },
+    "assemblies/Xamarin.Android.Support.Loader.dll": {
+      "Size": 13489
+    },
+    "assemblies/Xamarin.Android.Support.v7.AppCompat.dll": {
+      "Size": 92177
+    },
+    "assemblies/Xamarin.Essentials.dll": {
+      "Size": 14090
+    },
+    "classes.dex": {
+      "Size": 2940492
+    },
+    "lib/armeabi-v7a/libmono-btls-shared.so": {
+      "Size": 1112688
+    },
+    "lib/armeabi-v7a/libmono-native.so": {
+      "Size": 736396
+    },
+    "lib/armeabi-v7a/libmonodroid.so": {
+      "Size": 229116
+    },
+    "lib/armeabi-v7a/libmonosgen-2.0.so": {
+      "Size": 4456332
+    },
+    "lib/armeabi-v7a/libxa-internal-api.so": {
+      "Size": 48844
+    },
+    "lib/armeabi-v7a/libxamarin-app.so": {
+      "Size": 46912
+    },
+    "lib/x86/libmono-btls-shared.so": {
+      "Size": 1459584
+    },
+    "lib/x86/libmono-native.so": {
+      "Size": 803352
+    },
+    "lib/x86/libmonodroid.so": {
+      "Size": 297800
+    },
+    "lib/x86/libmonosgen-2.0.so": {
+      "Size": 4212220
+    },
+    "lib/x86/libxa-internal-api.so": {
+      "Size": 61112
+    },
+    "lib/x86/libxamarin-app.so": {
+      "Size": 45580
+    },
+    "META-INF/android.arch.core_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata-core.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_livedata.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_runtime.version": {
+      "Size": 6
+    },
+    "META-INF/android.arch.lifecycle_viewmodel.version": {
+      "Size": 6
+    },
+    "META-INF/android.support.design_material.version": {
+      "Size": 12
+    },
+    "META-INF/ANDROIDD.RSA": {
+      "Size": 1213
+    },
+    "META-INF/ANDROIDD.SF": {
+      "Size": 67139
+    },
+    "META-INF/androidx.appcompat_appcompat.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.browser_browser.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cardview_cardview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.core_core.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.cursoradapter_cursoradapter.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.customview_customview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.documentfile_documentfile.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.drawerlayout_drawerlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.fragment_fragment.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.interpolator_interpolator.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.loader_loader.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.print_print.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.recyclerview_recyclerview.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.transition_transition.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.viewpager_viewpager.version": {
+      "Size": 6
+    },
+    "META-INF/com.google.android.material_material.version": {
+      "Size": 10
+    },
+    "META-INF/MANIFEST.MF": {
+      "Size": 67012
+    },
+    "META-INF/proguard/androidx-annotations.pro": {
+      "Size": 308
+    },
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
     },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
@@ -40,12 +253,6 @@
     "res/anim/abc_tooltip_exit.xml": {
       "Size": 388
     },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
-    },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
-    },
     "res/anim/design_snackbar_in.xml": {
       "Size": 312
     },
@@ -82,14 +289,44 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
+    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 464
+    },
+    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_btn_colored_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_color_highlight_material.xml": {
+      "Size": 544
+    },
+    "res/color-v23/abc_tint_btn_checkable.xml": {
+      "Size": 624
+    },
+    "res/color-v23/abc_tint_default.xml": {
+      "Size": 1120
+    },
+    "res/color-v23/abc_tint_edittext.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_seek_thumb.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_tint_spinner.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_switch_track.xml": {
+      "Size": 664
+    },
+    "res/color-v23/design_tint_password_toggle.xml": {
+      "Size": 376
+    },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
     },
     "res/color/abc_background_cache_hint_selector_material_light.xml": {
       "Size": 468
-    },
-    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 464
     },
     "res/color/abc_btn_colored_text_material.xml": {
       "Size": 604
@@ -184,10 +421,10 @@
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
-    "res/color/mtrl_tabs_icon_color_selector.xml": {
+    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
       "Size": 464
     },
-    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
+    "res/color/mtrl_tabs_icon_color_selector.xml": {
       "Size": 464
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
@@ -205,395 +442,11 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_btn_colored_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_color_highlight_material.xml": {
-      "Size": 544
-    },
-    "res/color-v23/abc_tint_btn_checkable.xml": {
-      "Size": 624
-    },
-    "res/color-v23/abc_tint_default.xml": {
-      "Size": 1120
-    },
-    "res/color-v23/abc_tint_edittext.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_seek_thumb.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_tint_spinner.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_switch_track.xml": {
-      "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
-    },
-    "res/drawable-v21/$avd_hide_password__0.xml": {
-      "Size": 1176
-    },
-    "res/drawable-v21/$avd_hide_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_hide_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/$avd_show_password__0.xml": {
-      "Size": 1136
-    },
-    "res/drawable-v21/$avd_show_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_show_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
-      "Size": 264
-    },
-    "res/drawable/abc_btn_borderless_material.xml": {
-      "Size": 588
-    },
-    "res/drawable/abc_btn_check_material.xml": {
-      "Size": 464
-    },
-    "res/drawable-v21/abc_btn_colored_material.xml": {
-      "Size": 1716
-    },
-    "res/drawable/abc_btn_default_mtrl_shape.xml": {
-      "Size": 932
-    },
-    "res/drawable/abc_btn_radio_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_cab_background_internal_bg.xml": {
-      "Size": 372
-    },
-    "res/drawable/abc_cab_background_top_material.xml": {
-      "Size": 336
-    },
-    "res/drawable-v21/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable-v21/abc_edit_text_material.xml": {
-      "Size": 1172
-    },
-    "res/drawable/abc_ic_ab_back_material.xml": {
-      "Size": 692
-    },
-    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
-      "Size": 1000
-    },
-    "res/drawable/abc_ic_clear_material.xml": {
-      "Size": 684
-    },
-    "res/drawable/abc_ic_go_search_api_material.xml": {
-      "Size": 640
-    },
-    "res/drawable/abc_ic_menu_overflow_material.xml": {
-      "Size": 792
-    },
-    "res/drawable/abc_ic_search_api_material.xml": {
-      "Size": 812
-    },
-    "res/drawable/abc_ic_voice_search_api_material.xml": {
-      "Size": 828
-    },
-    "res/drawable/abc_item_background_holo_dark.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_item_background_holo_light.xml": {
-      "Size": 1012
-    },
-    "res/drawable-v21/abc_list_divider_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_holo_dark.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_list_selector_holo_light.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 704
-    },
-    "res/drawable/abc_seekbar_thumb_material.xml": {
-      "Size": 1100
-    },
-    "res/drawable/abc_seekbar_tick_mark_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_seekbar_track_material.xml": {
-      "Size": 1408
-    },
-    "res/drawable/abc_spinner_textfield_background_material.xml": {
-      "Size": 1160
-    },
-    "res/drawable/abc_switch_thumb_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_tab_indicator_material.xml": {
-      "Size": 468
-    },
-    "res/drawable/abc_text_cursor_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_textfield_search_material.xml": {
-      "Size": 756
-    },
-    "res/drawable/abc_vector_test.xml": {
-      "Size": 612
-    },
-    "res/drawable-v21/avd_hide_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/avd_show_password.xml": {
-      "Size": 660
-    },
-    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
-      "Size": 264
-    },
-    "res/drawable/design_fab_background.xml": {
-      "Size": 372
-    },
-    "res/drawable-v21/design_password_eye.xml": {
-      "Size": 816
-    },
-    "res/drawable/design_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/ic_mtrl_chip_checked_black.xml": {
-      "Size": 600
-    },
-    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
-      "Size": 940
-    },
-    "res/drawable/ic_mtrl_chip_close_circle.xml": {
-      "Size": 808
-    },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/mtrl_tabs_default_indicator.xml": {
-      "Size": 628
-    },
-    "res/drawable/navigation_empty_icon.xml": {
-      "Size": 516
-    },
-    "res/drawable-v21/notification_action_background.xml": {
-      "Size": 1180
-    },
-    "res/drawable/notification_bg.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_bg_low.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_icon_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/notification_tile_bg.xml": {
-      "Size": 304
-    },
-    "res/drawable/tooltip_frame_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/tooltip_frame_light.xml": {
-      "Size": 484
-    },
-    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
-      "Size": 372
-    },
-    "res/drawable-v23/abc_control_background_material.xml": {
-      "Size": 304
-    },
-    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
-      "Size": 267
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
-      "Size": 214
-    },
-    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
-      "Size": 321
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
-      "Size": 324
-    },
-    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
-      "Size": 356
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
-      "Size": 754
-    },
-    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
-      "Size": 825
-    },
-    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
-      "Size": 216
-    },
-    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
-      "Size": 173
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 251
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 152
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 139
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 270
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 193
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 364
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 467
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 253
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
-      "Size": 167
-    },
-    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
-      "Size": 222
-    },
-    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
-      "Size": 211
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
-      "Size": 207
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
-      "Size": 217
-    },
-    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
-      "Size": 541
-    },
-    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
-      "Size": 776
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
-      "Size": 159
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
-      "Size": 145
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
-      "Size": 197
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
-      "Size": 194
-    },
-    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 327
-    },
-    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
-      "Size": 395
-    },
-    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 311
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
-      "Size": 310
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 187
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
-      "Size": 186
-    },
-    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
-      "Size": 181
-    },
-    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
-      "Size": 178
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
-      "Size": 215
-    },
-    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 223
-    },
-    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
-      "Size": 98
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 127
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 253
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 318
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
+      "Size": 540
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -736,11 +589,11 @@
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-hdpi-v4/design_ic_visibility.png": {
-      "Size": 470
-    },
     "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
       "Size": 507
+    },
+    "res/drawable-hdpi-v4/design_ic_visibility.png": {
+      "Size": 470
     },
     "res/drawable-hdpi-v4/notification_bg_low_normal.9.png": {
       "Size": 212
@@ -748,11 +601,11 @@
     "res/drawable-hdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 225
     },
-    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
-      "Size": 212
-    },
     "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 225
+    },
+    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
+      "Size": 212
     },
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
@@ -765,6 +618,258 @@
     },
     "res/drawable-ldrtl-hdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 345
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 127
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 253
+    },
+    "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 318
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 178
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 494
+    },
+    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 417
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 260
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 705
+    },
+    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 525
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 325
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 905
+    },
+    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 437
+    },
+    "res/drawable-mdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
+      "Size": 267
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
+      "Size": 214
+    },
+    "res/drawable-mdpi-v4/abc_btn_check_to_on_mtrl_015.png": {
+      "Size": 321
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_000.png": {
+      "Size": 324
+    },
+    "res/drawable-mdpi-v4/abc_btn_radio_to_on_mtrl_015.png": {
+      "Size": 356
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00001.9.png": {
+      "Size": 754
+    },
+    "res/drawable-mdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
+      "Size": 825
+    },
+    "res/drawable-mdpi-v4/abc_cab_background_top_mtrl_alpha.9.png": {
+      "Size": 216
+    },
+    "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
+      "Size": 173
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
+      "Size": 133
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
+      "Size": 251
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
+      "Size": 152
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
+      "Size": 139
+    },
+    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
+      "Size": 270
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
+      "Size": 193
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
+      "Size": 364
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
+      "Size": 467
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
+      "Size": 146
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
+      "Size": 253
+    },
+    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
+      "Size": 167
+    },
+    "res/drawable-mdpi-v4/abc_list_focused_holo.9.png": {
+      "Size": 222
+    },
+    "res/drawable-mdpi-v4/abc_list_longpressed_holo.9.png": {
+      "Size": 211
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_dark.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_pressed_holo_light.9.png": {
+      "Size": 207
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_dark.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_list_selector_disabled_holo_light.9.png": {
+      "Size": 217
+    },
+    "res/drawable-mdpi-v4/abc_menu_hardkey_panel_mtrl_mult.9.png": {
+      "Size": 541
+    },
+    "res/drawable-mdpi-v4/abc_popup_background_mtrl_mult.9.png": {
+      "Size": 776
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_off_mtrl_alpha.png": {
+      "Size": 159
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
+      "Size": 145
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_control_to_pressed_mtrl_005.png": {
+      "Size": 197
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_primary_mtrl_alpha.9.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_scrubber_track_mtrl_alpha.9.png": {
+      "Size": 194
+    },
+    "res/drawable-mdpi-v4/abc_spinner_mtrl_am_alpha.9.png": {
+      "Size": 327
+    },
+    "res/drawable-mdpi-v4/abc_switch_track_mtrl_alpha.9.png": {
+      "Size": 395
+    },
+    "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+      "Size": 203
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
+      "Size": 311
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+      "Size": 310
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
+      "Size": 187
+    },
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+      "Size": 186
+    },
+    "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
+      "Size": 181
+    },
+    "res/drawable-mdpi-v4/abc_textfield_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_activated_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
+      "Size": 178
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
+      "Size": 351
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility.png": {
+      "Size": 309
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
+      "Size": 215
+    },
+    "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
+      "Size": 98
+    },
+    "res/drawable-v21/$avd_hide_password__0.xml": {
+      "Size": 1176
+    },
+    "res/drawable-v21/$avd_hide_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_hide_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/$avd_show_password__0.xml": {
+      "Size": 1136
+    },
+    "res/drawable-v21/$avd_show_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable-v21/$avd_show_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable-v21/abc_action_bar_item_background_material.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/abc_btn_colored_material.xml": {
+      "Size": 1716
+    },
+    "res/drawable-v21/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable-v21/abc_edit_text_material.xml": {
+      "Size": 1172
+    },
+    "res/drawable-v21/abc_list_divider_material.xml": {
+      "Size": 516
+    },
+    "res/drawable-v21/avd_hide_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/avd_show_password.xml": {
+      "Size": 660
+    },
+    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
+      "Size": 264
+    },
+    "res/drawable-v21/design_password_eye.xml": {
+      "Size": 816
+    },
+    "res/drawable-v21/notification_action_background.xml": {
+      "Size": 1180
+    },
+    "res/drawable-v23/abc_control_background_material.xml": {
+      "Size": 304
+    },
+    "res/drawable-watch-v20/abc_dialog_material_background.xml": {
+      "Size": 372
     },
     "res/drawable-xhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 280
@@ -907,11 +1012,11 @@
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
     },
-    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
-      "Size": 593
-    },
     "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
       "Size": 629
+    },
+    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
+      "Size": 593
     },
     "res/drawable-xhdpi-v4/notification_bg_low_normal.9.png": {
       "Size": 221
@@ -919,23 +1024,14 @@
     "res/drawable-xhdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 252
     },
-    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
-      "Size": 221
-    },
     "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 247
     },
+    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
+      "Size": 221
+    },
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 494
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 417
     },
     "res/drawable-xxhdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 286
@@ -1078,20 +1174,11 @@
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
-      "Size": 868
-    },
     "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 884
     },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 260
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 705
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 525
+    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
+      "Size": 868
     },
     "res/drawable-xxxhdpi-v4/abc_btn_check_to_on_mtrl_000.png": {
       "Size": 275
@@ -1171,26 +1258,146 @@
     "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
-      "Size": 1155
-    },
     "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 1201
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 325
+    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
+      "Size": 1155
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 905
+    "res/drawable/abc_btn_borderless_material.xml": {
+      "Size": 588
     },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
-      "Size": 437
+    "res/drawable/abc_btn_check_material.xml": {
+      "Size": 464
     },
-    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
-      "Size": 540
+    "res/drawable/abc_btn_default_mtrl_shape.xml": {
+      "Size": 932
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/drawable/abc_btn_radio_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_cab_background_internal_bg.xml": {
+      "Size": 372
+    },
+    "res/drawable/abc_cab_background_top_material.xml": {
+      "Size": 336
+    },
+    "res/drawable/abc_ic_ab_back_material.xml": {
+      "Size": 692
+    },
+    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
+      "Size": 1000
+    },
+    "res/drawable/abc_ic_clear_material.xml": {
+      "Size": 684
+    },
+    "res/drawable/abc_ic_go_search_api_material.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_ic_menu_overflow_material.xml": {
+      "Size": 792
+    },
+    "res/drawable/abc_ic_search_api_material.xml": {
+      "Size": 812
+    },
+    "res/drawable/abc_ic_voice_search_api_material.xml": {
+      "Size": 828
+    },
+    "res/drawable/abc_item_background_holo_dark.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_item_background_holo_light.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_holo_dark.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_list_selector_holo_light.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_ratingbar_indicator_material.xml": {
+      "Size": 704
+    },
+    "res/drawable/abc_ratingbar_material.xml": {
+      "Size": 704
+    },
+    "res/drawable/abc_ratingbar_small_material.xml": {
+      "Size": 704
+    },
+    "res/drawable/abc_seekbar_thumb_material.xml": {
+      "Size": 1100
+    },
+    "res/drawable/abc_seekbar_tick_mark_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_seekbar_track_material.xml": {
+      "Size": 1408
+    },
+    "res/drawable/abc_spinner_textfield_background_material.xml": {
+      "Size": 1160
+    },
+    "res/drawable/abc_switch_thumb_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_tab_indicator_material.xml": {
+      "Size": 468
+    },
+    "res/drawable/abc_text_cursor_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_textfield_search_material.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_vector_test.xml": {
+      "Size": 612
+    },
+    "res/drawable/design_fab_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/design_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/ic_mtrl_chip_checked_black.xml": {
+      "Size": 600
+    },
+    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
+      "Size": 940
+    },
+    "res/drawable/ic_mtrl_chip_close_circle.xml": {
+      "Size": 808
+    },
+    "res/drawable/mtrl_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/mtrl_tabs_default_indicator.xml": {
+      "Size": 628
+    },
+    "res/drawable/navigation_empty_icon.xml": {
+      "Size": 516
+    },
+    "res/drawable/notification_bg_low.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_bg.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_icon_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/notification_tile_bg.xml": {
+      "Size": 304
+    },
+    "res/drawable/tooltip_frame_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/tooltip_frame_light.xml": {
+      "Size": 484
     },
     "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
       "Size": 400
@@ -1198,11 +1405,41 @@
     "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
       "Size": 400
     },
+    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
+      "Size": 400
+    },
     "res/interpolator/mtrl_linear.xml": {
       "Size": 132
     },
-    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
+      "Size": 520
+    },
+    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
+      "Size": 520
+    },
+    "res/layout-v21/notification_action_tombstone.xml": {
+      "Size": 1228
+    },
+    "res/layout-v21/notification_action.xml": {
+      "Size": 1052
+    },
+    "res/layout-v21/notification_template_custom_big.xml": {
+      "Size": 2456
+    },
+    "res/layout-v21/notification_template_icon_group.xml": {
+      "Size": 988
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
+    "res/layout-v26/abc_screen_toolbar.xml": {
+      "Size": 1560
+    },
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
+    },
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
     },
     "res/layout/abc_action_bar_title_item.xml": {
       "Size": 872
@@ -1222,17 +1459,14 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 840
     },
-    "res/layout/abc_activity_chooser_view.xml": {
-      "Size": 1684
-    },
     "res/layout/abc_activity_chooser_view_list_item.xml": {
       "Size": 1304
     },
+    "res/layout/abc_activity_chooser_view.xml": {
+      "Size": 1684
+    },
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1536
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
     },
     "res/layout/abc_alert_dialog_material.xml": {
       "Size": 2480
@@ -1270,11 +1504,11 @@
     "res/layout/abc_screen_content_include.xml": {
       "Size": 548
     },
-    "res/layout/abc_screen_simple.xml": {
-      "Size": 832
-    },
     "res/layout/abc_screen_simple_overlay_action_mode.xml": {
       "Size": 792
+    },
+    "res/layout/abc_screen_simple.xml": {
+      "Size": 832
     },
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1504
@@ -1309,11 +1543,11 @@
     "res/layout/design_bottom_sheet_dialog.xml": {
       "Size": 1180
     },
-    "res/layout/design_layout_snackbar.xml": {
-      "Size": 520
-    },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1436
+    },
+    "res/layout/design_layout_snackbar.xml": {
+      "Size": 520
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -1324,9 +1558,6 @@
     "res/layout/design_menu_item_action_area.xml": {
       "Size": 320
     },
-    "res/layout/design_navigation_item.xml": {
-      "Size": 532
-    },
     "res/layout/design_navigation_item_header.xml": {
       "Size": 440
     },
@@ -1336,32 +1567,23 @@
     "res/layout/design_navigation_item_subheader.xml": {
       "Size": 564
     },
-    "res/layout/design_navigation_menu.xml": {
-      "Size": 524
+    "res/layout/design_navigation_item.xml": {
+      "Size": 532
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
     },
+    "res/layout/design_navigation_menu.xml": {
+      "Size": 524
+    },
     "res/layout/design_text_input_password_icon.xml": {
       "Size": 560
-    },
-    "res/layout/mtrl_layout_snackbar.xml": {
-      "Size": 520
     },
     "res/layout/mtrl_layout_snackbar_include.xml": {
       "Size": 1396
     },
-    "res/layout-v21/notification_action.xml": {
-      "Size": 1052
-    },
-    "res/layout-v21/notification_action_tombstone.xml": {
-      "Size": 1228
-    },
-    "res/layout-v21/notification_template_custom_big.xml": {
-      "Size": 2456
-    },
-    "res/layout-v21/notification_template_icon_group.xml": {
-      "Size": 988
+    "res/layout/mtrl_layout_snackbar.xml": {
+      "Size": 520
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -1381,35 +1603,14 @@
     "res/layout/support_simple_spinner_dropdown_item.xml": {
       "Size": 464
     },
-    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
-      "Size": 520
-    },
-    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 520
-    },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
-    },
-    "res/layout-v26/abc_screen_toolbar.xml": {
-      "Size": 1560
-    },
     "res/menu/menu_main.xml": {
       "Size": 560
     },
-    "res/mipmap-mdpi-v4/ic_launcher.png": {
-      "Size": 1362
+    "res/mipmap-anydpi-v26/ic_launcher_round.xml": {
+      "Size": 448
     },
-    "res/mipmap-mdpi-v4/ic_launcher_foreground.png": {
-      "Size": 958
-    },
-    "res/mipmap-mdpi-v4/ic_launcher_round.png": {
-      "Size": 2413
-    },
-    "res/mipmap-hdpi-v4/ic_launcher.png": {
-      "Size": 1634
+    "res/mipmap-anydpi-v26/ic_launcher.xml": {
+      "Size": 448
     },
     "res/mipmap-hdpi-v4/ic_launcher_foreground.png": {
       "Size": 1441
@@ -1417,8 +1618,17 @@
     "res/mipmap-hdpi-v4/ic_launcher_round.png": {
       "Size": 3552
     },
-    "res/mipmap-xhdpi-v4/ic_launcher.png": {
-      "Size": 2307
+    "res/mipmap-hdpi-v4/ic_launcher.png": {
+      "Size": 1634
+    },
+    "res/mipmap-mdpi-v4/ic_launcher_foreground.png": {
+      "Size": 958
+    },
+    "res/mipmap-mdpi-v4/ic_launcher_round.png": {
+      "Size": 2413
+    },
+    "res/mipmap-mdpi-v4/ic_launcher.png": {
+      "Size": 1362
     },
     "res/mipmap-xhdpi-v4/ic_launcher_foreground.png": {
       "Size": 2056
@@ -1426,17 +1636,17 @@
     "res/mipmap-xhdpi-v4/ic_launcher_round.png": {
       "Size": 4858
     },
-    "res/mipmap-xxhdpi-v4/ic_launcher.png": {
-      "Size": 3871
+    "res/mipmap-xhdpi-v4/ic_launcher.png": {
+      "Size": 2307
     },
     "res/mipmap-xxhdpi-v4/ic_launcher_foreground.png": {
-      "Size": 3184
+      "Size": 3187
     },
     "res/mipmap-xxhdpi-v4/ic_launcher_round.png": {
       "Size": 8001
     },
-    "res/mipmap-xxxhdpi-v4/ic_launcher.png": {
-      "Size": 5016
+    "res/mipmap-xxhdpi-v4/ic_launcher.png": {
+      "Size": 3871
     },
     "res/mipmap-xxxhdpi-v4/ic_launcher_foreground.png": {
       "Size": 4155
@@ -1444,225 +1654,15 @@
     "res/mipmap-xxxhdpi-v4/ic_launcher_round.png": {
       "Size": 10893
     },
-    "res/mipmap-anydpi-v26/ic_launcher.xml": {
-      "Size": 448
-    },
-    "res/mipmap-anydpi-v26/ic_launcher_round.xml": {
-      "Size": 448
+    "res/mipmap-xxxhdpi-v4/ic_launcher.png": {
+      "Size": 5016
     },
     "res/xml/xamarin_essentials_fileprovider_file_paths.xml": {
       "Size": 572
     },
     "resources.arsc": {
       "Size": 320016
-    },
-    "classes.dex": {
-      "Size": 2914972
-    },
-    "assemblies/VSAndroidApp.dll": {
-      "Size": 60889
-    },
-    "assemblies/Xamarin.Android.Arch.Lifecycle.Common.dll": {
-      "Size": 6971
-    },
-    "assemblies/Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll": {
-      "Size": 7017
-    },
-    "assemblies/Xamarin.Android.Arch.Lifecycle.ViewModel.dll": {
-      "Size": 4779
-    },
-    "assemblies/Xamarin.Android.Support.Compat.dll": {
-      "Size": 50728
-    },
-    "assemblies/Xamarin.Android.Support.CoordinaterLayout.dll": {
-      "Size": 17769
-    },
-    "assemblies/Xamarin.Android.Support.Design.dll": {
-      "Size": 28949
-    },
-    "assemblies/Xamarin.Android.Support.DrawerLayout.dll": {
-      "Size": 14618
-    },
-    "assemblies/Xamarin.Android.Support.Fragment.dll": {
-      "Size": 41190
-    },
-    "assemblies/Xamarin.Android.Support.Loader.dll": {
-      "Size": 13489
-    },
-    "assemblies/Xamarin.Android.Support.v7.AppCompat.dll": {
-      "Size": 92177
-    },
-    "assemblies/Xamarin.Essentials.dll": {
-      "Size": 14090
-    },
-    "assemblies/Java.Interop.dll": {
-      "Size": 68112
-    },
-    "assemblies/Mono.Android.dll": {
-      "Size": 324714
-    },
-    "assemblies/mscorlib.dll": {
-      "Size": 843669
-    },
-    "assemblies/System.Core.dll": {
-      "Size": 33884
-    },
-    "assemblies/System.dll": {
-      "Size": 208093
-    },
-    "assemblies/System.Numerics.dll": {
-      "Size": 15655
-    },
-    "assemblies/System.Net.Http.dll": {
-      "Size": 110898
-    },
-    "assemblies/Mono.Security.dll": {
-      "Size": 61468
-    },
-    "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 41668
-    },
-    "lib/x86/libxamarin-app.so": {
-      "Size": 41000
-    },
-    "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 216940
-    },
-    "lib/x86/libmonodroid.so": {
-      "Size": 272124
-    },
-    "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48620
-    },
-    "lib/x86/libxa-internal-api.so": {
-      "Size": 61312
-    },
-    "lib/armeabi-v7a/libmono-btls-shared.so": {
-      "Size": 1113088
-    },
-    "lib/x86/libmono-btls-shared.so": {
-      "Size": 1459984
-    },
-    "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456372
-    },
-    "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212484
-    },
-    "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736764
-    },
-    "lib/x86/libmono-native.so": {
-      "Size": 803736
-    },
-    "META-INF/proguard/androidx-annotations.pro": {
-      "Size": 308
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.viewpager_viewpager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.drawerlayout_drawerlayout.version": {
-      "Size": 6
-    },
-    "META-INF/android.support.design_material.version": {
-      "Size": 12
-    },
-    "META-INF/com.google.android.material_material.version": {
-      "Size": 10
-    },
-    "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.core_core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.appcompat_appcompat.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.browser_browser.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_viewmodel.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.transition_transition.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.customview_customview.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.core_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.documentfile_documentfile.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.slidingpanelayout_slidingpanelayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.fragment_fragment.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.recyclerview_recyclerview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cardview_cardview.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.loader_loader.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.cursoradapter_cursoradapter.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_livedata-core.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.coordinatorlayout_coordinatorlayout.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-ui.version": {
-      "Size": 6
-    },
-    "META-INF/android.arch.lifecycle_runtime.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.legacy_legacy-support-core-utils.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.interpolator_interpolator.version": {
-      "Size": 6
-    },
-    "META-INF/androidx.print_print.version": {
-      "Size": 6
-    },
-    "META-INF/ANDROIDD.SF": {
-      "Size": 67139
-    },
-    "META-INF/ANDROIDD.RSA": {
-      "Size": 1213
-    },
-    "META-INF/MANIFEST.MF": {
-      "Size": 67012
     }
   },
-  "PackageSize": 9440791
+  "PackageSize": 9498135
 }


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r23#changelog

The most important changes for Xamarin.Android:

NDK r23 removes GNU Binutils and so we need to switch to using our
bundled copy of them.

Upstream changes:

  * Includes Android 12 APIs.
  * Updated LLVM to clang-r416183b, based on LLVM 12 development.
    * [Issue 1047]: Fixes crash when using ASan with the CFI unwinder.
    * [Issue 1096]: Includes support for [Polly]. Enable by adding `-mllvm -polly`
      to your cflags.
    * [Issue 1230]: LLVM's libunwind is now used instead of libgcc for all
      architectures rather than just 32-bit Arm.
    * [Issue 1231]: LLVM's libclang_rt.builtins is now used instead of libgcc.
    * [Issue 1406]: Fixes crash with Neon intrinsic.
  * Vulkan validation layer source and binaries are no longer shipped in the NDK.
    The latest are now posted directly to [GitHub](https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases).
  * Vulkan tools source is also removed, specifically vulkan_wrapper.
    It should be downloaded upstream from [GitHub](https://github.com/KhronosGroup/Vulkan-Tools).
  * The toolchain file (android.toolchain.cmake) is refactored to base on CMake's
    integrated Android support. This new toolchain file will be enabled by default
    for CMake 3.21 and newer. No user side change is expected. But if anything goes
    wrong, please file a bug and set `ANDROID_USE_LEGACY_TOOLCHAIN_FILE=ON` to
    restore the legacy behavior.
      * When using the new behavior (when using CMake 3.21+ and not explicitly
        selecting the legacy toolchain), **default build flags may change**. One
        of the primary goals was to reduce the behavior differences between our
        toolchain and CMake, and CMake's default flags do not always match the
        legacy toolchain file. Most notably, if using `CMAKE_BUILD_TYPE=Release`,
        your optimization type will likely be `-O3` instead of `-O2` or `-Oz`. See
        [Issue 1536] for more information.
  * [Issue 929]: `find_library` now prefers shared libraries from the sysroot over
    static libraries.
  * [Issue 1390]: ndk-build now warns when building a static executable with the
    wrong API level.
  * [Issue 1452]: `NDK_ANALYZE=1` now sets `APP_CLANG_TIDY=true` rather than using
    scan-build. clang-tidy performs all the same checks by default, and scan-build
    was no longer working. See the bug for more details, but no user-side changes
    should be needed.

[Issue 929]: https://github.com/android/ndk/issues/929
[Issue 1047]: https://github.com/android/ndk/issues/1047
[Issue 1096]: https://github.com/android/ndk/issues/1096
[Issue 1230]: https://github.com/android/ndk/issues/1230
[Issue 1231]: https://github.com/android/ndk/issues/1231
[Issue 1390]: https://github.com/android/ndk/issues/1390
[Issue 1406]: https://github.com/android/ndk/issues/1406
[Issue 1452]: https://github.com/android/ndk/issues/1452
[Issue 1536]: https://github.com/android/ndk/issues/1536
[Polly]: https://polly.llvm.org/