### PR TITLE
Clarify XA0031

### DIFF
--- a/Documentation/guides/messages/xa0031.md
+++ b/Documentation/guides/messages/xa0031.md
@@ -1,16 +1,34 @@
 ---
 title: Xamarin.Android error XA0031
 description: XA0031 error code
-ms.date: 05/03/2018
+ms.date: 09/28/2021
 ---
 # Xamarin.Android error XA0031
 
 ## Issue
 
 The Android SDK platform you are targeting only works with certain versions of Java.
-If you get this error, it means either you don't have a Java SDK installed, or your
-Java version is too old or is not compatible with the targeted android platform.
+If you get this error, it means either:
+
+ 1. You don't have a Java SDK installed, or
+ 2. Your Java SDK version is too old or is otherwise not compatible with the targeted
+    Android platform.
 
 ## Solution
 
-Make sure you install a compatible JDK version (e.g. from the Oracle website).
+Make sure you install a compatible JDK version, such as the
+[Microsoft Build of OpenJDK](https://docs.microsoft.com/en-us/java/openjdk/download).
+
+> [!NOTE]
+> Java SDK 11.0 is required to use `$(TargetFrameworkVersion)` v12.0 (API-31) and later,
+> and to use `$(TargetFramework)`=`net6.0-android31.0` in .NET 6 and later.
+>
+> [Use of Java SDK 11.0 will break the Android Designer in Visual Studio 16.11 and earlier](https://aka.ms/vs2019-and-jdk-11).
+
+## Example messages
+
+```
+error XA0031: Java SDK 11.0 or above is required when using $(TargetFrameworkVersion) v12.0.
+Download the latest JDK at: https://aka.ms/msopenjdk
+Note: the Android Designer is incompatible with Java SDK 11.0: https://aka.ms/vs2019-and-jdk-11
+```

--- a/Documentation/guides/messages/xa0031.md
+++ b/Documentation/guides/messages/xa0031.md
@@ -8,9 +8,9 @@ ms.date: 05/03/2018
 ## Issue
 
 The Android SDK platform you are targeting only works with certain versions of Java.
-If you get this error, it means either your Java version is too old or
-is not compatible with the targeted android platform.
+If you get this error, it means either you don't have a Java SDK installed, or your
+Java version is too old or is not compatible with the targeted android platform.
 
 ## Solution
 
-Make sure you install a compatible JDK version.
+Make sure you install a compatible JDK version (e.g. from the Oracle website).


### PR DESCRIPTION
Two things fixed here:
1. XA0031 can also happen if no JDK was installed at all (while the previous text only mentioned differing or incompatible versions, as if Windows included a JDK by default?).
2. When the user gets this error for the first time, it's not clear if he has to download the Java SDK manually herself from the Oracle website or not. A Visual Studio user might think that this can be done under the hood by Visual Studio (in the same way that Android SDKs are downloaded and installed automatically within Visual Studio), but it is not the case for the Java SDK so it's better to mention the Oracle website here as a hint.