### PR TITLE
[One .NET] use rc.1 version number for main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>30.0.100</AndroidPackVersion>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/Documentation/guides/HowToBranch.md
+++ b/Documentation/guides/HowToBranch.md
@@ -12,27 +12,28 @@ sequence of events would be:
 3. `xamarin-android` branches `release/6.0.1xx-preview42`. GitHub Web
    UI is fine for this.
 
-4. Manually make a commit to `release/6.0.1xx-preview42` such as
-  [df122518][2], so that `$(_AndroidPackLabel)` is
-  `preview.42.$(PackVersionCommitCount)`.
-
-5. Subscribe to Maestro updates for [dotnet/installer][1] `release/6.0.1xx-preview42`:
+4. Subscribe to Maestro updates for [dotnet/installer][1] `release/6.0.1xx-preview42`:
 
 ```bash
 $ darc add-subscription --channel ".NET 6.0.1xx SDK Preview 42" --target-branch "release/6.0.1xx-preview42" --source-repo https://github.com/dotnet/installer --target-repo https://github.com/xamarin/xamarin-android
 ```
 
-6. Publish Maestro updates for `xamarin-android/release/6.0.1xx-preview42`:
+5. Publish Maestro updates for `xamarin-android/release/6.0.1xx-preview42`:
 
 ```bash
 $ darc add-default-channel --channel ".NET 6.0.1xx SDK Preview 42" --branch "release/6.0.1xx-preview42" --repo https://github.com/xamarin/xamarin-android
 ```
 
-See [eng/README.md][3] for details on `darc` commands.
+See [eng/README.md][2] for details on `darc` commands.
 
-This workflow might change slightly when previews become release candidates, such as RC1.
+6. Open a PR to `xamarin-android/main`, such that
+   `$(AndroidPackVersionSuffix)` in `Directory.Build.props` is
+   incremented to the *next* version: `preview.43`. You may also need
+   to update `$(AndroidPackVersion)` if `main` needs to target a new
+   .NET version band.
+
+Note that release candidates will use values such as `rc.1`, `rc.2`, etc.
 
 [0]: https://github.com/dotnet/maui/issues/598
 [1]: https://github.com/dotnet/installer
-[2]: https://github.com/xamarin/xamarin-android/commit/df12251856a172c7deefa9ee2a4b07a490dc9003
-[3]: ../../eng/README.md
+[2]: ../../eng/README.md

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -86,6 +86,7 @@
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
+      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(_AndroidPackBranch)' == 'main' or $(_AndroidPackBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
       <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
       <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>


### PR DESCRIPTION
Context: https://semvercompare.azurewebsites.net/?version=30.0.100-preview.7.110&version=30.0.100-ci.main.111

We have an issue currently where our version number on `main` is lower
than `preview.7`:

    30.0.100-ci.main.111 < 30.0.100-preview.7.110

With this setup, `dotnet workload install` cannot possibly update to
`ci.main` versions (it always grabs latest) -- unless we somehow
constructed a NuGet feed without `preview.7` builds.

The only way for people to use `ci.main` builds at present is with
`maui-check --main`, because it uses
`dotnet workload update --from-rollback-file` to manually specify
versions. We want `maui-check` to be *optional* if possible.

The solution for `ci.main` versions is:

* Switch `xamarin-android/main` to `rc.1` *now*.
* When we branch for `rc.1`, we update `main` to `rc.2`.

This follows the same pattern for dotnet/installer and other repos in
the dotnet organization. I updated `HowToBranch.md` accordingly.