### PR TITLE
[build] update nightly CI triggers

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -14,8 +14,11 @@ schedules:
   branches:
     include:
     - main
-    - d16-9
+    - d16-11
+    - d17-0
     - release/*
+    exclude:
+    - release/6.0.1xx-preview*
 
 # External sources, scripts, tests, and yaml template files.
 resources:


### PR DESCRIPTION
Context: https://docs.microsoft.com/azure/devops/pipelines/yaml-schema

Our nightly build is currently building all `release/*` branches.

Let's update this to ignore past preview branches.

Let's also update the VS branches this runs against.