### PR TITLE
[Xamarin.Android.Build.Tasks] fix XA0031 message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -181,7 +181,12 @@ In this message, the phrase "should not be reached" means that this error messag
     <value>Java SDK {0} or above is required when using {1}.</value>
     <comment>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</comment>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</comment>
+  </data>
+  <data name="XA0031_NET" xml:space="preserve">
+    <value>Java SDK {0} or above is required when using .NET 6 or higher.</value>
+    <comment>
+{0} - The Java SDK version number</comment>
   </data>
   <data name="XA0032" xml:space="preserve">
     <value>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">Když se používá {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
+        <target state="needs-review-translation">Když se používá {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">Bei Verwendung von {1} ist Java SDK {0} oder höher erforderlich.</target>
+        <target state="needs-review-translation">Bei Verwendung von {1} ist Java SDK {0} oder höher erforderlich.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">Se requiere el SDK de Java {0} o posterior cuando se use {1}.</target>
+        <target state="needs-review-translation">Se requiere el SDK de Java {0} o posterior cuando se use {1}.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">Le SDK Java {0} ou supérieur est nécessaire pour utiliser {1}.</target>
+        <target state="needs-review-translation">Le SDK Java {0} ou supérieur est nécessaire pour utiliser {1}.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">Quando si usa {1}, è richiesto Java SDK {0} o versione successiva.</target>
+        <target state="needs-review-translation">Quando si usa {1}, è richiesto Java SDK {0} o versione successiva.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">{1} を使用するときには、Java SDK {0} 以上が必要です。</target>
+        <target state="needs-review-translation">{1} を使用するときには、Java SDK {0} 以上が必要です。</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">{1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
+        <target state="needs-review-translation">{1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">W przypadku używania funkcji {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
+        <target state="needs-review-translation">W przypadku używania funkcji {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">O SDK do Java {0} ou superior é necessário ao usar {1}.</target>
+        <target state="needs-review-translation">O SDK do Java {0} ou superior é necessário ao usar {1}.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">При использовании компонента {1} требуется пакет SDK для Java как минимум версии {0}.</target>
+        <target state="needs-review-translation">При использовании компонента {1} требуется пакет SDK для Java как минимум версии {0}.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">{1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
+        <target state="needs-review-translation">{1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">使用 {1} 时需要 Java SDK {0} 或更高版本。</target>
+        <target state="needs-review-translation">使用 {1} 时需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,12 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="XA0031_NET">
+        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <note>
+{0} - The Java SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.
@@ -157,10 +163,10 @@ In this message, the phrase "should not be reached" means that this error messag
       </trans-unit>
       <trans-unit id="XA0031">
         <source>Java SDK {0} or above is required when using {1}.</source>
-        <target state="translated">使用 {1} 時，需要 Java SDK {0} 或更高版本。</target>
+        <target state="needs-review-translation">使用 {1} 時，需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number
-{1} - The feature being used: `$(TargetFrameworkVersion) v10.0` or `&lt;Project Sdk="Xamarin.Android.Sdk"&gt;`</note>
+{1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</note>
       </trans-unit>
       <trans-unit id="XA0032">
         <source>Java SDK {0} or above is required when using Android SDK Build-Tools {1}.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tasks
 				if (versionNumber != null) {
 					Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
 					if (versionNumber < required) {
-						Log.LogCodedError ("XA0031", Properties.Resources.XA0031, required, "`<Project Sdk=\"Xamarin.Android.Sdk\">`");
+						Log.LogCodedError ("XA0031", Properties.Resources.XA0031_NET, required);
 					}
 					var latest = Version.Parse (LatestSupportedJavaVersion);
 					if (versionNumber > latest) {


### PR DESCRIPTION
Testing latest xamarin-android/main, I got the error:

    error XA0031: Java SDK 11.0 or above is required when using `<Project Sdk="Xamarin.Android.Sdk">`.

This seems out of date, we should just say `.NET 6 or higher` instead. I made a new resource key for this.