### PR TITLE
[Xamarin.Android.Build.Tasks] Improve XA0031 error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -178,7 +178,7 @@ In this message, the phrase "should not be reached" means that this error messag
     <comment>The abbreviation "JDK" should not be translated.</comment>
   </data>
   <data name="XA0031" xml:space="preserve">
-    <value>Java SDK {0} or above is required when using {1}.</value>
+    <value>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</value>
     <comment>
 {0} - The Java SDK version number
 {1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Když se používá {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Bei Verwendung von {1} ist Java SDK {0} oder höher erforderlich.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Se requiere el SDK de Java {0} o posterior cuando se use {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Le SDK Java {0} ou supérieur est nécessaire pour utiliser {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Quando si usa {1}, è richiesto Java SDK {0} o versione successiva.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1} を使用するときには、Java SDK {0} 以上が必要です。</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">W przypadku używania funkcji {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">O SDK do Java {0} ou superior é necessário ao usar {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">При использовании компонента {1} требуется пакет SDK для Java как минимум версии {0}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">使用 {1} 时需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -162,7 +162,7 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.</source>
+        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">使用 {1} 時，需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number


### PR DESCRIPTION
Context: https://aka.ms/vs2019-and-jdk-11
Context: https://github.com/xamarin/xamarin-android/wiki/JDK-11-Warning

The XA0031 error will be generated when
`$(TargetFrameworkVersion)`=v12.0 and JDK 1.8 is detected, as JDK-11
is required for API-31; see also 8140991e, 26770284.

The problem is the XA0031 error message:

	error XA0031: Java SDK 11.0 or above is required when using $(TargetFrameworkVersion) v12.0.

The error message implies that error can be fixed by installing JDK-11.

Which is correct: the XA0031 error *can* be fixed by installing JDK-11.

The problem is that *once JDK-11 is installed*, the Android Designer
breaks, as the Android Designer, as shipped in Visual Studio 16.11 and
Visual Studio for Mac 8.10, only works with JDK 1.8.

This can easily result in a scenario where a customer wants to use
API-31, installs JDK-11, and then can no longer use the Designer.
(This could be mentioned in the Release Notes, but historically nobody
reads the release notes.)

Update the XA0031 error message so that this implicit dependency is
made explicit:

	error XA0031: Java SDK 11.0 or above is required when using $(TargetFrameworkVersion) v12.0.  Note: the Android Designer is incompatible with JDK-11: https://aka.ms/vs2019-and-jdk-11

<https://aka.ms/vs2019-and-jdk-11> provides more details.