### PR TITLE
Bump to r8 2.2.64

### DIFF
--- a/Documentation/release-notes/r8-2.2.64.md
+++ b/Documentation/release-notes/r8-2.2.64.md
@@ -1,0 +1,4 @@
+### D8/R8 version update to 2.2.64
+
+The version of the [D8 dexer and R8 shrinker](https://r8.googlesource.com/r8)
+included in Xamarin.Android has been updated from 2.1.75 to 2.2.64.

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '2.1.75'
+    compile group: 'com.android.tools', name: 'r8', version: '2.2.64'
 }
 
 jar {


### PR DESCRIPTION
Context: https://r8.googlesource.com/r8/+/refs/tags/2.2.64
Context: https://mvnrepository.com/artifact/com.android.tools/r8/2.2.64

Bump from r8 2.1.75 to 2.2.64.