### PR TITLE
[One .NET] add missing API documentation

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -39,6 +39,12 @@ by projects that use the Microsoft.Android framework in .NET 5.
 
     <ItemGroup>
       <_PackageFiles Include="@(_AndroidRefPackAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(_MonoAndroidNETOutputDir)Java.Interop.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles
+          Condition=" '$(CONVERT_JAVADOC_TO_XMLDOC)' == 'true' "
+          Include="$(_MonoAndroidNETOutputDir)Mono.Android.xml"
+          PackagePath="$(_AndroidRefPackAssemblyPath)"
+      />
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)AndroidApiInfo.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IncludeAndroidJavadoc Condition=" '$(IncludeAndroidJavadoc)' == '' And '$(CONVERT_JAVADOC_TO_XMLDOC)' == 'true' And '$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)'">True</IncludeAndroidJavadoc>
+    <IncludeAndroidJavadoc Condition=" '$(IncludeAndroidJavadoc)' == '' And '$(CONVERT_JAVADOC_TO_XMLDOC)' == 'true' And ('$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)' or '$(TargetFramework)' != 'monoandroid10')">True</IncludeAndroidJavadoc>
     <AndroidJavadocVerbosity Condition=" '$(AndroidJavadocVerbosity)' == '' ">intellisense</AndroidJavadocVerbosity>
   </PropertyGroup>
 
@@ -93,7 +93,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
     <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml">
       <LogicalName>ILLink.LinkAttributes.xml</LogicalName>


### PR DESCRIPTION
Right now in .NET 6, you don't get any `<summary>` documentation on
Android APIs.

This adds files like `Mono.Android.xml` and `Java.Interop.xml` to the
Microsoft.Android.Ref pack to solve this issue.

I also fixed a place in `Mono.Android.csproj` that used `net6.0`, so
this will continue to work in a future .NET 7.