### PR TITLE
[Xamarin.Android.Build.Tasks] .NET 6 builds fail on Apple M1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -386,6 +386,7 @@
     <Copy
         SourceFiles="@(_MonoUnixDylib)"
         DestinationFolder="$(OutputPath)"
+        Condition=" '$(HostOS)' != 'Darwin' "
     />
   </Target>
 


### PR DESCRIPTION
Fixes #6091

The code was executing the call to `lipo` to create the universal
binary. But then overwriting it with the 64 bit version later.
We should only do the Copy if we are not on MacOS.