### PR TITLE
[ci] Re-enable the Windows Android Designer tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1210,9 +1210,7 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
 
   # Check - "Xamarin.Android (Designer Tests Windows)"
-  # TODO: Enable once Windows test issues are fixed.
   - job: designer_integration_win
-    condition: false
     displayName: Windows
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 120


### PR DESCRIPTION
Context: 98cae2eaa11472a8c5b32a86c9f925529013906e

Do they build *now*?