### PR TITLE
[Xamarin.Android.Build.Tasks] Fix default $(LintToolPath)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -78,16 +78,11 @@ namespace Xamarin.Android.Tasks
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
 
-			var commandLineToolsDir = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
-				.FirstOrDefault () ?? "";
-
-			var lintPaths = new string [] {
-				LintToolPath ?? string.Empty,
-				commandLineToolsDir,
-				Path.Combine (commandLineToolsDir, "bin"),
-				Path.Combine (AndroidSdkPath, "tools"),
-				Path.Combine (AndroidSdkPath, "tools", "bin"),
-			};
+			var lintPaths = MonoAndroidHelper.AndroidSdk.GetCommandLineToolsPaths (CommandLineToolsVersion)
+				.SelectMany (p => new[]{
+					p,
+					Path.Combine (p, "bin"),
+				});
 
 			LintToolPath = null;
 			foreach (var path in lintPaths) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -626,12 +626,6 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(_AndroidToolsDirectory)" Condition="Exists ('$(_AndroidToolsDirectory)')">
-		<Output TaskParameter="Value" PropertyName="LintToolPath"
-				Condition="'$(LintToolPath)' == ''"
-		/>
-	</CreateProperty>
-
 	<CreateProperty Value="$(MonoAndroidToolsDirectory)\proguard\">
 		<Output TaskParameter="Value" PropertyName="ProguardToolPath"
 				Condition="'$(ProguardToolPath)' == ''"
@@ -730,6 +724,8 @@ because xbuild doesn't support framework reference assemblies.
 	<!-- We should slowly port all the <CreateProperty/> calls to <PropertyGroup/> here -->
 	<PropertyGroup>
 		<AProfUtilToolPath Condition=" '$(AProfUtilToolPath)' == '' ">$(MonoAndroidBinDirectory)</AProfUtilToolPath>
+		<_DefaultLintToolPath>$(_AndroidSdkDirectory)\cmdline-tools\$(AndroidCommandLineToolsVersion)\bin</_DefaultLintToolPath>
+		<LintToolPath Condition=" '$(LintToolPath)' == '' And Exists ($(_DefaultLintToolPath)) ">$(_DefaultLintToolPath)</LintToolPath>
 	</PropertyGroup>
 
 	<!-- Get the defined constants for this API Level -->


### PR DESCRIPTION
The [Android SDK Tools package][0] is deprecated, replaced by the
[Android SDK cmdline-tools package][1]:

> This SDK Tools package is deprecated and no longer receiving
> updates. Instead, please use the new command-line tools package.

The Android SDK Tools package hasn't seen an update since 2017-Sep.

We do have support for the cmdline-tools package, e.g. 92efdccb,
but the *default* `$(LintToolPath)` value was still using the
Android SDK Tools package, because:

 1. The [default `$(AndroidCommandLineToolsVersion)` value][2] is
    `2.1`, which isn't installed anywhere (current "latest" is 5.0).

 2. The `<ResolveAndroidTooling/>` task would only check
    `$(AndroidSdkDirectory)\cmdline-tools\$(AndroidCommandLineToolsVersion)`;
    if that didn't exist, it would eventually try the Tools dir.

The xamarin-android-tools repo should *absolutely* update the default
`$(AndroidCommandLineToolsVersion)` value, but as of *now*, we ~never
use the `lint` in the `cmdline-tools` package.

Update the `<ResolveAndroidTooling/>` task so that *all* paths
returned by [`AndroidSdkInfo.GetCommandLineToolsPaths()`][3] are
tried.  `AndroidSdkInfo.GetCommandLineToolsPaths()` will appropriately
"fall back" to the tools directory, should it need to, but *prefers*
any/every `cmdline-tools` directory over the `tools` directory.

[0]: https://developer.android.com/studio/releases/sdk-tools
[1]: https://developer.android.com/studio#cmdline-tools
[2]: https://github.com/xamarin/xamarin-android-tools/blob/9b658b29bd41157151f5515619d0d90dc062563d/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
[3]: https://github.com/xamarin/xamarin-android-tools/blob/9b658b29bd41157151f5515619d0d90dc062563d/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs#L201-L229