### PR TITLE
[ci] Use 1ES MicroBuild pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -44,7 +44,7 @@ variables:
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: android-win-2019
-  VSEngMicroBuild2019: VSEngSS-MicroBuild2019
+  VSEngMicroBuild2019: VSEngSS-MicroBuild2019-1ES
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)


### PR DESCRIPTION
Context: https://eng.ms/docs/cloud-ai-platform/developer-services/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/1es-hosted-azuredevops-agents

We've been tasked with migrating away from all scale set agent pools
to a new 1ES service.  The `VSEngSS-MicroBuild2019` pools are being
retired and replaced by `VSEngSS-MicroBuild2019-1ES`.