### PR TITLE
[NET6] Don't export the XA_TLS_PROVIDER envvar

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Android.Tasks
 		public string TlsProvider { get; set; }
 		public string AndroidSequencePointsMode { get; set; }
 		public bool EnableSGenConcurrent { get; set; }
+		public bool UsingAndroidNETSdk { get; set; }
 
 		[Output]
 		public string BuildId { get; set; }
@@ -206,8 +207,10 @@ namespace Xamarin.Android.Tasks
 					}
 					if (lineToWrite.StartsWith ("XA_HTTP_CLIENT_HANDLER_TYPE=", StringComparison.Ordinal))
 						haveHttpMessageHandler = true;
-					if (lineToWrite.StartsWith ("XA_TLS_PROVIDER=", StringComparison.Ordinal))
+
+					if (!UsingAndroidNETSdk && lineToWrite.StartsWith ("XA_TLS_PROVIDER=", StringComparison.Ordinal))
 						haveTlsProvider = true;
+
 					if (lineToWrite.StartsWith ("mono.enable_assembly_preload=", StringComparison.Ordinal)) {
 						int idx = lineToWrite.IndexOf ('=');
 						uint val;
@@ -243,7 +246,7 @@ namespace Xamarin.Android.Tasks
 					AddEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE", HttpClientHandlerType.Trim ());
 			}
 
-			if (!haveTlsProvider) {
+			if (!UsingAndroidNETSdk && !haveTlsProvider) {
 				if (TlsProvider == null)
 					AddEnvironmentVariable (defaultTlsProvider[0], defaultTlsProvider[1]);
 				else

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1596,6 +1596,7 @@ because xbuild doesn't support framework reference assemblies.
     BoundExceptionType="$(AndroidBoundExceptionType)"
     InstantRunEnabled="$(_InstantRunEnabled)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
+    UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
   >
     <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6140

`XA_TLS_PROVIDER` environment variable was used to set the TLS provider
for HttpClient in "legacy" Xamarin.Android.  NET6 and newer no longer
use that variable, so we can stop exporting it.