### PR TITLE
Bump to xamarin/monodroid/main@5676b84b

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@fb0d502139bc222d4e9ad82f912b1c6f1d4ca34e
+xamarin/monodroid:main@5676b84b411c39454cb52499613b936078834924
 mono/mono:2020-02@c633fe923832f0c3db3c4e6aa98e5592bf5a06e7

--- a/external/monodroid.override.props
+++ b/external/monodroid.override.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <XamarinAndroidToolsDirectory>$(MSBuildThisFileDirectory)xamarin-android-tools</XamarinAndroidToolsDirectory>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/fb0d502139bc222d4e9ad82f912b1c6f1d4ca34e...5676b84b411c39454cb52499613b936078834924

  * xamarin/monodroid@5676b84b4: Bump to xamarin/androidtools/main@0abc0d7c (#1223)
  * xamarin/monodroid@daf1aa909: [optimization] Replace 'new T[0]' with 'Array.Empty<T> ()' to reduce allocations. (#1221)
  * xamarin/monodroid@fb848118b: [tools/msbuild] Check `device.Properties.BuildVersionSdk` for `-1` (#1222)
  * xamarin/monodroid@489a389d1: [tools/msbuild] Check device additional output to see if its the same device. (#1218)
  * xamarin/monodroid@209a7c352: [tests/AndroidMSBuildTests] Remove Unused Unit Tests (#1215)