### PR TITLE
[xaprepare] don't install microsoft-net-runtime-android workload

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -51,12 +51,6 @@ namespace Xamarin.Android.Prepare
 				Utilities.CopyFileToDir (file, destination);
 			}
 
-			// Install the microsoft-net-runtime-android workload
-			if (!Utilities.RunCommand (dotnetTool, BuildPaths.XamarinAndroidSourceRoot, ignoreEmptyArguments: false, new [] { "workload", "install", "microsoft-net-runtime-android", "--skip-manifest-update", "--verbosity", "diag" })) {
-				Log.ErrorLine ($"dotnet workload install failed.");
-				return false;
-			}
-
 			return true;
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6112#pullrequestreview-712229556

The .NET Preview 7 bump is failing with:

    Running: /Users/builder/Library/Android/dotnet/dotnet "workload" "install" "microsoft-net-runtime-android" "--skip-manifest-update" "--verbosity" "diag"
    stderr | Workload with id microsoft-net-runtime-android is not recognized.

However, it was a bug in the `dotnet workload install` command that we
were even able to install this workload in the first place! The
concept behind "abstract" workloads is they are not user visible in
any way. They're meant to be an implementation detail.

In 0150bbbc, I setup `xaprepare` to install
`microsoft-net-runtime-android`, but we don't actually even need to do
this. We can simply update the `sdk-manifest` for this pack, so the
version matches `$(DotNetRuntimePacksVersion)`.

`microsoft-net-runtime-android` will get installed later during the
`ExtractWorkloadPacks` target:

https://github.com/xamarin/xamarin-android/blob/c1a2ee70214e86757541b5759c9ed54941bd4680/build-tools/create-packs/Directory.Build.targets#L119-L122

Since `android` and `android-aot` extend
`microsoft-net-runtime-android`, this step will install it.