### PR TITLE
[Xamarin.Android.Build.Tasks] <LinkAssembliesNoShrink/> can skip the main assembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1373,8 +1373,10 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
       DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(DestinationSubPath)')"
+      TargetName="$(TargetName)"
       AddKeepAlives="$(AndroidAddKeepAlives)"
       Deterministic="$(Deterministic)"
+      UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
   />
   <ItemGroup>
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)**" />


### PR DESCRIPTION
We found an incremental build in a `dotnet new android` app with C#
code changes has this duration:

    100 ms  LinkAssembliesNoShrink                     1 calls

It turns out we don't actually need to run `<LinkAssembliesNoShrink/>`
against the "main" assembly in .NET 6. After passing in
`$(TargetName)` and simply copying the file, this time improved to:

      9 ms  LinkAssembliesNoShrink                     1 calls

This change should improve incremental C# changes by ~91ms in `dotnet
new android` projects.

In "legacy" Xamarin.Android, it still seems possible for an
application project to reference a class library with a higher
`$(TargetFrameworkVersion)`. So we cannot apply this optimization for
Xamarin.Android.