### PR TITLE
[mac] Fix failing Designer test

### DIFF
--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -48,6 +48,7 @@ ApplicationConfig application_config = {
 	.environment_variable_count = 0,
 	.system_property_count = 0,
 	.number_of_assemblies_in_apk = 0,
+	.bundled_assembly_name_width = 0,
 	.android_package_name = "com.xamarin.test",
 };
 
@@ -66,6 +67,7 @@ XamarinAndroidBundledAssembly bundled_assemblies[] = {
 		.data_offset = 0,
 		.data_size = 0,
 		.data = nullptr,
+		.name_length = 0,
 		.name = first_assembly_name,
 	},
 
@@ -74,6 +76,7 @@ XamarinAndroidBundledAssembly bundled_assemblies[] = {
 		.data_offset = 0,
 		.data_size = 0,
 		.data = nullptr,
+		.name_length = 0,
 		.name = second_assembly_name,
 	},
 };

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -85,8 +85,10 @@ namespace xamarin::android::internal {
 
 		void prepare_for_multiple_threads () noexcept
 		{
+#if defined (ANDROID)
 			int ret = sem_init (&assembly_mmap_semaphore, 0 /* pshared */, 1 /* value */);
 			abort_unless (ret == 0, "Failed to initialize assembly mapping semaphore. %s", strerror (errno));
+#endif
 		}
 
 		/* returns current number of *all* assemblies found from all invocations */
@@ -234,7 +236,11 @@ namespace xamarin::android::internal {
 
 		bool                   register_debug_symbols;
 		bool                   have_and_want_debug_symbols;
+#if defined (ANDROID)
 		sem_t                  assembly_mmap_semaphore;
+#else
+		static std::mutex      assembly_mmap_mutex;
+#endif
 		size_t                 bundled_assembly_index = 0;
 #if defined (DEBUG) || !defined (ANDROID)
 		TypeMappingInfo       *java_to_managed_maps;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/69289d7811068aa56b39c58e99c69291b4e92259

69289d78 introduced the use of POSIX semaphore API to protect assembly
mmap code from race conditions.   However, it turns out that macOS
implementation of the semaphore is deprecated and always returns an
error, which in turn makes the Xamarin.Android runtime to [abort][0]
the application:

    [2021-08-18 23:45:32.5] Renderer (error) >> ../../../jni/embedded-assemblies.hh:89 (prepare_for_multiple_threads): Failed to initialize assembly mapping semaphore. Function not implemented
    [2021-08-18 23:45:32.5] Renderer >>
    [2021-08-18 23:45:32.5] Renderer >> =================================================================
    [2021-08-18 23:45:32.5] Renderer >> 	Native Crash Reporting
    [2021-08-18 23:45:32.5] Renderer >> =================================================================
    [2021-08-18 23:45:32.5] Renderer >> Got a abrt while executing native code. This usually indicates
    [2021-08-18 23:45:32.5] Renderer >> a fatal error in the mono runtime or one of the native libraries
    [2021-08-18 23:45:32.5] Renderer >> used by your application.
    [2021-08-18 23:45:32.5] Renderer >> =================================================================

While our MinGW Windows build supports and implements the semaphore API,
this commit changes the runtime code to use a standard mutex
(`std::mutex`) for both Windows and macOS instead of the semaphore API.

Additionally, fix a handful of warnings when building for desktop
platforms.

[0]: https://github.com/xamarin/xamarin-android/pull/6188/files#r691713959