### PR TITLE
[Mono.Android] Use android-31 sources for generating docs.

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-31_r01",   apiLevel: "31",  pkgRevision: "1"),
 
-				new AndroidToolchainComponent ("sources-30_r01",   destDir: Path.Combine ("platforms", $"android-30", "src"), pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
+				new AndroidToolchainComponent ("sources-31_r01",   destDir: Path.Combine ("platforms", $"android-31", "src"), pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1", dependencyType: AndroidToolchainComponentType.BuildDependency),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0", dependencyType: AndroidToolchainComponentType.BuildDependency),


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6215
Context: https://android-developers.googleblog.com/2021/10/android-12-is-live-in-aosp.html

Google has marked `android-31` "final", and has provided the `sources-31_r01.zip` file that we need to build our updated API documentation from.  Update `xaprepare` to provision this new documentation info for us.