### PR TITLE
[CI] Fix maestro manifest file generation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1318,6 +1318,7 @@ stages:
         & dotnet build -v:n -c $(XA.Build.Configuration)
         -t:PushManifestToBuildAssetRegistry
         -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+        -p:OutputPath=$(System.DefaultWorkingDirectory)\nuget-signed\
         $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
         -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
       displayName: generate and publish BAR manifest


### PR DESCRIPTION
Commit 810c9170 was not tested well enough, and attempting to push pack
info to Maestro has been failing:

    C:\a\1\s\build-tools\create-packs\Directory.Build.targets(150,5): error : No packages to create manifest from. [C:\a\1\s\build-tools\create-packs\Microsoft.Android.Sdk.proj]

Fix this by correctly setting the `$(OutputPath)` for this target to
find the signed .nupkg files that were previously downloaded.