### PR TITLE
[One .NET] support $(EnableLLVM) with AOT

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -49,7 +49,7 @@ variables:
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
   IsMonoBranch: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != LLVM & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
+  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
   NUnit.NumberOfTestWorkers: 4
   GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
   CONVERT_JAVADOC_TO_XMLDOC: $[ne(variables['Build.DefinitionName'], 'Xamarin.Android-PR')]
@@ -807,6 +807,17 @@ stages:
         extraBuildArgs: /p:TestsFlavor=Aot /p:RunAOTCompilation=true
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
         artifactFolder: net6-aot
+        useDotNet: true
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        testName: Mono.Android.NET_Tests-AotLlvm
+        project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)AotLlvm.xml
+        extraBuildArgs: /p:TestsFlavor=AotLlvm /p:RunAOTCompilation=true /p:EnableLlvm=true
+        artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.apk
+        artifactFolder: net6-aotllvm
         useDotNet: true
 
     - task: MSBuild@1

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -54,17 +54,26 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         AotOutputDirectory="$(_AndroidAotBinDirectory)"
         RuntimeIdentifier="$(RuntimeIdentifier)"
         EnableLLVM="$(EnableLLVM)"
+        UsingAndroidNETSdk="true"
         Profiles="@(_AotProfiles)">
       <Output PropertyName="_AotArguments" TaskParameter="Arguments" />
-      <Output PropertyName="_LLVMPath" TaskParameter="LLVMPath" />
+      <Output PropertyName="_AotOutputDirectory" TaskParameter="OutputDirectory" />
     </GetAotArguments>
+    <PropertyGroup>
+      <_MonoAOTCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', '$(RuntimeIdentifier)'))</_MonoAOTCompilerPath>
+      <_LLVMPath Condition=" '$(EnableLLVM)' == 'true' ">$([System.IO.Path]::GetDirectoryName ('$(_MonoAOTCompilerPath)'))</_LLVMPath>
+    </PropertyGroup>
     <ItemGroup>
-      <_MonoAOTAssemblies Include="@(_AndroidAotInputs->'%(FullPath)')" AotArguments="$(_AotArguments)" />
+      <_MonoAOTAssemblies
+          Include="@(_AndroidAotInputs->'%(FullPath)')"
+          TempDirectory="$([MSBuild]::EnsureTrailingSlash($(_AotOutputDirectory)))%(FileName)"
+          AotArguments="$(_AotArguments),temp-path=$([System.IO.Path]::GetFullPath(%(_MonoAOTAssemblies.TempDirectory)))"
+      />
     </ItemGroup>
-    <MakeDir Directories="$(IntermediateOutputPath)aot\" />
+    <MakeDir Directories="$(IntermediateOutputPath)aot\;@(_MonoAOTAssemblies->'%(TempDirectory)')" />
     <MonoAOTCompiler
         Assemblies="@(_MonoAOTAssemblies)"
-        CompilerBinaryPath="@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', '$(RuntimeIdentifier)'))"
+        CompilerBinaryPath="$(_MonoAOTCompilerPath)"
         DisableParallelAot="$(_DisableParallelAot)"
         LibraryFormat="So"
         Mode="$(AndroidAotMode)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -26,6 +26,10 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (!IsWindows)
 				return;
+			// Use standard NDK directory for now
+			// See: https://github.com/dotnet/runtime/issues/56163
+			if (Builder.UseDotNet)
+				return;
 
 			var sdkPath = AndroidSdkPath;
 			var ndkPath = AndroidNdkPath;
@@ -44,6 +48,10 @@ namespace Xamarin.Android.Build.Tests
 		public void TearDown ()
 		{
 			if (!IsWindows)
+				return;
+			// Use standard NDK directory for now
+			// See: https://github.com/dotnet/runtime/issues/56163
+			if (Builder.UseDotNet)
 				return;
 			Environment.SetEnvironmentVariable ("TEST_ANDROID_SDK_PATH", "");
 			Environment.SetEnvironmentVariable ("TEST_ANDROID_NDK_PATH", "");
@@ -150,8 +158,6 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("DotNetIgnore")] // Not currently working, see: https://github.com/dotnet/runtime/issues/56163
 		public void BuildAotApplicationAndÜmläüts (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
-			AssertLLVMSupported (enableLLVM);
-
 			var path = Path.Combine ("temp", string.Format ("BuildAotApplication AndÜmläüts_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -230,8 +236,6 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("DotNetIgnore")] // Not currently working, see: https://github.com/dotnet/runtime/issues/56163
 		public void BuildAotApplicationAndBundleAndÜmläüts (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
-			AssertLLVMSupported (enableLLVM);
-
 			var path = Path.Combine ("temp", string.Format ("BuildAotApplicationAndBundle AndÜmläüts_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -205,13 +205,6 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		protected static void AssertLLVMSupported (bool llvm)
-		{
-			if (Builder.UseDotNet && llvm) {
-				Assert.Ignore ($"EnableLLVM={llvm} is not yet supported in .NET 6+");
-			}
-		}
-
 		protected static void AssertTargetFrameworkVersionSupported (string targetFrameworkVersion)
 		{
 			if (Builder.UseDotNet)


### PR DESCRIPTION
Fixed some issues that allows `$(EnableLLVM)` to work:

* `$(_LLVMPath)` needs to point to Mono's AOT pack that contains `opt`
  and `llc`.
* We need to fill out `ld-name` and `ld-flags`.
* `ld-flags` needs some special workarounds in order for them to be
  passed in correctly on .NET 6.
    * Use space as a delimiter
    * Escape spaces in paths
* Added `temp-path` parameter. This prevents the warning on Windows:

```
'rm' is not recognized as an internal or external command
```

I enabled tests around .NET 6 and LLVM.

## Results ##

All tests:

 1. Were running on a [Google Pixel 5][0], and
 2. Enabled two architectures, arm64 and x86, and
 3. **AOT time** was average of 10 runs with `-c Release
    -p:RunAOTCompilation=true`, with the `Activity: Displayed` time
 4. **AOT+LLVM time** was average of 10 runs with `-c Release
    -p:RunAOTCompilation=true -p:EnableLLVM=true` with the
    `Activity: Displayed` time.

| Test                |      AOT time | AOT+LLVM time |  AOT apk size |  AOT+LLVM apk size |
| ------------------- | ------------: | ------------: | ------------: | -----------------: |
| [HelloAndroid][1]   |  00:00:00.238 |  00:00:00.226 |    12,073,931 |         12,602,315 |
| [HelloMaui][2]      |  00:00:00.624 |  00:00:00.596 |    43,167,801 |         47,546,425 |

[0]: https://store.google.com/us/product/pixel_5_specs?hl=en-US
[1]: https://github.com/dotnet/maui-samples/tree/714460431541f40570e91225e8ba4bc1fe08025f/HelloAndroid
[2]: https://github.com/dotnet/maui-samples/tree/714460431541f40570e91225e8ba4bc1fe08025f/HelloMaui