### PR TITLE
[One .NET] bump $(MinimumSupportedJavaVersion) to 11.0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -2,7 +2,7 @@
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
-    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">1.8.0</MinimumSupportedJavaVersion>
+    <MinimumSupportedJavaVersion Condition=" '$(MinimumSupportedJavaVersion)' == '' ">11.0</MinimumSupportedJavaVersion>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">System</AndroidBoundExceptionType>
     <MonoAndroidResourcePrefix Condition=" '$(MonoAndroidResourcePrefix)' == '' ">Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>


### PR DESCRIPTION
Since e7228252, API 31 is stable -- this requires JDK 11.

Unfortunately, if you build an app right now you hit:

    > dotnet new android ; dotnet build
    ...
    error XA0031: Java SDK 11.0 or above is required when using .NET 6 or higher.

You can fix the problem with:

    dotnet build -p:MinimumSupportedJavaVersion=11.0.0

Let's make `$(MinimumSupportedJavaVersion)` default to `11.0` going
forward in .NET 6.