### PR TITLE
[Mono.Android.Export] Fix DynamicDependency to JavaArray

### DIFF
--- a/src/Mono.Android.Export/CallbackCode.cs
+++ b/src/Mono.Android.Export/CallbackCode.cs
@@ -407,7 +407,7 @@ namespace Java.Interop
 		}
 	
 		// Ignore ToNative() overload that takes generic instancing mapping. The reflected method should have nothing to do with it.
-		[DynamicDependency ("ToLocalJniHandle", "Android.Runtime.JavaArray", "Mono.Android")]
+		[DynamicDependency ("ToLocalJniHandle", "Android.Runtime.JavaArray`1", "Mono.Android")]
 		[DynamicDependency ("ToLocalJniHandle", "Android.Runtime.JavaCollection", "Mono.Android")]
 		[DynamicDependency ("ToLocalJniHandle", "Android.Runtime.JavaCollection`1", "Mono.Android")]
 		[DynamicDependency ("ToLocalJniHandle", "Android.Runtime.JavaDictionary", "Mono.Android")]


### PR DESCRIPTION
For awhile, we've been observing ILLink warnings:

	ILLink warning IL2036: Java.Interop.DynamicInvokeTypeInfo.ToNative(CodeExpression): Unresolved type 'Android.Runtime.JavaArray' in DynamicDependencyAttribute

The cause is a "typo" in commit 15269f6f, which added the
`[DynamicDependency]` custom attributes to
`DynamicInvokeTypeInfo.ToNative()`: commit 15269f6f specified the
non-generic type `Android.Runtime.JavaArray`, which does not exist.

Fix the `[DynamicDependency]` custom attribute value to instead
mention ``Android.Runtime.JavaArray`1``, the type `JavaArray<T>`.
This should fix the IL2036 warning.