### PR TITLE
[monodroid] Use -lkernel32, not -lmincore

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -369,7 +369,7 @@ if(WIN32 OR MINGW)
   message(STATUS "Win32 or MinGW")
   add_compile_options(-fomit-frame-pointer)
   list(APPEND LOCAL_COMMON_LINKER_ARGS -static -pthread -dynamic)
-  list(APPEND LINK_LIBS -lmman -lmincore -lmswsock -lwsock32 -lshlwapi -lpsapi -lwinmm)
+  list(APPEND LINK_LIBS -lmman -lkernel32 -lmswsock -lwsock32 -lshlwapi -lpsapi -lwinmm)
 endif()
 
 if(UNIX)


### PR DESCRIPTION
There are (at least?) two ways to resolve WinAPI references:

  * by using the "legacy" library names, or
  * by using the UWP library names.

Consider [`FlushViewOfFile()`][0]: the "legacy" library is
`kernel32.dll`, while the UWP library is
[`api-ms-win-core-memory-l1-1-2.dll`][1].

I don't know why one style should be preferred over the other.
Regardless, commit 6be4bdbcfd introduced use of `-lmincore`, which
uses the UWP library name style.

*This works*, and *has* worked since 2019.

However, certain internal tools don't "know about" the UWP names,
resulting in spurious "warnings" about having "calls to potentially
undocumented Windows functions".

Appease the tools by using `-lkernel32` and not `-lmincore`.

[0]: https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile
[1]: https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-apis#apis-from-api-ms-win-core-memory-l1-1-2dll