### PR TITLE
[Tests] Disable Mono.Android WebSocket tests

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
+++ b/tests/Mono.Android-Tests/System.Net/WebSocketTests.cs
@@ -10,6 +10,7 @@ namespace System.NetTests
 	public class WebSocketTests
 	{
 		[Test, Category ("InetAccess")]
+		[Ignore ("echo.websocket.org is not available anymore")]
 		public void TestSocketConnection()
 		{
 			string testMessage = "This is a test!";


### PR DESCRIPTION
The `echo.websocket.org` server used by the tests appears to no
longer be available.

Disable the tests for now until we figure out what service we
can use to replace `echo.websocket.org`