### PR TITLE
Bump to xamarin/xamarin-android-tools/main@a5194e93

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -113,16 +113,16 @@
     <AllSupported64BitTargetAndroidAbis>arm64-v8a;x86_64</AllSupported64BitTargetAndroidAbis>
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
     <!--
-      For some reason, the URL for platform-tools/build-tools 30.0.2 is prefixed with what appears to be a GIT commit hash or some other checksum...
+      For some reason, the URL for platform-tools/build-tools 30.0.3 is prefixed with what appears to be a GIT commit hash or some other checksum...
       Linux packages don't have any prefix, but this forces us to have *some* mechanism to handle this...
     -->
-    <XABuildToolsPackagePrefixMacOS>5a6ceea22103d8dec989aefcef309949c0c42f1d.</XABuildToolsPackagePrefixMacOS>
-    <XABuildToolsPackagePrefixWindows>efbaa277338195608aa4e3dbd43927e97f60218c.</XABuildToolsPackagePrefixWindows>
+    <XABuildToolsPackagePrefixMacOS>f6d24b187cc6bd534c6c37604205171784ac5621.</XABuildToolsPackagePrefixMacOS>
+    <XABuildToolsPackagePrefixWindows>91936d4ee3ccc839f0addd53c9ebf087b1e39251.</XABuildToolsPackagePrefixWindows>
     <XABuildToolsPackagePrefixLinux></XABuildToolsPackagePrefixLinux>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildToolsPackagePrefixMacOS)</XABuildToolsPackagePrefix>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
-    <XABuildToolsVersion>30.0.2</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">30.0.2</XABuildToolsFolder>
+    <XABuildToolsVersion>30.0.3</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">30.0.3</XABuildToolsFolder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">b2be9c80582174e645d3736daa0d44d8610b38a8.</XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>30.0.2</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6300
Context: https://github.com/xamarin/java.interop/issues/883

Changes: http://github.com/xamarin/xamarin-android-tools/compare/9b658b29bd41157151f5515619d0d90dc062563d...a5194e93498e7f12225d87e2811415a45f742116

  * xamarin/xamarin-android-tools@a5194e9: [Xamarin.Android.Tools.AndroidSdk] Downgrade build-tools to API-30
  * xamarin/xamarin-android-tools@440e6be: [Xamarin.Android.Tools.AndroidSdk] Update SDK component for API-31 (#134)

Note: while this xamarin-android-tools bump updates the Android SDK
[Platform Tools][0] version to 31.0.3, we are *not* updating
`$(XAPlatformToolsVersion)` to 31.0.3.  As such, there will be a
mismatch between what we build xamarin-android against, vs. the
default suggested platform-tools package potentially installed
via the `/t:InstallAndroidDependencies` target.

The reason to *not* bump `$(XAPlatformToolsVersion)` is that
attempting to do so breaks the `src/Mono.Android` build:

 1. platform-tools r31.0.3 doesn't contain
    `platform-tools/api/annotations.zip`, which is used by
    `generator` to emit certain custom attributes such as
    `RequiresPermission`.

 2. While (1) can be worked around by instead using
    `$(AndroidSdkDirectory)/platforms/android-*/data/annotations.zip`,
    this introduces API changes reported by the
    `_CheckApiCompatibility` target, in particular changes due to
    custom attribute string changes.  These string changes happen
    because Google ships *invalid XML* in `data/annotations.zip` for
    API-29+ (?!):

        <!-- annotations.zip!android/accounts/annotations.xml -->
        -  <item name="android.accounts.AccountManager android.accounts.AccountManagerFuture&lt;android.os.Bundle&gt; addAccount(java.lang.String, java.lang.String, java.lang.String[], android.os.Bundle, android.app.Activity, android.accounts.AccountManagerCallback&lt;android.os.Bundle&gt;, android.os.Handler)">
        +  <item name="android.accounts.AccountManager android.accounts.AccountManagerFuture&lt;android.os.Bundle&gt; addAccount(java.lang.String, java.lang.String, java.lang.String[], android.os.Bundle, android.app.Activity, android.accounts.AccountManagerCallback<android.os.Bundle>, android.os.Handler)">

    `AccountManagerCallback<android.os.Bundle>` is not a valid value
    within an XML attribute.

    This change doesn't break the build, but instead causes
    [`AndroidAnnotationSupport`][1] to hit a "fallback" codepath
    which uses HtmlAgilityPack, and this causes attribute values
    to "gain" `quot;`:

        -[global::Android.Runtime.RequiresPermission ("android.permission.MANAGE_ACCOUNTS")]
        +[global::Android.Runtime.RequiresPermission ("quot;android.permission.MANAGE_ACCOUNTS&quot")]

    See also: https://github.com/xamarin/java.interop/issues/883

After manual review, no other file removals appear to be problematic,
so @jonpryor asserts that it should be acceptable for
`$(XAPlatformToolsVersion)` and `$(AndroidSdkPlatformToolsVersion)`
to be inconsistent with each other.

[0]: https://developer.android.com/studio/releases/platform-tools
[1]: https://github.com/xamarin/java.interop/blob/1e8f5137345db3160c99265ff3a56c43a132194f/src/Xamarin.Android.Tools.AnnotationSupport/AndroidAnnotationsSupport.cs#L58-L87