### PR TITLE
Use more standard C++ features + performance improvements

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] ResolvedUserAssemblies { get; set; }
 
+		public ITaskItem[] SatelliteAssemblies { get; set; }
+
 		[Required]
 		public string OutputDirectory { get; set; }
 
@@ -264,6 +266,11 @@ namespace Xamarin.Android.Tasks
 				throw new InvalidOperationException ($"Unsupported BoundExceptionType value '{BoundExceptionType}'");
 			}
 
+			int assemblyCount = ResolvedAssemblies.Length;
+			if (SatelliteAssemblies != null) {
+				assemblyCount += SatelliteAssemblies.Length;
+			}
+
 			bool haveRuntimeConfigBlob = !String.IsNullOrEmpty (RuntimeConfigBinFilePath) && File.Exists (RuntimeConfigBinFilePath);
 			var appConfState = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ApplicationConfigTaskState> (ApplicationConfigTaskState.RegisterTaskObjectKey, RegisteredTaskObjectLifetime.Build);
 			foreach (string abi in SupportedAbis) {
@@ -284,6 +291,7 @@ namespace Xamarin.Android.Tasks
 					InstantRunEnabled = InstantRunEnabled,
 					JniAddNativeMethodRegistrationAttributePresent = appConfState != null ? appConfState.JniAddNativeMethodRegistrationAttributePresent : false,
 					HaveRuntimeConfigBlob = haveRuntimeConfigBlob,
+					NumberOfAssembliesInApk = assemblyCount,
 				};
 
 				using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -30,9 +30,10 @@ namespace Xamarin.Android.Build.Tests
 			public uint   package_naming_policy;
 			public uint   environment_variable_count;
 			public uint   system_property_count;
+			public uint   number_of_assemblies_in_apk;
 			public string android_package_name;
 		};
-		const uint ApplicationConfigFieldCount = 13;
+		const uint ApplicationConfigFieldCount = 14;
 
 		static readonly object ndkInitLock = new object ();
 		static readonly char[] readElfFieldSeparator = new [] { ' ', '\t' };
@@ -176,7 +177,12 @@ namespace Xamarin.Android.Build.Tests
 						ret.system_property_count = ConvertFieldToUInt32 ("system_property_count", envFile, i, field [1]);
 						break;
 
-					case 12: // android_package_name: string / [pointer type]
+					case 12: // number_of_assemblies_in_apk: uint32_t / .word | .long
+						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile}:{i}': {field [0]}");
+						ret.number_of_assemblies_in_apk = ConvertFieldToUInt32 ("number_of_assemblies_in_apk", envFile, i, field [1]);
+						break;
+
+					case 13: // android_package_name: string / [pointer type]
 						Assert.IsTrue (expectedPointerTypes.Contains (field [0]), $"Unexpected pointer field type in '{envFile}:{i}': {field [0]}");
 						pointers.Add (field [1].Trim ());
 						break;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.Tasks
 		public bool InstantRunEnabled { get; set; }
 		public bool JniAddNativeMethodRegistrationAttributePresent { get; set; }
 		public bool HaveRuntimeConfigBlob { get; set; }
+		public int NumberOfAssembliesInApk { get; set; }
 
 		public PackageNamingPolicy PackageNamingPolicy { get; set; }
 
@@ -85,6 +86,9 @@ namespace Xamarin.Android.Tasks
 
 				WriteCommentLine (output, "system_property_count");
 				size += WriteData (output, systemProperties == null ? 0 : systemProperties.Count * 2);
+
+				WriteCommentLine (output, "number_of_assemblies_in_apk");
+				size += WriteData (output, NumberOfAssembliesInApk);
 
 				WriteCommentLine (output, "android_package_name");
 				size += WritePointer (output, MakeLocalLabel (stringLabel));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1574,6 +1574,7 @@ because xbuild doesn't support framework reference assemblies.
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
+    SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
     MainAssembly="$(TargetPath)"
     OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
     EnvironmentOutputDirectory="$(IntermediateOutputPath)android"

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -492,6 +492,7 @@ if(ANDROID)
       ${BIONIC_SOURCES_DIR}/cxa_guard.cc
       ${SOURCES_DIR}/cxx-abi/string.cc
       ${SOURCES_DIR}/cxx-abi/terminate.cc
+      ${SOURCES_DIR}/cxx-abi/vector.cc
       )
   endif()
 else()

--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -35,19 +35,20 @@ CompressedAssemblies compressed_assemblies = {
 };
 
 ApplicationConfig application_config = {
-	/*.uses_mono_llvm =*/ false,
-	/*.uses_mono_aot =*/ false,
-	/*.uses_assembly_preload =*/ false,
-	/*.is_a_bundled_app =*/ false,
-	/*.broken_exception_transitions =*/ false,
-	/*.instant_run_enabled =*/ false,
-	/*.jni_add_native_method_registration_attribute_present =*/ false,
-	/*.have_runtime_config_blob =*/ false,
-	/*.bound_exception_type =*/ 0, // System
-	/*.package_naming_policy =*/ 0,
-	/*.environment_variable_count =*/ 0,
-	/*.system_property_count =*/ 0,
-	/*.android_package_name =*/ "com.xamarin.test",
+	.uses_mono_llvm = false,
+	.uses_mono_aot = false,
+	.uses_assembly_preload = false,
+	.is_a_bundled_app = false,
+	.broken_exception_transitions = false,
+	.instant_run_enabled = false,
+	.jni_add_native_method_registration_attribute_present = false,
+	.have_runtime_config_blob = false,
+	.bound_exception_type = 0, // System
+	.package_naming_policy = 0,
+	.environment_variable_count = 0,
+	.system_property_count = 0,
+	.number_of_assemblies_in_apk = 0,
+	.android_package_name = "com.xamarin.test",
 };
 
 const char* mono_aot_mode_name = "";

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -16,9 +16,9 @@ void
 BasicAndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
 	// appDirs[2] points to the native library directory
-	simple_pointer_guard<char[]> libmonodroid_path = utils.path_combine (appDirs[2].get_cstr (), "libmonodroid.so");
+	std::unique_ptr<char> libmonodroid_path {utils.path_combine (appDirs[2].get_cstr (), "libmonodroid.so")};
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to %s", libmonodroid_path.get ());
-	if (!utils.file_exists (libmonodroid_path)) {
+	if (!utils.file_exists (libmonodroid_path.get ())) {
 		log_debug (LOG_ASSEMBLY, "%s not found, assuming application/android:extractNativeLibs == false", libmonodroid_path.get ());
 		set_embedded_dso_mode_enabled (true);
 	} else {

--- a/src/monodroid/jni/basic-utilities.cc
+++ b/src/monodroid/jni/basic-utilities.cc
@@ -65,14 +65,14 @@ BasicUtilities::create_directory (const char *pathname, mode_t mode)
 	mode_t oldumask;
 #endif
 	oldumask = umask (022);
-	simple_pointer_guard<char[]> path (strdup_new (pathname));
+	std::unique_ptr<char> path {strdup_new (pathname)};
 	int rv, ret = 0;
-	for (char *d = path; d != nullptr && *d; ++d) {
+	for (char *d = path.get (); d != nullptr && *d; ++d) {
 		if (*d != '/')
 			continue;
 		*d = 0;
 		if (*path) {
-			rv = make_directory (path, mode);
+			rv = make_directory (path.get (), mode);
 			if  (rv == -1 && errno != EEXIST)  {
 				ret = -1;
 				break;

--- a/src/monodroid/jni/basic-utilities.hh
+++ b/src/monodroid/jni/basic-utilities.hh
@@ -58,17 +58,17 @@ namespace xamarin::android
 			abort_unless (path1 != nullptr || path2 != nullptr, "At least one path must be a valid pointer");
 
 			if (path1 == nullptr) {
-				buf.append (path2);
+				buf.append_c (path2);
 				return;
 			}
 
 			if (path2 == nullptr) {
-				buf.append (path1);
+				buf.append_c (path1);
 				return;
 			}
 
 			buf.append (path1, path1_len);
-			buf.append (MONODROID_PATH_SEPARATOR, MONODROID_PATH_SEPARATOR_LENGTH);
+			buf.append (MONODROID_PATH_SEPARATOR);
 			buf.append (path2, path2_len);
 		}
 
@@ -107,6 +107,35 @@ namespace xamarin::android
 		{
 			char *p = const_cast<char*> (strstr (str, end));
 			return p != nullptr && p [N - 1] == '\0';
+		}
+
+		template<size_t N, size_t MaxStackSize, typename TStorage, typename TChar = char>
+		bool ends_with (internal::string_base<MaxStackSize, TStorage, TChar> const& str, const char (&end)[N]) const noexcept
+		{
+			constexpr size_t end_length = N - 1;
+
+			size_t len = str.length ();
+			if (XA_UNLIKELY (len < end_length)) {
+				return false;
+			}
+
+			return memcmp (str.get () + len - end_length, end, end_length) == 0;
+		}
+
+		template<size_t MaxStackSize, typename TStorage, typename TChar = char>
+		const TChar* find_last (internal::string_base<MaxStackSize, TStorage, TChar> const& str, const char ch) const noexcept
+		{
+			if (str.empty ()) {
+				return nullptr;
+			}
+
+			for (size_t i = str.length () - 1; i >= 0; i--) {
+				if (str[i] == ch) {
+					return str.get () + i;
+				}
+			}
+
+			return nullptr;
 		}
 
 		void *xmalloc (size_t size)

--- a/src/monodroid/jni/cxx-abi/terminate.cc
+++ b/src/monodroid/jni/cxx-abi/terminate.cc
@@ -4,7 +4,6 @@
 //  Does NOT support terminate handlers, since we don't use them.
 //
 #include <cstdlib>
-#include <exception>
 #include <android/log.h>
 
 namespace std {

--- a/src/monodroid/jni/cxx-abi/vector.cc
+++ b/src/monodroid/jni/cxx-abi/vector.cc
@@ -1,0 +1,12 @@
+//
+// Defining the macro will make the the explicit instantations below truely hidden
+//
+#define _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS
+
+#include <vector>
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template class __attribute__ ((__visibility__("hidden"))) __vector_base_common<true>;
+
+_LIBCPP_END_NAMESPACE_STD

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -82,18 +82,18 @@ Debug::monodroid_profiler_load (const char *libmono_path, const char *desc, cons
 	} else {
 		mname_ptr = utils.strdup_new (desc);
 	}
-	simple_pointer_guard<char[]> mname (mname_ptr);
+	std::unique_ptr<char> mname {mname_ptr};
 
 	unsigned int dlopen_flags = JAVA_INTEROP_LIB_LOAD_LOCALLY;
-	simple_pointer_guard<char[]> libname (utils.string_concat ("libmono-profiler-", mname.get (), ".so"));
+	std::unique_ptr<char> libname {utils.string_concat ("libmono-profiler-", mname.get (), ".so")};
 	bool found = false;
-	void *handle = androidSystem.load_dso_from_any_directories (libname, dlopen_flags);
-	found = load_profiler_from_handle (handle, desc, mname);
+	void *handle = androidSystem.load_dso_from_any_directories (libname.get (), dlopen_flags);
+	found = load_profiler_from_handle (handle, desc, mname.get ());
 
 	if (!found && libmono_path != nullptr) {
-		simple_pointer_guard<char[]> full_path (utils.path_combine (libmono_path, libname));
-		handle = androidSystem.load_dso (full_path, dlopen_flags, FALSE);
-		found = load_profiler_from_handle (handle, desc, mname);
+		std::unique_ptr<char> full_path {utils.path_combine (libmono_path, libname.get ())};
+		handle = androidSystem.load_dso (full_path.get (), dlopen_flags, FALSE);
+		found = load_profiler_from_handle (handle, desc, mname.get ());
 	}
 
 	if (found && logfile != nullptr)
@@ -129,8 +129,8 @@ Debug::load_profiler_from_handle (void *dso_handle, const char *desc, const char
 	if (!dso_handle)
 		return false;
 
-	simple_pointer_guard<char[]> symbol (utils.string_concat (INITIALIZER_NAME, "_", name));
-	bool result = load_profiler (dso_handle, desc, symbol);
+	std::unique_ptr<char> symbol {utils.string_concat (INITIALIZER_NAME, "_", name)};
+	bool result = load_profiler (dso_handle, desc, symbol.get ());
 
 	if (result)
 		return true;

--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -1,5 +1,7 @@
+#include <array>
 #include <cerrno>
 #include <cctype>
+#include <vector>
 #include <libgen.h>
 
 #include <mono/metadata/assembly.h>
@@ -9,6 +11,17 @@
 #include "globals.hh"
 
 using namespace xamarin::android::internal;
+
+// This type is needed when calling read(2) in a MinGW build, as it defines the `count` parameter as `unsigned int`
+// instead of `size_t` which then causes the following warning if we pass a value of type `size_t`:
+//
+//   warning: conversion from ‘size_t’ {aka ‘long long unsigned int’} to ‘unsigned int’ may change value [-Wconversion]
+//
+#if defined (WINDOWS)
+using read_count_type = unsigned int;
+#else
+using read_count_type = size_t;
+#endif
 
 void
 EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_should_register should_register)
@@ -32,19 +45,16 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 		exit (FATAL_EXIT_NO_ASSEMBLIES);
 	}
 
-	// C++17 allows template parameter type inference, but alas, Apple's antiquated compiler does
-	// not support this particular part of the spec...
-	simple_pointer_guard<uint8_t[]>  buf (new uint8_t[cd_size]);
+	std::vector<uint8_t>  buf (cd_size);
 	const char           *prefix     = get_assemblies_prefix ();
-	size_t                prefix_len = strlen (prefix);
+	size_t                prefix_len = get_assemblies_prefix_length ();
 	size_t                buf_offset = 0;
 	uint16_t              compression_method;
 	uint32_t              local_header_offset;
 	uint32_t              data_offset;
 	uint32_t              file_size;
-	char                 *file_name;
 
-	ssize_t nread = read (fd, buf.get (), cd_size);
+	ssize_t nread = read (fd, buf.data (), static_cast<read_count_type>(buf.size ()));
 	if (static_cast<size_t>(nread) != cd_size) {
 		log_fatal (LOG_ASSEMBLY, "Failed to read Central Directory from the APK archive %s. %s (nread: %d; errno: %d)", apk_name, std::strerror (errno), nread, errno);
 		exit (FATAL_EXIT_NO_ASSEMBLIES);
@@ -54,6 +64,19 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 #if defined (NET6)
 	bool runtime_config_blob_found = false;
 #endif // def NET6
+
+	bool bundled_assemblies_slow_path = false;
+	if (bundled_assemblies.empty ()) {
+		// We're called for the first time, let's allocate space for all the assemblies counted during build. resize()
+		// will allocate all the memory and zero it in one operation
+		bundled_assemblies.resize (application_config.number_of_assemblies_in_apk);
+	} else {
+		// We are probably registering some assemblies dynamically, possibly loading from another apk, we need to extend
+		// the storage instead of taking advantage of the pre-allocated slots.
+		bundled_assemblies_slow_path = true;
+	}
+
+	int64_t assembly_count = application_config.number_of_assemblies_in_apk;
 
 	// clang-tidy claims we have a leak in the loop:
 	//
@@ -66,13 +89,12 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 	for (size_t i = 0; i < cd_entries; i++) {
 		entry_name.clear ();
 
-		bool result = zip_read_entry_info (buf.get (), cd_size, buf_offset, compression_method, local_header_offset, file_size, entry_name);
-		file_name = entry_name.get ();
+		bool result = zip_read_entry_info (buf, buf_offset, compression_method, local_header_offset, file_size, entry_name);
 
 #ifdef DEBUG
-		log_warn (LOG_ASSEMBLY, "%s entry: %s", apk_name, file_name == nullptr ? "unknown" : file_name);
+		log_warn (LOG_ASSEMBLY, "%s entry: %s", apk_name, entry_name.get () == nullptr ? "unknown" : entry_name.get ());
 #endif
-		if (!result || file_name == nullptr) {
+		if (!result || entry_name.empty ()) {
 			log_fatal (LOG_ASSEMBLY, "Failed to read Central Directory info for entry %u in APK file %s", i, apk_name);
 			exit (FATAL_EXIT_NO_ASSEMBLIES);
 		}
@@ -87,14 +109,14 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 		if (compression_method != 0)
 			continue;
 
-		if (strncmp (prefix, file_name, prefix_len) != 0)
+		if (strncmp (prefix, entry_name.get (), prefix_len) != 0)
 			continue;
 
 #if defined (NET6)
 		if (application_config.have_runtime_config_blob && !runtime_config_blob_found) {
-			if (utils.ends_with (file_name, SharedConstants::RUNTIME_CONFIG_BLOB_NAME)) {
+			if (utils.ends_with (entry_name, SharedConstants::RUNTIME_CONFIG_BLOB_NAME)) {
 				runtime_config_blob_found = true;
-				runtime_config_blob_mmap = md_mmap_apk_file (fd, data_offset, file_size, file_name, apk_name);
+				runtime_config_blob_mmap = md_mmap_apk_file (fd, data_offset, file_size, entry_name.get (), apk_name);
 				continue;
 			}
 		}
@@ -102,64 +124,73 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 
 		// assemblies must be 4-byte aligned, or Bad Things happen
 		if ((data_offset & 0x3) != 0) {
-			log_fatal (LOG_ASSEMBLY, "Assembly '%s' is located at bad offset %lu within the .apk\n", file_name, data_offset);
+			log_fatal (LOG_ASSEMBLY, "Assembly '%s' is located at bad offset %lu within the .apk\n", entry_name.get (), data_offset);
 			log_fatal (LOG_ASSEMBLY, "You MUST run `zipalign` on %s\n", strrchr (apk_name, '/') + 1);
 			exit (FATAL_EXIT_MISSING_ZIPALIGN);
 		}
 
-		bool entry_is_overridden = !should_register (strrchr (file_name, '/') + 1);
+		const char *last_slash = utils.find_last (entry_name, '/');
+		bool entry_is_overridden = last_slash == nullptr ? false : !should_register (last_slash + 1);
 
-		if ((utils.ends_with (file_name, ".pdb") || utils.ends_with (file_name, ".mdb")) &&
+		if ((utils.ends_with (entry_name, ".pdb") || utils.ends_with (entry_name, ".mdb")) &&
 				register_debug_symbols &&
 				!entry_is_overridden &&
-				bundled_assemblies != nullptr) {
-			md_mmap_info map_info = md_mmap_apk_file(fd, data_offset, file_size, file_name, apk_name);
-			if (register_debug_symbols_for_assembly (file_name, (bundled_assemblies) [bundled_assemblies_count - 1], (const mono_byte*)map_info.area, static_cast<int>(file_size)))
+				bundled_assembly_index >= 1) {
+			md_mmap_info map_info = md_mmap_apk_file(fd, data_offset, file_size, entry_name.get (), apk_name);
+			if (register_debug_symbols_for_assembly (entry_name, bundled_assemblies [bundled_assembly_index - 1], (const mono_byte*)map_info.area, static_cast<int>(file_size)))
 				continue;
 		}
 
 #if !defined(NET6)
-		if (utils.ends_with (file_name, ".config") && bundled_assemblies != nullptr) {
-			char *assembly_name = strdup (basename (file_name));
+		if (utils.ends_with (entry_name, ".config") && !bundled_assemblies.empty ()) {
+			char *assembly_name = strdup (basename (entry_name.get ()));
 			// Remove '.config' suffix
 			*strrchr (assembly_name, '.') = '\0';
 
-			md_mmap_info map_info = md_mmap_apk_file (fd, data_offset, file_size, file_name, apk_name);
+			md_mmap_info map_info = md_mmap_apk_file (fd, data_offset, file_size, entry_name.get (), apk_name);
 			mono_register_config_for_assembly (assembly_name, (const char*)map_info.area);
 
 			continue;
 		}
 #endif // ndef NET6
 
-		if (!utils.ends_with (file_name, ".dll"))
+		if (!utils.ends_with (entry_name, ".dll"))
 			continue;
 
 		if (entry_is_overridden)
 			continue;
 
-		size_t alloc_size = MULTIPLY_WITH_OVERFLOW_CHECK (size_t, sizeof(void*), bundled_assemblies_count + 1);
-		bundled_assemblies = reinterpret_cast<MonoBundledAssembly**> (utils.xrealloc (bundled_assemblies, alloc_size));
-		MonoBundledAssembly *cur = bundled_assemblies [bundled_assemblies_count] = reinterpret_cast<MonoBundledAssembly*> (utils.xcalloc (1, sizeof (MonoBundledAssembly)));
-		++bundled_assemblies_count;
+		assembly_count--;
+		MonoBundledAssembly *cur;
+		if (XA_UNLIKELY (assembly_count < 0 || (bundled_assemblies_slow_path && bundled_assemblies.size () <= bundled_assembly_index))) {
+			if (assembly_count == -1) {
+				log_warn (LOG_ASSEMBLY, "Number of assemblies stored at build time (%u) was incorrect, switching to slow bundling path.");
+			}
+			bundled_assemblies.emplace_back ();
+			cur = &bundled_assemblies.back ();
+		} else {
+			cur = &bundled_assemblies [bundled_assembly_index];
+		}
+		bundled_assembly_index++;
 
-		md_mmap_info map_info = md_mmap_apk_file (fd, data_offset, file_size, file_name, apk_name);
-		cur->name = utils.monodroid_strdup_printf ("%s", strstr (file_name, prefix) + prefix_len);
+		md_mmap_info map_info = md_mmap_apk_file (fd, data_offset, file_size, entry_name.get (), apk_name);
+		cur->name = utils.strdup_new (entry_name.get () + prefix_len, entry_name.length () - prefix_len);
 		cur->data = (const unsigned char*)map_info.area;
 
 		// MonoBundledAssembly::size is const?!
 		unsigned int *psize = (unsigned int*) &cur->size;
 		*psize = static_cast<unsigned int>(file_size);
 
-		if (utils.should_log (LOG_ASSEMBLY)) {
+		if (XA_UNLIKELY (utils.should_log (LOG_ASSEMBLY))) {
 			const char *p = (const char*) cur->data;
 
-			char header[9];
-			for (size_t j = 0; j < sizeof(header)-1; ++j)
+			std::array<char, 9> header;
+			for (size_t j = 0; j < header.size () - 1; ++j)
 				header[j] = isprint (p [j]) ? p [j] : '.';
-			header [sizeof(header)-1] = '\0';
+			header [header.size () - 1] = '\0';
 
 			log_info_nocheck (LOG_ASSEMBLY, "file-offset: % 8x  start: %08p  end: %08p  len: % 12i  zip-entry:  %s name: %s [%s]",
-			                  (int) data_offset, cur->data, cur->data + *psize, (int) file_size, file_name, cur->name, header);
+			                  (int) data_offset, cur->data, cur->data + *psize, (int) file_size, entry_name.get (), cur->name, header.data ());
 		}
 	}
 }
@@ -167,11 +198,6 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 bool
 EmbeddedAssemblies::zip_read_cd_info (int fd, uint32_t& cd_offset, uint32_t& cd_size, uint16_t& cd_entries)
 {
-#if defined (WINDOWS)
-	using read_count_type = unsigned int;
-#else
-	using read_count_type = size_t;
-#endif
 	// The simplest case - no file comment
 	off_t ret = ::lseek (fd, -ZIP_EOCD_LEN, SEEK_END);
 	if (ret < 0) {
@@ -179,23 +205,23 @@ EmbeddedAssemblies::zip_read_cd_info (int fd, uint32_t& cd_offset, uint32_t& cd_
 		return false;
 	}
 
-	uint8_t eocd[ZIP_EOCD_LEN];
-	ssize_t nread = ::read (fd, eocd, static_cast<read_count_type>(ZIP_EOCD_LEN));
+	std::array<uint8_t, ZIP_EOCD_LEN> eocd;
+	ssize_t nread = ::read (fd, eocd.data (), static_cast<read_count_type>(eocd.size ()));
 	if (nread < 0 || nread != ZIP_EOCD_LEN) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD from the APK: %s (nread: %d; errno: %d)", std::strerror (errno), nread, errno);
 		return false;
 	}
 
 	size_t index = 0; // signature
-	uint8_t signature[4];
+	std::array<uint8_t, 4> signature;
 
-	if (!zip_read_field (eocd, ZIP_EOCD_LEN, index, signature)) {
+	if (!zip_read_field (eocd, index, signature)) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD signature");
 		return false;
 	}
 
-	if (memcmp (signature, ZIP_EOCD_MAGIC, sizeof(signature)) == 0) {
-		return zip_extract_cd_info (eocd, ZIP_EOCD_LEN, cd_offset, cd_size, cd_entries);
+	if (memcmp (signature.data (), ZIP_EOCD_MAGIC, signature.size ()) == 0) {
+		return zip_extract_cd_info (eocd, cd_offset, cd_size, cd_entries);
 	}
 
 	// Most probably a ZIP with comment
@@ -206,12 +232,9 @@ EmbeddedAssemblies::zip_read_cd_info (int fd, uint32_t& cd_offset, uint32_t& cd_
 		return false;
 	}
 
-	simple_pointer_guard<uint8_t[]> buf (new uint8_t[alloc_size]);
-	// The cast removes warning on mingw:
-	//
-	//   warning: conversion from ‘size_t’ {aka ‘long long unsigned int’} to ‘unsigned int’ may change value [-Wconversion]
-	//
-	nread = ::read (fd, buf, static_cast<read_count_type>(alloc_size));
+	std::vector<uint8_t> buf (alloc_size);
+
+	nread = ::read (fd, buf.data (), static_cast<read_count_type>(buf.size ()));
 
 	if (nread < 0 || static_cast<size_t>(nread) != alloc_size) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD and comment from the APK: %s (nread: %d; errno: %d)", std::strerror (errno), nread, errno);
@@ -220,12 +243,13 @@ EmbeddedAssemblies::zip_read_cd_info (int fd, uint32_t& cd_offset, uint32_t& cd_
 
 	// We scan from the end to save time
 	bool found = false;
+	const uint8_t* data = buf.data ();
 	for (ssize_t i = static_cast<ssize_t>(alloc_size - (ZIP_EOCD_LEN + 2)); i >= 0; i--) {
-		if (memcmp (buf.get () + i, ZIP_EOCD_MAGIC, sizeof(ZIP_EOCD_MAGIC)) != 0)
+		if (memcmp (data + i, ZIP_EOCD_MAGIC, sizeof(ZIP_EOCD_MAGIC)) != 0)
 			continue;
 
 		found = true;
-		memcpy (eocd, buf.get () + i, ZIP_EOCD_LEN);
+		memcpy (eocd.data (), data + i, ZIP_EOCD_LEN);
 		break;
 	}
 
@@ -234,7 +258,7 @@ EmbeddedAssemblies::zip_read_cd_info (int fd, uint32_t& cd_offset, uint32_t& cd_
 		return false;
 	}
 
-	return zip_extract_cd_info (eocd, ZIP_EOCD_LEN, cd_offset, cd_size, cd_entries);
+	return zip_extract_cd_info (eocd, cd_offset, cd_size, cd_entries);
 }
 
 bool
@@ -249,36 +273,36 @@ EmbeddedAssemblies::zip_adjust_data_offset (int fd, size_t local_header_offset, 
 		return false;
 	}
 
-	uint8_t local_header[ZIP_LOCAL_LEN];
-	uint8_t signature[4];
+	std::array<uint8_t, ZIP_LOCAL_LEN> local_header;
+	std::array<uint8_t, 4> signature;
 
-	ssize_t nread = ::read (fd, local_header, static_cast<size_t>(ZIP_LOCAL_LEN));
+	ssize_t nread = ::read (fd, local_header.data (), static_cast<size_t>(ZIP_LOCAL_LEN));
 	if (nread < 0 || nread != ZIP_LOCAL_LEN) {
 		log_error (LOG_ASSEMBLY, "Failed to read local header at offset %u: %s (nread: %d; errno: %d)", local_header_offset, std::strerror (errno), nread, errno);
 		return false;
 	}
 
 	size_t index = 0;
-	if (!zip_read_field (local_header, ZIP_LOCAL_LEN, index, signature)) {
+	if (!zip_read_field (local_header, index, signature)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Local Header entry signature at offset %u", local_header_offset);
 		return false;
 	}
 
-	if (memcmp (signature, ZIP_LOCAL_MAGIC, sizeof(signature)) != 0) {
+	if (memcmp (signature.data (), ZIP_LOCAL_MAGIC, sizeof(signature)) != 0) {
 		log_error (LOG_ASSEMBLY, "Invalid Local Header entry signature at offset %u", local_header_offset);
 		return false;
 	}
 
 	uint16_t file_name_length;
 	index = LH_FILE_NAME_LENGTH_OFFSET;
-	if (!zip_read_field (local_header, ZIP_LOCAL_LEN, index, file_name_length)) {
+	if (!zip_read_field (local_header, index, file_name_length)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Local Header 'file name length' field at offset %u", (local_header_offset + index));
 		return false;
 	}
 
 	uint16_t extra_field_length;
 	index = LH_EXTRA_LENGTH_OFFSET;
-	if (!zip_read_field (local_header, ZIP_LOCAL_LEN, index, extra_field_length)) {
+	if (!zip_read_field (local_header, index, extra_field_length)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Local Header 'extra field length' field at offset %u", (local_header_offset + index));
 		return false;
 	}
@@ -288,29 +312,27 @@ EmbeddedAssemblies::zip_adjust_data_offset (int fd, size_t local_header_offset, 
 	return true;
 }
 
+template<size_t BufSize>
 bool
-EmbeddedAssemblies::zip_extract_cd_info (uint8_t* buf, size_t buf_len, uint32_t& cd_offset, uint32_t& cd_size, uint16_t& cd_entries)
+EmbeddedAssemblies::zip_extract_cd_info (std::array<uint8_t, BufSize> const& buf, uint32_t& cd_offset, uint32_t& cd_size, uint16_t& cd_entries)
 {
 	static constexpr size_t EOCD_TOTAL_ENTRIES_OFFSET = 10;
 	static constexpr size_t EOCD_CD_SIZE_OFFSET       = 12;
 	static constexpr size_t EOCD_CD_START_OFFSET      = 16;
 
-	if (buf_len < ZIP_EOCD_LEN) {
-		log_fatal (LOG_ASSEMBLY, "Buffer too short for EOCD");
-		exit (FATAL_EXIT_OUT_OF_MEMORY);
-	}
+	static_assert (BufSize >= ZIP_EOCD_LEN, "Buffer too short for EOCD");
 
-	if (!zip_read_field (buf, buf_len, EOCD_TOTAL_ENTRIES_OFFSET, cd_entries)) {
+	if (!zip_read_field (buf, EOCD_TOTAL_ENTRIES_OFFSET, cd_entries)) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD 'total number of entries' field");
 		return false;
 	}
 
-	if (!zip_read_field (buf, buf_len, EOCD_CD_START_OFFSET, cd_offset)) {
+	if (!zip_read_field (buf, EOCD_CD_START_OFFSET, cd_offset)) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD 'central directory size' field");
 		return false;
 	}
 
-	if (!zip_read_field (buf, buf_len, EOCD_CD_SIZE_OFFSET, cd_size)) {
+	if (!zip_read_field (buf, EOCD_CD_SIZE_OFFSET, cd_size)) {
 		log_error (LOG_ASSEMBLY, "Failed to read EOCD 'central directory offset' field");
 		return false;
 	}
@@ -318,15 +340,11 @@ EmbeddedAssemblies::zip_extract_cd_info (uint8_t* buf, size_t buf_len, uint32_t&
 	return true;
 }
 
-bool
-EmbeddedAssemblies::zip_ensure_valid_params (uint8_t* buf, size_t buf_len, size_t index, size_t to_read)
+template<class T>
+force_inline bool
+EmbeddedAssemblies::zip_ensure_valid_params (T const& buf, size_t index, size_t to_read) const noexcept
 {
-	if (buf == nullptr) {
-		log_error (LOG_ASSEMBLY, "No buffer to read ZIP data into");
-		return false;
-	}
-
-	if (index + to_read > buf_len) {
+	if (index + to_read > buf.size ()) {
 		log_error (LOG_ASSEMBLY, "Buffer too short to read %u bytes of data", to_read);
 		return false;
 	}
@@ -334,59 +352,62 @@ EmbeddedAssemblies::zip_ensure_valid_params (uint8_t* buf, size_t buf_len, size_
 	return true;
 }
 
+template<ByteArrayContainer T>
 bool
-EmbeddedAssemblies::zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint16_t& u)
+EmbeddedAssemblies::zip_read_field (T const& src, size_t source_index, uint16_t& dst) const noexcept
 {
-	if (!zip_ensure_valid_params (buf, buf_len, index, sizeof (u))) {
+	if (!zip_ensure_valid_params (src, source_index, sizeof (dst))) {
 		return false;
 	}
 
-	u = static_cast<uint16_t>((buf [index + 1] << 8) | buf [index]);
+	dst = static_cast<uint16_t>((src [source_index + 1] << 8) | src [source_index]);
 
 	return true;
 }
 
+template<ByteArrayContainer T>
 bool
-EmbeddedAssemblies::zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint32_t& u)
+EmbeddedAssemblies::zip_read_field (T const& src, size_t source_index, uint32_t& dst) const noexcept
 {
-	if (!zip_ensure_valid_params (buf, buf_len, index, sizeof (u))) {
+	if (!zip_ensure_valid_params (src, source_index, sizeof (dst))) {
 		return false;
 	}
 
-	u = (static_cast<uint32_t> (buf [index + 3]) << 24) |
-		(static_cast<uint32_t> (buf [index + 2]) << 16) |
-		(static_cast<uint32_t> (buf [index + 1]) << 8)  |
-		(static_cast<uint32_t> (buf [index + 0]));
+	dst =
+		(static_cast<uint32_t> (src [source_index + 3]) << 24) |
+		(static_cast<uint32_t> (src [source_index + 2]) << 16) |
+		(static_cast<uint32_t> (src [source_index + 1]) << 8)  |
+		(static_cast<uint32_t> (src [source_index + 0]));
 
 	return true;
 }
 
+template<ByteArrayContainer T>
 bool
-EmbeddedAssemblies::zip_read_field (uint8_t* buf, size_t buf_len, size_t index, uint8_t (&sig)[4])
+EmbeddedAssemblies::zip_read_field (T const& src, size_t source_index, std::array<uint8_t, 4>& dst_sig) const noexcept
 {
-	static constexpr size_t sig_size = sizeof(sig);
-
-	if (!zip_ensure_valid_params (buf, buf_len, index, sig_size)) {
+	if (!zip_ensure_valid_params (src, source_index, dst_sig.size ())) {
 		return false;
 	}
 
-	memcpy (sig, buf + index, sig_size);
+	memcpy (dst_sig.data (), src.data () + source_index, dst_sig.size ());
+	return true;
+}
+
+template<ByteArrayContainer T>
+bool
+EmbeddedAssemblies::zip_read_field (T const& buf, size_t index, size_t count, dynamic_local_string<SENSIBLE_PATH_MAX>& characters) const noexcept
+{
+	if (!zip_ensure_valid_params (buf, index, count)) {
+		return false;
+	}
+
+	characters.assign (reinterpret_cast<const char*>(buf.data () + index), count);
 	return true;
 }
 
 bool
-EmbeddedAssemblies::zip_read_field (uint8_t* buf, size_t buf_len, size_t index, size_t count, dynamic_local_string<SENSIBLE_PATH_MAX>& characters)
-{
-	if (!zip_ensure_valid_params (buf, buf_len, index, count)) {
-		return false;
-	}
-
-	characters.assign (reinterpret_cast<const char*>(buf) + index, count);
-	return true;
-}
-
-bool
-EmbeddedAssemblies::zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& buf_offset, uint16_t& compression_method, uint32_t& local_header_offset, uint32_t& file_size, dynamic_local_string<SENSIBLE_PATH_MAX>& file_name)
+EmbeddedAssemblies::zip_read_entry_info (std::vector<uint8_t> const& buf, size_t& buf_offset, uint16_t& compression_method, uint32_t& local_header_offset, uint32_t& file_size, dynamic_local_string<SENSIBLE_PATH_MAX>& file_name)
 {
 	static constexpr size_t CD_COMPRESSION_METHOD_OFFSET = 10;
 	static constexpr size_t CD_UNCOMPRESSED_SIZE_OFFSET  = 24;
@@ -396,54 +417,54 @@ EmbeddedAssemblies::zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& b
 	static constexpr size_t CD_COMMENT_LENGTH_OFFSET     = 32;
 
 	size_t index = buf_offset;
-	zip_ensure_valid_params (buf, buf_len, index, ZIP_CENTRAL_LEN);
+	zip_ensure_valid_params (buf, index, ZIP_CENTRAL_LEN);
 
-	uint8_t signature[4];
-	if (!zip_read_field (buf, buf_len, index, signature)) {
+	std::array<uint8_t, 4> signature;
+	if (!zip_read_field (buf, index, signature)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry signature");
 		return false;
 	}
 
-	if (memcmp (signature, ZIP_CENTRAL_MAGIC, sizeof(signature)) != 0) {
+	if (memcmp (signature.data (), ZIP_CENTRAL_MAGIC, sizeof(signature)) != 0) {
 		log_error (LOG_ASSEMBLY, "Invalid Central Directory entry signature");
 		return false;
 	}
 
 	index = buf_offset + CD_COMPRESSION_METHOD_OFFSET;
-	if (!zip_read_field (buf, buf_len, index, compression_method)) {
+	if (!zip_read_field (buf, index, compression_method)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'compression method' field");
 		return false;
 	}
 
 	index = buf_offset + CD_UNCOMPRESSED_SIZE_OFFSET;;
-	if (!zip_read_field (buf, buf_len, index, file_size)) {
+	if (!zip_read_field (buf, index, file_size)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'uncompressed size' field");
 		return false;
 	}
 
 	uint16_t file_name_length;
 	index = buf_offset + CD_FILENAME_LENGTH_OFFSET;
-	if (!zip_read_field (buf, buf_len, index, file_name_length)) {
+	if (!zip_read_field (buf, index, file_name_length)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'file name length' field");
 		return false;
 	}
 
 	uint16_t extra_field_length;
 	index = buf_offset + CD_EXTRA_LENGTH_OFFSET;
-	if (!zip_read_field (buf, buf_len, index, extra_field_length)) {
+	if (!zip_read_field (buf, index, extra_field_length)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'extra field length' field");
 		return false;
 	}
 
 	uint16_t comment_length;
 	index = buf_offset + CD_COMMENT_LENGTH_OFFSET;
-	if (!zip_read_field (buf, buf_len, index, comment_length)) {
+	if (!zip_read_field (buf, index, comment_length)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'file comment length' field");
 		return false;
 	}
 
 	index = buf_offset + CD_LOCAL_HEADER_POS_OFFSET;
-	if (!zip_read_field (buf, buf_len, index, local_header_offset)) {
+	if (!zip_read_field (buf, index, local_header_offset)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'relative offset of local header' field");
 		return false;
 	}
@@ -451,11 +472,33 @@ EmbeddedAssemblies::zip_read_entry_info (uint8_t* buf, size_t buf_len, size_t& b
 
 	if (file_name_length == 0) {
 		file_name.clear ();
-	} else if (!zip_read_field (buf, buf_len, index, file_name_length, file_name)) {
+	} else if (!zip_read_field (buf, index, file_name_length, file_name)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'file name' field");
 		return false;
 	}
 
 	buf_offset += ZIP_CENTRAL_LEN + file_name_length + extra_field_length + comment_length;
+	return true;
+}
+
+template<size_t BufferSize>
+bool
+EmbeddedAssemblies::register_debug_symbols_for_assembly (dynamic_local_string<BufferSize> const& entry_name, MonoBundledAssembly const& assembly, const mono_byte *debug_contents, int debug_size)
+{
+	const char *entry_basename = utils.find_last (entry_name, '/') + 1; // strrchr (entry_name, '/') + 1;
+	// System.dll, System.dll.mdb case
+	if (strncmp (assembly.name, entry_basename, strlen (assembly.name)) != 0) {
+		// That failed; try for System.dll, System.pdb case
+		const char *eb_ext = utils.find_last (entry_name, '.');
+		if (eb_ext == nullptr)
+			return false;
+		off_t basename_len    = static_cast<off_t>(eb_ext - entry_basename);
+		abort_unless (basename_len > 0, "basename must have a length!");
+		if (strncmp (assembly.name, entry_basename, static_cast<size_t>(basename_len)) != 0)
+			return false;
+	}
+
+	mono_register_symfile_for_assembly (assembly.name, debug_contents, debug_size);
+
 	return true;
 }

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -118,6 +118,7 @@ namespace xamarin::android::internal
 		true;
 #endif
 
+#if !defined (NET6)
 #define MAKE_API_DSO_NAME(_ext_) "libxa-internal-api." # _ext_
 #if defined (WINDOWS)
 		static constexpr char API_DSO_NAME[] = MAKE_API_DSO_NAME (dll);
@@ -126,6 +127,7 @@ namespace xamarin::android::internal
 #else   // !defined(WINDOWS) && !defined(APPLE_OS_X)
 		static constexpr char API_DSO_NAME[] = MAKE_API_DSO_NAME (so);
 #endif  // defined(WINDOWS)
+#endif // ndef NET6
 	public:
 		static constexpr int XA_LOG_COUNTERS = MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS | MONO_COUNTER_INTERP;
 

--- a/src/monodroid/jni/new_delete.cc
+++ b/src/monodroid/jni/new_delete.cc
@@ -1,5 +1,10 @@
 #include <stdlib.h>
-#include <new>
+
+namespace std
+{
+	struct nothrow_t {};
+	extern const nothrow_t nothrow;
+}
 
 #include "java-interop-util.h"
 
@@ -9,6 +14,7 @@ do_alloc (size_t size)
 	return ::malloc (size == 0 ? 1 : size);
 }
 
+__attribute__((__weak__))
 void*
 operator new (size_t size)
 {
@@ -27,6 +33,7 @@ operator new (size_t size, const std::nothrow_t&) noexcept
 	return do_alloc (size);
 }
 
+__attribute__((__weak__))
 void*
 operator new[] (size_t size)
 {
@@ -39,8 +46,9 @@ operator new[] (size_t size, const std::nothrow_t&) noexcept
 	return do_alloc (size);
 }
 
+__attribute__((__weak__))
 void
-operator delete (void* ptr)
+operator delete (void* ptr) noexcept
 {
 	if (ptr)
 		::free (ptr);
@@ -58,8 +66,9 @@ operator delete (void* ptr, size_t) noexcept
 	::operator delete (ptr);
 }
 
+__attribute__((__weak__))
 void
-operator delete[] (void* ptr)
+operator delete[] (void* ptr) noexcept
 {
 	::operator delete (ptr);
 }

--- a/src/monodroid/jni/pinvoke-override-api.cc
+++ b/src/monodroid/jni/pinvoke-override-api.cc
@@ -633,13 +633,6 @@ MonodroidRuntime::fetch_or_create_pinvoke_map_entry (std::string const& library_
 void*
 MonodroidRuntime::monodroid_pinvoke_override (const char *library_name, const char *entrypoint_name)
 {
-	log_warn (LOG_DEFAULT, "MonodroidRuntime::monodroid_pinvoke_override (\"%s\", \"%s\")", library_name, entrypoint_name);
-
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_start ();
-	}
-
 	if (library_name == nullptr || *library_name == '\0' || entrypoint_name == nullptr || *entrypoint_name == '\0') {
 		return nullptr;
 	}
@@ -688,19 +681,9 @@ MonodroidRuntime::monodroid_pinvoke_override (const char *library_name, const ch
 			handle = fetch_or_create_pinvoke_map_entry (lib_name, func_name, iter->second, /* need_lock */ true);
 		}
 
-		if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-			total_time.mark_end ();
-
-			TIMING_LOG_INFO (total_time, "p/invoke override for '%s' (foreign)", entrypoint_name);
-		}
-
 		return handle;
 	}
 
-	timing_period lookup_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		lookup_time.mark_start ();
-	}
 	auto iter = xa_pinvoke_map.find (entrypoint_name);
 	if (iter == xa_pinvoke_map.end ()) {
 		log_fatal (LOG_ASSEMBLY, "Internal p/invoke symbol '%s @ %s' not found in compile-time map.", library_name, entrypoint_name);
@@ -712,13 +695,5 @@ MonodroidRuntime::monodroid_pinvoke_override (const char *library_name, const ch
 		return nullptr;
 	}
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		lookup_time.mark_end ();
-		total_time.mark_end ();
-
-		TIMING_LOG_INFO (lookup_time, "p/invoke cache lookup for '%s' (internal)", entrypoint_name);
-		TIMING_LOG_INFO (total_time, "p/invoke override for '%s' (internal)", entrypoint_name);
-	}
-	log_warn (LOG_DEFAULT, "Found %s@%s in internal p/invoke map (%p)", library_name, entrypoint_name, iter->second);
 	return iter->second;
 }

--- a/src/monodroid/jni/xamarin-app.hh
+++ b/src/monodroid/jni/xamarin-app.hh
@@ -110,6 +110,7 @@ struct ApplicationConfig
 	uint32_t package_naming_policy;
 	uint32_t environment_variable_count;
 	uint32_t system_property_count;
+	uint32_t number_of_assemblies_in_apk;
 	const char *android_package_name;
 };
 


### PR DESCRIPTION
C++ features:

 * Use C++20 concepts to make compile-time correctness verification
   stronger
 * Use `std::vector` for dynamic heap buffers
 * Use `std::array` for static stack buffers
 * Use `std::unique_ptr` instead of the home-grown equivalent (also for
   C-allocated memory)
 * Use C++20 structure designators

Optimizations:

 * Add string routines (`ends_with` and `find_last`) optimized for the
   stack string types (derived from `string_base`)
 * Count assemblies at the build time and pre-allocate enough memory (in
   the form of `std::vector` instance) to store information about the
   bundled assemblies, thus avoiding 2 allocations per assembly (one
   `realloc` and one `malloc`) making the bundled assemblies loading
   algorithm closer to O(1) instead of the previous O(n*2)
 * Use character arrays instead of "plain" string literals to optimize
   some string operations.

These changes improve plain XA test app startup time by around 11%