### PR TITLE
[CI] Remove temporary .NET 6 installer jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1250,11 +1250,11 @@ stages:
 
     - template: yaml-templates/fail-on-issue.yaml
 
-- stage: dotnet_installers
-  displayName: .NET 6 Preview Installers
+- stage: dotnet_prepare_release
+  displayName: .NET 6 Prepare Release
   dependsOn: mac_build
   jobs:
-  # Check - "Xamarin.Android (.NET 6 Preview Installers Sign NuGets)"
+  # Check - "Xamarin.Android (.NET 6 Prepare Release Sign NuGets)"
   - template: sign-artifacts/jobs/v2.yml@yaml
     parameters:
       artifactName: $(NuGetArtifactName)
@@ -1262,7 +1262,7 @@ stages:
       usePipelineArtifactTasks: true
       condition: eq(variables['MicroBuildSignType'], 'Real')
 
-  # Check - "Xamarin.Android (.NET 6 Preview Installers Convert NuGet to MSI)"
+  # Check - "Xamarin.Android (.NET 6 Prepare Release Convert NuGet to MSI)"
   - template: nuget-msi-convert/job/v2.yml@yaml
     parameters:
       yamlResourceName: yaml
@@ -1274,178 +1274,34 @@ stages:
       signType: $(MicroBuildSignType)
       condition: eq(variables['MicroBuildSignType'], 'Real')
 
-  # Check - "Xamarin.Android (.NET 6 Preview Installers Create .pkg)"
-  - job: dotnet_create_pkg
-    displayName: Create .pkg
-    ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-      dependsOn: signing
-    pool:
-      name: $(VSEngMacBuildPool)
-      demands:
-      - agent.osversionfamily -equals 10.15
-    timeoutInMinutes: 120
-    workspace:
-      clean: all
-    steps:
-    - template: yaml-templates/setup-test-environment.yaml
-      parameters:
-        xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
-
-    - checkout: release_scripts
-      clean: true
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: nuget-signed
-        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: $(NuGetArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
-
-    - task: NuGetCommand@2
-      displayName: push nupkgs
-      inputs:
-        command: push
-        packagesToPush: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/*.nupkg
-        nuGetFeedType: external
-        publishFeedCredentials: xamarin-impl public feed
-      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
-
-    - template: yaml-templates/install-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - task: MSBuild@1
-      displayName: msbuild Xamarin.Android.BootstrapTasks
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/Xamarin.Android.BootstrapTasks.sln
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/msbuild-bootstraptasks.binlog
-
-    - task: MSBuild@1
-      displayName: msbuild /t:Restore create-dotnet-pkg.proj
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-dotnet-pkg/create-dotnet-pkg.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:Restore /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/restore-create-pkg.binlog
-
-    - task: DotNetCoreCLI@2
-      displayName: create workload .pkg installer
-      inputs:
-        projects: $(System.DefaultWorkingDirectory)/xamarin-android/Xamarin.Android.sln
-        arguments: >-
-          -t:CreateWorkloadInstallers -c $(XA.Build.Configuration) -v:n
-          -p:SignType=$(MicroBuildSignType) -p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
-          -bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/msbuild-workload.binlog
-
-    - powershell: |
-        $pkg = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/*" -Include *.pkg -File
-        if (![System.IO.File]::Exists($pkg)) {
-            throw [System.IO.FileNotFoundException] "Pkg File not found in $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)"
-        }
-        Write-Host "##vso[task.setvariable variable=XA.NET6.Pkg]$pkg"
-      displayName: set variable to pkg path
-
-    - script: >
-        cd $(System.DefaultWorkingDirectory)/release-scripts &&
-        pwsh notarize.ps1 -FolderForApps $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)
-      failOnStderr: true
-      displayName: Notarize PKG
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - script: xcrun stapler validate $(XA.NET6.Pkg)
-      displayName: validate notarized pkg
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload pkg
-      inputs:
-        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: net6-pkg-signed
-        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: net6-pkg-unsigned
-        targetPath: $(XA.NET6.Pkg)
-
-    - template: yaml-templates/remove-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-        artifactName: Build Results - .NET 6 Preview .pkg
-
-  # Check - "Xamarin.Android (.NET 6 Preview Installers Create .msi and Upload)"
-  - job: dotnet_create_msi
-    displayName: Create .msi and Upload
-    dependsOn: dotnet_create_pkg
+ # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
+  - job: push_signed_nugets
+    displayName: Push NuGets
+    dependsOn: signing
+    condition: and(eq(dependencies.signing.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+    timeoutInMinutes: 60
     pool: VSEngSS-MicroBuild2019
-    timeoutInMinutes: 120
     workspace:
       clean: all
     variables:
     - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
       - group: Publish-Build-Assets
     steps:
-    - template: yaml-templates/setup-test-environment.yaml
-      parameters:
-        configuration: $(XA.Build.Configuration)
+    - checkout: self
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: nuget-signed
-        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: $(NuGetArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\$(NuGetArtifactName)
+        artifactName: nuget-signed
+        downloadPath: $(System.DefaultWorkingDirectory)\nuget-signed
 
-    - task: DownloadPipelineArtifact@2
+    - task: NuGetCommand@2
+      displayName: push nupkgs
       inputs:
-        ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: net6-pkg-signed
-        ${{ if ne(variables['MicroBuildSignType'], 'Real') }}:
-          artifactName: net6-pkg-unsigned
-        downloadPath: $(System.DefaultWorkingDirectory)\installer-artifacts
-        patterns: Microsoft.*.pkg
-
-    - template: yaml-templates\install-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - task: MSBuild@1
-      displayName: msbuild Xamarin.Android.BootstrapTasks
-      inputs:
-        solution: Xamarin.Android.BootstrapTasks.sln
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-bootstraptasks.binlog
-
-    - task: MSBuild@1
-      displayName: msbuild /t:Restore create-dotnet-msi.csproj
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)\build-tools\create-dotnet-msi\create-dotnet-msi.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:Restore /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\restore-create-msi.binlog
-
-    - task: MSBuild@1
-      displayName: msbuild /t:CreateWorkloadInstallers
-      inputs:
-        solution: Xamarin.Android.sln
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:CreateWorkloadInstallers /p:SignType=$(MicroBuildSignType) /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-workload.binlog
-
-    - script: copy /Y $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\*.msi $(System.DefaultWorkingDirectory)\installer-artifacts
-      displayName: copy .msi
-
-    - template: upload-to-storage\win\v1.yml@yaml
-      parameters:
-        ArtifactsDirectory: $(System.DefaultWorkingDirectory)\installer-artifacts
-        Azure.ContainerName: $(Azure.Container.Name)
-        Azure.BlobPrefix: $(Build.DefinitionName)/public/net6/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
-        GitHub.Context: .NET 6 Preview Installers
-
-    - template: yaml-templates\remove-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
+        command: push
+        packagesToPush: $(System.DefaultWorkingDirectory)\nuget-signed\*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: xamarin-impl public feed
+      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
     - powershell: >-
         & dotnet build -v:n -c $(XA.Build.Configuration)
@@ -1454,7 +1310,7 @@ stages:
         $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
         -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
       displayName: generate and publish BAR manifest
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      condition: eq(variables['PushXAPackageInfoToMaestro'], 'true')
 
     - powershell: |
         $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
@@ -1463,19 +1319,14 @@ stages:
         & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
         & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
       displayName: add build to default darc channel
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - template: yaml-templates/upload-results.yaml
-      parameters:
-        solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
-        artifactName: Build Results - .NET 6 Preview .msi
+      condition: eq(variables['PushXAPackageInfoToMaestro'], 'true')
 
 # .NET 6 VS Insertion Stage
 # Check - "Xamarin.Android (VS Insertion - Wait For Approval)"
 # Check - "Xamarin.Android (VS Insertion - Create VS Drop and Open PR)"
 - template: vs-insertion/stage/v1.yml@yaml
   parameters:
-    dependsOn: dotnet_installers
+    dependsOn: dotnet_prepare_release
     condition: eq(variables['MicroBuildSignType'], 'Real')
 
 - stage: finalize_installers


### PR DESCRIPTION
With `dotnet workload install` and the soon to come Visual Studio based
acqusition paths, we should no longer need the .pkg and .msi installers
for our .NET 6 content.  Signing and notarization for these installers
takes a decent amount of time in our official build pipeline.  We can
save some turnaround time by removing these jobs as they should no
longer be needed.  The source used to create these installers is not
being removed in case it's ever needed in the future.