### PR TITLE
[build] delete platform-31 folder on test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -171,6 +171,8 @@ stages:
 
     - template: yaml-templates\clean.yaml
 
+    - template: yaml-templates\delete-platform-31.yaml
+
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)
       displayName: set JI_JAVA_HOME
@@ -290,6 +292,8 @@ stages:
     - template: yaml-templates\kill-processes.yaml
 
     - template: yaml-templates\clean.yaml
+
+    - template: yaml-templates\delete-platform-31.yaml
 
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\$(XA.Jdk11.Folder)

--- a/build-tools/automation/yaml-templates/delete-platform-31.yaml
+++ b/build-tools/automation/yaml-templates/delete-platform-31.yaml
@@ -1,0 +1,10 @@
+# NOTE: temporary workaround to delete platform-31
+steps:
+
+- script: rm -rfv "$HOME/Library/Android/sdk/platforms/android-31"
+  displayName: delete API 31
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- script: if exist "%USERPROFILE%\android-toolchain\sdk\platforms\android-31" rmdir /s /q "%USERPROFILE%\android-toolchain\sdk\platforms\android-31"
+  displayName: delete API 31
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -19,6 +19,8 @@ steps:
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
+- template: delete-platform-31.yaml
+
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/Library/Android/${{ parameters.jdkTestFolder }}"
     echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]$HOME/Library/Android/dotnet/dotnet"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6089

We currently have lots of test failures due to the warning:

    warning XA1008: The TargetFrameworkVersion (Android API level 30) is lower than the targetSdkVersion (31). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.

Looking at `Properties\AndroidManifest.xml`, Xamarin.ProjectTools
generated:

    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="31" />

This appears to be due to the `GetMaxInstalledPlatform()` method:

https://github.com/xamarin/xamarin-android/blob/1b71da0cd3a44861b006ac41c77a24eedf066281/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs#L121-L138

I think what happened is:

* #6089 is opened, platform-31 gets installed on many of the CI
  machines.
* Future PRs install `platform-31` side-by-side `platform-S`.

And so we ended up with test failures...

To fix this for now, manually delete the `sdk/platform-31` folder on
test jobs.