### PR TITLE
[ci] Push .NET 6 packages to dnceng dotnet6 feed

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -128,7 +128,7 @@
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.4.0</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
-    <MauiFeedUrl>https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json</MauiFeedUrl>
+    <MauiFeedUrl>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json</MauiFeedUrl>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
     <_TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_TestsAotName>
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>

--- a/Documentation/workflow/DevelopmentTips.md
+++ b/Documentation/workflow/DevelopmentTips.md
@@ -527,4 +527,4 @@ package on the [nightly Azure DevOps feed][maui-feed]. Or look for the
 `Microsoft.NET.Sdk.Maui.Manifest-6.0.100` package on NuGet.org for public
 releases.
 
-[maui-feed]: https://dev.azure.com/azure-public/vside/_packaging?_a=package&feed=xamarin-impl%40Local&package=Microsoft.NET.Sdk.Maui.Manifest-6.0.100&protocolType=NuGet&version=6.0.100-rc.1.1351%2Bsha.3fbb791e7-azdo.5078933
+[maui-feed]: https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet6%40Local

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1274,12 +1274,33 @@ stages:
 
 - stage: dotnet_prepare_release
   displayName: .NET 6 Prepare Release
-  dependsOn: []
-  condition: eq(variables['MicroBuildSignType'], 'Real')
+  dependsOn: mac_build
   jobs:
+  # Check - "Xamarin.Android (.NET 6 Prepare Release Sign NuGets)"
+  - template: sign-artifacts/jobs/v2.yml@yaml
+    parameters:
+      artifactName: $(NuGetArtifactName)
+      signType: $(MicroBuildSignType)
+      usePipelineArtifactTasks: true
+      condition: eq(variables['MicroBuildSignType'], 'Real')
+
+  # Check - "Xamarin.Android (.NET 6 Prepare Release Convert NuGet to MSI)"
+  - template: nuget-msi-convert/job/v2.yml@yaml
+    parameters:
+      yamlResourceName: yaml
+      dependsOn: signing
+      artifactName: nuget-signed
+      artifactPatterns: |
+        !*Darwin*
+      propsArtifactName: nuget-unsigned
+      signType: $(MicroBuildSignType)
+      condition: eq(variables['MicroBuildSignType'], 'Real')
+
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
   - job: push_signed_nugets
     displayName: Push NuGets
+    dependsOn: nuget_convert
+    condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
     timeoutInMinutes: 60
     pool: VSEngSS-MicroBuild2019
     workspace:
@@ -1292,25 +1313,8 @@ stages:
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        source: specific
-        project: DevDiv
-        pipeline: 11410
-        runVersion: latestFromBranch
-        runBranch: refs/heads/main
-        allowFailedBuilds: true
-        artifact: nuget-signed
-        path: $(System.DefaultWorkingDirectory)\nuget-signed
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        source: specific
-        project: DevDiv
-        pipeline: 11410
-        runVersion: latestFromBranch
-        runBranch: refs/heads/main
-        allowFailedBuilds: true
-        artifact: vs-msi-nugets
-        path: $(System.DefaultWorkingDirectory)\vs-msi-nugets
+        artifactName: nuget-signed
+        downloadPath: $(System.DefaultWorkingDirectory)\nuget-signed
 
     - task: NuGetCommand@2
       displayName: push nupkgs
@@ -1320,6 +1324,11 @@ stages:
         nuGetFeedType: external
         publishFeedCredentials: dnceng-dotnet6
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vs-msi-nugets
+        downloadPath: $(System.DefaultWorkingDirectory)\vs-msi-nugets
 
     - task: NuGetCommand@2
       displayName: push msi nupkgs

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1274,27 +1274,7 @@ stages:
 
 - stage: dotnet_prepare_release
   displayName: .NET 6 Prepare Release
-  dependsOn: mac_build
-  jobs:
-  # Check - "Xamarin.Android (.NET 6 Prepare Release Sign NuGets)"
-  - template: sign-artifacts/jobs/v2.yml@yaml
-    parameters:
-      artifactName: $(NuGetArtifactName)
-      signType: $(MicroBuildSignType)
-      usePipelineArtifactTasks: true
-      condition: eq(variables['MicroBuildSignType'], 'Real')
-
-  # Check - "Xamarin.Android (.NET 6 Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@yaml
-    parameters:
-      yamlResourceName: yaml
-      dependsOn: signing
-      artifactName: nuget-signed
-      artifactPatterns: |
-        !*Darwin*
-      propsArtifactName: nuget-unsigned
-      signType: $(MicroBuildSignType)
-      condition: eq(variables['MicroBuildSignType'], 'Real')
+  dependsOn: []
 
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
   - job: push_signed_nugets
@@ -1313,8 +1293,25 @@ stages:
 
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifactName: nuget-signed
-        downloadPath: $(System.DefaultWorkingDirectory)\nuget-signed
+        source: specific
+        project: DevDiv
+        pipeline: 11410
+        runVersion: latestFromBranch
+        runBranch: refs/heads/main
+        allowFailedBuilds: true
+        artifact: nuget-signed
+        path: $(System.DefaultWorkingDirectory)\nuget-signed
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: specific
+        project: DevDiv
+        pipeline: 11410
+        runVersion: latestFromBranch
+        runBranch: refs/heads/main
+        allowFailedBuilds: true
+        artifact: msi-nupkgs
+        path: $(System.DefaultWorkingDirectory)\msi-nupkgs
 
     - task: NuGetCommand@2
       displayName: push nupkgs
@@ -1324,11 +1321,6 @@ stages:
         nuGetFeedType: external
         publishFeedCredentials: dnceng-dotnet6
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: msi-nupkgs
-        downloadPath: $(System.DefaultWorkingDirectory)\msi-nupkgs
 
     - task: NuGetCommand@2
       displayName: push msi nupkgs

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1275,12 +1275,11 @@ stages:
 - stage: dotnet_prepare_release
   displayName: .NET 6 Prepare Release
   dependsOn: []
-
+  condition: eq(variables['MicroBuildSignType'], 'Real')
+  jobs:
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
   - job: push_signed_nugets
     displayName: Push NuGets
-    dependsOn: nuget_convert
-    condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
     timeoutInMinutes: 60
     pool: VSEngSS-MicroBuild2019
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1309,8 +1309,8 @@ stages:
         runVersion: latestFromBranch
         runBranch: refs/heads/main
         allowFailedBuilds: true
-        artifact: msi-nupkgs
-        path: $(System.DefaultWorkingDirectory)\msi-nupkgs
+        artifact: vs-msi-nugets
+        path: $(System.DefaultWorkingDirectory)\vs-msi-nugets
 
     - task: NuGetCommand@2
       displayName: push nupkgs
@@ -1325,7 +1325,7 @@ stages:
       displayName: push msi nupkgs
       inputs:
         command: push
-        packagesToPush: $(System.DefaultWorkingDirectory)\msi-nupkgs\*.nupkg
+        packagesToPush: $(System.DefaultWorkingDirectory)\vs-msi-nugets\*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: dnceng-dotnet6
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1299,8 +1299,8 @@ stages:
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
   - job: push_signed_nugets
     displayName: Push NuGets
-    dependsOn: signing
-    condition: and(eq(dependencies.signing.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+    dependsOn: nuget_convert
+    condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
     timeoutInMinutes: 60
     pool: VSEngSS-MicroBuild2019
     workspace:
@@ -1322,7 +1322,21 @@ stages:
         command: push
         packagesToPush: $(System.DefaultWorkingDirectory)\nuget-signed\*.nupkg
         nuGetFeedType: external
-        publishFeedCredentials: xamarin-impl public feed
+        publishFeedCredentials: dnceng-dotnet6
+      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: msi-nupkgs
+        downloadPath: $(System.DefaultWorkingDirectory)\msi-nupkgs
+
+    - task: NuGetCommand@2
+      displayName: push msi nupkgs
+      inputs:
+        command: push
+        packagesToPush: $(System.DefaultWorkingDirectory)\msi-nupkgs\*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: dnceng-dotnet6
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
     - powershell: >-

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -141,7 +141,7 @@
     <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />

--- a/tests/Mono.Android-Tests/Directory.Build.targets
+++ b/tests/Mono.Android-Tests/Directory.Build.targets
@@ -42,8 +42,6 @@
 <![CDATA[
 <configuration>
   <packageSources>
-    <add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="local-xa" value="$(LocalNupkgDirectory)" />
   </packageSources>


### PR DESCRIPTION
We now have the ability to push to the `dotnet6` feed that contains
the rest of the .NET 6 SDK Workload packages.  Begin pushing packages
to the `dotnet6` feed.

This should help simplify workload acquisition.

The `.nupkg` files containing the `.msi` installers used for
Visual Studio insertions will also now be pushed to this feed.
