### PR TITLE
[build] update nightly CI triggers, again

### DIFF
--- a/Documentation/guides/HowToBranch.md
+++ b/Documentation/guides/HowToBranch.md
@@ -30,7 +30,8 @@ See [eng/README.md][2] for details on `darc` commands.
    `$(AndroidPackVersionSuffix)` in `Directory.Build.props` is
    incremented to the *next* version: `preview.43`. You may also need
    to update `$(AndroidPackVersion)` if `main` needs to target a new
-   .NET version band.
+   .NET version band. In the same PR, update `azure-pipelines-nightly.yaml`
+   to build the new release branch.
 
 Note that release candidates will use values such as `rc.1`, `rc.2`, etc.
 

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -16,9 +16,7 @@ schedules:
     - main
     - d16-11
     - d17-0
-    - release/*
-    exclude:
-    - release/6.0.1xx-preview*
+    - release/6.0.1xx-preview9
 
 # External sources, scripts, tests, and yaml template files.
 resources:


### PR DESCRIPTION
`release/6.0.1xx-rc2` is going to be named `release/6.0.1xx-preview9`
for the dotnet/maui, xamarin-android, and xamarin-macios repos. I
renamed the branch in xamarin-android.

We need to update the nightly CI triggers. I added this to the
`HowToBranch.md` doc as well.