### PR TITLE
[build] Fix release branch package versions

### DIFF
--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -86,7 +86,7 @@
       <!-- See Azure Pipelines predefined variables. -->
       <_AndroidPackLabel Condition=" '$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != '' ">ci.pr.gh$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
-      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(_AndroidPackBranch)' == 'main' or $(_AndroidPackBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
+      <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(XAVersionBranch)' == 'main' or $(XAVersionBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
       <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
       <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>


### PR DESCRIPTION
I noticed our `release/6.0.1xx-rc1` branch was producing packs with a
strange version string:

    30.0.100-ci.release-6-0-1xx-rc1.14

The regex performed on `$(_AndroidPackBranch)` strips all `/` characters
from the branch name, causing the release branch condition specified in
`$(_AndroidPackBranch.StartsWith('release/'))` to never be true.

Fix this condition by using the unaltered `$(XAVersionBranch)` property
value.