### PR TITLE
[One .NET] exclude Microsoft.AspNetCore.App.Runtime.linux-* packages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -14,6 +14,16 @@ _ResolveAssemblies MSBuild target.
   <UsingTask TaskName="Xamarin.Android.Tasks.ProcessNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.StripNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
+  <!-- HACK: workaround for: https://github.com/dotnet/sdk/issues/19891 -->
+  <Target Name="_RemoveLinuxFrameworkReferences"
+      AfterTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
+      <PackageDownload Remove="Microsoft.AspNetCore.App.Runtime.%(_ProblematicRIDs.Identity)" />
+      <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' == 'true' ">
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -416,15 +416,12 @@ $@"<Project>
 			if (File.Exists (repoNuGetConfig) && !File.Exists (projNugetConfig)) {
 				Directory.CreateDirectory (Path.GetDirectoryName (projNugetConfig));
 				File.Copy (repoNuGetConfig, projNugetConfig, overwrite: true);
-				// Write additional sources to NuGet.config if needed
-				if (ExtraNuGetConfigSources != null) {
-					var doc = XDocument.Load (projNugetConfig);
-					AddNuGetConfigSources (doc);
-					doc.Save (projNugetConfig);
-				}
+
+				var doc = XDocument.Load (projNugetConfig);
+				AddNuGetConfigSources (doc);
+
 				// Set a local PackageReference installation folder if specified
 				if (!string.IsNullOrEmpty (GlobalPackagesFolder)) {
-					var doc = XDocument.Load (projNugetConfig);
 					XElement gpfElement = doc.Descendants ().FirstOrDefault (c => c.Name.LocalName.ToLowerInvariant () == "add"
 						&& c.Attributes ().Any (a => a.Name.LocalName.ToLowerInvariant () == "key" && a.Value.ToLowerInvariant () == "globalpackagesfolder"));
 					if (gpfElement != default (XElement)) {
@@ -442,18 +439,37 @@ $@"<Project>
 							doc.Root.Add (configParentElement);
 						}
 					}
-					doc.Save (projNugetConfig);
 				}
+
+				doc.Save (projNugetConfig);
 			}
 		}
 
 		/// <summary>
 		/// Updates a NuGet.config based on sources in ExtraNuGetConfigSources
+		/// Removes the dotnet6 source, which should not be needed by tests
 		/// </summary>
 		protected void AddNuGetConfigSources (XDocument doc)
 		{
+			const string elementName = "packageSources";
+			XElement pkgSourcesElement = doc.Root.Elements ().FirstOrDefault (d => string.Equals (d.Name.LocalName, elementName, StringComparison.OrdinalIgnoreCase));
+			if (pkgSourcesElement == null) {
+				doc.Root.Add (pkgSourcesElement= new XElement (elementName));
+			}
+
+			// Remove dotnet6 feed
+			foreach (XElement element in pkgSourcesElement.Elements ()) {
+				XAttribute value = element.Attribute ("value");
+				if (value != null && value.Value == "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json") {
+					element.Remove ();
+					break;
+				}
+			}
+
+			// Add extra sources
+			if (ExtraNuGetConfigSources == null)
+				return;
 			int sourceIndex = 0;
-			XElement pkgSourcesElement = doc.Descendants ().FirstOrDefault (d => d.Name.LocalName.ToLowerInvariant () == "packagesources");
 			foreach (var source in ExtraNuGetConfigSources) {
 				var sourceElement = new XElement ("add");
 				sourceElement.SetAttributeValue ("key", $"testsource{++sourceIndex}");


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/19891

If you `dotnet new android` and `dotnet build` it without a
`NuGet.config` you hit:

    error NU1102: Unable to find package Microsoft.AspNetCore.App.Runtime.linux-arm64 with version (= 6.0.0-rc.1.21417.2)

I found I could workaround the problem by removing `linux-*` packages
at a certain point during the build:

    <Target Name="_RemoveLinuxFrameworkReferences"
        AfterTargets="ProcessFrameworkReferences">
      <ItemGroup>
        <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
        <PackageDownload Remove="Microsoft.AspNetCore.App.Runtime.%(_ProblematicRIDs.Identity)" />
        <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />
      </ItemGroup>
    </Target>

With this target in place, I can build projects without a
`NuGet.config` file. Let's put this workaround in place until we have
another solution for dotnet/sdk#19891.

To validate these changes, I removed any instances of the `dotnet6`
feed in our MSBuild tests.