### PR TITLE
[build] Update Pipelines var used for branch name

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			var build_sourcebranchname = Environment.GetEnvironmentVariable ("BUILD_SOURCEBRANCH");
 			if (!string.IsNullOrEmpty (build_sourcebranchname) && build_sourcebranchname.IndexOf ("merge", StringComparison.OrdinalIgnoreCase) == -1) {
 				Branch = build_sourcebranchname.Replace ("refs/heads/", string.Empty);
-				Console.WriteLine ($"Using BUILD_SOURCEBRANCH value: {Branch}");
+				Log.LogMessage ($"Using BUILD_SOURCEBRANCH value: {Branch}");
 				return true;
 			}
 

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -28,10 +28,10 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GitBranch)}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
 
-			var build_sourcebranchname = Environment.GetEnvironmentVariable ("BUILD_SOURCEBRANCHNAME");
-			if (!string.IsNullOrEmpty (build_sourcebranchname) && build_sourcebranchname != "merge") {
-				Log.LogMessage ("Using $BUILD_SOURCEBRANCHNAME");
-				Branch = build_sourcebranchname;
+			var build_sourcebranchname = Environment.GetEnvironmentVariable ("BUILD_SOURCEBRANCH");
+			if (!string.IsNullOrEmpty (build_sourcebranchname) && build_sourcebranchname.IndexOf ("merge", StringComparison.OrdinalIgnoreCase) == -1) {
+				Branch = build_sourcebranchname.Replace ("refs/heads/", string.Empty);
+				Console.WriteLine ($"Using BUILD_SOURCEBRANCH value: {Branch}");
 				return true;
 			}
 


### PR DESCRIPTION
According to the [Pipelines predefined variables doc][0], the
`$(BUILD_SOURCEBRANCHNAME)` variable will only contain the last path
segment in the branch name value.  This is the example they provide:

    For example, in `refs/heads/main` this value is `main`. In
    `refs/heads/feature/tools` this value is `tools`.

CI builds for branches containing `/` would produce .NET 6 packs and
manifests with incomplete branch information, which can be fixed by
using (and trimming) the `$(BUILD_SOURCEBRANCH)` variable instead.

Possible values for `$(BUILD_SOURCEBRANCH)`:

 * Git repo branch: refs/heads/main
 * Git repo pull request: refs/pull/1/merge

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services