### PR TITLE
[Xamarin.Android.Build.Tests] Fix GetMaxInstalledPlatform threading.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -117,11 +117,11 @@ namespace Xamarin.ProjectTools
 		}
 
 		static int? maxInstalled;
-		static object lockObject = new object ();
+		static object maxInstalledLock = new object ();
 
 		public static int GetMaxInstalledPlatform ()
 		{
-			lock (lockObject) {
+			lock (maxInstalledLock) {
 				return GetMaxInstalledPlatformInternal ();
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -117,8 +117,16 @@ namespace Xamarin.ProjectTools
 		}
 
 		static int? maxInstalled;
+		static object lockObject = new object ();
 
 		public static int GetMaxInstalledPlatform ()
+		{
+			lock (lockObject) {
+				return GetMaxInstalledPlatformInternal ();
+			}
+		}
+
+		static int GetMaxInstalledPlatformInternal ()
 		{
 			if (maxInstalled != null)
 				return maxInstalled.Value;


### PR DESCRIPTION
When we have unit tests running in parallel we sometimes get issues
where the method `GetMaxInstalledPlatform` returns a lower API level
than the max installed. This is because multiple tests are calling
the method at the same time. As a result they overwrite each other
as they are both scanning the directories. The results in some tests
getting a lower API level than expected becuase the `maxInstalled`
field has a value.