### PR TITLE
Revert "[tests] try to use jdk 11 for device tests"

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1033,7 +1033,7 @@ stages:
     parameters:
       job_name: mac_msbuilddevice_tests
       job_suffix: Legacy
-      jdkTestFolder: $(XA.Jdk11.Folder)
+      jdkTestFolder: $(XA.Jdk8.Folder)
 
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
   - template: yaml-templates/run-msbuild-device-tests.yaml


### PR DESCRIPTION
This reverts commit d14f4a2349f6be660ab6a109a1065ffb08fb12dd.

Wanting to see the error we saw for: https://github.com/xamarin/xamarin-android/pull/6084

```
/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(1728,3):
error JAVAC0000: java.lang.AssertionError: annotationType() : unrecognized Attribute name MODULE (class com.sun.tools.javac.util.SharedNameTable$NameImpl)
```

What is the actual case this fails? Do we even need #6084?