### PR TITLE
[xaprepare] always delete ~/android-toolchain/dotnet

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -21,65 +21,8 @@ namespace Xamarin.Android.Prepare
 			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion);
 			var dotnetTestRuntimeVersion = Configurables.Defaults.DotNetTestRuntimeVersion;
 
-			// Delete any custom Microsoft.Android packs that may have been installed by test runs. Other ref/runtime packs will be ignored.
-			var packsPath = Path.Combine (dotnetPath, "packs");
-			if (Directory.Exists (packsPath)) {
-				foreach (var packToRemove in Directory.EnumerateDirectories (packsPath)) {
-					var info = new DirectoryInfo (packToRemove);
-					if (info.Name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
-						Log.StatusLine ($"Removing Android pack: {packToRemove}");
-						Utilities.DeleteDirectory (packToRemove);
-					}
-				}
-			}
-
-			// Delete Workload manifests, such as sdk-manifests/6.0.100/Microsoft.NET.Sdk.Android
-			var sdkManifestsPath = Path.Combine (dotnetPath, "sdk-manifests");
-			if (Directory.Exists (sdkManifestsPath)) {
-				foreach (var versionBand in Directory.EnumerateDirectories (sdkManifestsPath)) {
-					foreach (var workloadManifestDirectory in Directory.EnumerateDirectories (versionBand)) {
-						var info = new DirectoryInfo (workloadManifestDirectory);
-						if (info.Name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
-							Log.StatusLine ($"Removing Android manifest directory: {workloadManifestDirectory}");
-							Utilities.DeleteDirectory (workloadManifestDirectory);
-						}
-					}
-				}
-			}
-
-			// Delete any unnecessary SDKs if they exist.
-			var sdkPath = Path.Combine (dotnetPath, "sdk");
-			if (Directory.Exists (sdkPath)) {
-				foreach (var sdkToRemove in Directory.EnumerateDirectories (sdkPath).Where (s => new DirectoryInfo (s).Name != dotnetPreviewVersion)) {
-					Log.StatusLine ($"Removing out of date SDK: {sdkToRemove}");
-					Utilities.DeleteDirectory (sdkToRemove);
-				}
-			}
-
-			// Delete Android template-packs
-			var templatePacksPath = Path.Combine (dotnetPath, "template-packs");
-			if (Directory.Exists (templatePacksPath)) {
-				foreach (var templateToRemove in Directory.EnumerateFiles (templatePacksPath)) {
-					var name = Path.GetFileName (templateToRemove);
-					if (name.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1) {
-						Log.StatusLine ($"Removing Android template: {templateToRemove}");
-						Utilities.DeleteFile (templateToRemove);
-					}
-				}
-			}
-
-			// Delete the metadata folder, which contains old workload data
-			var metadataPath = Path.Combine (dotnetPath, "metadata");
-			if (Directory.Exists (metadataPath)) {
-				Utilities.DeleteDirectory (metadataPath);
-			}
-
-			if (File.Exists (dotnetTool)) {
-				if (!TestDotNetSdk (dotnetTool)) {
-					Log.WarningLine ($"Attempt to run `dotnet --version` failed, reinstalling the SDK.");
-					Utilities.DeleteDirectory (dotnetPath);
-				}
-			}
+			// Always delete the ~/android-toolchain/dotnet/ directory
+			Utilities.DeleteDirectory (dotnetPath);
 
 			if (!await InstallDotNetAsync (context, dotnetPath, dotnetPreviewVersion)) {
 				Log.ErrorLine ($"Installation of dotnet SDK {dotnetPreviewVersion} failed.");


### PR DESCRIPTION
I'm seeing failures on CI such as:

    C:\a\_work\2\s\build-tools\xaprepare\xaprepare\package-download.proj : warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. Inconsistency in workload manifest 'microsoft.net.workload.mono.toolchain': missing dependency 'Microsoft.NET.Workload.Emscripten'
    C:\Users\cloudtest\android-toolchain\dotnet\sdk\6.0.100-preview.7.21369.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.ImportWorkloads.props(14,3): warning MSB4242: The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed to run. Inconsistency in workload manifest 'microsoft.net.workload.mono.toolchain': missing dependency 'Microsoft.NET.Workload.Emscripten'
    C:\Users\cloudtest\android-toolchain\dotnet\sdk\6.0.100-preview.7.21369.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4236: The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found. [C:\a\_work\2\s\build-tools\xaprepare\xaprepare\package-download.proj]
    Error: dotnet restore C:\a\_work\2\s\build-tools\xaprepare\xaprepare\package-download.proj failed.
    Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
        at Xamarin.Android.Prepare.Scenario.<Run>d__26.MoveNext() in C:\a\_work\2\s\build-tools\xaprepare\xaprepare\Application\Scenario.cs:line 50
        --- End of stack trace from previous location where exception was thrown ---
        at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at Xamarin.Android.Prepare.Context.<Execute>d__210.MoveNext() in C:\a\_work\2\s\build-tools\xaprepare\xaprepare\Application\Context.cs:line 827
        --- End of stack trace from previous location where exception was thrown ---
        at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at Xamarin.Android.Prepare.App.<Run>d__3.MoveNext() in C:\a\_work\2\s\build-tools\xaprepare\xaprepare\Main.cs:line 171

I saw the same thing locally, and noticed this folder was out of date:

    ~/android-toolchain/dotnet/sdk-manifests/6.0.100/microsoft.net.workload.mono.toolchain

If we have an outdated `WorkloadManifest.json` or
`WorkloadManifest.targets`, the build can get in a state where this
step can't succeed.

I manually deleted this folder to solve the problem:

    ~/android-toolchain/dotnet/

Going forward, let's make the `Prepare` step do this every time. This
should simplify our .NET 6 provisioning & upgrade process.