### PR TITLE
[One .NET] fix for %(AndroidSkipResourceProcessing)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -26,13 +26,17 @@ projects.
       <_AarFromLibraries     Include="%(_AarDistinctDirectory.Identity)*.aar" />
     </ItemGroup>
     <ItemGroup Condition=" '@(_AarFromLibraries->Count())' != '0' ">
-      <!-- NOTE: set %(Pack) to false for located .aar files, we should not repackage into NuGets -->
-      <AndroidAarLibrary Include="@(_AarFromLibraries)" Exclude="@(AndroidAarLibrary)" Pack="false" />
       <!--
-        NOTE: %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
-        Update in a second step, in case there was an existing @(AndroidAarLibrary) with the same path.
+        NOTE:
+        * set %(Pack) to false for located .aar files, we should not repackage into NuGets
+        * %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
       -->
-      <AndroidAarLibrary Update="@(_AarFromLibraries)" AndroidSkipResourceProcessing="false" />
+      <AndroidAarLibrary
+          Include="@(_AarFromLibraries)"
+          Exclude="@(AndroidAarLibrary)"
+          Pack="false"
+          AndroidSkipResourceProcessing="false"
+      />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -506,7 +506,17 @@ class MemTest {
 				var files = new List<string> {
 					"material-menu-1.1.0.aar",
 				};
-				if (!Builder.UseDotNet) {
+				// .NET 6 tests use AndroidX, others use Support
+				if (Builder.UseDotNet) {
+					files.Add ("androidx.core.core.aar");
+					files.Add ("androidx.transition.transition.aar");
+					files.Add ("androidx.recyclerview.recyclerview.aar");
+					files.Add ("androidx.coordinatorlayout.coordinatorlayout.aar");
+					files.Add ("androidx.cardview.cardview.aar");
+					files.Add ("androidx.appcompat.appcompat-resources.aar");
+					files.Add ("androidx.appcompat.appcompat.aar");
+					files.Add ("com.google.android.material.material.aar");
+				} else {
 					files.Add ("Xamarin.Android.Support.Compat.dll");
 					files.Add ("Xamarin.Android.Support.Design.dll");
 					files.Add ("Xamarin.Android.Support.Media.Compat.dll");


### PR DESCRIPTION
Building a `dotnet new maui` app, I noticed a lot of time spent in
`<ConvertResourcesCases/>`:

    1346 ms ConvertResourcesCases

Reviewing the build logs, I found `%(AndroidSkipResourceProcessing)`
was set to `false` for all AndroidX `.aar` files. This should not be
the case, because we don't need to fix up casing in these libraries.

After review, I found a bug in the `_ResolveAars` MSBuild target:

    <AndroidAarLibrary Include="@(_AarFromLibraries)" Exclude="@(AndroidAarLibrary)" Pack="false" />
    <AndroidAarLibrary Update="@(_AarFromLibraries)" AndroidSkipResourceProcessing="false" />

The second update was setting `%(AndroidSkipResourceProcessing)` on
libraries it shouldn't have.

I collapsed these two item groups into a single `Include` and this
fixes the issue.

I could reproduce the problem by updating a test we had -- it wasn't
properly listing AndroidX libraries used in .NET 6 in the test.

Results of an initial build of `dotnet new maui` were improved by:

    Before:
    1346 ms ConvertResourcesCases
    After:
      52 ms ConvertResourcesCases

So this should improve the initial build by 1.3s, or incremental
builds that update `.aar` files.