### PR TITLE
[Xamarin.Android.Build.Tasks] don't add exported="true" if already present

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -134,10 +134,9 @@ namespace Bug12935
 			};
 			proj.MainActivity = ScreenOrientationActivity;
 			proj.AndroidUseAapt2 = useAapt2;
-			var directory = $"temp/CheckElementReOrdering_{useAapt2}";
-			using (var builder = CreateApkBuilder (directory)) {
+			using (var builder = CreateApkBuilder ()) {
 				proj.AndroidManifest = ElementOrderManifest;
-				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+				Assert.IsTrue (builder.Build (proj), "first build should have succeeded");
 				var manifestFile = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				XDocument doc = XDocument.Load (manifestFile);
 				var ns = doc.Root.GetNamespaceOfPrefix ("android");
@@ -152,6 +151,11 @@ namespace Bug12935
 				AssertAttribute (action, ns + "name", "android.intent.action.MAIN");
 				var category = GetElement (intent_filter, "category");
 				AssertAttribute (category, ns + "name", "android.intent.category.LAUNCHER");
+
+				// Add Exported=true and build again
+				proj.MainActivity = proj.MainActivity.Replace ("MainLauncher = true,", "MainLauncher = true, Exported = true,");
+				proj.Touch ("MainActivity.cs");
+				Assert.IsTrue (builder.Build (proj), "second build should have succeeded");
 			}
 
 			static XElement GetElement (XContainer parent, XName name)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -798,7 +798,13 @@ namespace Xamarin.Android.Tasks {
 				return;
 
 			var filter = new XElement ("intent-filter");
-			activity.Add (new XAttribute (androidNs + "exported", "true"));
+
+			// Add android:exported="true" if not already present
+			XName exported = androidNs + "exported";
+			if (activity.Attribute (exported) == null) {
+				activity.Add (new XAttribute (exported, "true"));
+			}
+
 			activity.AddFirst (filter);
 			foreach (KeyValuePair<string, string> e in LauncherIntentElements) {
 				if (!filter.Elements (e.Key).Any (x => ((string) x.Attribute (attName)) == e.Value))


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6284

Building an Android application with:

    [Activity(
        MainLauncher = true,
        Exported = true,
    //...

Fails with:

    Xamarin.Android.Common.targets(1424,3): error XAGJS7009: System.InvalidOperationException: Duplicate attribute.
        at System.Xml.Linq.XElement.AddAttributeSkipNotify(XAttribute a)
        at System.Xml.Linq.XContainer.AddContentSkipNotify(Object content)
        at System.Xml.Linq.XContainer.Add(Object content)
        at Xamarin.Android.Tasks.ManifestDocument.AddLauncherIntentElements(XElement activity)
        at Xamarin.Android.Tasks.ManifestDocument.<>c__DisplayClass99_0.<ActivityFromTypeDefinition>b__1(ActivityAttribute aa, XElement element)
        at Xamarin.Android.Tasks.ManifestDocument.ToElement[TAttribute](TypeDefinition type, String name, Func`2 parser, Func`2 toElement, Action`2 update)
        at Xamarin.Android.Tasks.ManifestDocument.ActivityFromTypeDefinition(TypeDefinition type, String name, Int32 targetSdkVersion)
        at Xamarin.Android.Tasks.ManifestDocument.Merge(TaskLoggingHelper log, TypeDefinitionCache cache, List`1 subclasses, String applicationClass, Boolean embed, String bundledWearApplicationName, IEnumerable`1 mergedManifestDocuments)
        at Xamarin.Android.Tasks.GenerateJavaStubs.Run(DirectoryAssemblyResolver res)
        at Xamarin.Android.Tasks.GenerateJavaStubs.RunTask()
        at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\AndroidTask.cs:line 17

In d304060, I added the automatic inclusion of
`android:exported="true"` for activities, but we should only do this
if the attribute is not present.

I updated a test for this scenario.