### PR TITLE
[One .NET] add $(AndroidGenerateResourceDesigner) property

### DIFF
--- a/Documentation/guides/OneDotNetBindingProjects.md
+++ b/Documentation/guides/OneDotNetBindingProjects.md
@@ -217,5 +217,19 @@ As the default for .NET 6 is `disable`, the same applies for Xamarin Android pro
 
 Use `enable` as shown above to enable NRT support.
 
-
 [11-0-release-notes]: https://docs.microsoft.com/en-us/xamarin/android/release-notes/11/11.0
+
+### `Resource.designer.cs`
+
+In Xamarin.Android, Java binding projects did not support generating a `Resource.designer.cs` file.
+Since binding projects are just class libraries in .NET 6, this file will be generated. This could
+be a breaking change when migrating existing projects.
+
+To disable `Resource.designer.cs` generation, set `$(AndroidGenerateResourceDesigner)` to `false`
+in your `.csproj`:
+
+```xml
+<PropertyGroup>
+  <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+</PropertyGroup>
+```

--- a/Documentation/guides/OneDotNetBindingProjects.md
+++ b/Documentation/guides/OneDotNetBindingProjects.md
@@ -225,6 +225,23 @@ In Xamarin.Android, Java binding projects did not support generating a `Resource
 Since binding projects are just class libraries in .NET 6, this file will be generated. This could
 be a breaking change when migrating existing projects.
 
+One example of a failure from this change, is if your binding generates a class named `Resource`
+in the root namespace:
+
+```
+error CS0101: The namespace 'MyBinding' already contains a definition for 'Resource'
+```
+
+Or in the case of AndroidX, we have project files with `-` in the name such as
+`androidx.window/window-extensions.csproj`. This results in the root namespace `window-extensions`
+and invalid C# in `Resource.designer.cs`:
+
+```
+error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+error CS1514: { expected 
+error CS1022: Type or namespace definition, or end-of-file expected
+```
+
 To disable `Resource.designer.cs` generation, set `$(AndroidGenerateResourceDesigner)` to `false`
 in your `.csproj`:
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -569,6 +569,12 @@ Enables generation of [layout code-behind](https://github.com/xamarin/xamarin-an
 if set to `true` or disables it completely if set to `false`. The
 default value is `false`.
 
+## AndroidGenerateResourceDesigner
+
+Defaults to `true`. When set to `false`, disables the generation of `Resource.designer.cs`.
+
+Added in .NET 6 RC 1. Not supported in Xamarin.Android.
+
 ## AndroidHttpClientHandlerType
 
 Controls the default

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -7,11 +7,11 @@
     <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
     <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
-    <AndroidResgenFile Condition=" '$(AndroidResgenFile)' == '' ">$(MonoAndroidResourcePrefix)\$(_AndroidResourceDesigner)</AndroidResgenFile>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' == 'true' ">Xamarin.Android.Net.AndroidMessageHandler</AndroidHttpClientHandlerType>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' != 'true' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
+    <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">true</AndroidGenerateResourceDesigner>
+    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseIntermediateDesignerFile>
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' ">false</ComputeNETCoreBuildOutputFiles>

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
@@ -7,6 +7,7 @@
     <_ApkDebugKeyStore>debug.keystore</_ApkDebugKeyStore>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AppendTargetFrameworkToIntermediateOutputPath>false</AppendTargetFrameworkToIntermediateOutputPath>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <Compile Remove="..\Resources\Resource.designer.cs" />
-    <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="System\AppContextTests.cs" />
     <!-- Mono.Data.Sqlite is not supported in .NET 6 -->
     <Compile Remove="..\Mono.Data.Sqlite\SqliteTests.cs" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6198

When migrating Xamarin.Android binding projects to .NET 6, one
difference is that `Resource.designer.cs` will be generated by .NET 6
class libraries.

There is not currently a way to turn this off, if you pass:

    dotnet build -p:AndroidUseIntermediateDesignerFile=false

Then `Resources\Resource.designer.cs` will be generated instead. There
is no way to prevent this behavior, because `$(AndroidResgenFile)`
defaults to this value.

To solve cases where you *don't* want `Resource.designer.cs` at all:

1. Remove the `$(AndroidResgenFile)` default value.
2. Add a new `$(AndroidGenerateResourceDesigner)` MSBuild property,
   that seems like it will be a better name for .NET 6.
3. `$(AndroidUseIntermediateDesignerFile)` is based on
   `$(AndroidGenerateResourceDesigner)`.

I added a test for the new property.