### PR TITLE
[tests] remove HttpClient code in FilterAssembliesTests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -3,9 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Xamarin.Android.Tasks;
+using Xamarin.ProjectTools;
 using Xamarin.Tools.Zip;
 using TaskItem = Microsoft.Build.Utilities.TaskItem;
 
@@ -15,7 +15,6 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("Node-2")]
 	public class FilterAssembliesTests : BaseTest
 	{
-		HttpClient httpClient = new HttpClient ();
 		string tempDirectory;
 
 		[SetUp]
@@ -31,17 +30,8 @@ namespace Xamarin.Android.Build.Tests
 			Directory.Delete (tempDirectory, recursive: true);
 		}
 
-		async Task<string> DownloadFromNuGet (string url)
-		{
-			var response = await httpClient.GetAsync (url);
-			response.EnsureSuccessStatusCode ();
-			var temp = Path.Combine (tempDirectory, Path.GetRandomFileName ());
-			using (var httpStream = await response.Content.ReadAsStreamAsync ())
-			using (var fileStream = File.Create (temp)) {
-				await httpStream.CopyToAsync (fileStream);
-			}
-			return temp;
-		}
+		Task<string> DownloadFromNuGet (string url) =>
+			Task.Factory.StartNew (() => new DownloadedCache ().GetAsFile (url));
 
 		async Task<string []> GetAssembliesFromNuGet (string url, string path)
 		{


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5202425&view=ms.vss-test-web.build-test-results-tab&runId=25843494&resultId=100119&paneView=debug

I saw the test failure:

    System.Threading.Tasks.TaskCanceledException : A task was canceled.
        at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at Xamarin.Android.Build.Tests.FilterAssembliesTests.<DownloadFromNuGet>d__4.MoveNext() in /Users/builder/azdo/_work/2/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs:line 36
        --- End of stack trace from previous location where exception was thrown ---
        at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at Xamarin.Android.Build.Tests.FilterAssembliesTests.<GetAssembliesFromNuGet>d__5.MoveNext() in /Users/builder/azdo/_work/2/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs:line 49
        --- End of stack trace from previous location where exception was thrown ---
        at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at Xamarin.Android.Build.Tests.FilterAssembliesTests.<GuavaListenableFuture>d__9.MoveNext() in /Users/builder/azdo/_work/2/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs:line 104
        --- End of stack trace from previous location where exception was thrown ---
        at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
        at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
        at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
        at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
        at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
        at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
        at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)

The `FilterAssembliesTests` class has some custom `HttpClient` logic
for downloading `.nupkg` files.

We should just use the existing helper method in Xamarin.ProjectTools
-- so we have the same code downloading files in these tests.

Xamarin.ProjectTools also has the benefit of caching files in a
directory for future test runs.