### PR TITLE
[tests] use .binlog only for all MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -845,7 +845,7 @@ namespace Lib1 {
 					foo.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					libBuilder.Output.AssertTargetIsSkipped (target);
-					appBuilder.BuildLogFile = "build1.log";
+					appBuilder.BuildLogFile = "build1.binlog";
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
 					appBuilder.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
 					// Check Contents of the file in the apk are correct.
@@ -867,7 +867,7 @@ namespace Lib1 {
 					raw.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					libBuilder.Output.AssertTargetIsNotSkipped (target);
-					appBuilder.BuildLogFile = "build2.log";
+					appBuilder.BuildLogFile = "build2.binlog";
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
 					string resource_designer_cs = GetResourceDesignerPath (appBuilder, appProj);
 					string text = File.ReadAllText (resource_designer_cs);
@@ -894,7 +894,7 @@ namespace Lib1 {
 						archive = Path.Combine (Root, path, libProj.ProjectName, libProj.IntermediateOutputPath, "__AndroidLibraryProjects__.zip");
 					}
 					Assert.IsNull (ZipHelper.ReadFileFromZip (archive, "res/values/theme.xml"), "res/values/theme.xml should have been removed from __AndroidLibraryProjects__.zip");
-					appBuilder.BuildLogFile = "build3.log";
+					appBuilder.BuildLogFile = "build3.binlog";
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
 					Assert.IsNull (ZipHelper.ReadFileFromZip (apk, "res/raw/test2.txt"), "res/raw/test2.txt should have been removed from the apk.");
 				}
@@ -923,12 +923,12 @@ namespace Lib1 {
 				StringAssert.Contains ("myButton", designerContents, $"{designerFile} should contain Resources.Id.myButton");
 				StringAssert.Contains ("Icon", designerContents, $"{designerFile} should contain Resources.Drawable.Icon");
 				StringAssert.Contains ("Main", designerContents, $"{designerFile} should contain Resources.Layout.Main");
-				appBuilder.BuildLogFile = "build.log";
+				appBuilder.BuildLogFile = "build.binlog";
 				Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true),
 					"Normal Application Build should have succeeded.");
 				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
 					"Target '_ManagedUpdateAndroidResgen' should not have run.");
-				appBuilder.BuildLogFile = "designtimebuild.log";
+				appBuilder.BuildLogFile = "designtimebuild.binlog";
 				Assert.IsTrue (appBuilder.DesignTimeBuild (appProj, doNotCleanupOnUpdate: true), "DesignTime Application Build should have succeeded.");
 				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
 					"Target '_ManagedUpdateAndroidResgen' should not have run.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -416,8 +416,9 @@ class MemTest {
 			if (multidex)
 				proj.SetProperty ("AndroidEnableMultiDex", "True");
 			using (var b = CreateApkBuilder ()) {
+				b.BuildLogFile = "build1.binlog";
 				Assert.IsTrue (b.Build (proj), "first should have succeeded.");
-				b.BuildLogFile = "build2.log";
+				b.BuildLogFile = "build2.binlog";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second should have succeeded.");
 				var targets = new [] {
 					"_CompileResources",
@@ -427,13 +428,13 @@ class MemTest {
 					b.Output.AssertTargetIsSkipped (target);
 				}
 				proj.Touch ("MainPage.xaml");
-				b.BuildLogFile = "build3.log";
+				b.BuildLogFile = "build3.binlog";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "third should have succeeded.");
 				foreach (var target in targets) {
 					b.Output.AssertTargetIsSkipped (target);
 				}
 				b.Output.AssertTargetIsNotSkipped ("CoreCompile");
-				b.BuildLogFile = "build4.log";
+				b.BuildLogFile = "build4.binlog";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "forth should have succeeded.");
 				foreach (var target in targets) {
 					b.Output.AssertTargetIsSkipped (target);
@@ -548,7 +549,7 @@ class MemTest {
 				});
 
 				//The key here, is a build afterward should work
-				b.BuildLogFile = "after.log";
+				b.BuildLogFile = "after.binlog";
 				Assert.IsTrue (b.Build (proj), "The build after a parallel failed build should succeed!");
 			}
 		}
@@ -903,7 +904,7 @@ namespace UnamedProject
 				var expectedAcwMap = File.ReadAllText (acwmapPath);
 
 				b.Target = "Rebuild";
-				b.BuildLogFile = "rebuild.log";
+				b.BuildLogFile = "rebuild.binlog";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Rebuild should have succeeded.");
 
 				var secondAssemblyVersion = AssemblyName.GetAssemblyName (assemblyPath).Version;
@@ -2826,9 +2827,9 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 							"assemblies/PdbTestLibrary.pdb"),
 							"assemblies/PdbTestLibrary.pdb should not exist in the apk.");
 				}
-				b.BuildLogFile = "build1.log";
+				b.BuildLogFile = "build1.binlog";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build failed");
-				b.BuildLogFile = "build2.log";
+				b.BuildLogFile = "build2.binlog";
 				var lastTime = File.GetLastWriteTimeUtc (pdbToMdbPath);
 				pdb.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -699,7 +699,7 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName)
 		{
 			return new LocalBuilder {
-				BuildLogFile = $"{baseLogFileName}.log"
+				BuildLogFile = $"{baseLogFileName}.binlog"
 			};
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName, string projectDir)
 		{
 			return new LocalBuilder (projectDir) {
-				BuildLogFile = $"{baseLogFileName}.log"
+				BuildLogFile = $"{baseLogFileName}.binlog"
 			};
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -749,9 +749,9 @@ namespace Lib2
 
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName), false))
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
-				libBuilder.BuildLogFile = "build.log";
+				libBuilder.BuildLogFile = "build.binlog";
 				Assert.IsTrue (libBuilder.Build (lib), "first library build should have succeeded.");
-				appBuilder.BuildLogFile = "build.log";
+				appBuilder.BuildLogFile = "build.binlog";
 				Assert.IsTrue (appBuilder.Build (app), "first app build should have succeeded.");
 
 				if (useAapt2) {
@@ -766,9 +766,9 @@ namespace Lib2
 
 				lib.Touch ("Bar.cs");
 
-				libBuilder.BuildLogFile = "build2.log";
+				libBuilder.BuildLogFile = "build2.binlog";
 				Assert.IsTrue (libBuilder.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
-				appBuilder.BuildLogFile = "build2.log";
+				appBuilder.BuildLogFile = "build2.binlog";
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
 				var targetsShouldSkip = new [] {
@@ -1073,7 +1073,7 @@ namespace Lib2
 					Assert.Ignore ($"Cross compiler for {supportedAbis} was not available");
 				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
 					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
-				b.BuildLogFile = "first.log";
+				b.BuildLogFile = "first.binlog";
 				b.CleanupAfterSuccessfulBuild = false;
 				b.CleanupOnDispose = false;
 				b.ThrowOnBuildFailure = false;
@@ -1084,7 +1084,7 @@ namespace Lib2
 					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped on first build!");
 				}
 
-				b.BuildLogFile = "second.log";
+				b.BuildLogFile = "second.binlog";
 				b.CleanupAfterSuccessfulBuild = false;
 				b.CleanupOnDispose = false;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Second build should have succeeded.");
@@ -1094,7 +1094,7 @@ namespace Lib2
 
 				proj.Touch ("MainActivity.cs");
 
-				b.BuildLogFile = "third.log";
+				b.BuildLogFile = "third.binlog";
 				b.CleanupAfterSuccessfulBuild = false;
 				b.CleanupOnDispose = false;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Third build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
@@ -313,7 +313,7 @@ namespace Xamarin.Android.Build.Tests
 		LocalBuilder GetBuilder (string baseLogFileName)
 		{
 			return new LocalBuilder {
-				BuildLogFile = $"{baseLogFileName}.log"
+				BuildLogFile = $"{baseLogFileName}.binlog"
 			};
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -256,7 +256,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.Touch ("Properties\\AndroidManifest.xml");
 				proj.SetProperty ("AndroidStoreUncompressedFileExtensions", ".bar");
 
-				b.BuildLogFile = "build2.log";
+				b.BuildLogFile = "build2.binlog";
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded");
 
 				FileAssert.Exists (apk);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/AssertionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO;
+using Microsoft.Build.Logging.StructuredLogger;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
@@ -93,13 +94,15 @@ namespace Xamarin.Android.Build.Tests
 		[DebuggerHidden]
 		public static void AssertHasNoWarnings (this ProjectBuilder builder)
 		{
-			Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, " 0 Warning(s)"), $"{builder.BuildLogFile} should have no MSBuild warnings.");
+			Assert.IsTrue (builder.Log?.FindFirstChild<Warning> () == null,
+				$"{builder.BuildLogFile} should have no MSBuild warnings.");
 		}
 
 		[DebuggerHidden]
 		public static void AssertHasNoWarnings (this DotNetCLI dotnet)
 		{
-			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, " 0 Warning(s)"), $"{dotnet.BuildLogFile} should have no MSBuild warnings.");
+			Assert.IsTrue (dotnet.Log?.FindFirstChild<Warning> () == null,
+				$"{dotnet.BuildLogFile} should have no MSBuild warnings.");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
     <ProjectReference Include="..\..\..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
       <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
       <Name>Xamarin.Android.Tools.AndroidSdk</Name>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.545" />
     <ProjectReference Include="..\..\..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
       <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
       <Name>Xamarin.Android.Tools.AndroidSdk</Name>

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.5" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.500" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.545" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
 				WaitForAppBuiltForOlderAndroidWarning (proj.PackageName, Path.Combine (Root, b.ProjectDirectory, "oldsdk-logcat.log"));
 				System.Threading.Thread.Sleep (5000);
-				b.BuildLogFile = "build2.log";
+				b.BuildLogFile = "build2.binlog";
 				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling", doNotCleanupOnUpdate: true), "Run of FinishAotProfiling should have succeeded.");
 				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
 				FileAssert.Exists (customProfile);

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -252,7 +252,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			AssertHasDevices ();
 
-			appBuilder.BuildLogFile = "install.log";
+			appBuilder.BuildLogFile = "install.binlog";
 			Assert.IsTrue (appBuilder.RunTarget (app, "Install"), "App should have installed.");
 
 			var aab = Path.Combine (intermediate, "android", "bin", $"{app.PackageName}.apks");

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Build.Tests
 				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				AssertExtractNativeLibs (manifest, extractNativeLibs);
 				ClearAdbLogcat ();
-				b.BuildLogFile = "run.log";
+				b.BuildLogFile = "run.binlog";
 				if (CommercialBuildAvailable)
 					Assert.True (b.RunTarget (proj, "_Run"), "Project should have run.");
 				else
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Build.Tests
 
 				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
 					Path.Combine (Root, b.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
-				b.BuildLogFile = "uninstall.log";
+				b.BuildLogFile = "uninstall.binlog";
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 			}
 		}
@@ -126,7 +126,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (libBuilder.Build (lib), "library build should have succeeded.");
 				Assert.True (appBuilder.Install (app), "app should have installed.");
 				ClearAdbLogcat ();
-				appBuilder.BuildLogFile = "run.log";
+				appBuilder.BuildLogFile = "run.binlog";
 				if (CommercialBuildAvailable)
 					Assert.True (appBuilder.RunTarget (app, "_Run"), "Project should have run.");
 				else
@@ -230,7 +230,7 @@ namespace ${ROOT_NAMESPACE} {
 				};
 				options.EvaluationOptions.UseExternalTypeResolver = true;
 				ClearAdbLogcat ();
-				b.BuildLogFile = "run.log";
+				b.BuildLogFile = "run.binlog";
 				Assert.True (b.RunTarget (proj, "_Run", doNotCleanupOnUpdate: true, parameters: new string [] {
 					$"AndroidSdbTargetPort={port}",
 					$"AndroidSdbHostPort={port}",
@@ -261,7 +261,7 @@ namespace ${ROOT_NAMESPACE} {
 				WaitFor (2000);
 				int expected = 2;
 				Assert.AreEqual (expected, breakcountHitCount, $"Should have hit {expected} breakpoints. Only hit {breakcountHitCount}");
-				b.BuildLogFile = "uninstall.log";
+				b.BuildLogFile = "uninstall.binlog";
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 				session.Exit ();
 			}
@@ -405,7 +405,7 @@ namespace ${ROOT_NAMESPACE} {
 				};
 				options.EvaluationOptions.UseExternalTypeResolver = true;
 				ClearAdbLogcat ();
-				appBuilder.BuildLogFile = "run.log";
+				appBuilder.BuildLogFile = "run.binlog";
 
 				parameters.Add ($"AndroidSdbTargetPort={port}");
 				parameters.Add ($"AndroidSdbHostPort={port}");
@@ -442,7 +442,7 @@ namespace ${ROOT_NAMESPACE} {
 				}
 				expected = 1;
 				Assert.AreEqual (expected, breakcountHitCount, $"Should have hit {expected} breakpoints. Only hit {breakcountHitCount}");
-				appBuilder.BuildLogFile = "uninstall.log";
+				appBuilder.BuildLogFile = "uninstall.binlog";
 				Assert.True (appBuilder.Uninstall (app), "Project should have uninstalled.");
 				session.Exit ();
 			}

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -139,9 +139,9 @@ namespace Xamarin.Android.Build.Tests
 </manifest> ";
 				Assert.IsTrue (l1.Build (library, doNotCleanupOnUpdate: true), $"Build of {library.ProjectName} should have suceeded.");
 				Assert.IsTrue (l2.Build (library2, doNotCleanupOnUpdate: true), $"Build of {library2.ProjectName} should have suceeded.");
-				b.BuildLogFile = "build1.log";
+				b.BuildLogFile = "build1.binlog";
 				Assert.IsTrue (b.Build (app, doNotCleanupOnUpdate: true), $"Build of {app.ProjectName} should have suceeded.");
-				b.BuildLogFile = "install1.log";
+				b.BuildLogFile = "install1.binlog";
 				Assert.IsTrue (b.Install (app, doNotCleanupOnUpdate: true), "Install should have suceeded.");
 				AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
 				WaitForPermissionActivity (Path.Combine (Root, builder.ProjectDirectory, "permission-logcat.log"));
@@ -150,7 +150,7 @@ namespace Xamarin.Android.Build.Tests
 				XDocument ui = GetUI ();
 				XElement node = ui.XPathSelectElement ($"//node[contains(@resource-id,'myButton')]");
 				StringAssert.AreEqualIgnoringCase ("Click Me! One", node.Attribute ("text").Value, "Text of Button myButton should have been \"Click Me! One\"");
-				b.BuildLogFile = "clean.log";
+				b.BuildLogFile = "clean.binlog";
 				Assert.IsTrue (b.Clean (app, doNotCleanupOnUpdate: true), "Clean should have suceeded.");
 
 				app = new XamarinAndroidApplicationProject () {
@@ -178,9 +178,9 @@ namespace Xamarin.Android.Build.Tests
 	<application android:label=""${{PROJECT_NAME}}"">
 	</application >
 </manifest> ";
-				b.BuildLogFile = "build.log";
+				b.BuildLogFile = "build.binlog";
 				Assert.IsTrue (b.Build (app, doNotCleanupOnUpdate: true), $"Build of {app.ProjectName} should have suceeded.");
-				b.BuildLogFile = "install.log";
+				b.BuildLogFile = "install.binlog";
 				Assert.IsTrue (b.Install (app, doNotCleanupOnUpdate: true), "Install should have suceeded.");
 				AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
 				WaitForPermissionActivity (Path.Combine (Root, builder.ProjectDirectory, "permission-logcat.log"));

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -421,7 +421,7 @@ namespace Xamarin.Android.Build.Tests
 					StringAssertEx.Contains (expected, b.LastBuildOutput,
 					"The Wrong keystore was used to sign the apk");
 				}
-				b.BuildLogFile = "install.log";
+				b.BuildLogFile = "install.binlog";
 				Assert.AreEqual (shouldInstall, b.Install (proj, doNotCleanupOnUpdate: true), $"Install should have {(shouldInstall ? "succeeded" : "failed")}.");
 				if (packageFormat == "aab") {
 					StringAssertEx.Contains (expected, b.LastBuildOutput,
@@ -429,7 +429,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 				if (!shouldInstall)
 					return;
-				b.BuildLogFile = "uninstall.log";
+				b.BuildLogFile = "uninstall.binlog";
 				Assert.IsTrue (b.Uninstall (proj, doNotCleanupOnUpdate: true), "Uninstall should have succeeded.");
 			}
 		}
@@ -469,7 +469,7 @@ namespace Xamarin.Android.Build.Tests
 				foreach (var res in resourceFilesFromDisk) {
 					StringAssert.Contains (res, overrideContents, $"{res} did not exist in the .__override__ directory.\nFound:{overrideContents}");
 				}
-				appBuilder.BuildLogFile = "uninstall.log";
+				appBuilder.BuildLogFile = "uninstall.binlog";
 				appBuilder.Uninstall (app);
 			}
 		}
@@ -521,14 +521,14 @@ namespace Xamarin.Android.Build.Tests
 
 			using (var builder = CreateApkBuilder (Path.Combine (rootPath, app.ProjectName))) {
 				builder.ThrowOnBuildFailure = false;
-				builder.BuildLogFile = "install.log";
+				builder.BuildLogFile = "install.binlog";
 				Assert.IsTrue (builder.Install (app), "First install should have succeeded.");
 				var logLines = builder.LastBuildOutput;
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("UnnamedProject.dll")), "UnnamedProject.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Library1.dll")), "Library1.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Library2.dll")), "Library2.dll should have been uploaded");
 				var firstInstallTime = builder.LastBuildTime;
-				builder.BuildLogFile = "install2.log";
+				builder.BuildLogFile = "install2.binlog";
 				Assert.IsTrue (builder.Install (app, doNotCleanupOnUpdate: true, saveProject: false), "Second install should have succeeded.");
 				var secondInstallTime = builder.LastBuildTime;
 
@@ -549,14 +549,14 @@ namespace Xamarin.Android.Build.Tests
 				long lib1SecondBuildSize = new FileInfo (Path.Combine (rootPath, lib1.ProjectName, lib1.OutputPath, "Library1.dll")).Length;
 				Assert.AreEqual (lib1FirstBuildSize, lib1SecondBuildSize, "Library2.dll was not the same size.");
 
-				builder.BuildLogFile = "install3.log";
+				builder.BuildLogFile = "install3.binlog";
 				Assert.IsTrue (builder.Install (app, doNotCleanupOnUpdate: true, saveProject: false), "Third install should have succeeded.");
 				logLines = builder.LastBuildOutput;
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("UnnamedProject.dll")), "UnnamedProject.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("Library1.dll")), "Library1.dll should have been uploaded");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync SkipCopyFile") && l.Contains ("Library2.dll")), "Library2.dll should not have been uploaded");
 				var thirdInstallTime = builder.LastBuildTime;
-				builder.BuildLogFile = "install4.log";
+				builder.BuildLogFile = "install4.binlog";
 				Assert.IsTrue (builder.Install (app, doNotCleanupOnUpdate: true, saveProject: false), "Fourth install should have succeeded.");
 				var fourthInstalTime = builder.LastBuildTime;
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -160,7 +160,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": Android.Support.V7.App.AppCompatActivity");
 			var b = CreateApkBuilder (Path.Combine ("temp", TestName));
 			Assert.IsTrue (b.Install (proj), "install should have succeeded.");
-			File.WriteAllLines (Path.Combine (Root, b.ProjectDirectory, b.BuildLogFile + ".bak"), b.LastBuildOutput);
 
 			// slightly (but significantly) modify the sources that causes dll changes.
 			proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
@@ -346,7 +345,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_Upload\" completely")), "_Upload target should have run");
 				Assert.IsTrue (logLines.Any (l => l.Contains ("NotifySync CopyFile") && l.Contains ("classes.dex")), "classes.dex should have been uploaded");
 				ClearAdbLogcat ();
-				b.BuildLogFile = "run.log";
+				b.BuildLogFile = "run.binlog";
 				if (CommercialBuildAvailable)
 					Assert.True (b.RunTarget (proj, "_Run"), "Project should have run.");
 				else
@@ -354,7 +353,7 @@ namespace Xamarin.Android.Build.Tests
 
 				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
 					Path.Combine (Root, b.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
-				b.BuildLogFile = "uninstall.log";
+				b.BuildLogFile = "uninstall.binlog";
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 			}
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -119,7 +119,7 @@ namespace UnnamedProject
 </manifest>";
 				Assert.True (b.Install (proj), "Project should have installed.");
 				ClearAdbLogcat ();
-				b.BuildLogFile = "run.log";
+				b.BuildLogFile = "run.binlog";
 				Assert.True (b.RunTarget (proj, "StartAndroidActivity", doNotCleanupOnUpdate: true), "Project should have run.");
 
 				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -79,14 +79,6 @@ namespace Xamarin.Android.Build.Tests
 			return duration.TotalMilliseconds;
 		}
 
-		ProjectBuilder CreateBuilderWithoutLogFile (string directory = null, bool isApp = true)
-		{
-			var builder = isApp ? CreateApkBuilder (directory) : CreateDllBuilder (directory);
-			builder.BuildLogFile = null;
-			builder.Verbosity = LoggerVerbosity.Quiet;
-			return builder;
-		}
-
 		XamarinAndroidApplicationProject CreateApplicationProject ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -100,7 +92,7 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_From_Clean_DontIncludeRestore ()
 		{
 			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.AutomaticNuGetRestore = false;
 				builder.Target = "Build";
 				builder.Restore (proj);
@@ -114,7 +106,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = CreateApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity;
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -138,7 +130,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = CreateApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity;
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -155,7 +147,7 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_AndroidResource_Change ()
 		{
 			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -187,8 +179,8 @@ namespace Xamarin.Android.Build.Tests
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("Assets\\foo.bar") {
 				BinaryContent = () => bytes,
 			});
-			using (var libBuilder = CreateBuilderWithoutLogFile (Path.Combine ("temp", TestName, lib.ProjectName), isApp: false))
-			using (var builder = CreateBuilderWithoutLogFile (Path.Combine ("temp", TestName, proj.ProjectName))) {
+			using (var libBuilder = CreateDllBuilder (Path.Combine ("temp", TestName, lib.ProjectName)))
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName, proj.ProjectName))) {
 				builder.Target = "Build";
 				libBuilder.Build (lib);
 				builder.Build (proj);
@@ -209,7 +201,7 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_Designer_Change ()
 		{
 			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -234,7 +226,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {
 				TextContent = () => $"class {className} : Java.Lang.Object {{}}"
 			});
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -251,7 +243,7 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_AndroidManifest_Change ()
 		{
 			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -268,7 +260,7 @@ namespace Xamarin.Android.Build.Tests
 		public void Build_CSProj_Change ()
 		{
 			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 				builder.AutomaticNuGetRestore = false;
@@ -348,8 +340,8 @@ namespace Xamarin.Android.Build.Tests
 			lib.SetProperty ("ProduceReferenceAssembly", produceReferenceAssembly.ToString ());
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
 
-			using (var libBuilder = CreateBuilderWithoutLogFile (Path.Combine (path, lib.ProjectName), isApp: false))
-			using (var appBuilder = CreateBuilderWithoutLogFile (Path.Combine (path, app.ProjectName))) {
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				libBuilder.Build (lib);
 				appBuilder.Target = "Build";
 				if (install) {
@@ -384,7 +376,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = CreateApplicationProject ();
 			proj.PackageName = "com.xamarin.install_csharp_change";
 			proj.MainActivity = proj.DefaultMainActivity;
-			using (var builder = CreateBuilderWithoutLogFile ()) {
+			using (var builder = CreateApkBuilder ()) {
 				builder.Install (proj);
 				builder.AutomaticNuGetRestore = false;
 

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -129,7 +129,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			options.EvaluationOptions.UseExternalTypeResolver = true;
 			ClearAdbLogcat ();
-			dotnet.BuildLogFile = Path.Combine (Root, dotnet.ProjectDirectory, "run.log");
+			dotnet.BuildLogFile = Path.Combine (Root, dotnet.ProjectDirectory, "run.binlog");
 			Assert.True (dotnet.Build ("Run", new string [] {
 				$"AndroidSdbTargetPort={port}",
 				$"AndroidSdbHostPort={port}",


### PR DESCRIPTION
Right now we are building most tests with:

    /noconsolelogger /flp1:LogFile=build.log;Encoding=UTF-8;Verbosity=Diagnostic /bl

Let's drop the verbose file logger completely, and use `.binlog` only. Let's see how this improves test run times.