### PR TITLE
Bump to JamesNK/Newtonsoft.Json@ae9fe44e [13.0.1]

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,7 @@
     <LibZipSharpVersion>2.0.0-alpha7</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
+    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
     <LZ4PackageVersion>1.1.11</LZ4PackageVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -531,7 +531,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 					},
 					new Package () {
 						Id = "Newtonsoft.Json",
-						Version = "10.0.3"
+						Version = "13.0.1"
 					},
 				},
 				OtherBuildItems = {
@@ -663,6 +663,7 @@ namespace App1
 				"Mono.Android.dll",
 				"mscorlib.dll",
 				"System.Core.dll",
+				"System.Data.dll",
 				"System.dll",
 				"System.Runtime.Serialization.dll",
 				"System.IO.Packaging.dll",
@@ -688,7 +689,6 @@ namespace App1
 				"System.Net.Http.dll",
 				"System.ServiceModel.Internals.dll",
 				"Newtonsoft.Json.dll",
-				"Microsoft.CSharp.dll",
 				"System.Numerics.dll",
 				"System.Xml.Linq.dll",
 			};

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" Version="1.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="NuGet.Common" Version="$(NuGetApiPackageVersion)" />
     <PackageReference Include="NuGet.Configuration" Version="$(NuGetApiPackageVersion)" />
     <PackageReference Include="NuGet.DependencyResolver.Core" Version="$(NuGetApiPackageVersion)" />

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -58,7 +58,7 @@
       <Name>Xamarin.Forms.Performance.Integration</Name>
       <Project>{195BE9C2-1F91-40DC-BD6D-DE860BF083FB}</Project>
     </ProjectReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Condition=" '$(BundleAssemblies)' == 'true' " Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Condition=" '$(BundleAssemblies)' != 'true' " Include="Xamarin.Forms" Version="4.5.0.617" />
   </ItemGroup>

--- a/tests/Xamarin.Forms-Performance-Integration/Xamarin.Forms.Performance.Integration.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Xamarin.Forms.Performance.Integration.csproj
@@ -8,7 +8,7 @@
     <Compile Remove="Droid\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Xam.Plugin.Connectivity" Version="3.2.0" />
     <PackageReference Condition=" '$(BundleAssemblies)' == 'true' " Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Condition=" '$(BundleAssemblies)' != 'true' " Include="Xamarin.Forms" Version="4.5.0.617" />


### PR DESCRIPTION
Changes: https://github.com/JamesNK/Newtonsoft.Json/compare/12.0.3...13.0.1

  * JamesNK/Newtonsoft.Json@ae9fe44e: Remove compiler package and update sourcelink (#2498)
  * JamesNK/Newtonsoft.Json@8ef66218: Remove prerelease for 13.0.1
  * JamesNK/Newtonsoft.Json@11331f50: Update SDK to 5.0.200 (#2495)
  * JamesNK/Newtonsoft.Json@c7e8abc0: Update to 13.0.1-beta2
  * JamesNK/Newtonsoft.Json@1745d7c1: Fix JTokenWriter when writing comment to an object (#2493)
  * JamesNK/Newtonsoft.Json@583eb120: Fix missing error when deserializing JToken with a contract type mismatch (#2494)
  * JamesNK/Newtonsoft.Json@b6dc05be: Change MaxDepth default to 64 (#2473)
  * JamesNK/Newtonsoft.Json@15525f1c: Fix JsonWriter.WriteToken to allow null with string token (#2472)
  * JamesNK/Newtonsoft.Json@926d2f0f: Enable embed untracked sources (#2471)
  * JamesNK/Newtonsoft.Json@0a56633b: Fixes #2372 - variable typos (#2465)
  * JamesNK/Newtonsoft.Json@5a35c77d: Update version to 13.0.1 (#2463)
  * JamesNK/Newtonsoft.Json@7e77bbe1: Change JsonReader and JsonSerializer default max depth to 128 (#2462)
  * JamesNK/Newtonsoft.Json@42139ea6: Add JsonSelectSettings and regex timeout
  * JamesNK/Newtonsoft.Json@95a6eb3a: jpath regex timeout support added for a single regex expression, global umbrella for all regex calls, and support for allowing regex calls to get compiled if necessary
  * JamesNK/Newtonsoft.Json@1403f5d3: Fix serializing nullable struct dictionaries (#2452)
  * JamesNK/Newtonsoft.Json@60be32f4: Use naming strategy when deserializing dictionary enum keys (#2448)
  * JamesNK/Newtonsoft.Json@ff5ffb28: Copy annotations when cloning elements (#2442)
  * JamesNK/Newtonsoft.Json@0cf47a46: Missing nullability annotation (#2438)
  * JamesNK/Newtonsoft.Json@6795ca55: Fixed tests to work in Moscow, Russia UTC+3 timezone. (#2416)
  * JamesNK/Newtonsoft.Json@c918ca86: Code Typo Fix: Universial => Universal (#2383)
  * JamesNK/Newtonsoft.Json@c298f3d6: Fix typo in SerializeTypeNameHandling sample (#2428)
  * JamesNK/Newtonsoft.Json@a222c8b6: Update to net50 and fix warnings (#2424)
  * JamesNK/Newtonsoft.Json@666d9760: Fix wrong define is used in StringUtils.ToLower() (#2304)
  * JamesNK/Newtonsoft.Json@a31156e9: Update NullValueHandlingIgnore.aml (#2226)
  * JamesNK/Newtonsoft.Json@936acbf6: Update version to 13.0.1-beta and remove portable builds (#2228)
  * JamesNK/Newtonsoft.Json@9be95e0f: Do not treat ignored field as missing member when deserializing from overriden json constructor (#2224)