### PR TITLE
[Microsoft.Android.Sdk.ILLink] delete System.Private.CoreLib.xml

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -101,6 +101,7 @@ namespace Xamarin.Android.Prepare
 
 				if (file.Contains ("src/Microsoft.Android.Sdk.ILLink")) {
 					testAreas.Add ("MSBuild");
+					testAreas.Add ("MSBuildDevice");
 				}
 
 				if (file.Contains ("src/Mono.Android")) {

--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- Temporary workaround for crash in GlobalizationNative_GetSortHandle, context: https://github.com/xamarin/xamarin-android/pull/5669 -->
-<linker>
-	<assembly fullname="System.Private.CoreLib">
-		<type fullname="System.Globalization.GlobalizationMode" />
-		<type fullname="System.Runtime.CompilerServices.InternalsVisibleToAttribute" />
-	</assembly>
-</linker>


### PR DESCRIPTION
The linked runtime issue is fixed:

https://github.com/dotnet/runtime/issues/49073

We should be able to remove this now.