### PR TITLE
[build-tools] setup a way to install .NET MAUI

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -128,6 +128,7 @@
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.4.0</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
+    <MauiFeedUrl>https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json</MauiFeedUrl>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
     <_TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_TestsAotName>
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>

--- a/Documentation/workflow/DevelopmentTips.md
+++ b/Documentation/workflow/DevelopmentTips.md
@@ -506,3 +506,25 @@ be preferred if it is not blank.
 
 [mono-logging]: https://www.mono-project.com/docs/advanced/runtime/logging-runtime-events/
 [6e58ce4]: https://github.com/xamarin/xamarin-android/commit/6e58ce405d00a965f3c206e2d509f5a5343b16f7
+
+## Installing .NET MAUI
+
+`make pack-dotnet` or `msbuild Xamarin.Android.sln -t:PackDotNet`
+provisions a .NET SDK and locally built Android workload in:
+
+    ~/android-toolchain/dotnet/
+
+If you *also* want .NET MAUI, you don't want to `dotnet workload
+install maui`, because it will blow away your local build of the
+Android workload.
+
+To simplify things, we have an MSBuild target to install .NET MAUI:
+
+    msbuild Xamarin.Android.sln -t:InstallMaui -p:MauiVersion=6.0.100-rc.1.1351
+
+To find the version number of .NET MAUI you want to install, find the
+package on the [nightly Azure DevOps feed][maui-feed]. Or look for the
+`Microsoft.NET.Sdk.Maui.Manifest-6.0.100` package on NuGet.org for public
+releases.
+
+[maui-feed]: https://dev.azure.com/azure-public/vside/_packaging?_a=package&feed=xamarin-impl%40Local&package=Microsoft.NET.Sdk.Maui.Manifest-6.0.100&protocolType=NuGet&version=6.0.100-rc.1.1351%2Bsha.3fbb791e7-azdo.5078933

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -33,4 +33,32 @@
         Properties="Configuration=$(Configuration)"
     />
   </Target>
+  <Target Name="InstallMaui">
+    <PropertyGroup>
+      <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
+    </PropertyGroup>
+    <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' " />
+    <MakeDir Directories="$(_TempDirectory)" />
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; restore maui.proj -p:MauiVersion=$(MauiVersion)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+        EnvironmentVariables="NUGET_PACKAGES=$(_TempDirectory)"
+    />
+
+    <!-- Copy WorkloadManifest.* files-->
+    <ItemGroup>
+      <_WLManifest Include="$(_TempDirectory)\microsoft.net.sdk.maui.manifest-$(DotNetPreviewVersionBand)\$(MauiVersion)\data\WorkloadManifest.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WLManifest)" DestinationFolder="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.maui" />
+
+    <!-- dotnet workload install maui-android -->
+    <ItemGroup>
+      <_InstallArguments Include="--skip-manifest-update" />
+      <_InstallArguments Include="--verbosity diag" />
+      <_InstallArguments Include="--source $(MauiFeedUrl)" />
+      <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
+    </ItemGroup>
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install maui-android @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
+    <RemoveDir Directories="$(_TempDirectory)" />
+  </Target>
 </Project>

--- a/build-tools/scripts/maui.proj
+++ b/build-tools/scripts/maui.proj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../Configuration.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RestoreAdditionalProjectSources>$(MauiFeedUrl)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-$(DotNetPreviewVersionBand)" Version="[$(MauiVersion)]" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
We need a way for testing to install builds of .NET MAUI alongside a
local build of the Android workload.

This creates a new target such as:

    msbuild Xamarin.Android.sln -t:InstallMaui -p:MauiVersion=6.0.100-rc.1.1351

You will need to lookup the version of the
`Microsoft.NET.Sdk.Maui.Manifest-6.0.100` package you want on [Azure
DevOps][0] or nuget.org.

[0]: https://dev.azure.com/azure-public/vside/_packaging?_a=package&feed=xamarin-impl%40Local&package=Microsoft.NET.Sdk.Maui.Manifest-6.0.100&protocolType=NuGet&version=6.0.100-rc.1.1351%2Bsha.3fbb791e7-azdo.5078933