### PR TITLE
[build] bump xamarin-android/main to preview.10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>31.0.101</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.9</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.10</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/d61aae7f120f9c39c2186908fb3cd791b3bde871/Documentation/guides/HowToBranch.md
Context: https://github.com/xamarin/xamarin-android/pull/6312
Context: https://github.com/xamarin/xamarin-android/tree/release/6.0.1xx-preview9

I branched because we saw "rtm" builds coming from dotnet/installer
this morning.

Going forward, our version number will be slightly confusing:

1. .NET 6 RC2 == 31.0.101.preview.9
2. .NET 6 RTM == 31.0.101.preview.10