### PR TITLE
[One .NET] select defaults for App Bundles

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -172,8 +172,8 @@ Added in Xamarin.Android 10.2.
 ## AndroidBoundInterfacesContainConstants
 
 A boolean property that
-determines whether binding constants on interfaces will be supported, 
-or the workaround of creating an `IMyInterfaceConsts` class 
+determines whether binding constants on interfaces will be supported,
+or the workaround of creating an `IMyInterfaceConsts` class
 will be used.
 
 Defaults to `True` in .NET 6 and `False` for legacy.
@@ -181,8 +181,8 @@ Defaults to `True` in .NET 6 and `False` for legacy.
 ## AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods
 
 A boolean property that
-whether default and static members on interfaces will be supported, 
-or  old workaround of creating a sibling class containing static 
+whether default and static members on interfaces will be supported,
+or  old workaround of creating a sibling class containing static
 members like `abstract class MyInterface`.
 
 Defaults to `True` in .NET 6 and `False` for legacy.
@@ -190,7 +190,7 @@ Defaults to `True` in .NET 6 and `False` for legacy.
 ## AndroidBoundInterfacesContainTypes
 
 A boolean property that
-whether types nested in interfaces will be supported, or the workaround 
+whether types nested in interfaces will be supported, or the workaround
 of creating a non-nested type like `IMyInterfaceMyNestedClass`.
 
 Defaults to `True` in .NET 6 and `False` for legacy.
@@ -913,6 +913,43 @@ properties are set, which are required for Android App Bundles:
 
 [apk]: https://en.wikipedia.org/wiki/Android_application_package
 [bundle]: https://developer.android.com/platform/technology/app-bundle
+
+This property will be deprecated for .net 6. Users should switch over to
+the newer [`AndroidPackageFormats`](~/android/deploy-test/building-apps/build-properties.md#androidpackageformats).
+
+## AndroidPackageFormats
+
+A semi-colon delimited property with valid values of `apk` and `aab`.
+This indicates if you want to package the Android application as
+an [APK file][apk] or [Android App Bundle][bundle]. App Bundles
+are a new format for `Release` builds that are intended for
+submission on Google Play.
+
+When building a Release build you might want to generate both
+and `aab` and an `apk` for distribution to various stores.
+
+Setting `AndroidPackageFormats` to `aab;apk` will result in both
+being generated. Setting `AndroidPackageFormats` to either `aab`
+or `apk` will generate only one file.
+
+For .net 6 `AndroidPackageFormats` will be set to `aab;apk` for
+`Release` builds only. It is recommended that you continue to use
+just `apk` for debugging.
+
+For Legacy Xamarin.Android this value currently defaults to `""`.
+As a result Legacy Xamarin.Android will NOT by default produce
+both as part of a release build. If a user wants to produce both
+outputs they will need to define the following in their `Release`
+configuration.
+
+```
+<AndroidPackageFormats>aab;apk</AndroidPackageFormats>
+```
+
+You will also need to remove the existing `AndroidPackageFormat` for
+that configuration if you have it.
+
+Added in Xamarin.Android 11.5.
 
 ## AndroidPackageNamingPolicy
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -771,6 +771,7 @@ stages:
         testName: Mono.Android.NET_Tests
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration).xml
+        extraBuildArgs: /p:AndroidPackageFormat=apk
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-Default
         useDotNet: true
@@ -793,7 +794,7 @@ stages:
         testName: Mono.Android.NET_Tests-Interpreter
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Interpreter.xml
-        extraBuildArgs: /p:TestsFlavor=Interpreter /p:UseInterpreter=True
+        extraBuildArgs: /p:TestsFlavor=Interpreter /p:UseInterpreter=True /p:AndroidPackageFormat=apk
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-Interpreter
         useDotNet: true
@@ -804,7 +805,7 @@ stages:
         testName: Mono.Android.NET_Tests-Aot
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Aot.xml
-        extraBuildArgs: /p:TestsFlavor=Aot /p:RunAOTCompilation=true
+        extraBuildArgs: /p:TestsFlavor=Aot /p:RunAOTCompilation=true /p:AndroidPackageFormat=apk
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-aot
         useDotNet: true
@@ -815,7 +816,7 @@ stages:
         testName: Mono.Android.NET_Tests-AotLlvm
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)AotLlvm.xml
-        extraBuildArgs: /p:TestsFlavor=AotLlvm /p:RunAOTCompilation=true /p:EnableLlvm=true
+        extraBuildArgs: /p:TestsFlavor=AotLlvm /p:RunAOTCompilation=true /p:EnableLlvm=true /p:AndroidPackageFormat=apk
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-aotllvm
         useDotNet: true

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -19,7 +19,7 @@ steps:
       solution: ${{ parameters.project }}
       configuration: ${{ parameters.configuration }}
       msbuildArguments: >-
-        /restore
+        /restore /v:diag
         /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
         /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         ${{ parameters.extraBuildArgs }}
@@ -34,7 +34,7 @@ steps:
       arguments: >-
         -t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
         -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
-        -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
+        -v:d -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}
 
 - script: >

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -19,7 +19,7 @@ steps:
       solution: ${{ parameters.project }}
       configuration: ${{ parameters.configuration }}
       msbuildArguments: >-
-        /restore /v:diag
+        /restore
         /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
         /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         ${{ parameters.extraBuildArgs }}
@@ -34,7 +34,7 @@ steps:
       arguments: >-
         -t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
         -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
-        -v:d -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
+        -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}
 
 - script: >

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -37,6 +37,7 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       $(BuildDependsOn);
       _CopyPackage;
       _Sign;
+      _CreateUniversalApkFromBundle;
     </BuildDependsOn>
     <IncrementalCleanDependsOn>
       _PrepareAssemblies;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -18,7 +18,7 @@
     <!-- mono-symbolicate is not supported -->
     <MonoSymbolArchive>false</MonoSymbolArchive>
     <!--
-      Disable @(Content) from referenced projects 
+      Disable @(Content) from referenced projects
       See: https://github.com/dotnet/sdk/blob/955c0fc7b06e2fa34bacd076ed39f61e4fb61716/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L16
     -->
     <_GetChildProjectCopyToPublishDirectoryItems>false</_GetChildProjectCopyToPublishDirectoryItems>
@@ -46,6 +46,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>
     <AndroidManagedSymbols Condition=" '$(AndroidManagedSymbols)' == '' ">true</AndroidManagedSymbols>
+    <AndroidPackageFormats Condition=" '$(AndroidPackageFormats)' == '' " >aab;apk</AndroidPackageFormats>
   </PropertyGroup>
 
   <!-- Application project settings -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
@@ -2,7 +2,7 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk"
       Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
   <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.BundleTool"
-      Condition=" '$(AndroidPackageFormat)' == 'aab' " />
+      Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
     <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -54,13 +54,16 @@ namespace Xamarin.Android.Tasks
 
 		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)
 		{
+			string pass = value.Replace ("env:", string.Empty)
+				.Replace ("file:", string.Empty)
+				.Replace ("pass:", string.Empty);
 			if (value.StartsWith ("env:", StringComparison.Ordinal)) {
-				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} ", value);
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} env:", pass);
 			}
 			else if (value.StartsWith ("file:", StringComparison.Ordinal)) {
-				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} file:", value.Replace ("file:", string.Empty));
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} file:", pass);
 			} else {
-				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} pass:", value);
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} pass:", pass);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -71,7 +71,9 @@ namespace Xamarin.Android.Tasks
 
 		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)
 		{
-			string pass = value.Replace ("env:", string.Empty).Replace ("file:", string.Empty);
+			string pass = value.Replace ("env:", string.Empty)
+				.Replace ("file:", string.Empty)
+				.Replace ("pass:", string.Empty);
 			if (value.StartsWith ("env:", StringComparison.Ordinal)) {
 				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch}:env ", pass);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -244,6 +244,10 @@ namespace Xamarin.Android.Tasks
 								Log.LogDebugMessage ($"Skipping {path} as the archive file is up to date.");
 								continue;
 							}
+							if (string.Compare (Path.GetFileName (name), "AndroidManifest.xml", StringComparison.OrdinalIgnoreCase) == 0) {
+								Log.LogDebugMessage ("Ignoring jar entry {0} from {1}: the same file already exists in the apk", name, Path.GetFileName (jarFile));
+								continue;
+							}
 							if (apk.Archive.Any (e => e.FullName == path)) {
 								Log.LogDebugMessage ("Failed to add jar entry {0} from {1}: the same file already exists in the apk", name, Path.GetFileName (jarFile));
 								continue;
@@ -253,7 +257,7 @@ namespace Xamarin.Android.Tasks
 								jarItem.Extract (d);
 								data = d.ToArray ();
 							}
-							Log.LogDebugMessage ($"Adding {path} as the archive file is out of date.");
+							Log.LogDebugMessage ($"Adding {path} from {jarFile} as the archive file is out of date.");
 							apk.Archive.AddEntry (data, path);
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
@@ -14,14 +14,29 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] Sources { get; set; }
 		public ITaskItem [] DestinationDirectories { get; set; }
+		public ITaskItem [] Files { get; set; }
 
 		public override bool RunTask ()
 		{
 			foreach (var pair in Sources.Zip (DestinationDirectories, (s, d) => new { Source = s, Destination = d })) {
 				if (!Directory.Exists (pair.Destination.ItemSpec))
 					Directory.CreateDirectory (pair.Destination.ItemSpec);
-				using (var z = ZipArchive.Open (pair.Source.ItemSpec, FileMode.Open))
-					z.ExtractAll (pair.Destination.ItemSpec);
+				using (var z = ZipArchive.Open (pair.Source.ItemSpec, FileMode.Open)) {
+					if (Files == null || Files.Length == 0) {
+						z.ExtractAll (pair.Destination.ItemSpec);
+					} else {
+						foreach (var file in Files) {
+							ZipEntry entry = z.ReadEntry (file.ItemSpec);
+							if (entry == null) {
+								Log.LogDebugMessage ($"Skipping not existant file {file.ItemSpec}");
+								continue;
+							}
+							string destinationFileName = file.GetMetadata ("DestinationFileName");
+							Log.LogDebugMessage ($"Extracting {file.ItemSpec} to {destinationFileName ?? file.ItemSpec}");
+							entry.Extract (pair.Destination.ItemSpec, destinationFileName ?? file.ItemSpec);
+						}
+					}
+				}
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -210,14 +210,14 @@ namespace Xamarin.Android.Build.Tests
 						"aot", abi, "libaot-UnnamedProject.dll.so");
 					Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
 					var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 					using (var zipFile = ZipHelper.OpenZip (apk)) {
 						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 							string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
-							$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}.apk", abi);
+							$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}-Signed.apk", abi);
 						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 							"assemblies/UnnamedProject.dll"),
-							$"UnnamedProject.dll should be in the {proj.PackageName}.apk");
+							$"UnnamedProject.dll should be in the {proj.PackageName}-Signed.apk");
 					}
 				}
 				Assert.AreEqual (expectedResult, b.Build (proj), "Second Build should have {0}.", expectedResult ? "succeeded" : "failed");
@@ -263,14 +263,14 @@ namespace Xamarin.Android.Build.Tests
 						"aot", abi, "libaot-UnnamedProject.dll.so");
 					Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
 					var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 					using (var zipFile = ZipHelper.OpenZip (apk)) {
 						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 							string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
-							$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}.apk", abi);
+							$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}-Signed.apk", abi);
 						Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
 							"assemblies/UnnamedProject.dll"),
-							$"UnnamedProject.dll should not be in the {proj.PackageName}.apk");
+							$"UnnamedProject.dll should not be in the {proj.PackageName}-Signed.apk");
 					}
 				}
 				Assert.AreEqual (expectedResult, b.Build (proj), "Second Build should have {0}.", expectedResult ? "succeeded" : "failed");
@@ -410,7 +410,7 @@ namespace "+ libName + @" {
 
 				b.Build (proj);
 
-				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var entry = zip.ReadEntry ($"assemblies/{proj.ProjectName}.dll");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (libb.Build (libproj), "{0} should have built successfully.", libproj.ProjectName);
 				using (var b = CreateApkBuilder (Path.Combine (projectPath, proj.ProjectName))) {
 					Assert.IsTrue (b.Build (proj), "{0} should have built successfully.", proj.ProjectName);
-					using (var apk = ZipHelper.OpenZip (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk"))) {
+					using (var apk = ZipHelper.OpenZip (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk"))) {
 						foreach (var a in libproj.OtherBuildItems.Where (x => x is AndroidItem.AndroidAsset)) {
 							var item = a.Include ().ToLower ().Replace ("\\", "/");
 							if (item.EndsWith ("/"))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1000,14 +1000,14 @@ namespace UnamedProject
 					"bundles", "armeabi-v7a", "libmonodroid_bundle_app.so");
 				Assert.IsTrue (File.Exists (libapp), "libmonodroid_bundle_app.so does not exist");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zipFile = ZipHelper.OpenZip (apk)) {
 					Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 						"lib/armeabi-v7a/libmonodroid_bundle_app.so"),
-						$"lib/armeabi-v7a/libmonodroid_bundle_app.so should be in the {proj.PackageName}.apk");
+						$"lib/armeabi-v7a/libmonodroid_bundle_app.so should be in the {proj.PackageName}-Signed.apk");
 					Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
 						Path.Combine ("assemblies", "UnnamedProject.dll")),
-						$"UnnamedProject.dll should not be in the {proj.PackageName}.apk");
+						$"UnnamedProject.dll should not be in the {proj.PackageName}-Signed.apk");
 				}
 			}
 		}
@@ -1028,14 +1028,14 @@ namespace UnamedProject
 						"bundles", abi, "libmonodroid_bundle_app.so");
 					Assert.IsTrue (File.Exists (libapp), abi + " libmonodroid_bundle_app.so does not exist");
 					var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 					using (var zipFile = ZipHelper.OpenZip (apk)) {
 						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 							"lib/" + abi + "/libmonodroid_bundle_app.so"),
-							$"lib/{0}/libmonodroid_bundle_app.so should be in the {proj.PackageName}.apk", abi);
+							$"lib/{0}/libmonodroid_bundle_app.so should be in the {proj.PackageName}-Signed.apk", abi);
 						Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
 							Path.Combine ("assemblies", "UnnamedProject.dll")),
-							$"UnnamedProject.dll should not be in the {proj.PackageName}.apk");
+							$"UnnamedProject.dll should not be in the {proj.PackageName}-Signed.apk");
 					}
 				}
 			}
@@ -1174,7 +1174,7 @@ namespace UnamedProject
 			using (var b = CreateApkBuilder ()) {
 				string intermediateDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
 				string androidBinDir = Path.Combine (intermediateDir, "android", "bin");
-				string apkPath = Path.Combine (androidBinDir, $"{proj.PackageName}.apk");
+				string apkPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				FileAssert.Exists (Path.Combine (androidBinDir, "classes.dex"));
@@ -1904,7 +1904,7 @@ namespace App1
 				var runtimeInfo = b.GetSupportedRuntimes ();
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var apkPath = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath,"android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var apk = ZipHelper.OpenZip (apkPath)) {
 					var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == supportedAbi && x.Runtime == expectedRuntime);
 					Assert.IsNotNull (runtime, "Could not find the expected runtime.");
@@ -1948,13 +1948,13 @@ namespace App1
 					Assert.Ignore ("Cross compiler was not available");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				var msymarchive = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + ".apk.mSYM");
 				using (var zipFile = ZipHelper.OpenZip (apk)) {
 					var mdbExits = ZipHelper.ReadFileFromZip (zipFile, "assemblies/UnnamedProject.dll.mdb") != null ||
 						ZipHelper.ReadFileFromZip (zipFile, "assemblies/UnnamedProject.pdb") != null;
 					Assert.AreEqual (embedMdb, mdbExits,
-						$"assemblies/UnnamedProject.dll.mdb or assemblies/UnnamedProject.pdb should{0}be in the {proj.PackageName}.apk", embedMdb ? " " : " not ");
+						$"assemblies/UnnamedProject.dll.mdb or assemblies/UnnamedProject.pdb should{0}be in the {proj.PackageName}-Signed.apk", embedMdb ? " " : " not ");
 					if (aotAssemblies) {
 						foreach (var abi in abis) {
 							var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
@@ -1973,10 +1973,10 @@ namespace App1
 							Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
 							Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 								string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
-								$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}.apk", abi);
+								$"lib/{0}/libaot-UnnamedProject.dll.so should be in the {proj.PackageName}-Signed.apk", abi);
 							Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 								"assemblies/UnnamedProject.dll"),
-								$"UnnamedProject.dll should be in the {proj.PackageName}.apk");
+								$"UnnamedProject.dll should be in the {proj.PackageName}-Signed.apk");
 						}
 					}
 					var runtimeInfo = b.GetSupportedRuntimes ();
@@ -2062,7 +2062,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 					using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName))) {
 						Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 						var apk = Path.Combine (Root, builder.ProjectDirectory,
-							proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+							proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+						FileAssert.Exists (apk);
 						Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "warning XA4301: APK already contains the item lib/armeabi-v7a/libRSSupport.so; ignoring."),
 							"warning about skipping libRSSupport.so should have been raised");
 						using (var zipFile = ZipHelper.OpenZip (apk)) {
@@ -2813,7 +2814,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "NetStandard16.pdb")),
 					"NetStandard16.pdb must be copied to Intermediate directory");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zipFile = ZipHelper.OpenZip (apk)) {
 					Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
 							"assemblies/NetStandard16.pdb"),
@@ -3969,7 +3970,7 @@ namespace UnnamedProject
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var archive = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.{packageFormat}");
+					proj.OutputPath, $"{proj.PackageName}.{packageFormat}");
 				var prefix = packageFormat == "apk" ? "" : "base/root/";
 				var expectedFiles = new [] {
 					prefix + "META-INF/maven/com.google.code.gson/gson/pom.xml",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -273,8 +273,14 @@ namespace Xamarin.Android.Build.Tests
 				$"{ProjectName}.dll",
 				"CommonSampleLibrary.dll",
 				$"{PackageName}-Signed.apk",
-				$"{PackageName}.apk",
 			};
+
+			if (!Builder.UseDotNet) {
+				produced_binaries.Add ($"{PackageName}.apk");
+			} else {
+				produced_binaries.Add ($"{PackageName}.aab");
+				produced_binaries.Add ($"{PackageName}-Signed.aab");
+			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -248,7 +248,8 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetProperty ("AndroidTlsProvider", androidTlsProvider);
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var intermediateOutputDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
-				var apk = Path.Combine (intermediateOutputDir, "android", "bin", $"{proj.PackageName}.apk");
+				var outpath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
+				var apk = Path.Combine (outpath, $"{proj.PackageName}-Signed.apk");
 				using (var zipFile = ZipHelper.OpenZip (apk)) {
 					foreach (var abi in supportedAbis) {
 						if (expected) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1271,7 +1271,7 @@ namespace Lib2
 				TextContent = () => text
 			});
 			using (var b = CreateApkBuilder ()) {
-				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				Assert.IsTrue (b.Build (proj), "first build should succeed");
 				AssertAssetContents (apk);
 
@@ -1312,7 +1312,7 @@ namespace Lib2
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "first build should succeed");
 
-				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ("assets/foo/bar.txt"), "bar.txt should exist in apk!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -537,7 +537,7 @@ namespace Bug12935
 				Assert.IsTrue (manifest.Contains (" android:label=\"val1\""), "#1");
 				Assert.IsTrue (manifest.Contains (" x=\"a=b\\c\"".Replace ('\\', Path.DirectorySeparatorChar)), "#2");
 				Assert.IsTrue (manifest.Contains ("package=\"com.foo.bar\""), "PackageName should have been replaced with 'com.foo.bar'");
-				var apk = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, $"com.foo.bar.apk");
+				var apk = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, $"com.foo.bar-Signed.apk");
 				FileAssert.Exists (apk, $"'{apk}' should have been created.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var existingFiles = zip.Where (a => a.FullName.StartsWith ("assemblies/", StringComparison.InvariantCultureIgnoreCase));
 					var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assemblies/" + Path.GetFileName (x)));
@@ -138,7 +138,7 @@ namespace Xamarin.Android.Build.Tests
 
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ("classes.dex"), "Apk should contain classes.dex");
 				}
@@ -161,7 +161,7 @@ namespace Xamarin.Android.Build.Tests
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				CompressionMethod method = compressNativeLibraries ? CompressionMethod.Deflate : CompressionMethod.Store;
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var libFiles = zip.Where (x => x.FullName.StartsWith("lib/") && !x.FullName.Equals("lib/", StringComparison.InvariantCultureIgnoreCase));
@@ -192,7 +192,7 @@ namespace Xamarin.Android.Build.Tests
 				AssertExtractNativeLibs (manifest, extractNativeLibs: false);
 
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				AssertEmbeddedDSOs (apk);
 
 				//Delete the apk & build again
@@ -241,7 +241,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
 
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-						proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					foreach (var entry in zip) {
@@ -698,7 +698,7 @@ namespace App1
 					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
 					Assert.IsTrue (ab.Build (app), "App should have built.");
 					var apk = Path.Combine (Root, ab.ProjectDirectory,
-						app.IntermediateOutputPath, "android", "bin", $"{app.PackageName}.apk");
+						app.OutputPath, $"{app.PackageName}-Signed.apk");
 					using (var zip = ZipHelper.OpenZip (apk)) {
 						var existingFiles = zip.Where (a => a.FullName.StartsWith ("assemblies/", StringComparison.InvariantCultureIgnoreCase));
 						var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assemblies/" + Path.GetFileName (x)));
@@ -808,7 +808,7 @@ namespace App1
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ("classes.dex"), "Apk should contain classes.dex");
 				}
@@ -845,7 +845,7 @@ namespace App1
 				Assert.IsTrue (appBuilder.Build (app), "App SignAndroidPackage should have succeeded.");
 
 				var apk = Path.Combine (Root, appBuilder.ProjectDirectory,
-					app.IntermediateOutputPath, "android", "bin", $"{app.PackageName}.apk");
+					app.OutputPath, $"{app.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ($"assemblies/es/{lib.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
 				}
@@ -874,7 +874,7 @@ namespace App1
 				Assert.IsTrue (b.Build (proj), "SignAndroidPackage should have succeeded.");
 
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll"), "Apk should contain satellite assemblies!");
 				}
@@ -924,8 +924,8 @@ public class Test
 				using (var b = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 					Assert.IsTrue (b.Build (app), "Build of jar should have succeeded.");
 					var jar = Builder.UseDotNet ? "2965D0C9A2D5DB1E.jar" : "test.jar";
-					string expected = $"Failed to add jar entry AndroidManifest.xml from {jar}: the same file already exists in the apk";
-					Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"AndroidManifest.xml for test.jar should have been ignored.");
+					string expected = $"Ignoring jar entry AndroidManifest.xml from {jar}: the same file already exists in the apk";
+					Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"AndroidManifest.xml for {jar} should have been ignored.");
 				}
 			}
 		}
@@ -947,7 +947,7 @@ public class Test
 
 				// All .so files should be compressed
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					foreach (var entry in zip) {
 						if (entry.FullName.EndsWith (".so")) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Android.Build.Tests
 			string assemblyName = proj.ProjectName;
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
-				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					Assert.IsTrue (zip.ContainsEntry ($"assemblies/{assemblyName}.dll"), $"{assemblyName}.dll should exist in apk!");
@@ -252,7 +252,7 @@ $@"<linker>
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded.");
 
-				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}.apk");
+				var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var entry = zip.ReadEntry ($"assemblies/{assembly_name}.dll");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -127,12 +127,15 @@ namespace Xamarin.ProjectTools
 			foreach (var dir in Directory.EnumerateDirectories (Path.Combine (sdkPath, "platforms"))) {
 				int version;
 				string v = Path.GetFileName (dir).Replace ("android-", "");
+				Console.WriteLine ($"GetMaxInstalledPlatform: Parsing {v}");
 				if (!int.TryParse (v, out version))
 					continue;
 				if (version < maxInstalled)
 					continue;
+				Console.WriteLine ($"GetMaxInstalledPlatform: Setting maxInstalled to {version}");
 				maxInstalled = version;
 			}
+			Console.WriteLine ($"GetMaxInstalledPlatform: Returning maxInstalled as {version}");
 			return maxInstalled ?? 0;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -135,7 +135,6 @@ namespace Xamarin.ProjectTools
 				Console.WriteLine ($"GetMaxInstalledPlatform: Setting maxInstalled to {version}");
 				maxInstalled = version;
 			}
-			Console.WriteLine ($"GetMaxInstalledPlatform: Returning maxInstalled as {version}");
 			return maxInstalled ?? 0;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -91,6 +91,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.PrepareAbiItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.WriteLockFile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="GenerateCompressedAssembliesNativeSourceFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.Unzip" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
 <!--
 *******************************************
@@ -261,6 +262,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>
+
+	<!-- Figure out which is the main packaging format we want-->
+	<AndroidPackageFormat Condition=" $(AndroidPackageFormats.Contains('aab')) And '$(AndroidPackageFormat)' == '' ">aab</AndroidPackageFormat>
+	<_AndroidAdditionalPackageFormats Condition=" $(AndroidPackageFormats.Contains('apk')) And '$(AndroidPackageFormat)' == 'aab' ">apk</_AndroidAdditionalPackageFormats>
 	<AndroidPackageFormat       Condition=" '$(AndroidPackageFormat)' == '' ">apk</AndroidPackageFormat>
 	<AndroidUseAapt2            Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</AndroidUseAapt2>
 	<AndroidUseApkSigner        Condition=" '$(AndroidPackageFormat)' == 'aab' ">False</AndroidUseApkSigner>
@@ -529,6 +534,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<_BaseZipIntermediate>$(IntermediateOutputPath)android\bin\base.zip</_BaseZipIntermediate>
 		<_AppBundleIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).aab</_AppBundleIntermediate>
 		<_ApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apks</_ApkSetIntermediate>
+		<_UniversalApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage)-Universal.apks</_UniversalApkSetIntermediate>
 		<ApkFile>$(OutDir)$(_AndroidPackage).apk</ApkFile>
 		<ApkFileSigned>$(OutDir)$(_AndroidPackage)-Signed.apk</ApkFileSigned>
 		<_AabFile>$(OutDir)$(_AndroidPackage).aab</_AabFile>
@@ -2291,11 +2297,47 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)" />
 </Target>
 
+<Target Name="_CreateUniversalApkFromBundle"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' And $(_AndroidAdditionalPackageFormats.Contains('apk')) "
+    Inputs="$(_AppBundleIntermediate)"
+    Outputs="$(OutDir)$(_AndroidPackage)-Signed.apk"
+  >
+  <!-- Delete the existing files or bundetool will fail. -->
+  <Delete Files="$(_UniversalApkSetIntermediate);$(OutDir)$(_AndroidPackage)*-Signed.apk" />
+  <BuildApkSet
+      ToolPath="$(JavaToolPath)"
+      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+      JavaOptions="$(JavaOptions)"
+      JarPath="$(AndroidBundleToolJarPath)"
+      AdbToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Aapt2ToolPath="$(Aapt2ToolPath)"
+      AppBundle="$(_AppBundleIntermediate)"
+      Output="$(_UniversalApkSetIntermediate)"
+      KeyStore="$(_ApkKeyStore)"
+      KeyAlias="$(_ApkKeyAlias)"
+      KeyPass="$(_ApkKeyPass)"
+      StorePass="$(_ApkStorePass)"
+      ExtraArgs="$(AndroidBundleToolExtraArgs)"
+      GenerateUniversalApkSet="True"
+  />
+  <!-- Extract the univeral.apk from the $(_UniversalApkSetIntermediate) to the output directory -->
+  <ItemGroup>
+    <_FilestoExtract Include="universal.apk" >
+      <DestinationFileName>$(_AndroidPackage)-Signed.apk</DestinationFileName>
+    </_FilestoExtract>
+    <FileWrites Include="$(_UniversalApkSetIntermediate)" />
+    <FileWrites Include="$(OutDir)$(_AndroidPackage)-Signed.apk" />
+  </ItemGroup>
+  <Unzip Sources="$(_UniversalApkSetIntermediate)" DestinationDirectories="$(OutDir)" Files="@(_FilestoExtract)" />
+</Target>
+
 <PropertyGroup>
   <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'True' ">
     Build;
     Package;
     _Sign;
+    _CreateUniversalApkFromBundle;
   </SignAndroidPackageDependsOn>
   <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
   <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'True' ">
@@ -2306,6 +2348,7 @@ because xbuild doesn't support framework reference assemblies.
     CreateSatelliteAssemblies;
     _CopyPackage;
     _Sign;
+    _CreateUniversalApkFromBundle;
   </SignAndroidPackageDependsOn>
 </PropertyGroup>
 <Target Name="SignAndroidPackage" DependsOnTargets="$(SignAndroidPackageDependsOn)">
@@ -2481,6 +2524,16 @@ because xbuild doesn't support framework reference assemblies.
       KeyPass="$(_ApkKeyPass)"
       StorePass="$(_ApkStorePass)"
       ExtraArgs="$(AndroidBundleToolExtraArgs)"
+      Condition="!Exists('$(_ApkSetIntermediate)')"
+  />
+  <PropertyGroup>
+    <_UninstallCommand>&quot;$(AdbToolPath)adb&quot; $(AdbTarget) uninstall -k &quot;$(_AndroidPackage)&quot;</_UninstallCommand>
+  </PropertyGroup>
+  <Exec
+      ContinueOnError="True"
+      Command="$(_UninstallCommand)"
+      ConsoleToMSBuild="True"
+      Condition=" '$(EmbedAssembliesIntoApk)' == 'true' "
   />
   <InstallApkSet
       ToolPath="$(JavaToolPath)"

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -15,6 +15,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidPackageFormat>apk</AndroidPackageFormat>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -316,7 +316,7 @@ namespace Xamarin.Android.Build.Tests
 			string aapt2 = Path.Combine (task.Aapt2ToolPath, task.Aapt2ToolExe);
 			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
 			string cmd = task.GetCommandLineBuilder ().ToString ();
-			Assert.AreEqual ($"build-apks --connected-device --bundle foo.aab --output foo.apks --mode default --adb \"{adb}\" --device-id emulator-5554 --aapt2 \"{aapt2}\" --ks foo.keystore --ks-key-alias alias --key-pass pass:keypass --ks-pass pass:storepass", cmd);
+			Assert.AreEqual ($"build-apks --connected-device --mode default --adb \"{adb}\" --device-id emulator-5554 --bundle foo.aab --output foo.apks --aapt2 \"{aapt2}\" --ks foo.keystore --ks-key-alias alias --key-pass pass:keypass --ks-pass pass:storepass", cmd);
 		}
 
 		[Test]

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -54,6 +54,10 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			}
 			proj.SetDefaultTargetDevice ();
+			if (Builder.UseDotNet && isRelease) {
+				// bundle tool does NOT support embeddedDex files it seems.
+				useEmbeddedDex = false;
+			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				SetTargetFrameworkAndManifest (proj, b);
 				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:extractNativeLibs=\"{extractNativeLibs.ToString ().ToLowerInvariant ()}\" android:useEmbeddedDex=\"{useEmbeddedDex.ToString ().ToLowerInvariant ()}\" ");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -133,6 +133,7 @@ namespace Xamarin.Android.Build.Tests
 			// Set debuggable=true to allow run-as command usage with a release build
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			proj.SetProperty ("AndroidPackageFormat", "apk");
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Build (proj));
 				Assert.IsTrue (builder.Install (proj));
@@ -180,6 +181,7 @@ namespace Xamarin.Android.Build.Tests
 			if (Builder.UseDotNet) {
 				// NOTE: in .NET 6, EmbedAssembliesIntoApk=true by default for Release builds
 				proj.SetProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk", "false");
+				proj.SetProperty (proj.ReleaseProperties, "AndroidPackageFormat", "apk");
 			} else {
 				proj.RemoveProperty (proj.ReleaseProperties, "EmbedAssembliesIntoApk");
 			}
@@ -191,7 +193,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (builder.Install (proj));
 				var runtimeInfo = builder.GetSupportedRuntimes ();
 				var apkPath = Path.Combine (Root, builder.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var apk = ZipHelper.OpenZip (apkPath)) {
 					foreach (var abi in abis) {
 						string runtimeAbiName;
@@ -346,6 +348,7 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { true,  true  , "apk"     , "True"         , "env:android",  "--ks test.keystore"     , true},
 			new object[] { true,  false , "apk"     , "True"         , "file:android", "--ks test.keystore"     , true},
 			new object[] { true,  true  , "apk"     , "True"         , "file:android", "--ks test.keystore"     , true},
+			new object[] { true,  true  , "apk"     , "True"         , "pass:android", "--ks test.keystore"     , true},
 			// dont use apksigner
 			new object[] { false, false , "apk"     , "False"        , "android",      "debug.keystore"         , true},
 			new object[] { false, true  , "apk"     , "False"        , "android",      "debug.keystore"         , true},
@@ -361,6 +364,7 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { true,  true  , "aab"     , "True"         , "android",      "-ks test.keystore"      , true},
 			new object[] { true,  true  , "aab"     , "True"         , "file:android", "-ks test.keystore"      , true},
 			new object[] { true,  true  , "aab"     , "True"         , "env:android",  "-ks test.keystore"      , false},
+			new object[] { true,  true  , "aab"     , "True"         , "pass:android", "-ks test.keystore"      , true},
 		};
 #pragma warning restore 414
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -266,7 +266,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Install (proj), "packaging should have succeeded. 0");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
-					proj.IntermediateOutputPath, "android", "bin", $"{proj.PackageName}.apk");
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				Assert.IsNull (ZipHelper.ReadFileFromZip (apk, "Mono.Android.typemap"), $"Mono.Android.typemap should NOT be in {apk}.");
 				var logLines = b.LastBuildOutput;
 				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_BuildApkFastDev\" completely.") ||


### PR DESCRIPTION
Fixes #6059

Users will probably want to target more than one App Store. Google is now requiring the `aab` format for 
Google Play Store uploads. Unfortunately this package format is not compatible with other stores. 
Users can build their app twice producing an `aab` for one build and `apk` for another, but we should
try to make this a bit easier. 

`bundle-tool` has the ability to create a universal apk from the `aab` file. So lets make use of that to 
generate one along side the `aab`. We are introducing a new property `AndroidPackageFormats`.
Under .net 6 this will have a value of `aab;apk` by default for Release builds, for Legacy it will be 
empty. 

If `AndroidPackageFormats` is specified and `AndroidPackageFormat` is empty we will use the 
values in `AndroidPackageFormats` to populate `AndroidPackageFormat`. If none of these values
are provided the `AndroidPackageFormat` will still default to `apk` as it has always done. 

The following setting will produce both an `aab` and an `apk`.
```
<PropertyGroup>
  <AndroidPackageFormats>aab;apk</AndroidPackageFormats>
</PropertyGroup>
```

This will produce just an `aab`

```
<PropertyGroup>
  <AndroidPackageFormats>aab</AndroidPackageFormats>
</PropertyGroup>
```

and this will produce just an `apk`

```
<PropertyGroup>
  <AndroidPackageFormats>apk</AndroidPackageFormats>
</PropertyGroup>
```

For .net 6 users this will be enabled by default for Release builds. For legacy users they will need
to define the property manually.  