### PR TITLE
[ci] Increase job timeouts for .NET 6 installers

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1288,6 +1288,7 @@ stages:
       name: $(VSEngMacBuildPool)
       demands:
       - agent.osversionfamily -equals 10.15
+    timeoutInMinutes: 120
     workspace:
       clean: all
     steps:
@@ -1384,6 +1385,7 @@ stages:
     displayName: Create .msi and Upload
     dependsOn: dotnet_create_pkg
     pool: VSEngSS-MicroBuild2019
+    timeoutInMinutes: 120
     workspace:
       clean: all
     variables:


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4954055&view=logs&j=a62e275d-46d5-5c3b-5a47-c4e00ae7427d&s=998e29ca-850b-59f2-4134-6ed1d0ce6c3a

I've seen our .NET 6 installer jobs time out after 60 minutes a couple
of times recently, we should be able to avoid this by increasing the
default timeout value.