### PR TITLE
[One .NET] fix binding generation for .jar in application projects

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -87,6 +87,10 @@ This item group populates the Build Action drop-down in IDEs.
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
       <LibraryProjectZip  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
     </ItemGroup>
+    <!-- .NET 6 application projects -->
+    <ItemGroup Condition=" '$(AndroidApplication)' == 'true' and '$(UsingAndroidNETSdk)' == 'true' ">
+      <InputJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
+    </ItemGroup>
     <!-- .NET 6 class libraries-->
     <ItemGroup Condition=" '$(AndroidApplication)' != 'true' and '$(UsingAndroidNETSdk)' == 'true' ">
       <AndroidAarLibrary  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' != 'true' " />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -289,6 +289,28 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void AppWithSingleJar ()
+		{
+			var proj = new XASdkProject {
+				Sources = {
+					new AndroidItem.AndroidLibrary ("Jars\\javaclasses.jar") {
+						BinaryContent = () => ResourceData.JavaSourceJarTestJar,
+					}
+				}
+			};
+
+			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Build (), "build should succeed");
+
+			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.dll");
+			FileAssert.Exists (assemblyPath);
+			using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
+				var typeName = "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceJarTest";
+				Assert.IsNotNull (assembly.MainModule.GetType (typeName), $"{assemblyPath} should contain {typeName}");
+			}
+		}
+
+		[Test]
 		public void GenerateResourceDesigner_false()
 		{
 			var proj = new XASdkProject (outputType: "Library") {


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297837953679412/885897167900934175

Adding a single `.jar` file to a .NET 6 application project does not
produce bindings:

1. The file is added to `@(AndroidLibrary)` and
   `@(AndroidJavaLibrary)` item groups, but not `@(EmbeddedJar)` or
   `@(InputJar)`.
2. Any MSBuild targets related to C# binding generation are skipped.

I could reproduce this issue in a new test.

To solve the issue, we can add `.jar` files to `@(InputJar)` for all
.NET 6 application projects in the `_CategorizeAndroidLibraries`
MSBuild target.