### PR TITLE
[One .NET] use preview.9 version number

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,8 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>31.0.100</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>31.0.101</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.9</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://devblogs.microsoft.com/dotnet/update-on-dotnet-maui/
Context: https://semvercompare.azurewebsites.net/?version=31.0.101-preview.9.1&version=31.0.100-rc.1.12

.NET MAUI (and underlying optional .NET workloads) will be in a
"preview" status until Q2 2022.

Going forward in xamarin-android/main, our version number will be
`31.0.101-preview.9.*`.

We need to bump to 101, so the version number will be higher than the
currently released `31.0.100-rc.1.12`.