### PR TITLE
[tests] Fix TargetFramework8_1_Requires_1_8_0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -54,7 +55,9 @@ namespace Xamarin.Android.Build.Tests
 				MinimumSupportedJavaVersion = "1.7.0",
 			};
 			Assert.False (validateJavaVersion.Execute (), "Execute should *not* succeed!");
-			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when using $(TargetFrameworkVersion) {validateJavaVersion.TargetFrameworkVersion}."), "Should get error about TargetFrameworkVersion=v8.1");
+			Assert.IsTrue (
+					errors.Any (e => e.Message.StartsWith ($"Java SDK 1.8 or above is required when using $(TargetFrameworkVersion) {validateJavaVersion.TargetFrameworkVersion}.", StringComparison.OrdinalIgnoreCase)),
+					"Should get error about TargetFrameworkVersion=v8.1");
 		}
 
 		[Test]
@@ -71,7 +74,9 @@ namespace Xamarin.Android.Build.Tests
 				MinimumSupportedJavaVersion = "1.7.0",
 			};
 			Assert.False (validateJavaVersion.Execute (), "Execute should *not* succeed!");
-			Assert.IsTrue (errors.Any (e => e.Message == $"Java SDK 1.8 or above is required when using Android SDK Build-Tools {validateJavaVersion.AndroidSdkBuildToolsVersion}."), "Should get error about build-tools=27.0.0");
+			Assert.IsTrue (
+					errors.Any (e => e.Message.StartsWith ($"Java SDK 1.8 or above is required when using Android SDK Build-Tools {validateJavaVersion.AndroidSdkBuildToolsVersion}.", StringComparison.OrdinalIgnoreCase)),
+					"Should get error about build-tools=27.0.0");
 		}
 
 		[Test]


### PR DESCRIPTION
Commit 658db25e inadvertently broke the
`ValidateJavaVersionTests.TargetFramework8_1_Requires_1_8_0()`
and `ValidateJavaVersionTests.BuildTools27_Requires_1_8_0()` tests,
by updating the XA0031 error message text.  Because these tests use
string.operator==() to compare the string contents, updating the
XA0031 message text broke the tests.

(This also means that the tests will fail if/when localizations are
ever actually used… 🤔)

Update these tests to instead use `string.StartsWith()`, as the *end*
of the XA0031 message was changed, not the beginning.