### PR TITLE
[One .NET] run per-RID builds in parallel

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -69,21 +69,25 @@ _ResolveAssemblies MSBuild target.
       <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
     </ItemGroup>
     <PropertyGroup>
-      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
+      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">;_ProguardProjectConfiguration=$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
       <_AdditionalProperties>
-        _ComputeFilesToPublishForRuntimeIdentifiers=true;
-        AppendRuntimeIdentifierToOutputPath=true;
-        SkipCompilerExecution=true;
-        _OuterIntermediateAssembly=@(IntermediateAssembly);
-        _OuterOutputPath=$(OutputPath);
-        _OuterIntermediateOutputPath=$(IntermediateOutputPath);
-        _ProguardProjectConfiguration=$(_ProguardProjectConfiguration);
+        _ComputeFilesToPublishForRuntimeIdentifiers=true
+        ;AppendRuntimeIdentifierToOutputPath=true
+        ;SkipCompilerExecution=true
+        ;_OuterIntermediateAssembly=@(IntermediateAssembly)
+        ;_OuterOutputPath=$(OutputPath)
+        ;_OuterIntermediateOutputPath=$(IntermediateOutputPath)
+        $(_ProguardProjectConfiguration)
       </_AdditionalProperties>
+      <_AndroidBuildRuntimeIdentifiersInParallel Condition=" '$(_AndroidBuildRuntimeIdentifiersInParallel)' == '' ">true</_AndroidBuildRuntimeIdentifiersInParallel>
     </PropertyGroup>
+    <ItemGroup>
+      <_ProjectToBuild Include="$(MSBuildProjectFile)" AdditionalProperties="RuntimeIdentifier=%(_RIDs.Identity);$(_AdditionalProperties)" />
+    </ItemGroup>
     <MSBuild
-        Projects="$(MSBuildProjectFile)"
-        Targets="_ComputeFilesToPublishForRuntimeIdentifiers"
-        Properties="RuntimeIdentifier=%(_RIDs.Identity);$(_AdditionalProperties)">
+        Projects="@(_ProjectToBuild)"
+        BuildInParallel="$(_AndroidBuildRuntimeIdentifiersInParallel)"
+        Targets="_ComputeFilesToPublishForRuntimeIdentifiers">
       <Output TaskParameter="TargetOutputs" ItemName="ResolvedFileToPublish" />
     </MSBuild>
     <ItemGroup>


### PR DESCRIPTION
Context: https://docs.microsoft.com/visualstudio/msbuild/msbuild-task

During .NET 6 builds, we run a portion of the build in an `<MSBuild/>`
task nested build per-`$(RuntimeIdentifier)`.

The work in the nested build is done in separate directories for each
RID, so we should be able to do the work in parallel for:

* `ILLink`
* AOT compilation

We have to use the `%(AdditionalProperties)` item metadata for the
list of projects (which is the same project) passed to the
`<MSBuild/>` task.

One point of concern is if you have a property at the end of
`%(AdditionalProperties)`:

    _OuterIntermediateOutputPath=$(IntermediateOutputPath);

The `;` will be included in the path if this is the last property!

I reworked the `$(_AdditionalProperties)` so there will not be any
trailing `;` that could cause issues.

## Results ##

Building `dotnet new android` on my Windows PC with `--no-restore`.
This is currently two RIDs by default.

A `Debug` build has small improvement:

    Before:
    Time Elapsed 00:00:06.86
    After:
    Time Elapsed 00:00:06.76

A `Release` build:

    Before:
    Time Elapsed 00:00:19.00
    After:
    Time Elapsed 00:00:13.53

A `Release` build with AOT:

    Before:
    Time Elapsed 00:00:23.95
    After:
    Time Elapsed 00:00:17.72

`Release` builds have the most improvement, saving 5-6 seconds. Apps
with four RIDs, could have even more savings.