### PR TITLE
[macOS] Do not pin mingw version

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -28,8 +28,6 @@ namespace Xamarin.Android.Prepare
 
 		static readonly HomebrewProgram mingw = new HomebrewProgram ("mingw-w64") {
 			MinimumVersion = "7.0.0_2",
-			MaximumVersion = "7.0.0_3",
-			Pin = true,
 		};
 
 		protected override void InitializeDependencies ()


### PR DESCRIPTION
Homebrew allows pinning of a package to a specific version of it, but
the solution is far from perfect for us.  The problem is that if you
updated your mingw version to any version other than we require,
`xaprepare` will detect it and will try to install version of the
package that we need, but if it's older than the current version, we'll
get the latest version installed anyway since there's no direct way of
specifying a package/formula version.

Instead of trying o work around the issue, let's always install the
latest version of mingw (currently 9.0.0).