### PR TITLE
[Mono.Android] Fix WeakGlobalReferenceCount

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -109,8 +109,12 @@ namespace Android.Runtime {
 			get {return _monodroid_gref_get ();}
 		}
 
+
+		[DllImport (AndroidRuntime.InternalDllName, CallingConvention = CallingConvention.Cdecl)]
+		static extern int _monodroid_weak_gref_get ();
+
 		public override int WeakGlobalReferenceCount {
-			get {return -1;}
+			get {return _monodroid_weak_gref_get ();}
 		}
 
 		public override JniObjectReference CreateLocalReference (JniObjectReference value, ref int localReferenceCount)

--- a/src/monodroid/jni/internal-pinvoke-api.cc
+++ b/src/monodroid/jni/internal-pinvoke-api.cc
@@ -123,6 +123,13 @@ _monodroid_gref_get (void)
 	return internal_calls->monodroid_gref_get ();
 }
 
+// Used by Mono.Android.dll!Java.Interop.Runtime.WeakGlobalReferenceCount
+MONO_API int
+_monodroid_weak_gref_get (void)
+{
+	return internal_calls->monodroid_weak_gref_get ();
+}
+
 // Used by Mono.Android.dll!Android.Runtime.JNIEnv
 MONO_API void
 _monodroid_gref_log (const char *message)

--- a/src/monodroid/jni/osbridge.hh
+++ b/src/monodroid/jni/osbridge.hh
@@ -74,6 +74,11 @@ namespace xamarin::android::internal
 			return gc_gref_count;
 		}
 
+		int get_gc_weak_gref_count () const
+		{
+			return gc_weak_gref_count;
+		}
+
 		const MonoJavaGCBridgeType& get_java_gc_bridge_type (uint32_t index)
 		{
 			if (index < NUM_XA_GC_BRIDGE_TYPES)

--- a/src/monodroid/jni/pinvoke-override-api.cc
+++ b/src/monodroid/jni/pinvoke-override-api.cc
@@ -116,6 +116,12 @@ _monodroid_gref_log_delete (jobject handle, char type, const char *threadName, i
         osBridge._monodroid_gref_log_delete (handle, type, threadName, threadId, from, from_writable);
 }
 
+static int
+_monodroid_weak_gref_get ()
+{
+	return osBridge.get_gc_weak_gref_count ();
+}
+
 static void
 _monodroid_weak_gref_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable)
 {
@@ -571,6 +577,7 @@ MonodroidRuntime::pinvoke_api_map MonodroidRuntime::xa_pinvoke_map = {
 	PINVOKE_SYMBOL (monodroid_timing_stop),
 	PINVOKE_SYMBOL (monodroid_TypeManager_get_java_class_name),
 	PINVOKE_SYMBOL (_monodroid_weak_gref_delete),
+	PINVOKE_SYMBOL (_monodroid_weak_gref_get),
 	PINVOKE_SYMBOL (_monodroid_weak_gref_new),
 	PINVOKE_SYMBOL (path_combine),
 	PINVOKE_SYMBOL (recv_uninterrupted),
@@ -696,8 +703,11 @@ MonodroidRuntime::monodroid_pinvoke_override (const char *library_name, const ch
 	}
 	auto iter = xa_pinvoke_map.find (entrypoint_name);
 	if (iter == xa_pinvoke_map.end ()) {
-		// TODO: perhaps it should be fatal?
 		log_fatal (LOG_ASSEMBLY, "Internal p/invoke symbol '%s @ %s' not found in compile-time map.", library_name, entrypoint_name);
+		log_fatal (LOG_ASSEMBLY, "compile-time map contents:");
+		for (iter = xa_pinvoke_map.begin (); iter != xa_pinvoke_map.end (); ++iter) {
+			log_fatal (LOG_ASSEMBLY, "\t'%s'=%p", iter->first.c_str (), iter->second);
+		}
 		abort ();
 		return nullptr;
 	}

--- a/src/monodroid/jni/xa-internal-api-impl.hh
+++ b/src/monodroid/jni/xa-internal-api-impl.hh
@@ -23,6 +23,7 @@ namespace xamarin::android::internal
 		virtual void monodroid_gref_log (const char *message) final override;
 		virtual int monodroid_gref_log_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable) final override;
 		virtual void monodroid_gref_log_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) final override;
+		virtual int monodroid_weak_gref_get () final override;
 		virtual void monodroid_weak_gref_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable) final override;
 		virtual void monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) final override;
 		virtual void monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) final override;

--- a/src/monodroid/jni/xa-internal-api.cc
+++ b/src/monodroid/jni/xa-internal-api.cc
@@ -138,6 +138,12 @@ MonoAndroidInternalCalls_Impl::monodroid_gref_get ()
 	return osBridge.get_gc_gref_count ();
 }
 
+int
+MonoAndroidInternalCalls_Impl::monodroid_weak_gref_get ()
+{
+	return osBridge.get_gc_weak_gref_count ();
+}
+
 void
 MonoAndroidInternalCalls_Impl::monodroid_gref_log (const char *message)
 {

--- a/src/monodroid/jni/xa-internal-api.hh
+++ b/src/monodroid/jni/xa-internal-api.hh
@@ -38,6 +38,7 @@ namespace xamarin::android
 		virtual void monodroid_gref_log (const char *message) = 0;
 		virtual int monodroid_gref_log_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable) = 0;
 		virtual void monodroid_gref_log_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) = 0;
+		virtual int monodroid_weak_gref_get () = 0;
 		virtual void monodroid_weak_gref_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable) = 0;
 		virtual void monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) = 0;
 		virtual void monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable) = 0;


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/commit/cb49134f6126f56ab9eec6efd52d85b45694dfe4
Context: https://github.com/xamarin/java.interop/blob/4a02bc3291ccf81e82379a426a731716a31741f8/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs#L156-L157

The `JniRuntime.JniObjectReferenceManager.WeakGlobalReferenceCount`
property is supposed to return the number of JNI Weak Global References
which have been created by Xamarin.Android.

Unfortunately, `AndroidObjectReferenceManager.WeakGlobalReferenceCount`
always returned -1, which had the nasty side effect of breaking
`JniObjectReferenceManager.CreateWeakGlobalReference()`, which
*asserts* that `WeakGlobalReferenceCount` is not negative.

The result is that the [`JavaObjectTest.UnregisterFromRuntime()`][0]
unit test *always fails* when you use a Debug build of
`Java.Interop.dll` with .NET 6:

	D Mono.Android.NET_Tests: WGREF count is -1, expected to be >= 0 when dealing with handle 0x36a6/G on thread ''(27).
	D Mono.Android.NET_Tests: DebugAssertLongMessage
	D Mono.Android.NET_Tests:
	D Mono.Android.NET_Tests:    at System.Diagnostics.DebugProvider.Fail(String message, String detailMessage) in System.Private.CoreLib.dll:token 0x6005d37+0x0
	D Mono.Android.NET_Tests:    at System.Diagnostics.Debug.Fail(String message, String detailMessage) in System.Private.CoreLib.dll:token 0x6005cf9+0x0
	D Mono.Android.NET_Tests:    at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage) in System.Private.CoreLib.dll:token 0x6005cf6+0x0
	D Mono.Android.NET_Tests:    at System.Diagnostics.Debug.Assert(Boolean condition, String message) in System.Private.CoreLib.dll:token 0x6005cf5+0x0
	D Mono.Android.NET_Tests:    at Java.Interop.JniRuntime.JniObjectReferenceManager.AssertCount(Int32 count, String type, String value) in Java.Interop.dll:token 0x600048a+0x0
	D Mono.Android.NET_Tests:    at Java.Interop.JniRuntime.JniObjectReferenceManager.CreateWeakGlobalReference(JniObjectReference reference) in Java.Interop.dll:token 0x6000485+0x0
	D Mono.Android.NET_Tests:    at Android.Runtime.AndroidObjectReferen

This only impacts .NET 6 + Debug builds because "legacy Mono" doesn't
exit the process when an assertion fails.  .NET 6 + Release builds
don't have the assertion either, so the assertion is only visible to
xamarin-android developers using Debug builds on .NET 6.

Fix the assertion by properly implementing
`AndroidObjectReferenceManager.WeakGlobalReferenceCount`, by having
it use the value from `OSBridge::gc_weak_gref_count`.

[0]: https://github.com/xamarin/java.interop/blob/4a02bc3291ccf81e82379a426a731716a31741f8/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs#L47-L65