### PR TITLE
[Xamarin.Android.Build.Tests] Ensure UseDotNet is set before NUnit evaluates test parameters.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -49,12 +49,6 @@ namespace Xamarin.Android.Build.Tests
 
 			static SetUp ()
 			{
-#if NETCOREAPP
-				Builder.UseDotNet = true;
-#else
-				Builder.UseDotNet = false;
-#endif
-
 				using (var builder = new Builder ()) {
 					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 					AndroidMSBuildDirectory = builder.AndroidMSBuildDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -22,7 +22,7 @@ namespace Xamarin.ProjectTools
 		/// <summary>
 		/// If true, use `dotnet build` and IShortFormProject throughout the tests
 		/// </summary>
-		public static bool UseDotNet { get; set; }
+		public static bool UseDotNet => Environment.Version.Major >= 5;
 
 		string root;
 		string buildLogFullPath;


### PR DESCRIPTION
We set `Builder.UseDotNet` for `Xamarin.Android.Build.Tests` tests in a static `SetUp ()` constructor in an NUnit `[SetUpFixture]`.  However this is not getting set before it is consumed by NUnit for test parameters.

For example:
```
// BuildTest.cs
public void BuildBasicApplication ([ValueSource (nameof (SupportedTargetFrameworks))] string tfv, [Values (true, false)] bool isRelease)
```

is being evaluated as `UseDotNet=false`, and thus running this test on all TFV's for .NET 6, when it should only be run for the latest TFV.

By changing `Builder.UseDotNet` to an evaluated property-getter, we can ensure that it is always correct for running on .NET 5+.

The net result of this change is that the `MSBuild - One .NET - Node-1` test suites run 24 fewer tests for both Windows and Mac.