### PR TITLE
[Linux] Properly detect Debian bookworm/sid

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override bool InitOS ()
+		protected override bool EnsureVersionInformation (Context context)
 		{
 			Version ubuntuRelease;
 			if (!Version.TryParse (Release, out ubuntuRelease)) {
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Prepare
 			}
 			UbuntuRelease = ubuntuRelease;
 
-			return base.InitOS ();
+			return true;
 		}
 	};
 }

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
@@ -172,6 +172,11 @@ and re-enable it after building with the following command:
 			return true;
 		}
 
+		protected virtual bool EnsureVersionInformation (Context context)
+		{
+			return true;
+		}
+
 		public static Linux DetectAndCreate (Context context)
 		{
 			string name = String.Empty;
@@ -233,6 +238,10 @@ and re-enable it after building with the following command:
 			linux.warnBinFmt = ShouldWarnAboutBinfmt ();
 			linux.codeName = codeName;
 			linux.derived = usingBaseDistro;
+
+			if (!linux.EnsureVersionInformation (context)) {
+				throw new InvalidOperationException ("Unable to detect version of your Linux distribution");
+			}
 
 			return linux;
 		}


### PR DESCRIPTION
The current Debian unstable distribution (codenamed "bookworm") no
longer contains any release version information in the `/etc/os-release`
file (the `VERSION` and `VERSION_ID` and `VERSION_CODENAME` fields were
removed) causing `xaprepare` to fail when running on this version of
Debian.

Fix the Debian/unstable version detection by looking for known release
codenames and faking the version number.