### PR TITLE
[Mono.Android] add missing property in AndroidMessageHandler

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -120,6 +121,8 @@ namespace Xamarin.Android.Net
 		public int MaxResponseHeadersLength { get; set; } = 64; // Units in K (1024) bytes.
 
 		public bool CheckCertificateRevocationList { get; set; } = false;
+
+		public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get; set; }
 
 		// See: https://developer.android.com/reference/javax/net/ssl/SSLSocket#protocols
 		public SslProtocols SslProtocols { get; set; } =

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.NET.csproj
@@ -13,6 +13,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);NO_MARSHAL_MEMBER_BUILDER_SUPPORT</DefineConstants>
+    <JavaInteropTestDirectory>$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\</JavaInteropTestDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\**\*.cs" />
-    <Compile Remove="$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\Java.Interop\JavaVMFixture.cs" />
-    <Compile Remove="$(JavaInteropSourceDirectory)\tests\Java.Interop-Tests\Java.Interop\JniReferenceSafeHandleTest.cs" />
+    <Compile Include="$(JavaInteropTestDirectory)**\*.cs" Exclude="$(JavaInteropTestDirectory)obj\**;$(JavaInteropTestDirectory)bin\**" />
+    <Compile Remove="$(JavaInteropTestDirectory)Java.Interop\JavaVMFixture.cs" />
+    <Compile Remove="$(JavaInteropTestDirectory)Java.Interop\JniReferenceSafeHandleTest.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -19,6 +19,7 @@
     <EnableDefaultAndroidAssetItems>false</EnableDefaultAndroidAssetItems>
     <_MonoAndroidTestPackage>Mono.Android.NET_Tests</_MonoAndroidTestPackage>
     <PlotDataLabelSuffix>-$(TestsFlavor)NET6</PlotDataLabelSuffix>
+    <WarningsAsErrors>IL2037</WarningsAsErrors>
     <!--
       TODO: Fix excluded tests
       For AOT, InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -89,6 +89,7 @@ namespace Xamarin.Android.NetTests {
 			Assert.IsFalse (h.UseDefaultCredentials, "#13");
 			Assert.IsTrue (h.UseProxy, "#14");
 			Assert.AreEqual (ClientCertificateOption.Manual, h.ClientCertificateOptions, "#15");
+			Assert.IsNull (h.ServerCertificateCustomValidationCallback, "#16");
 		}
 
 		[Test]


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/commit/01c4028969fafb927762477d6991c483f3b3cc5c

I found usage of the `ServerCertificateCustomValidationCallback`
property triggered ILLink warnings:

    warning IL2037: System.Net.Http.HttpClientHandler.GetServerCertificateCustomValidationCallback(): No members were resolved for 'get_ServerCertificateCustomValidationCallback'.

This would also fail at runtime.

Going forward:

* Add a test that sets `ServerCertificateCustomValidationCallback`.
* Add `IL2037` to `$(WarningsAsErrors)`

I also found a bug in `Java.Interop-Tests.NET.csproj`, it fails to
build for me:

    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\.NETFramework,Version=v4.7.2.AssemblyAttributes.cs(4,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(14,12): error CS0579: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(15,12): error CS0579: Duplicate 'System.Reflection.AssemblyConfigurationAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(16,12): error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(17,12): error CS0579: Duplicate 'System.Reflection.AssemblyInformationalVersionAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(18,12): error CS0579: Duplicate 'System.Reflection.AssemblyProductAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(19,12): error CS0579: Duplicate 'System.Reflection.AssemblyTitleAttribute' attributej]
    external\Java.Interop\tests\Java.Interop-Tests\obj\Debug\Java.Interop-Tests.AssemblyInfo.cs(20,12): error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\.NETCoreApp,Version=v6.0.AssemblyAttributes.cs(4,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(13,12): error CS0579: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(14,12): error CS0579: Duplicate 'System.Reflection.AssemblyConfigurationAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(15,12): error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(16,12): error CS0579: Duplicate 'System.Reflection.AssemblyInformationalVersionAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(17,12): error CS0579: Duplicate 'System.Reflection.AssemblyProductAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(18,12): error CS0579: Duplicate 'System.Reflection.AssemblyTitleAttribute' attributej]
    tests\Mono.Android-Tests\Java.Interop-Tests\obj\Release\net6.0-android\Java.Interop-Tests.NET.AssemblyInfo.cs(19,12): error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attributej]
    16 Error(s)

We needed to exclude some `.cs` files in `obj`:

    Exclude="$(JavaInteropTestDirectory)obj\**;$(JavaInteropTestDirectory)bin\**"

I'm unsure how this is currently working on CI.