### PR TITLE
[Xamarin.Android.Build.Tasks] include openjdk link in error messages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -178,13 +178,15 @@ In this message, the phrase "should not be reached" means that this error messag
     <comment>The abbreviation "JDK" should not be translated.</comment>
   </data>
   <data name="XA0031" xml:space="preserve">
-    <value>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</value>
+    <value>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</value>
     <comment>
 {0} - The Java SDK version number
 {1} - The feature being used: `$(TargetFrameworkVersion) v10.0`</comment>
   </data>
   <data name="XA0031_NET" xml:space="preserve">
-    <value>Java SDK {0} or above is required when using .NET 6 or higher.</value>
+    <value>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</value>
     <comment>
 {0} - The Java SDK version number</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Když se používá {1}, vyžaduje se sada Java SDK {0} nebo novější.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Bei Verwendung von {1} ist Java SDK {0} oder höher erforderlich.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Se requiere el SDK de Java {0} o posterior cuando se use {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Le SDK Java {0} ou supérieur est nécessaire pour utiliser {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">Quando si usa {1}, è richiesto Java SDK {0} o versione successiva.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1} を使用するときには、Java SDK {0} 以上が必要です。</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1}을(를) 사용하는 경우 Java SDK {0} 이상이 필요합니다.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">W przypadku używania funkcji {1} jest wymagany zestaw Java SDK {0} lub nowszy.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">O SDK do Java {0} ou superior é necessário ao usar {1}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">При использовании компонента {1} требуется пакет SDK для Java как минимум версии {0}.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">{1} kullanılırken Java SDK {0} veya üzeri bir sürüm gerekir.</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">使用 {1} 时需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="XA0031_NET">
-        <source>Java SDK {0} or above is required when using .NET 6 or higher.</source>
-        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher.</target>
+        <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
+        <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
@@ -162,7 +162,9 @@ In this message, the phrase "should not be reached" means that this error messag
         <note>The abbreviation "JDK" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA0031">
-        <source>Java SDK {0} or above is required when using {1}.  Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
+        <source>Java SDK {0} or above is required when using {1}.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11</source>
         <target state="needs-review-translation">使用 {1} 時，需要 Java SDK {0} 或更高版本。</target>
         <note>
 {0} - The Java SDK version number


### PR DESCRIPTION
`XA0031` doesn't include a download link. Let's make the error message more helpful.