### PR TITLE
[One .NET] Include symbol files in runtime packs

### DIFF
--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -59,7 +59,7 @@ jobs:
         testRunTitle: MSBuildDeviceIntegration On Device - macOS - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
         nunitConsoleExtraArgs: --where "cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
-        dotNetTestExtraArgs: --filter "TestCategory != TimeZoneInfo & TestCategory != SmokeTests ${{ parameters.nunit_categories }}"
+        dotNetTestExtraArgs: --filter "TestCategory != TimeZoneInfo ${{ parameters.nunit_categories }}"
         testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -46,6 +46,7 @@ projects that use the Microsoft.Android framework in .NET 5.
 
     <ItemGroup>
       <_PackageFiles Include="@(_AndroidRuntimePackAssemblies)" PackagePath="$(_AndroidRuntimePackAssemblyPath)" TargetPath="$(_AndroidRuntimePackAssemblyPath)" />
+      <_PackageFiles Include="@(_AndroidRuntimePackAssemblies->'%(RelativeDir)%(Filename).pdb')" PackagePath="$(_AndroidRuntimePackAssemblyPath)" />
       <_PackageFiles Include="@(_AndroidRuntimePackAssets)" PackagePath="$(_AndroidRuntimePackNativePath)" TargetPath="$(_AndroidRuntimePackNativePath)" IsNative="true" />
     </ItemGroup>
   </Target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1436,6 +1436,9 @@ namespace App1
 					var assetsPdb = Path.Combine (intermediate, "android", "assets", "Library1.pdb");
 					var binSrc = Path.Combine (outputPath, "Library1.pdb");
 					Assert.IsTrue (
+						File.Exists (Path.Combine (intermediate, "android", "assets", "Mono.Android.pdb")),
+						"Mono.Android.pdb must be copied to Intermediate directory");
+					Assert.IsTrue (
 						File.Exists (assetsPdb),
 						"Library1.pdb must be copied to Intermediate directory");
 					Assert.IsTrue (

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -361,11 +361,13 @@ namespace ${ROOT_NAMESPACE} {
 				Assert.True (appBuilder.Install (app, parameters: parameters.ToArray ()), "App should have installed.");
 
 				if (!embedAssemblies) {
-					// Check that we deployed .pdb files
+					// Check that we deployed app and framework .pdb files
 					StringAssertEx.ContainsRegex ($@"NotifySync CopyFile.+{app.ProjectName}\.pdb", appBuilder.LastBuildOutput,
 						$"{app.ProjectName}.pdb should be deployed!");
 					StringAssertEx.ContainsRegex ($@"NotifySync CopyFile.+{lib.ProjectName}\.pdb", appBuilder.LastBuildOutput,
 						$"{lib.ProjectName}.pdb should be deployed!");
+					StringAssertEx.ContainsRegex ($@"NotifySync CopyFile.+Mono.Android\.pdb", appBuilder.LastBuildOutput,
+						$"Mono.Android.pdb should be deployed!");
 				}
 
 				int breakcountHitCount = 0;


### PR DESCRIPTION
Adds the .pdb files associated with our framework assemblies to the .NET
runtime packs.  This will allow them to be fast deployed or included in
an .aab/.apk for Debug builds.  A couple of symbol related tests have
been updated to also check for Mono.Android.pdb.

I also noticed that the `SmokeTest` category was not running for the
`net6.0` MSBuildDeviceIntegration tests, as the emulator smoke test job
only runs against the `net472` test assembly.  This currently doesn't
matter as all `net6.0` smoke tests are ignored through other category
attributes, but this fix should be needed in the future.