### PR TITLE
[ci] Fix parallelization issues in msi generation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -13,7 +13,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/pjc/test-no-parallel
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -1289,7 +1289,7 @@ stages:
         !*Darwin*
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
-      arcadePackageVersion: 6.0.0-beta.21452.2
+      runInParallel: false
       condition: eq(variables['MicroBuildSignType'], 'Real')
 
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1289,6 +1289,7 @@ stages:
         !*Darwin*
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
+      arcadePackageVersion: 6.0.0-beta.21452.2
       condition: eq(variables['MicroBuildSignType'], 'Real')
 
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/pull/7813

We've been often seeing .NET 6 msi generation failing after updating to
a version of arcade that added parallelization to the msi creation.  The
latest version of arcade should hopefully fix these issues.