### PR TITLE
[tests] simpler test case for org.apache.http.legacy

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3363,22 +3363,22 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 
 		//See: https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client
 		[Test]
-		[Retry (5)]
 		public void MissingOrgApacheHttpClient ([Values ("dx", "d8")] string dexTool)
 		{
 			AssertDexToolSupported (dexTool);
 			var proj = new XamarinAndroidApplicationProject {
 				DexTool = dexTool,
+				Sources = {
+					new BuildItem.Source ("ApacheHttpClient.cs") {
+						BinaryContent = () => ResourceData.ApacheHttpClient_cs,
+					},
+				},
 			};
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("</application>",
 				"<uses-library android:name=\"org.apache.http.legacy\" android:required=\"false\" /></application>");
 			proj.SetProperty ("AndroidEnableMultiDex", "True");
 
-			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Maps);
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				string downloaddir = Path.Combine (Root, b.ProjectDirectory, "Downloads");
-				Directory.CreateDirectory (downloaddir);
-				proj.SetProperty ("XamarinBuildDownloadDir", downloaddir);
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/ApacheHttpClient.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/ApacheHttpClient.cs
@@ -1,0 +1,30 @@
+using System;
+using Org.Apache.Http;
+using Org.Apache.Http.Client;
+using Org.Apache.Http.Client.Methods;
+using Org.Apache.Http.Conn;
+using Org.Apache.Http.Params;
+using Org.Apache.Http.Protocol;
+
+class ApacheHttpClient : Java.Lang.Object, IHttpClient
+{
+	public IClientConnectionManager ConnectionManager => throw new NotImplementedException();
+
+	public IHttpParams Params => throw new NotImplementedException();
+
+	public IHttpResponse Execute(IHttpUriRequest request) => throw new NotImplementedException();
+
+	public Java.Lang.Object Execute(IHttpUriRequest request, IResponseHandler responseHandler) => throw new NotImplementedException();
+
+	public Java.Lang.Object Execute(IHttpUriRequest request, IResponseHandler responseHandler, IHttpContext context) => throw new NotImplementedException();
+
+	public IHttpResponse Execute(IHttpUriRequest request, IHttpContext context) => throw new NotImplementedException();
+
+	public IHttpResponse Execute(HttpHost target, IHttpRequest request) => throw new NotImplementedException();
+
+	public Java.Lang.Object Execute(HttpHost target, IHttpRequest request, IResponseHandler responseHandler) => throw new NotImplementedException();
+
+	public Java.Lang.Object Execute(HttpHost target, IHttpRequest request, IResponseHandler responseHandler, IHttpContext context) => throw new NotImplementedException();
+
+	public IHttpResponse Execute(HttpHost target, IHttpRequest request, IHttpContext context) => throw new NotImplementedException();
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
@@ -15,12 +15,14 @@ namespace Xamarin.Android.Build.Tests
 		static Lazy<byte[]> javaSourceJarTestJavadocJar = new Lazy<byte[]>(() => GetResourceData ("javasourcejartest-javadoc.jar"));
 		static Lazy<byte []> library1Aar = new Lazy<byte []> (() => GetResourceData ("library1.aar"));
 		static Lazy<byte []> library2Aar = new Lazy<byte []> (() => GetResourceData ("library2.aar"));
+		static Lazy<byte []> apacheHttpClient_cs = new Lazy<byte []> (() => GetResourceData ("ApacheHttpClient.cs"));
 
 		public  static  byte[]  JavaSourceJarTestJar            => javaSourceJarTestJar.Value;
 		public  static  byte[]  JavaSourceJarTestSourcesJar     => javaSourceJarTestSourcesJar.Value;
 		public  static  byte[]  JavaSourceJarTestJavadocJar     => javaSourceJarTestJavadocJar.Value;
 		public  static  byte [] Library1Aar => library1Aar.Value;
 		public  static  byte [] Library2Aar => library2Aar.Value;
+		public  static  byte [] ApacheHttpClient_cs => apacheHttpClient_cs.Value;
 
 		static byte[] GetResourceData (string name)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Compile Remove="DebuggingTasksTests.cs" Condition="!Exists('$(XAInstallPrefix)xbuild\Xamarin\Android\Xamarin.Android.Build.Debugging.Tasks.dll')" />
+    <Compile Remove="Resources\ApacheHttpClient.cs" />
     <Compile Remove="Expected\**" />
     <Compile Include="..\..\..\..\tools\xabuild\SymbolicLink.cs" />
     <Content Include="Expected\GenerateDesignerFileExpected.cs">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6263#issuecomment-912671300

We have a "flaky" test:

    Xamarin.Android.Build.Tests.BuildTest.MissingOrgApacheHttpClient("dx")
    Xamarin.ProjectTools.FailedBuildException : Build failure:
    ...
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(131,5):
    error : Could not find file '/Users/runner/.nuget/packages/xamarin.googleplayservices.tasks/117.0.0/bsd2z4yg.43k'.
    [/Users/runner/work/1/s/bin/TestRelease/temp/MissingOrgApacheHttpClientdx/UnnamedProject.csproj]

We have a `[Retry(5)]` on this, which doesn't seem to help.

To simplify what this is testing, we don't actually need to bring in
Google Play Services & Xamarin.Build.Download.

I could create an `ApacheHttpClient.cs` file that uses the deprecated
org.apache.http APIs. This test still fails if I remove this from the
`AndroidManifest.xml`:

    <uses-library android:name="org.apache.http.legacy" android:required="false" />

I think this is sufficient to test what we need, and should hopefully
pass more reliably.