### PR TITLE
[One .NET] add a single-RID "fast path" for <ProcessAssemblies/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -98,6 +98,7 @@ _ResolveAssemblies MSBuild target.
         Condition=" '%(Identity)' != '' "
     />
     <ProcessAssemblies
+        RuntimeIdentifiers="@(_RIDs)"
         InputAssemblies="@(_ResolvedAssemblyFiles->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles->Distinct())"
         PublishTrimmed="$(PublishTrimmed)">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -78,9 +78,6 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		/// <summary>
-		/// Called when RuntimeIdentifiers has one item
-		/// </summary>
 		void SetMetadataForAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
 		{
 			foreach (var assembly in InputAssemblies) {
@@ -93,9 +90,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		/// <summary>
-		/// Called when RuntimeIdentifiers has more than one item
-		/// </summary>
 		void DeduplicateAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
 		{
 			// Group by assembly file name
@@ -124,7 +118,7 @@ namespace Xamarin.Android.Tasks
 				// If we end up with more than 1 unique mvid, we need *all* assemblies
 				if (mvids.Count > 1) {
 					foreach (var assembly in group) {
-						var symbol = GetOrCreateSymbolItem(symbols, assembly);
+						var symbol = GetOrCreateSymbolItem (symbols, assembly);
 						SetDestinationSubDirectory (assembly, group.Key, symbol);
 						output.Add (assembly);
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,18 +23,21 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "PRAS";
 
+		[Required]
+		public string [] RuntimeIdentifiers { get; set; } = Array.Empty<string>();
+
 		public bool PublishTrimmed { get; set; }
 
-		public ITaskItem [] InputAssemblies { get; set; }
+		public ITaskItem [] InputAssemblies { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Output]
-		public ITaskItem [] OutputAssemblies { get; set; }
+		public ITaskItem []? OutputAssemblies { get; set; }
 
 		[Output]
-		public ITaskItem [] ShrunkAssemblies { get; set; }
+		public ITaskItem []? ShrunkAssemblies { get; set; }
 
 		[Output]
-		public ITaskItem [] ResolvedSymbols { get; set; }
+		public ITaskItem []? ResolvedSymbols { get; set; }
 
 		public override bool RunTask ()
 		{
@@ -46,65 +50,13 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			// Group by assembly file name
-			foreach (var group in InputAssemblies.Where (Filter).GroupBy (a => Path.GetFileName (a.ItemSpec))) {
-				// Get the unique list of MVIDs
-				var mvids = new HashSet<Guid> ();
-				bool? frameworkAssembly = null, hasMonoAndroidReference = null;
-				foreach (var assembly in group) {
-					using (var pe = new PEReader (File.OpenRead (assembly.ItemSpec))) {
-						var reader = pe.GetMetadataReader ();
-						var module = reader.GetModuleDefinition ();
-						var mvid = reader.GetGuid (module.Mvid);
-						mvids.Add (mvid);
-
-						// Calculate %(FrameworkAssembly) and %(HasMonoAndroidReference) for the first
-						if (frameworkAssembly == null) {
-							string packageId = assembly.GetMetadata ("NuGetPackageId") ?? "";
-							frameworkAssembly = packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
-								packageId.StartsWith ("Microsoft.Android.Runtime.");
-						}
-						if (hasMonoAndroidReference == null) {
-							hasMonoAndroidReference = MonoAndroidHelper.HasMonoAndroidReference (reader);
-						}
-						assembly.SetMetadata ("FrameworkAssembly", frameworkAssembly.ToString ());
-						assembly.SetMetadata ("HasMonoAndroidReference", hasMonoAndroidReference.ToString ());
-					}
-				}
-				// If we end up with more than 1 unique mvid, we need *all* assemblies
-				if (mvids.Count > 1) {
-					foreach (var assembly in group) {
-						var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
-						if (!symbols.TryGetValue (symbolPath, out var symbol)) {
-							// Sometimes .pdb files are not included in @(ResolvedFileToPublish), so add them if they exist
-							if (File.Exists (symbolPath)) {
-								symbols [symbolPath] = symbol = new TaskItem (symbolPath);
-							}
-						}
-						SetDestinationSubDirectory (assembly, group.Key, symbol);
-						output.Add (assembly);
-					}
-				} else {
-					// Otherwise only include the first assembly
-					bool first = true;
-					foreach (var assembly in group) {
-						var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
-						if (first) {
-							first = false;
-							if (!symbols.TryGetValue (symbolPath, out var symbol)) {
-								// Sometimes .pdb files are not included in @(ResolvedFileToPublish), so add them if they exist
-								if (File.Exists (symbolPath)) {
-									symbols [symbolPath] = symbol = new TaskItem (symbolPath);
-								}
-							}
-							symbol?.SetDestinationSubPath ();
-							assembly.SetDestinationSubPath ();
-							output.Add (assembly);
-						} else {
-							symbols.Remove (symbolPath);
-						}
-					}
-				}
+			// We only need to "dedup" assemblies when there is more than one RID
+			if (RuntimeIdentifiers.Length > 1) {
+				Log.LogDebugMessage ("Deduplicating assemblies per RuntimeIdentifier");
+				DeduplicateAssemblies (output, symbols);
+			} else {
+				Log.LogDebugMessage ("Found a single RuntimeIdentifier");
+				SetMetadataForAssemblies (output, symbols);
 			}
 
 			OutputAssemblies = output.ToArray ();
@@ -112,16 +64,106 @@ namespace Xamarin.Android.Tasks
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
 			if (PublishTrimmed) {
-				ShrunkAssemblies = OutputAssemblies.Select (a => {
-					var dir = Path.GetDirectoryName (a.ItemSpec);
-					var file = Path.GetFileName (a.ItemSpec);
-					return new TaskItem (a) {
+				var shrunkAssemblies = new List<ITaskItem> (OutputAssemblies.Length);
+				foreach (var assembly in OutputAssemblies) {
+					var dir = Path.GetDirectoryName (assembly.ItemSpec);
+					var file = Path.GetFileName (assembly.ItemSpec);
+					shrunkAssemblies.Add (new TaskItem (assembly) {
 						ItemSpec = Path.Combine (dir, "shrunk", file),
-					};
-				}).ToArray ();
+					});
+				}
+				ShrunkAssemblies = shrunkAssemblies.ToArray ();
 			}
 
 			return !Log.HasLoggedErrors;
+		}
+
+		/// <summary>
+		/// Called when RuntimeIdentifiers has one item
+		/// </summary>
+		void SetMetadataForAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
+		{
+			foreach (var assembly in InputAssemblies) {
+				var symbol = GetOrCreateSymbolItem (symbols, assembly);
+				symbol?.SetDestinationSubPath ();
+				assembly.SetDestinationSubPath ();
+				assembly.SetMetadata ("FrameworkAssembly", IsFrameworkAssembly (assembly).ToString ());
+				assembly.SetMetadata ("HasMonoAndroidReference", MonoAndroidHelper.HasMonoAndroidReference (assembly).ToString ());
+				output.Add (assembly);
+			}
+		}
+
+		/// <summary>
+		/// Called when RuntimeIdentifiers has more than one item
+		/// </summary>
+		void DeduplicateAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
+		{
+			// Group by assembly file name
+			foreach (var group in InputAssemblies.Where (Filter).GroupBy (a => Path.GetFileName (a.ItemSpec))) {
+				// Get the unique list of MVIDs
+				var mvids = new HashSet<Guid> ();
+				bool? frameworkAssembly = null, hasMonoAndroidReference = null;
+				foreach (var assembly in group) {
+					using var pe = new PEReader (File.OpenRead (assembly.ItemSpec));
+					var reader = pe.GetMetadataReader ();
+					var module = reader.GetModuleDefinition ();
+					var mvid = reader.GetGuid (module.Mvid);
+					mvids.Add (mvid);
+
+					// Calculate %(FrameworkAssembly) and %(HasMonoAndroidReference) for the first
+					if (frameworkAssembly == null) {
+						frameworkAssembly = IsFrameworkAssembly (assembly);
+					}
+					if (hasMonoAndroidReference == null) {
+						hasMonoAndroidReference = MonoAndroidHelper.IsMonoAndroidAssembly (assembly) ||
+							MonoAndroidHelper.HasMonoAndroidReference (reader);
+					}
+					assembly.SetMetadata ("FrameworkAssembly", frameworkAssembly.ToString ());
+					assembly.SetMetadata ("HasMonoAndroidReference", hasMonoAndroidReference.ToString ());
+				}
+				// If we end up with more than 1 unique mvid, we need *all* assemblies
+				if (mvids.Count > 1) {
+					foreach (var assembly in group) {
+						var symbol = GetOrCreateSymbolItem(symbols, assembly);
+						SetDestinationSubDirectory (assembly, group.Key, symbol);
+						output.Add (assembly);
+					}
+				} else {
+					// Otherwise only include the first assembly
+					bool first = true;
+					foreach (var assembly in group) {
+						if (first) {
+							first = false;
+
+							var symbol = GetOrCreateSymbolItem (symbols, assembly);
+							symbol?.SetDestinationSubPath ();
+							assembly.SetDestinationSubPath ();
+							output.Add (assembly);
+						} else {
+							symbols.Remove (Path.ChangeExtension (assembly.ItemSpec, ".pdb"));
+						}
+					}
+				}
+			}
+		}
+
+		static bool IsFrameworkAssembly (ITaskItem assembly)
+		{
+			string packageId = assembly.GetMetadata ("NuGetPackageId") ?? "";
+			return packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
+				packageId.StartsWith ("Microsoft.Android.Runtime.");
+		}
+
+		static ITaskItem? GetOrCreateSymbolItem (Dictionary<string, ITaskItem> symbols, ITaskItem assembly)
+		{
+			var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
+			if (!symbols.TryGetValue (symbolPath, out var symbol)) {
+				// Sometimes .pdb files are not included in @(ResolvedFileToPublish), so add them if they exist
+				if (File.Exists (symbolPath)) {
+					symbols [symbolPath] = symbol = new TaskItem (symbolPath);
+				}
+			}
+			return symbol;
 		}
 
 		bool Filter (ITaskItem item)
@@ -136,7 +178,7 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Sets %(DestinationSubDirectory) and %(DestinationSubPath) based on %(RuntimeIdentifier)
 		/// </summary>
-		void SetDestinationSubDirectory (ITaskItem assembly, string fileName, ITaskItem symbol)
+		void SetDestinationSubDirectory (ITaskItem assembly, string fileName, ITaskItem? symbol)
 		{
 			var rid = assembly.GetMetadata ("RuntimeIdentifier");
 			var abi = AndroidRidAbiHelper.RuntimeIdentifierToAbi (rid);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -272,6 +272,17 @@ namespace Xamarin.Android.Tasks
 			return bool.TryParse (hasReference, out bool value) && value;
 		}
 
+		public static bool HasMonoAndroidReference (ITaskItem assembly)
+		{
+			// Check item metadata and return early
+			if (IsMonoAndroidAssembly (assembly))
+				return true;
+
+			using var pe = new PEReader (File.OpenRead (assembly.ItemSpec));
+			var reader = pe.GetMetadataReader ();
+			return HasMonoAndroidReference (reader);
+		}
+
 		public static bool HasMonoAndroidReference (MetadataReader reader)
 		{
 			foreach (var handle in reader.AssemblyReferences) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6308
Context: https://github.com/xamarin/monodroid/commit/2e93b630e47701dae56f426fe5934846d571832b

When a device or emulator is selected during a build with Fast
Deployment enabled, a single `$(RuntimeIdentifier)` is selected. This
gives us a reasonable speedup for the build.

One place we can do more is the `<ProcessAssemblies/>` MSBuild task.
Add a "fast path", where we don't need to read the MVIDs from every
assembly. We can simply loop over the assemblies and set required item
metadata.

I also made various changes to refactor the `<ProcessAssemblies/>` so
there is more shared helper methods within the task, etc.

## Results ##

An incremental build of a `dotnet new android` project with no changes:

    Two RIDs:
    81 ms  ProcessAssemblies                          1 calls
    One RID:
    45 ms  ProcessAssemblies                          1 calls

An incremental build of a `dotnet new maui` project with no changes:

    Two RIDs:
    85 ms  ProcessAssemblies                          1 calls
    One RID:
    54 ms  ProcessAssemblies                          1 calls

This should save 30-40ms on every build, when you are debugging and
have a device or emulator selected.