### PR TITLE
[ci] Opt in to auto .NET 6 VS pr creation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -13,7 +13,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjc/auto-vs-main-pr
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -13,7 +13,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/pjc/auto-vs-main-pr
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <TargetName>Microsoft.NET.Sdk.Android.Workload</TargetName>
+    <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/124

VS PR produced: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/343772

The VS Insertion stage will now automatically open a PR against VS main
once approved.  The primary limitation with the current workflow is that
there is no good way to automatically create a PR against a branch other
than VS main.  This can be addressed at a later date, as we can still do
manual insertions into release branches during QB mode as needed