### PR TITLE
[ci] Make logging less verbose

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -91,26 +91,26 @@ stages:
 
     # Prepare and build everything
     - script: >
-        echo "make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'" &&
-        make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'
+        echo "make prepare-update-mono CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'" &&
+        make prepare-update-mono CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make prepare-update-mono
 
     - script: >
-        echo "make prepare CONFIGURATION=$(XA.Build.Configuration) V=1 $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'" &&
-        make prepare CONFIGURATION=$(XA.Build.Configuration) V=1 $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'
+        echo "make prepare CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'" &&
+        make prepare CONFIGURATION=$(XA.Build.Configuration) $(PREPARE_FLAGS) MSBUILD_ARGS='$(EXTRA_MSBUILD_ARGS)'
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make prepare
 
     - script: >
-        echo "make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1" &&
-        make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+        echo "make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1" &&
+        make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make jenkins
 
     - script: >
-        echo "make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)" &&
-        make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+        echo "make create-installers CONFIGURATION=$(XA.Build.Configuration)" &&
+        make create-installers CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: create installers
 
@@ -134,20 +134,20 @@ stages:
         targetPath: $(Build.SourcesDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - script: >
-        echo "all-tests CONFIGURATION=$(XA.Build.Configuration) V=1" &&
-        make all-tests CONFIGURATION=$(XA.Build.Configuration) V=1
+        echo "all-tests CONFIGURATION=$(XA.Build.Configuration)" &&
+        make all-tests CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: make all-tests
 
     - script: >
-        echo "make package-build-status CONFIGURATION=$(XA.Build.Configuration) V=1" &&
-        make package-build-status CONFIGURATION=$(XA.Build.Configuration) V=1
+        echo "make package-build-status CONFIGURATION=$(XA.Build.Configuration)" &&
+        make package-build-status CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: package build status
 
     - script: >
-        echo "make run-performance-tests CONFIGURATION=$(XA.Build.Configuration) V=1" &&
-        make run-performance-tests CONFIGURATION=$(XA.Build.Configuration) V=1
+        echo "make run-performance-tests CONFIGURATION=$(XA.Build.Configuration)" &&
+        make run-performance-tests CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(Build.SourcesDirectory)
       displayName: run performance tests
       condition: and(succeeded(), eq(variables['EnableTestExecution'], 'true'))   # The variable is defined on the pipeline definition
@@ -174,16 +174,16 @@ stages:
 
     - template: yaml-templates/setup-ubuntu.yaml
 
-    - script: make prepare V=1 PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+    - script: make prepare PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make prepare
 
-    - script: make jenkins V=1 PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+    - script: make jenkins PREPARE_CI_PR=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make jenkins
 
-    - script: make create-nupkgs V=1 CONFIGURATION=$(XA.Build.Configuration)
+    - script: make create-nupkgs CONFIGURATION=$(XA.Build.Configuration)
       displayName: make create-nupkgs
 
-    - script: make package-deb V=1 CONFIGURATION=$(XA.Build.Configuration)
+    - script: make package-deb CONFIGURATION=$(XA.Build.Configuration)
       displayName: make package-deb
 
     - script: >

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -441,7 +441,7 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare
 
-    - script: make jenkins V=1 PREPARE_CI=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+    - script: make jenkins PREPARE_CI=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make jenkins
 
@@ -507,7 +507,7 @@ stages:
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
       displayName: install emulator
 
-    - script: make prepare V=1 CONFIGURATION=$(ApkTestConfiguration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
+    - script: make prepare CONFIGURATION=$(ApkTestConfiguration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
 
@@ -758,7 +758,7 @@ stages:
     - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
       displayName: install emulator
 
-    - script: make prepare V=1 CONFIGURATION=$(XA.Build.Configuration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
+    - script: make prepare CONFIGURATION=$(XA.Build.Configuration) JI_JAVA_HOME=$(JI_JAVA_HOME) JAVA_HOME=$(JI_JAVA_HOME)
       workingDirectory: $(System.DefaultWorkingDirectory)/external/Java.Interop
       displayName: prepare java.interop
 

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -26,7 +26,7 @@ steps:
     provisioning_script: ${{ parameters.xaSourcePath }}/build-tools/provisioning/xcode.csx
     provisioning_extra_args: '-v -v -v -v'
 
-- script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+- script: make prepare-update-mono CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make prepare-update-mono
 
@@ -46,12 +46,12 @@ steps:
   displayName: make prepare-external-git-dependencies
 
 # Prepare and Build everything
-- script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
+- script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
 
 # Build and package test assemblies
-- script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+- script: make all-tests CONFIGURATION=$(XA.Build.Configuration)
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make all-tests
 
@@ -85,7 +85,7 @@ steps:
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-pkg-content.binlog
 
-- script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+- script: make create-installers CONFIGURATION=$(XA.Build.Configuration)
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make create-installers
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Unix.cs
@@ -21,7 +21,6 @@ namespace Xamarin.Android.Prepare
 				workingDirectory: javaInteropDir,
 				arguments: new List <string> {
 					"prepare",
-					"V=1",
 					$"CONFIGURATION={context.Configuration}",
 					$"JI_JAVA_HOME={context.OS.JavaHome}",
 					$"JAVA_HOME={context.OS.JavaHome}",


### PR DESCRIPTION
Context: https://twitter.com/KirillOsenkov/status/1440192351528374279

Our verbose logging is getting a little out of control.  The `make jenkins` log is ~870 MB and can no longer be viewed in the AzDO UI.

Remove `V=1` from our invocations, which removes `/v:diag`.

Timings aren't stable across build agents so numbers aren't very accurate, but there are definitely improvements:
- Log file of `make jenkins` went from 870 MB to 32 MB
- Build time of `make jenkins` went from 42:49 to 34:43

Full logs are still available in the `.binlog`'s we already produce and place in artifacts.