### PR TITLE
Bump to MSbuild.StructuredLogger 2.1.500

### DIFF
--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.5" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.303" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -68,21 +68,15 @@ namespace Xamarin.Android.Build.Tests
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, "msbuild.binlog");
 			FileAssert.Exists (binlog);
 
-			try {
-				var build = BinaryLog.ReadBuild (binlog);
-				var duration = build
-					.FindChildrenRecursive<Project> ()
-					.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
+			var build = BinaryLog.ReadBuild (binlog);
+			var duration = build
+				.FindChildrenRecursive<Project> ()
+				.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
 
-				if (duration == TimeSpan.Zero)
-					throw new InvalidDataException ($"No project build duration found in {binlog}");
+			if (duration == TimeSpan.Zero)
+				throw new InvalidDataException ($"No project build duration found in {binlog}");
 
-				return duration.TotalMilliseconds;
-			} catch (NotSupportedException) {
-				// See: https://github.com/dotnet/msbuild/issues/6225
-				Assert.Ignore ($"Test requires an updated MSBuild.StructuredLogger");
-				return 0;
-			}
+			return duration.TotalMilliseconds;
 		}
 
 		ProjectBuilder CreateBuilderWithoutLogFile (string directory = null, bool isApp = true)


### PR DESCRIPTION
Some of our `PerformanceTest`'s are currently ignored due to:

    Ignored : Xamarin.Android.Build.Tests.PerformanceTest.Build_No_Changes
    Test requires an updated MSBuild.StructuredLogger

We ignored these tests in 304e6989. This was failing due to changes in
the `.binlog` file format.

I think we can remove this with the latest MSBuild.StructuredLogger.