### PR TITLE
[One .NET] specify platforms for android and android-aot workloads

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -13,10 +13,12 @@
         "Microsoft.Android.Runtime.android-x64",
         "Microsoft.Android.Templates"
       ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "microsoft-net-runtime-android" ]
     },
     "android-aot": {
       "description": ".NET SDK Workload for building Android applications with AOT support.",
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "android", "microsoft-net-runtime-android-aot" ]
     }
   },


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/blob/main/accepted/2020/workloads/workload-manifest.md#workload-definitions
Context: https://github.com/dotnet/runtime/blob/c21a701f59557aa55add95ea4b44f56d6dac46d6/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in#L27

We should align our workloads with the list of supported platforms of the `microsoft-net-runtime-android` workload in dotnet/runtime.