### PR TITLE
[xaprepare] add retry logic when building remap-assembly-ref

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -12,9 +12,9 @@ namespace Xamarin.Android.Prepare
 {
 	static partial class Utilities
 	{
-		static readonly TimeSpan ExceptionRetryInitialDelay = TimeSpan.FromSeconds (30);
-		static readonly TimeSpan WebRequestTimeout = TimeSpan.FromMinutes (60);
-		static readonly int ExceptionRetries = 5;
+		public static readonly TimeSpan ExceptionRetryInitialDelay = TimeSpan.FromSeconds (30);
+		public static readonly TimeSpan WebRequestTimeout = TimeSpan.FromMinutes (60);
+		public static readonly int ExceptionRetries = 5;
 
 		const string MSBuildPropertyListSeparator = ":";
 
@@ -470,7 +470,7 @@ namespace Xamarin.Android.Prepare
 					}
 				} catch (Exception ex) {
 					if (i < ExceptionRetries - 1) {
-						WaitAWhile ($"GetDownloadSize {url}", i, ref ex, ref delay);
+						WaitAWhile ($"GetDownloadSize {url}", i, ex.Message, ref delay);
 					}
 				}
 			}
@@ -495,7 +495,7 @@ namespace Xamarin.Android.Prepare
 					break;
 				} catch (Exception ex) {
 					if (i < ExceptionRetries - 1) {
-						WaitAWhile ($"Download {url}", i, ref ex, ref delay);
+						WaitAWhile ($"Download {url}", i, ex.Message, ref delay);
 					}
 				}
 			}
@@ -621,7 +621,7 @@ namespace Xamarin.Android.Prepare
 				} catch (Exception e) {
 					ex = e;
 				}
-				WaitAWhile ($"Reset timestamp for {filePath}", i, ref ex, ref delay);
+				WaitAWhile ($"Reset timestamp for {filePath}", i, ex.Message, ref delay);
 			}
 
 			if (ex != null) {
@@ -644,7 +644,7 @@ namespace Xamarin.Android.Prepare
 				} catch (Exception e) {
 					ex = e;
 				}
-				WaitAWhile ($"File move ({source} -> {destination})", i, ref ex, ref delay);
+				WaitAWhile ($"File move ({source} -> {destination})", i, ex.Message, ref delay);
 			}
 
 			if (ex != null)
@@ -690,18 +690,18 @@ namespace Xamarin.Android.Prepare
 					tryResetFilePermissions = true;
 				}
 
-				WaitAWhile ($"Directory {directoryPath} deletion", i, ref ex, ref delay);
+				WaitAWhile ($"Directory {directoryPath} deletion", i, ex.Message, ref delay);
 			}
 
 			if (ex != null)
 				throw ex;
 		}
 
-		static void WaitAWhile (string what, int which, ref Exception ex, ref TimeSpan delay)
+		public static void WaitAWhile (string what, int which, string error, ref TimeSpan delay)
 		{
 			Log.DebugLine ($"{what} attempt no. {which + 1} failed, retrying after delay of {delay}");
-			if (ex != null)
-				Log.DebugLine ($"Failure cause: {ex.Message}");
+			if (!string.IsNullOrEmpty (error))
+				Log.DebugLine ($"Failure cause: {error}");
 			Thread.Sleep (delay);
 			delay = TimeSpan.FromMilliseconds (delay.TotalMilliseconds * 2);
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
@@ -87,7 +87,16 @@ namespace Xamarin.Android.Prepare
 		async Task<bool> ConjureXamarinCecilAndRemapRef (Context context, bool haveManagedRuntime, string managedRuntime)
 		{
 			StatusStep (context, "Building remap-assembly-ref");
-			bool result = await Utilities.BuildRemapRef (context, haveManagedRuntime, managedRuntime, quiet: true);
+			var delay = Utilities.ExceptionRetryInitialDelay;
+			bool result = false;
+			for (int i = 0; i < Utilities.ExceptionRetries; i++) {
+				result = await Utilities.BuildRemapRef (context, haveManagedRuntime, managedRuntime, quiet: true);
+				if (!result) {
+					Utilities.WaitAWhile ("Building remap-assembly-ref", i, error: "", delay: ref delay);
+				} else {
+					break;
+				}
+			}
 			if (!result)
 				return false;
 


### PR DESCRIPTION
Fixes? https://github.com/xamarin/xamarin-android/issues/6283

Linux builds commonly fail with errors during NuGet restore:

    RestoreTask
    ...
    Errors
      /usr/lib/mono/msbuild/Current/bin/NuGet.targets(131,5): Failed to download package 'Mono.Cecil.0.11.4' from 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/mono.cecil/0.11.4/mono.cecil.0.11.4.nupkg'.
    The SSL connection could not be established, see inner exception.
      Authentication failed, see inner exception.
      Ssl error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
        at /build/mono-6.12.0.147/external/boringssl/ssl/handshake_client.c:1132 [/mnt/vss/_work/1/s/xamarin-android/build-tools/remap-assembly-ref/remap-assembly-ref.csproj]
        /usr/lib/mono/msbuild/Current/bin/NuGet.targets(131,5): Failed to retrieve information about 'Mono.Cecil' from remote source 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/mono.cecil/index.json'.
      The SSL connection could not be established, see inner exception.
      Authentication failed, see inner exception.
      Ssl error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
        at /build/mono-6.12.0.147/external/boringssl/ssl/handshake_client.c:1132 [/mnt/vss/_work/1/s/xamarin-android/build-tools/remap-assembly-ref/remap-assembly-ref.csproj]

This always happens when `xaprepare` builds the `remap-assembly-ref`
project.

Let's add a default retry to see if that helps anything here.