### PR TITLE
Bump to google/bundletool/main@5ba6c05

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -126,7 +126,7 @@
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">b2be9c80582174e645d3736daa0d44d8610b38a8.</XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>30.0.2</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.4.0</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.8.1</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
     <MauiFeedUrl>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json</MauiFeedUrl>

--- a/Documentation/release-notes/bundletool-1.8.1.md
+++ b/Documentation/release-notes/bundletool-1.8.1.md
@@ -1,0 +1,8 @@
+### bundletool version update to 1.8.1
+
+The version of the [`bundletool`][bundletool] executable included in
+Xamarin.Android has been updated from 1.4.0 to [1.8.1][bundletool-1.8.1],
+bringing in several improvements and bug fixes.
+
+[bundletool]: https://developer.android.com/studio/command-line/bundletool
+[bundletool-1.8.1]: https://github.com/google/bundletool/releases/tag/1.8.1


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/1.8.1
Changes: https://github.com/google/bundletool/compare/1.4.0...1.8.1
Fixes: https://github.com/xamarin/xamarin-android/issues/6354

`dotnet build -c Release -t:Install` fails on an API-31 emulator with:

    [BT : 1.4.0] error : Error retrieving device density. Please try again.

Updating `bundletool` with the fix:

    Android12 emulator fails due to 'Error retrieving device density'

https://github.com/google/bundletool/issues/241