### PR TITLE
[One .NET] fix Mono.Android.Export for Release builds

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Runtime.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Runtime.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<!-- This preserves type forwards for Java stub generation -->
+	<assembly fullname="System.Runtime">
+		<type fullname="System.Boolean">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Byte">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Char">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Decimal">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Double">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Int16">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Int32">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Int64">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.IntPtr">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Object">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.SByte">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.Single">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.String">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.UInt16">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.UInt32">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.UInt64">
+			<method name="ToString" />
+		</type>
+		<type fullname="System.UIntPtr">
+			<method name="ToString" />
+		</type>
+		<!-- System.Void has no methods -->
+		<type fullname="System.Void" />
+	</assembly>
+</linker>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -20,7 +20,7 @@
       "Size": 533257
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2681
+      "Size": 2832
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 3535

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -128,7 +128,7 @@
       "Size": 1844
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2877
+      "Size": 3013
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
       "Size": 3945


### PR DESCRIPTION
Usage of `[Export]` in a Release build triggers an NRE during the build:

    Xamarin.Android.Common.targets(1413,3): error XA4209: Failed to generate Java type for class: UnnamedProject.ContainsExportedMethods due to System.NullReferenceException: Object reference not set to an instance of an object.
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator.Signature..ctor(String name, String signature, String connector, String managedParameters, String outerType, String superCall) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 696
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator.Signature..ctor(MethodDefinition method, ExportAttribute export, IMetadataResolver cache) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 664
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator.AddMethod(MethodDefinition registeredMethod, MethodDefinition implementedMethod) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 391
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator..ctor(TypeDefinition type, String outerType, Action`2 log, IMetadataResolver resolver) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 145
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator..ctor(TypeDefinition type, Action`2 log, IMetadataResolver resolver) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 70
        at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator..ctor(TypeDefinition type, Action`2 log, TypeDefinitionCache cache) in C:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGenerator.cs:line 65
        at Xamarin.Android.Tasks.GenerateJavaStubs.CreateJavaSources(IEnumerable`1 javaTypes, TypeDefinitionCache cache)

This in the case of the method having a `void` return type, this fails
because the type forward is linked away in `System.Runtime.dll` for:

    [assembly: TypeForwardedTo(typeof(void))]

I could reproduce this issue in `MonoAndroidExportTest.cs`, by just
parameterizing `Release` builds.

I found we could solve this issue by preserving:

    <?xml version="1.0" encoding="utf-8" ?>
    <linker>
        <assembly fullname="System.Runtime">
            <type fullname="System.Void" />
        </assembly>
    </linker>

I went ahead and listed the built-in system types like `Int32`,
`Boolean`, etc. that are C# keywords.

The only hitch I found was that we need to specify either a method or
field -- otherwise `System.Private.CoreLib.dll` grew in size quite a
bit because it completely preserved all these types. I listed
`ToString()` on all these types, as it seemed like the most basic
method. The file size tradeoff looks reasonable now.

The test now passes, and I believe most usage of `[Export]` should
work now for `Release` builds.