### PR TITLE
[One .NET] implement $(SupportedPlatformOSVersion) for minSdkVersion

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -15,5 +15,14 @@
   "primaryOutputs": [
     { "path": "AndroidBinding1.csproj" }
   ],
+  "symbols": {
+    "supportedOSVersion": {
+      "type": "parameter",
+      "description": "Overrides $(SupportedOSPlatformVersion) in the project",
+      "datatype": "string",
+      "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
+      "defaultValue": "21"
+    }
+  },
   "defaultName": "AndroidBinding1"
 }

--- a/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
+++ b/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>SUPPORTED_OS_PLATFORM_VERSION</SupportedOSPlatformVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidBinding1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -28,6 +28,13 @@
       "description": "Overrides the package name in the AndroidManifest.xml",
       "datatype": "string",
       "replaces": "com.companyname.AndroidApp1"
+    },
+    "supportedOSVersion": {
+      "type": "parameter",
+      "description": "Overrides $(SupportedOSPlatformVersion) in the project",
+      "datatype": "string",
+      "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
+      "defaultValue": "21"
     }
   },
   "defaultName": "AndroidApp1"

--- a/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>SUPPORTED_OS_PLATFORM_VERSION</SupportedOSPlatformVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidApp1</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/Microsoft.Android.Templates/android/AndroidManifest.xml
+++ b/src/Microsoft.Android.Templates/android/AndroidManifest.xml
@@ -3,7 +3,6 @@
           android:versionCode="1" 
           android:versionName="1.0" 
           package="com.companyname.AndroidApp1">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
   </application>
 </manifest>

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -15,5 +15,14 @@
   "primaryOutputs": [
     { "path": "AndroidLib1.csproj" }
   ],
+  "symbols": {
+    "supportedOSVersion": {
+      "type": "parameter",
+      "description": "Overrides $(SupportedOSPlatformVersion) in the project",
+      "datatype": "string",
+      "replaces": "SUPPORTED_OS_PLATFORM_VERSION",
+      "defaultValue": "21"
+    }
+  },
   "defaultName": "AndroidLib1"
 }

--- a/src/Microsoft.Android.Templates/androidlib/AndroidLib1.csproj
+++ b/src/Microsoft.Android.Templates/androidlib/AndroidLib1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>SUPPORTED_OS_PLATFORM_VERSION</SupportedOSPlatformVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidLib1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -99,6 +99,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
       AcwMapFile="$(_AcwMapFile)"
       SupportedAbis="$(_BuildTargetAbis)"
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       InstantRunEnabled="$(_InstantRunEnabled)">
   </GenerateJavaStubs>
   <ManifestMerger

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -23,6 +23,8 @@
     -->
     <_GetChildProjectCopyToPublishDirectoryItems>false</_GetChildProjectCopyToPublishDirectoryItems>
     <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' ">true</UseMonoRuntime>
+    <!-- $(SupportedOSPlatformVersion) must be '21.0', but we should support integer values like '21' -->
+    <SupportedOSPlatformVersion Condition=" '$(SupportedOSPlatformVersion)' != '' and !$(SupportedOSPlatformVersion.Contains('.')) ">$(SupportedOSPlatformVersion).0</SupportedOSPlatformVersion>
 
     <!-- Bindings properties -->
     <!-- jar2xml is not supported -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -263,7 +263,7 @@ namespace Xamarin.Android.Tasks
 			Directory.CreateDirectory (manifestDir);
 			manifestFile = Path.Combine (manifestDir, Path.GetFileName (ManifestFile));
 			ManifestDocument manifest = new ManifestDocument (ManifestFile);
-			manifest.SdkVersion = AndroidSdkPlatform;
+			manifest.TargetSdkVersion = AndroidSdkPlatform;
 			if (!string.IsNullOrEmpty (VersionCodePattern)) {
 				try {
 					manifest.CalculateVersionCode (currentAbi, VersionCodePattern, VersionCodeProperties);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Android.Tasks {
 			Directory.CreateDirectory (manifestDir);
 			string manifestFile = Path.Combine (manifestDir, Path.GetFileName (ManifestFile));
 			ManifestDocument manifest = new ManifestDocument (ManifestFile);
-			manifest.SdkVersion = AndroidSdkPlatform;
+			manifest.TargetSdkVersion = AndroidSdkPlatform;
 			if (!string.IsNullOrEmpty (VersionCodePattern)) {
 				try {
 					manifest.CalculateVersionCode (currentAbi, VersionCodePattern, VersionCodeProperties);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -82,6 +82,8 @@ namespace Xamarin.Android.Tasks
 
 		public string CheckedBuild { get; set; }
 
+		public string SupportedOSPlatformVersion { get; set; }
+
 		[Output]
 		public string [] GeneratedBinaryTypeMaps { get; set; }
 
@@ -259,6 +261,12 @@ namespace Xamarin.Android.Tasks
 					Log.LogCodedError ("XA4215", Properties.Resources.XA4215_Details, kvp.Key, typeName);
 			}
 
+			// NOTE: $(SupportedOSPlatformVersion) will potentially be 21.0
+			string minSdkVersion = null;
+			if (Version.TryParse (SupportedOSPlatformVersion, out var version)) {
+				minSdkVersion = version.Major.ToString ();
+			}
+
 			// Step 3 - Merge [Activity] and friends into AndroidManifest.xml
 			var manifest = new ManifestDocument (ManifestTemplate) {
 				PackageName = PackageName,
@@ -267,7 +275,8 @@ namespace Xamarin.Android.Tasks
 				Placeholders = ManifestPlaceholders,
 				Resolver = res,
 				SdkDir = AndroidSdkDir,
-				SdkVersion = AndroidSdkPlatform,
+				TargetSdkVersion = AndroidSdkPlatform,
+				MinSdkVersion = minSdkVersion,
 				Debug = Debug,
 				MultiDex = MultiDex,
 				NeedsInternet = NeedsInternet,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -17,6 +17,7 @@ namespace Xamarin.ProjectTools
 		public const string RuntimeIdentifier = "RuntimeIdentifier";
 		public const string RuntimeIdentifiers = "RuntimeIdentifiers";
 		public const string PublishTrimmed = "PublishTrimmed";
+		public const string SupportedOSPlatformVersion = "SupportedOSPlatformVersion";
 
 		public const string Deterministic = "Deterministic";
 		public const string BundleAssemblies = "BundleAssemblies";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -56,8 +56,7 @@ namespace Xamarin.ProjectTools
 		{
 			Sdk = "Microsoft.NET.Sdk";
 			TargetFramework = "net6.0-android";
-
-			TargetSdkVersion = AndroidSdkResolver.GetMaxInstalledPlatform ().ToString ();
+			SupportedOSPlatformVersion = "21";
 			PackageName = $"com.xamarin.{(packageName ?? ProjectName).ToLower ()}";
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
 			GlobalPackagesFolder = FileSystemUtils.FindNugetGlobalPackageFolder ();
@@ -89,34 +88,19 @@ namespace Xamarin.ProjectTools
 		public string AndroidManifest { get; set; } = default_android_manifest;
 
 		/// <summary>
-		/// Defaults to AndroidSdkResolver.GetMaxInstalledPlatform ()
+		/// Defaults to 21.0
 		/// </summary>
-		public string TargetSdkVersion { get; set; }
-
-		/// <summary>
-		/// Defaults to API 19
-		/// </summary>
-		public string MinSdkVersion { get; set; } = "19";
+		public string SupportedOSPlatformVersion {
+			get { return GetProperty (KnownProperties.SupportedOSPlatformVersion); }
+			set { SetProperty (KnownProperties.SupportedOSPlatformVersion, value); }
+		}
 
 		public virtual string ProcessManifestTemplate ()
 		{
-			var uses_sdk = new StringBuilder ("<uses-sdk ");
-			if (!string.IsNullOrEmpty (MinSdkVersion)) {
-				uses_sdk.Append ("android:minSdkVersion=\"");
-				uses_sdk.Append (MinSdkVersion);
-				uses_sdk.Append ("\" ");
-			}
-			if (!string.IsNullOrEmpty (TargetSdkVersion)) {
-				uses_sdk.Append ("android:targetSdkVersion=\"");
-				uses_sdk.Append (TargetSdkVersion);
-				uses_sdk.Append ("\" ");
-			}
-			uses_sdk.Append ("/>");
-
 			return AndroidManifest
 				.Replace ("${PROJECT_NAME}", ProjectName)
 				.Replace ("${PACKAGENAME}", PackageName)
-				.Replace ("${USES_SDK}", uses_sdk.ToString ());
+				.Replace ("${USES_SDK}", "");
 		}
 
 		public override string ProcessSourceTemplate (string source)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1449,6 +1449,7 @@ because xbuild doesn't support framework reference assemblies.
       FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
       AcwMapFile="$(_AcwMapFile)"
       SupportedAbis="@(_BuildTargetAbis)"
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       SkipJniAddNativeMethodRegistrationAttributeScan="$(_SkipJniAddNativeMethodRegistrationAttributeScan)"
       CheckedBuild="$(_AndroidCheckedBuild)">
     <Output TaskParameter="GeneratedBinaryTypeMaps" ItemName="_AndroidTypeMapping" Condition=" '$(_InstantRunEnabled)' == 'True' " />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6107#issuecomment-884391615

In .NET 6, we are wanting `AndroidManifest.xml` in project templates
to no longer contain:

    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />

This is because we can define these values such as:

    <TargetFramework>net6.0-android30</TargetFramework>
    <SupportedPlatformOSVersion>21.0</SupportedPlatformOSVersion>

There is not really a reason to put this information in two places.
`$(SupportedPlatformOSVersion)` is also required for enabling C#
compiler warnings such as:

    MainActivity.cs(28,4): warning CA1416: This call site is reachable on: 'Android' 21.0 and later. 'View.AccessibilityTraversalAfter.get' is only supported on: 'android' 22.0 and later.

This is an example of calling an API from 22, with a
`$(SupportedPlatformOSVersion)` for 21.

If `<uses-sdk/>` is still *used* in `AndroidManifest.xml` in a
project, it will be preferred as the final source of truth.

One other improvement is that `$(SupportedPlatformOSVersion)` is
expected to include `.0`, or you get the warning:

    UnnamedProject.AssemblyInfo.cs(21,12): warning CA1418: Version '21' is not valid for platform 'Android'. Use a version with 2-4 parts for this platform.

Android unique in that this value is always an integer. In order for
users to be able to specify `21`, I added a check in
`Microsoft.Android.Sdk.DefaultProperties.targets` so that we append
`.0` when needed.

I added some tests around this scenario.