### PR TITLE
[build] Add standalone VS2022 support to vsix

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(XAPackagesDir)\microsoft.vssdk.buildtools\15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('$(XAPackagesDir)\microsoft.vssdk.buildtools\15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
 
   <PropertyGroup>
     <CreateVsixContainer Condition=" '$(CreateVsixContainer)' == '' ">False</CreateVsixContainer>
@@ -46,21 +45,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6070" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="7.10.6071" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="8.0.50727" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="9.0.30729" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="7.10.6070" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="8.0.50727" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.0.240" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.0.82" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26201" ExcludeAssets="all" />
-    <PackageReference Include="System.Resources.Extensions" Version="5.0.0-alpha.1.19618.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.0-previews-4-31709-430" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.4207-preview4" PrivateAssets="All" IncludeAssets="runtime;build;native;contentfiles;analyzers" />
+    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition=" '$(_BuildVsix)' == 'True' " />

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -102,34 +102,4 @@
         DestinationFolder="$(_VsixDir)"
     />
   </Target>
-  <!--
-    This *replaces* `Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets`
-    -->
-  <PropertyGroup>
-    <_TasksAssembly Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll') ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</_TasksAssembly>
-    <_TasksAssembly Condition=" '$(_TasksAssembly)' == '' ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</_TasksAssembly>
-  </PropertyGroup>
-  <UsingTask TaskName="SetVsSDKEnvironmentVariables"
-      TaskFactory="CodeTaskFactory"
-      AssemblyFile="$(_TasksAssembly)">
-    <ParameterGroup>
-      <ProjectDirectory Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        var toolsPath = System.IO.Path.Combine(ProjectDirectory, "tools", "VSSDK", "bin");
-        System.Environment.SetEnvironmentVariable("VsSDKToolsPath",
-            System.IO.Path.GetFullPath(toolsPath),
-            EnvironmentVariableTarget.Process);
-        var schemaDir = System.IO.Path.Combine(ProjectDirectory, "tools", "VSSDK", "schemas");
-        System.Environment.SetEnvironmentVariable("VsSDKSchemaDir",
-            System.IO.Path.GetFullPath(schemaDir),
-            EnvironmentVariableTarget.Process);
-      </Code>
-    </Task>
-  </UsingTask>
-  <Target Name="SetVsSDKEnvironmentVariables"
-      BeforeTargets="GeneratePkgDef;VSCTCompile;VSIXNameProjectOutputGroup">
-    <SetVsSDKEnvironmentVariables ProjectDirectory="$(ThisPackageDirectory)" />
-  </Target>
 </Project>

--- a/build-tools/create-vsix/source.extension.vsixmanifest
+++ b/build-tools/create-vsix/source.extension.vsixmanifest
@@ -7,7 +7,10 @@
     <Icon>Resources\AndroidSdkPackage.ico</Icon>
   </Metadata>
   <Installation AllUsers="true" Experimental="|create-vsix;GetIsExperimental|">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)"  />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)" >
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/visualstudio/extensibility/migration/update-visual-studio-extension?view=vs-2022#extensions-without-running-code

Our .vsix installer can't be installed "on top" of VS2022.  This is
something we'll want to continue to support for testing purposes, and
for our OSS installer.  Adding an `amd64` installation target and
updating VS SDK and Tools package reference versions should fix this.

The workaround from commit 4799ea2 has been removed as it no
longer appears to be needed.