### PR TITLE
[ci] Don't convert nuget to msi in parallel

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -13,7 +13,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjc/msi-parallel-option
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -1366,8 +1366,6 @@ stages:
     pushToShippingFeed: true
     nupkgArtifactName: nuget-signed
     msiNupkgArtifactName: vs-msi-nugets
-    archiveSymbols: false
-    createVSPR: false
     condition: eq(variables['MicroBuildSignType'], 'Real')
 
 - stage: finalize_installers

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -13,7 +13,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/pjc/msi-parallel-option
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -1289,6 +1289,7 @@ stages:
         !*Darwin*
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
+      runInParallel: false
       condition: eq(variables['MicroBuildSignType'], 'Real')
 
  # Check - "Xamarin.Android (.NET 6 Prepare Release Push NuGets)"
@@ -1362,6 +1363,11 @@ stages:
     symbolArtifactName: nuget-signed
     symbolArtifactPatterns: |
       !*Darwin*
+    pushToShippingFeed: true
+    nupkgArtifactName: nuget-signed
+    msiNupkgArtifactName: vs-msi-nugets
+    archiveSymbols: false
+    createVSPR: false
     condition: eq(variables['MicroBuildSignType'], 'Real')
 
 - stage: finalize_installers


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5180358&view=logs&j=5b07041f-3ad2-50e1-dcc0-0b413b70a215&t=aaad43f1-f8e0-5332-447f-d87e37c943fe&l=125
Context: https://github.com/xamarin/yaml-templates/pull/135
Context: https://github.com/xamarin/yaml-templates/pull/134

The `Convert NuGet to MSI` job has been failing consistently since we
updated to a version of dotnet/arcade that introduced some changes to
run in parallel.  I've added a parameter to opt-out of parallelization
until those issues can be fixed.

Additionally, our .NET 6 packs will now be pushed to a public xamarin
`net6-maui-shipping` feed during the `VS Insertion` stage.