### PR TITLE
jfrog/bintray removals/replacements

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			proj.Jars.Add (new AndroidItem.AndroidLibrary ("Jars\\material-menu-1.1.0.aar") {
-				WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
+				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 			});
 			proj.AndroidClassParser = classParser;
 			using (var b = CreateDllBuilder ()) {
@@ -501,7 +501,7 @@ namespace Foo {
 				AndroidClassParser = classParser
 			};
 			proj.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\material-menu-1.1.0.aar") {
-				WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
+				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 			});
 			using (var b = CreateDllBuilder ()) {
 				Assert.IsTrue (b.DesignTimeBuild (proj), "design-time build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -461,7 +461,7 @@ class MemTest {
 			var proj = new XamarinFormsAndroidApplicationProject ();
 			proj.AndroidUseAapt2 = useAapt2;
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidAarLibrary", "Jars\\material-menu-1.1.0.aar") {
-				WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
+				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -387,7 +387,7 @@ namespace Xamarin.Android.Build.Tests
 						TextContent = () => "<metadata><remove-node path=\"/api/package[@name='com.balysv.material.drawable.menu']/class[@name='MaterialMenuView']/method[@name='onRestoreInstanceState']\" /><remove-node path=\"/api/package[@name='com.balysv.material.drawable.menu']/class[@name='MaterialMenuView']/method[@name='onSaveInstanceState']\" /></metadata>",
 					},
 					new AndroidItem.AndroidLibrary ("material-menu-1.1.0.aar") {
-						WebContent = "https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
+						WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar"
 					},
 				}
 			};


### PR DESCRIPTION
Context: https://blog.gradle.org/jcenter-shutdown

Context: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

JCenter is shutting down. It is no longer browsable as of May 1, and artifacts hosted on JCenter repository will be read-only accessible indefinitely.

Stop using JCenter, and instead use Maven Central.

NOTE: unable to find url replacements:

* jetbrains runtime jbrsdk
* twitter-core

```
./build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs:35:			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-8u202-linux-x64-b1483.37.tar.gz
./build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs:36:			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-8u202-osx-x64-b1483.37.tar.gz
./build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs:37:			// https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-8u202-windows-x64-b1483.37.tar.gz
```

```
./src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs:3277:				WebContent = "https://dl.bintray.com/twitteross/twitterkit/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
```

Related:

xamarin/java.interop@9444570

Closed PR https://github.com/xamarin/xamarin-android/pull/5911