### PR TITLE
[build] use explicit folder names in DeleteExtractedWorkloadPacks

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -119,12 +119,21 @@
 
   <Target Name="DeleteExtractedWorkloadPacks" >
     <ItemGroup>
-      <_PackFilesToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.android\**\*.*" />
-      <_PackFilesToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.workload.android\**\*.*" />
-      <_PackFilesToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android*\**\*.*" />
-      <_PackFilesToDelete Include="$(DotNetPreviewPath)template-packs\Microsoft.Android.Templates.*.nupkg" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)metadata" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.android" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.workload.android" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Ref" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-arm" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-arm64" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-x86" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-x64" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.BundleTool" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Darwin" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Linux" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Windows" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)template-packs" />
     </ItemGroup>
-    <RemoveDir Directories="%(_PackFilesToDelete.RootDir)%(_PackFilesToDelete.Directory)" />
+    <RemoveDir Directories="@(_PackFoldersToDelete)" />
   </Target>
 
   <Target Name="PushManifestToBuildAssetRegistry" >


### PR DESCRIPTION
When working on .NET 6, I've occasionally hit the build error:

    Microsoft.NET.TargetFrameworkInference.targets(109,5): error NETSDK1139: The target platform identifier android was not recognized.

After looking at the contents of `dotnet\packs`, I
have an empty folder such as:

    ~\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\30.0.100-ci.main.76\

Yet the workload said it actually installed the pack:

    Writing workload pack installation record for Microsoft.Android.Sdk version 30.0.100-ci.main.76...

I think the `dotnet workload` command must skip over folders if the
folder *exists*. It does not actually validate if content is missing.

To make matters worse, our logic would not actually delete folders
when using this wildcard:

    <_PackFilesToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android*\**\*.*" />

Since there are no files, the `packs\Microsoft.Android.Sdk.Windows`
folder would not be deleted.

To solve this issue, I think we should just explicitly list each
folder. There are not that many, and I don't anticipate us having a
long list of packs.

Additionally, let's delete the `metadata` folder as it stores
information about which workloads are installed. It may be an
additional source of confusion down the road.