### PR TITLE
[tests] we don't need to check if Clean deletes directories

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -97,13 +97,6 @@ namespace Xamarin.Android.Build.Tests
 				};
 				var files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
 					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
-				var directories = Directory.GetDirectories (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
-					// designtime folder is left behind, so Intellisense continues to work after a Clean
-					.Where (x => Path.GetFileName (x) != "designtime")
-					// .NET 5+ sets $(ProduceReferenceAssembly) by default
-					// https://github.com/dotnet/sdk/blob/18ee4eac8b3abe6d554d2e0c39d8952da0f23ce5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L242-L244
-					.Where (x => Path.GetFileName (x) != "ref");
-				CollectionAssert.IsEmpty (directories, $"{proj.IntermediateOutputPath} should have no directories.");
 				CollectionAssert.IsEmpty (files, $"{proj.IntermediateOutputPath} should have no files.");
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6112

The .NET 6 Preview 7 bump had a test failure:

    CleanBasicBindingLibrary("class-parse")
    obj/Release should have no directories.
    Expected: <empty>
    But was:  < "/Users/runner/work/1/s/bin/TestRelease/temp/CleanBasicBindingLibraryclass-parse/obj/Release/refint" >

`refint` is a new directory, see:

* https://github.com/dotnet/sdk/pull/19114/commits/e424c0eae2dcbdb71ff60014c6bdad82ddb3175d
* https://github.com/dotnet/msbuild/blob/9e576281e638d60701ca34411e2483bed01e35c7/src/Tasks/Microsoft.Common.CurrentVersion.targets#L397

Clean doesn't actually delete directories, no need to test for this.

The test already is checking if any files exist, and that should be
sufficient.