### PR TITLE
[build] Enable globalization analyzer errors and fix issues.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -238,11 +238,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(XABuildingForNetCoreApp)' != 'True' And '$(XAShouldAnalyzeAssembly)' == 'True' ">
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <WarningsAsErrors>$(WarningsAsErrors);CA1309;CA1310</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(XABuildingForNetCoreApp)' == 'True' And '$(XAShouldAnalyzeAssembly)' == 'True' ">
-    <NoWarn>$(NoWarn);CA1309;CA1310</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\Ndk.targets" />

--- a/Configuration.props
+++ b/Configuration.props
@@ -226,6 +226,24 @@
 
   <!-- Fix for IDEs -->
   <Target Name="CreateManifestResourceNames" />
+   
+  <!-- Don't analyze code from external repos -->
+  <PropertyGroup Condition=" !$(MSBuildProjectDirectory.Contains ('external')) and !$(MSBuildProjectDirectory.Contains ('NUnitLite')) ">
+    <XAShouldAnalyzeAssembly>True</XAShouldAnalyzeAssembly>
+  </PropertyGroup>
+   
+  <!-- The net6.0 versions of these analyzers are stricter and require overloads not available in .NET Framework, so start with just .NET Framework -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != '' And (!$(TargetFramework.StartsWith('nets')) And !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('monoandroid'))) ">
+    <XABuildingForNetCoreApp>True</XABuildingForNetCoreApp>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(XABuildingForNetCoreApp)' != 'True' And '$(XAShouldAnalyzeAssembly)' == 'True' ">
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1309;CA1310</WarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(XABuildingForNetCoreApp)' == 'True' And '$(XAShouldAnalyzeAssembly)' == 'True' ">
+    <NoWarn>$(NoWarn);CA1309;CA1310</NoWarn>
+  </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\Ndk.targets" />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RoslynAnalyzers.projitems" Condition=" '$(EnableRoslynAnalyzers)' == 'true' " />

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			}
 
 			TargetImplementationPath = implementationPath.FullName;
-			if (TargetImplementationPath.EndsWith ("\\") || TargetImplementationPath.EndsWith ("/")) {
+			if (TargetImplementationPath.EndsWith ("\\", StringComparison.Ordinal) || TargetImplementationPath.EndsWith ("/", StringComparison.Ordinal)) {
 				TargetImplementationPath = TargetImplementationPath.Substring (0, TargetImplementationPath.Length - 1);
 			}
 
@@ -189,7 +189,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						if (!string.IsNullOrWhiteSpace (args.Data)) {
 							lines.Add (args.Data.Trim ());
 
-							if (args.Data.IndexOf ("Native Crash Reporting") != -1) {
+							if (args.Data.IndexOf ("Native Crash Reporting", StringComparison.Ordinal) != -1) {
 								processHasCrashed = true;
 							}
 						}
@@ -245,13 +245,13 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						Log.LogMessage (MessageImportance.High, $"{Environment.NewLine}*** CodeGen missing items***{Environment.NewLine}");
 						var indent = 0;
 						foreach (var item in missingItems) {
-							if (item.StartsWith ("}")) {
+							if (item.StartsWith ("}", StringComparison.Ordinal)) {
 								indent--;
 							}
 
-							Log.LogMessage (MessageImportance.High, $"{(item.StartsWith ("namespace ") ? Environment.NewLine : string.Empty)}{new string (' ', indent * 2)}{item}");
+							Log.LogMessage (MessageImportance.High, $"{(item.StartsWith ("namespace ", StringComparison.Ordinal) ? Environment.NewLine : string.Empty)}{new string (' ', indent * 2)}{item}");
 
-							if (item.StartsWith ("{")) {
+							if (item.StartsWith ("{", StringComparison.Ordinal)) {
 								indent++;
 							}
 						}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CodeGenDiff.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CodeGenDiff.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						return;
 					}
 
-					if (content.StartsWith ("namespace ") || content.IndexOf (" interface ") != -1 || content.IndexOf (" class ") != -1 || content.IndexOf (" partial struct ") != -1 || content.IndexOf (" enum ") != -1) {
+					if (content.StartsWith ("namespace ", StringComparison.Ordinal) || content.IndexOf (" interface ", StringComparison.Ordinal) != -1 || content.IndexOf (" class ", StringComparison.Ordinal) != -1 || content.IndexOf (" partial struct ", StringComparison.Ordinal) != -1 || content.IndexOf (" enum ", StringComparison.Ordinal) != -1) {
 						if (string.IsNullOrWhiteSpace (currentObject.Item)) {
 							currentObject.Item = content;
 						} else {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -121,13 +122,13 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			packWriter.WriteAttributeString ("FileSource", directory);
 			foreach (var child in Directory.EnumerateDirectories (directory)) {
 				var directoryName = Path.GetFileName (child);
-				if (directoryName.StartsWith (".") || directoryName.StartsWith ("_"))
+				if (directoryName.StartsWith (".", StringComparison.Ordinal) || directoryName.StartsWith ("_", StringComparison.Ordinal))
 					continue;
 				RecurseDirectory (top_dir, packWriter, componentWriter, child);
 			}
 			foreach (var file in Directory.EnumerateFiles (directory)) {
 				var fileName = Path.GetFileName (file);
-				if (fileName.StartsWith (".") || fileName.StartsWith ("_"))
+				if (fileName.StartsWith (".", StringComparison.Ordinal) || fileName.StartsWith ("_", StringComparison.Ordinal))
 					continue;
 				AddFile (top_dir, packWriter, componentWriter, file);
 			}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
 		{
 			var name        = Path.GetFileNameWithoutExtension (sourceFile);
-			if (name.StartsWith ("TestResult-"))
+			if (name.StartsWith ("TestResult-", StringComparison.Ordinal))
 				name    = name.Substring ("TestResult-".Length);
 			testSuiteName   = name;
 			testCaseName    = $"Possible Crash / {config}";

--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -397,7 +397,7 @@ namespace Xamarin.Android.ApiMerge {
 				return "*";
 
 			// varargs should be normalized.
-			if (type.EndsWith ("..."))
+			if (type.EndsWith ("...", StringComparison.Ordinal))
 				return GetParameterType (type.Substring (0, type.Length - 3) + "[]", mappings);
 
 			int first = type.IndexOfAny (type_sep);

--- a/build-tools/api-merge/Mono.Options-PCL.cs
+++ b/build-tools/api-merge/Mono.Options-PCL.cs
@@ -1353,11 +1353,11 @@ namespace Mono.Options
 			for (int i = 0; i < nameStart.Length; ++i) {
 				int start, j = 0;
 				do {
-					start = description.IndexOf (nameStart [i], j);
+					start = description.IndexOf (nameStart [i], j, StringComparison.Ordinal);
 				} while (start >= 0 && j != 0 ? description [j++ - 1] == '{' : false);
 				if (start == -1)
 					continue;
-				int end = description.IndexOf ("}", start);
+				int end = description.IndexOf ("}", start, StringComparison.Ordinal);
 				if (end == -1)
 					continue;
 				return description.Substring (start + nameStart [i].Length, end - start - nameStart [i].Length);

--- a/build-tools/check-boot-times/Program.cs
+++ b/build-tools/check-boot-times/Program.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Android.Tools
 
 				var activity = i % 2 == 0 ? "com.google.android.apps.photos/.home.HomeActivity" : "com.android.settings/.wifi.WifiStatusTest";
 				await RunProcess (adbPath, $"-e shell am start -n '{activity}'", 5000, (data, mre) => {
-					if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("com.android") != -1) {
+					if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("com.android", StringComparison.Ordinal) != -1) {
 						mre.Set ();
 					}
 					return true;
@@ -375,7 +375,7 @@ namespace Xamarin.Android.Tools
 		{
 			bool validation (string data, ManualResetEvent mre)
 			{
-				if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("100%") != -1) {
+				if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("100%", StringComparison.Ordinal) != -1) {
 					mre.Set ();
 				}
 

--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Android.JniEnv
 
 				switch (entry.ApiName) {
 				case "NewArray":
-					var copyArray = JNIEnvEntries.Single (e => e.Name.StartsWith ("Get") && e.Name.EndsWith ("ArrayRegion") &&
+					var copyArray = JNIEnvEntries.Single (e => e.Name.StartsWith ("Get", StringComparison.Ordinal) && e.Name.EndsWith ("ArrayRegion", StringComparison.Ordinal) &&
 							e.Parameters [0].Type.Type == entry.ReturnType.Type);
 					o.Write ("\t\t{2} static {0} {1} (", entry.ReturnType.ManagedType, entry.ApiName, entry.Visibility);
 					o.WriteLine ("{0} array)", copyArray.Parameters [3].Type.ManagedType);
@@ -233,7 +233,7 @@ namespace Xamarin.Android.JniEnv
 					break;
 				case "CopyArray":
 					o.Write ("\t\t{2} static unsafe {0} {1} (", entry.ReturnType.ManagedType, entry.ApiName, entry.Visibility);
-					if (entry.Name.StartsWith ("G")) {
+					if (entry.Name.StartsWith ("G", StringComparison.Ordinal)) {
 						o.WriteLine ("IntPtr src, {0} dest)", entry.Parameters [3].Type.ManagedType);
 						o.WriteLine ("\t\t{");
 						o.WriteLine ("\t\t\tif (src == IntPtr.Zero)");
@@ -319,7 +319,7 @@ namespace Xamarin.Android.JniEnv
 			o.Write ("Env.{0} (Handle", entry.Name);
 			for (int i = 0; i < entry.Parameters.Length; i++) {
 				o.Write (", ");
-				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out "))
+				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out ", StringComparison.Ordinal))
 					o.Write ("out ");
 				o.Write (Escape (entry.Parameters [i].Name));
 			}
@@ -327,7 +327,7 @@ namespace Xamarin.Android.JniEnv
 			RaiseException (o, entry);
 			if (is_void) {
 			}
-			else if (entry.ReturnType.ManagedType == "IntPtr" && entry.ReturnType.Type.StartsWith ("j") && !entry.ReturnType.Type.EndsWith ("ID")) {
+			else if (entry.ReturnType.ManagedType == "IntPtr" && entry.ReturnType.Type.StartsWith ("j", StringComparison.Ordinal) && !entry.ReturnType.Type.EndsWith ("ID", StringComparison.Ordinal)) {
 				o.WriteLine ("\t\t\treturn LogCreateLocalRef (tmp);");
 			} else {
 				o.WriteLine ("\t\t\treturn tmp;");
@@ -381,13 +381,13 @@ namespace Xamarin.Android.JniEnv
 			if (!is_void)
 				o.Write ("return ");
 			var n = entry.Name;
-			if (n.StartsWith ("Call"))
+			if (n.StartsWith ("Call", StringComparison.Ordinal))
 				n = n.TrimEnd (new[]{'A'});
 			o.Write ("JniEnvironment.{0}.{1} (", entry.DeclaringType, n);
 			for (int i = 0; i < entry.Parameters.Length; i++) {
 				if (i > 0)
 					o.Write (", ");
-				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out "))
+				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out ", StringComparison.Ordinal))
 					o.Write ("out ");
 				if (entry.Parameters [i].Type.ManagedType == "JValue*")
 					o.Write ("(JniArgumentValue*) " + Escape (entry.Parameters [i].Name));
@@ -445,7 +445,7 @@ namespace Xamarin.Android.JniEnv
 				case "jweak":
 					return true;
 			}
-			if (type.Type.StartsWith ("j") && type.Type.EndsWith("Array"))
+			if (type.Type.StartsWith ("j", StringComparison.Ordinal) && type.Type.EndsWith("Array", StringComparison.Ordinal))
 				return true;
 			return false;
 		}
@@ -643,9 +643,9 @@ namespace Xamarin.Android.JniEnv
 			case "jobjectRefType":
 				return "int";
 			default:
-				if (native_type.EndsWith ("Array"))
+				if (native_type.EndsWith ("Array", StringComparison.Ordinal))
 					return "IntPtr";
-				if (native_type.EndsWith ("*"))
+				if (native_type.EndsWith ("*", StringComparison.Ordinal))
 					return "IntPtr";
 				return native_type;
 			}

--- a/build-tools/jnienv-gen/Mono.Options-PCL.cs
+++ b/build-tools/jnienv-gen/Mono.Options-PCL.cs
@@ -1353,11 +1353,11 @@ namespace Mono.Options
 			for (int i = 0; i < nameStart.Length; ++i) {
 				int start, j = 0;
 				do {
-					start = description.IndexOf (nameStart [i], j);
+					start = description.IndexOf (nameStart [i], j, StringComparison.Ordinal);
 				} while (start >= 0 && j != 0 ? description [j++ - 1] == '{' : false);
 				if (start == -1)
 					continue;
-				int end = description.IndexOf ("}", start);
+				int end = description.IndexOf ("}", start, StringComparison.Ordinal);
 				if (end == -1)
 					continue;
 				return description.Substring (start + nameStart [i].Length, end - start - nameStart [i].Length);

--- a/build-tools/scripts/RoslynAnalyzers.projitems
+++ b/build-tools/scripts/RoslynAnalyzers.projitems
@@ -1,6 +1,6 @@
 <Project>
-  <!-- Add Roslyn analyzers NuGet to all projects (except NRefactory which has violations but is only used for running tests and XamarinManifestGenerator which uses packages.config ) -->
-  <ItemGroup Condition=" !$(AssemblyName.StartsWith ('ICSharpCode.NRefactory')) and !$(AssemblyName.StartsWith ('XamarinManifestGenerator')) ">
+
+  <ItemGroup Condition=" $(XAShouldAnalyzeAssembly) ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
+++ b/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Android.Prepare
 				if (be == null || String.IsNullOrEmpty (be.Line))
 					continue;
 
-				if (be.Line.IndexOf ("<ProductVersion>") >= 0) {
+				if (be.Line.IndexOf ("<ProductVersion>", StringComparison.Ordinal) >= 0) {
 					Log.DebugLine ($"Last version change on {GetCommitDate (be)} by {be.Author}");
 					CommitOfLastVersionChange = be.Commit;
 					Log.StatusLine ("    Commit: ", be.Commit, tailColor: ConsoleColor.Cyan);

--- a/src-ThirdParty/android-platform-tools-base/PackagingUtils.cs
+++ b/src-ThirdParty/android-platform-tools-base/PackagingUtils.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Tasks
 			return !EqualsIgnoreCase (folderName, "CVS") &&
 				!EqualsIgnoreCase (folderName, ".svn") &&
 				!EqualsIgnoreCase (folderName, "SCCS") &&
-				!folderName.StartsWith ("_");
+				!folderName.StartsWith ("_", StringComparison.Ordinal);
 		}
 
 		/// <summary>

--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -132,7 +132,7 @@ namespace Java.Interop {
 			if (arguments.Length == 0)
 				return type.Assembly.GetType (type + suffix);
 			Type definition = type.GetGenericTypeDefinition ();
-			int bt = definition.FullName!.IndexOf ("`");
+			int bt = definition.FullName!.IndexOf ("`", StringComparison.Ordinal);
 			if (bt == -1)
 				throw new NotSupportedException ("Generic type doesn't follow generic type naming convention! " + type.FullName);
 			Type? suffixDefinition = definition.Assembly.GetType (

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/GenerateProguardConfiguration.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/GenerateProguardConfiguration.cs
@@ -86,7 +86,7 @@ namespace Mono.Linker.Steps {
 				return;
 			var jname = ra.ConstructorArguments.First ().Value.ToString ();
 			var jargs = ra.ConstructorArguments [1].Value.ToString ();
-			var pargs = jargs.StartsWith ("()") ? string.Empty : "***";
+			var pargs = jargs.StartsWith ("()", StringComparison.Ordinal) ? string.Empty : "***";
 			// FIXME: do not preserve all overroads.
 			if (jname == ".ctor")
 				writer.WriteLine ("   <init>(...);", pargs);

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
@@ -152,7 +152,7 @@ namespace MonoDroid.Tuner {
 
 		string TypeNameWithoutKey (string name)
 		{
-			var idx = name.IndexOf (", PublicKeyToken=");
+			var idx = name.IndexOf (", PublicKeyToken=", StringComparison.Ordinal);
 			if (idx > 0)
 				name = name.Substring (0, idx);
 
@@ -266,7 +266,7 @@ namespace MonoDroid.Tuner {
 
 		static bool IsImplementor (TypeDefinition type)
 		{
-			return type.Name.EndsWith ("Implementor") && type.Inherits ("Java.Lang.Object");
+			return type.Name.EndsWith ("Implementor", StringComparison.Ordinal) && type.Inherits ("Java.Lang.Object");
 		}
 
 		static bool IsUserType (TypeDefinition type)
@@ -280,7 +280,7 @@ namespace MonoDroid.Tuner {
 				return;
 
 			foreach (MethodDefinition method in type.Methods)
-				if (method.Name.EndsWith ("Handler"))
+				if (method.Name.EndsWith ("Handler", StringComparison.Ordinal))
 					PreserveMethod (type, method);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 						if (!string.IsNullOrEmpty (ProjectDir)) {
 							var fullRelPath = Path.GetFullPath (rel).Normalize (NormalizationForm.FormC);
 							var fullProjectPath = Path.GetFullPath (ProjectDir).Normalize (NormalizationForm.FormC);
-							if (fullRelPath.StartsWith (fullProjectPath)) {
+							if (fullRelPath.StartsWith (fullProjectPath, StringComparison.Ordinal)) {
 								rel = fullRelPath.Replace (fullProjectPath, string.Empty);
 							}
 						}
@@ -109,7 +109,7 @@ namespace Xamarin.Android.Tasks
 
 				if (prefixes != null) {
 					foreach (var p in prefixes) {
-						if (rel.StartsWith (p))
+						if (rel.StartsWith (p, StringComparison.Ordinal))
 							rel = rel.Substring (p.Length);
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 						if (!string.IsNullOrEmpty (ProjectDir)) {
 							var fullRelPath = Path.GetFullPath (rel).Normalize (NormalizationForm.FormC);
 							var fullProjectPath = Path.GetFullPath (ProjectDir).Normalize (NormalizationForm.FormC);
-							if (fullRelPath.StartsWith (fullProjectPath, StringComparison.Ordinal)) {
+							if (fullRelPath.StartsWith (fullProjectPath, StringComparison.OrdinalIgnoreCase)) {
 								rel = fullRelPath.Replace (fullProjectPath, string.Empty);
 							}
 						}
@@ -109,7 +109,7 @@ namespace Xamarin.Android.Tasks
 
 				if (prefixes != null) {
 					foreach (var p in prefixes) {
-						if (rel.StartsWith (p, StringComparison.Ordinal))
+						if (rel.StartsWith (p, StringComparison.OrdinalIgnoreCase))
 							rel = rel.Substring (p.Length);
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Android.Tasks
 			if (singleLine.Length == 0)
 				return;
 
-			if (singleLine.StartsWith ("Warning:")) {
+			if (singleLine.StartsWith ("Warning:", StringComparison.Ordinal)) {
 				hasWarnings = true;
 				return;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -215,7 +215,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.Ordinal)) : null;
+				var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) : null;
 				if (jarFiles != null && JavaLibraries != null)
 					jarFiles = jarFiles.Concat (JavaLibraries);
 				else if (JavaLibraries != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -215,7 +215,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar")) : null;
+				var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.Ordinal)) : null;
 				if (jarFiles != null && JavaLibraries != null)
 					jarFiles = jarFiles.Concat (JavaLibraries);
 				else if (JavaLibraries != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -482,7 +482,7 @@ namespace Xamarin.Android.Tasks
 			bool capitalize = false;
 			if (id.StartsWith ("@id/", StringComparison.Ordinal) || id.StartsWith ("@+id/", StringComparison.Ordinal))
 				ns = "Resource.Id";
-			else if (id.StartsWith ("@android:id/")) {
+			else if (id.StartsWith ("@android:id/", StringComparison.Ordinal)) {
 				ns = $"{GlobalIdPrefix}Android.Resource.Id";
 				capitalize = true;
 			} else

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar")) : null;
+			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.Ordinal)) : null;
 			if (jarFiles != null && JavaLibraries != null)
 				jarFiles = jarFiles.Concat (JavaLibraries);
 			else if (JavaLibraries != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.Ordinal)) : null;
+			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) : null;
 			if (jarFiles != null && JavaLibraries != null)
 				jarFiles = jarFiles.Concat (JavaLibraries);
 			else if (JavaLibraries != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Tasks {
 				string stampFile = directory.GetMetadata ("StampFile");
 				string directoryHash = Files.HashString (directory.ItemSpec);
 				if (string.IsNullOrEmpty (stampFile)) {
-					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.Ordinal)) {
 						// If inside the `lp` directory
 						stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
 					} else {
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tasks {
 				IEnumerable<string> files;
 				string filesCache = directory.GetMetadata ("FilesCache");
 				if (string.IsNullOrEmpty (filesCache)) {
-					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.Ordinal)) {
 						filesCache = Path.Combine (directory.ItemSpec, "..", "files.cache");
 					} else {
 						filesCache = Path.Combine (directory.ItemSpec, "..", $"{directoryHash}-files.cache");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Tasks {
 				string stampFile = directory.GetMetadata ("StampFile");
 				string directoryHash = Files.HashString (directory.ItemSpec);
 				if (string.IsNullOrEmpty (stampFile)) {
-					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.Ordinal)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.OrdinalIgnoreCase)) {
 						// If inside the `lp` directory
 						stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
 					} else {
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tasks {
 				IEnumerable<string> files;
 				string filesCache = directory.GetMetadata ("FilesCache");
 				if (string.IsNullOrEmpty (filesCache)) {
-					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.Ordinal)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir, StringComparison.OrdinalIgnoreCase)) {
 						filesCache = Path.Combine (directory.ItemSpec, "..", "files.cache");
 					} else {
 						filesCache = Path.Combine (directory.ItemSpec, "..", $"{directoryHash}-files.cache");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Tasks {
 			}
 			var output = new Dictionary<string, ITaskItem> (processed.Count);
 			foreach (var file in processed) {
-				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
+				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec, StringComparison.Ordinal)) ?? null;
 				var hash = resdir?.GetMetadata ("Hash") ?? null;
 				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Tasks {
 			}
 			var output = new Dictionary<string, ITaskItem> (processed.Count);
 			foreach (var file in processed) {
-				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec, StringComparison.Ordinal)) ?? null;
+				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec, StringComparison.OrdinalIgnoreCase)) ?? null;
 				var hash = resdir?.GetMetadata ("Hash") ?? null;
 				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -181,9 +181,9 @@ namespace Xamarin.Android.Tasks
 			var ordered = new SortedList<int,string> ();
 			foreach (var line in File.ReadAllLines (singleFile)) {
 				var s = line.Trim ();
-				if (s.StartsWith ("#"))
+				if (s.StartsWith ("#", StringComparison.Ordinal))
 					continue;
-				if (!s.StartsWith (librefspec))
+				if (!s.StartsWith (librefspec, StringComparison.Ordinal))
 					continue;
 				int eqpos = s.IndexOf ('=');
 				if (eqpos < 0)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Android.Tasks
 				string outPath = Path.Combine (IntermediateOutputDirectory, "aidl");
 				var ret = tool.Run (opts, assemblyFile => AssemblyDefinition.ReadAssembly (assemblyFile), (dir, file) => {
 					var dst = Path.GetFullPath (Path.Combine (outPath, Path.ChangeExtension (file, ".cs")));
-					if (!dst.StartsWith (outPath, StringComparison.Ordinal))
+					if (!dst.StartsWith (outPath, StringComparison.OrdinalIgnoreCase))
 						dst = Path.Combine (outPath, Path.ChangeExtension (Path.GetFileName (file), ".cs"));
 					string dstdir = Path.GetDirectoryName (dst);
 					if (!Directory.Exists (dstdir))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Android.Tasks
 				string outPath = Path.Combine (IntermediateOutputDirectory, "aidl");
 				var ret = tool.Run (opts, assemblyFile => AssemblyDefinition.ReadAssembly (assemblyFile), (dir, file) => {
 					var dst = Path.GetFullPath (Path.Combine (outPath, Path.ChangeExtension (file, ".cs")));
-					if (!dst.StartsWith (outPath))
+					if (!dst.StartsWith (outPath, StringComparison.Ordinal))
 						dst = Path.Combine (outPath, Path.ChangeExtension (Path.GetFileName (file), ".cs"));
 					string dstdir = Path.GetDirectoryName (dst);
 					if (!Directory.Exists (dstdir))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -219,7 +219,7 @@ namespace Xamarin.Android.Tasks
 						}
 						continue;
 					}
-					if (lineToWrite.StartsWith ("XA_BROKEN_EXCEPTION_TRANSITIONS=")) {
+					if (lineToWrite.StartsWith ("XA_BROKEN_EXCEPTION_TRANSITIONS=", StringComparison.Ordinal)) {
 						brokenExceptionTransitions = true;
 						continue;
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -276,7 +276,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (ldName)) {
 					ldName = Path.GetFileName (ldName);
 					if (ldName.IndexOf ('-') >= 0) {
-						ldName = ldName.Substring (ldName.LastIndexOf ("-") + 1);
+						ldName = ldName.Substring (ldName.LastIndexOf ("-", StringComparison.Ordinal) + 1);
 					}
 				}
 			} else {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -143,11 +143,11 @@ namespace Xamarin.Android.Tasks
 				return false;
 			} else if (foundError) {
 				if (singleLine.Trim () == "^") {
-					column = singleLine.IndexOf ("^");
+					column = singleLine.IndexOf ("^", StringComparison.Ordinal);
 					return true;
 				}
 
-				if (singleLine.StartsWith ("Note:") || singleLine.Trim ().EndsWith ("errors")) {
+				if (singleLine.StartsWith ("Note:", StringComparison.Ordinal) || singleLine.Trim ().EndsWith ("errors", StringComparison.Ordinal)) {
 					// See if we have one last error to print out
 					Log.LogError (ToolName, DefaultErrorCode, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
 					errorText.Clear ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 			var options = new LinkerOptions ();
 			options.MainAssembly = res.GetAssembly (MainAssembly);
 			options.OutputDirectory = Path.GetFullPath (OutputDirectory);
-			options.LinkSdkOnly = string.Compare (LinkMode, "SdkOnly", true) == 0;
+			options.LinkSdkOnly = string.Compare (LinkMode, "SdkOnly", StringComparison.OrdinalIgnoreCase) == 0;
 			options.LinkNone = false;
 			options.Resolver = resolver;
 			options.LinkDescriptions = LinkDescriptions.Select (item => Path.GetFullPath (item.ItemSpec)).ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -316,11 +316,11 @@ namespace Xamarin.Android.Tasks
 			}
 			if (matched) {
 				if (singleLine.Trim () == "^") {
-					column = singleLine.IndexOf ("^");
+					column = singleLine.IndexOf ("^", StringComparison.Ordinal);
 					GenerateErrorOrWarning ();
 				}
 				if (singleLine.Trim ().Contains ("~")) {
-					column = singleLine.IndexOf ("~");
+					column = singleLine.IndexOf ("~", StringComparison.Ordinal);
 					GenerateErrorOrWarning ();
 				}
 			} else

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -144,8 +144,8 @@ namespace Xamarin.Android.Tasks
 		static bool IsFrameworkAssembly (ITaskItem assembly)
 		{
 			string packageId = assembly.GetMetadata ("NuGetPackageId") ?? "";
-			return packageId.StartsWith ("Microsoft.NETCore.App.Runtime.") ||
-				packageId.StartsWith ("Microsoft.Android.Runtime.");
+			return packageId.StartsWith ("Microsoft.NETCore.App.Runtime.", StringComparison.Ordinal) ||
+				packageId.StartsWith ("Microsoft.Android.Runtime.", StringComparison.Ordinal);
 		}
 
 		static ITaskItem? GetOrCreateSymbolItem (Dictionary<string, ITaskItem> symbols, ITaskItem assembly)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -187,7 +187,7 @@ namespace Xamarin.Android.Tasks
 			}
 			foreach (var folder in lockFile.PackageFolders) {
 				var path = assemblyPath.Replace (folder.Path, string.Empty);
-				if (path.StartsWith ($"{Path.DirectorySeparatorChar}"))
+				if (path.StartsWith ($"{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
 					path = path.Substring (1);
 				var libraryPath = lockFile.Libraries.FirstOrDefault (x => path.StartsWith (x.Path.Replace('/', Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase));
 				if (libraryPath == null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -60,9 +60,9 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 				IEnumerable<string> taskOutput = builder.LastBuildOutput
 					.Select (x => x.Trim ())
-					.SkipWhile (x => !x.StartsWith ("Task \"CalculateProjectDependencies\""))
-					.SkipWhile (x => !x.StartsWith ("Output Item(s):"))
-					.TakeWhile (x => !x.StartsWith ("Done executing task \"CalculateProjectDependencies\""));
+					.SkipWhile (x => !x.StartsWith ("Task \"CalculateProjectDependencies\"", StringComparison.Ordinal))
+					.SkipWhile (x => !x.StartsWith ("Output Item(s):", StringComparison.Ordinal))
+					.TakeWhile (x => !x.StartsWith ("Done executing task \"CalculateProjectDependencies\"", StringComparison.Ordinal));
 				if (ndkRequired)
 					StringAssertEx.Contains ("ndk-bundle", taskOutput, "ndk-bundle should be a dependency.");
 				else

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -402,7 +402,7 @@ namespace "+ libName + @" {
 					b.ThrowOnBuildFailure = false;
 					Assert.IsFalse (b.Build (proj), "Build should have failed.");
 					string error = b.LastBuildOutput
-							.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+							.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
 							.FirstOrDefault (x => x.Contains ("error XA1025:"));
 					Assert.IsNotNull (error, "Build should have failed with XA1025.");
 					return;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -609,7 +609,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
 				string error = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ("error XA1019:"));
 				Assert.IsNotNull (error, "Build should have failed with XA1019.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Android.Build.Tests
 					using (var apk = ZipHelper.OpenZip (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk"))) {
 						foreach (var a in libproj.OtherBuildItems.Where (x => x is AndroidItem.AndroidAsset)) {
 							var item = a.Include ().ToLower ().Replace ("\\", "/");
-							if (item.EndsWith ("/"))
+							if (item.EndsWith ("/", StringComparison.Ordinal))
 								continue;
 							var data = ZipHelper.ReadFileFromZip (apk, item);
 							Assert.IsNotNull (data, "{0} should be in the apk.", item);
@@ -124,7 +124,7 @@ namespace Xamarin.Android.Build.Tests
 						}
 						foreach (var a in proj.OtherBuildItems.Where (x => x is AndroidItem.AndroidAsset)) {
 							var item = a.Include ().ToLower ().Replace ("\\", "/");
-							if (item.EndsWith ("/"))
+							if (item.EndsWith ("/", StringComparison.Ordinal))
 								continue;
 							var data = ZipHelper.ReadFileFromZip (apk, item);
 							Assert.IsNotNull (data, "{0} should be in the apk.", item);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -693,7 +693,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					b.ThrowOnBuildFailure = false;
 					Assert.IsFalse (b.Build (proj), "Build should have failed.");
 					string error = b.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ("error XA1011:"));
 					Assert.IsNotNull (error, "Build should have failed with XA1011.");
 					return;
@@ -2141,7 +2141,7 @@ namespace UnnamedProject
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
 				string error = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ("error XA1018:"));
 				Assert.IsNotNull (error, "Build should have failed with XA1018.");
 				StringAssert.Contains ("DoesNotExist", error, "Error should include the name of the nonexistent file");
@@ -2163,7 +2163,7 @@ namespace UnnamedProject
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (shouldSucceed, builder.Build (proj), $"Build should have {expectedText}.");
 				string error = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ($"Build {expectedText}."))
+						.SkipWhile (x => !x.StartsWith ($"Build {expectedText}.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ($"{warnOrError} XA4313"));
 				Assert.IsNotNull (error, $"Build should have {expectedText} with XA4313 {warnOrError}.");
 			}
@@ -2247,7 +2247,7 @@ namespace UnnamedProject
 				builder.Build (proj);
 				Assert.IsNotNull(
 					builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith (expectedBuildResult ? "Build succeeded." : "Build FAILED."))
+						.SkipWhile (x => !x.StartsWith (expectedBuildResult ? "Build succeeded." : "Build FAILED.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains (expectedWarning)),
 					$"Build output should contain '{expectedWarning}'.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1067,7 +1067,7 @@ namespace UnamedProject
 					b.ThrowOnBuildFailure = false;
 					Assert.IsFalse (b.Build (proj), "Build should have failed.");
 					string error = b.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build FAILED."))
+						.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ("error XA1011:"));
 					Assert.IsNotNull (error, "Build should have failed with XA1011.");
 					return;
@@ -1353,7 +1353,7 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 			using (var builder = CreateApkBuilder ()) {
 				Assert.True (builder.Build (proj), "Build should have succeeded.");
 				string warning = builder.LastBuildOutput
-						.SkipWhile (x => !x.StartsWith ("Build succeeded."))
+						.SkipWhile (x => !x.StartsWith ("Build succeeded.", StringComparison.Ordinal))
 						.FirstOrDefault (x => x.Contains ("R8 : warning : Missing class: java.lang.ClassValue"));
 				if (useConfig) {
 					Assert.IsNull (warning, "Build should have completed without an R8 warning for `java.lang.ClassValue`.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -58,10 +58,10 @@ namespace Xamarin.Android.Build.Tests
 				string monoDebugVar;
 				Assert.IsTrue (envvars.TryGetValue ("MONO_DEBUG", out monoDebugVar), "Environment should contain MONO_DEBUG");
 				Assert.IsFalse (String.IsNullOrEmpty (monoDebugVar), "Environment must contain MONO_DEBUG with a value");
-				Assert.IsTrue (monoDebugVar.IndexOf ("soft-breakpoints") >= 0, "Environment must contain MONO_DEBUG with 'soft-breakpoints' in its value");
+				Assert.IsTrue (monoDebugVar.IndexOf ("soft-breakpoints", StringComparison.Ordinal) >= 0, "Environment must contain MONO_DEBUG with 'soft-breakpoints' in its value");
 
 				if (!String.IsNullOrEmpty (sequencePointsMode))
-					Assert.IsTrue (monoDebugVar.IndexOf ("gen-compact-seq-points") >= 0, "The values from Mono.env should have been merged into environment");
+					Assert.IsTrue (monoDebugVar.IndexOf ("gen-compact-seq-points", StringComparison.Ordinal) >= 0, "The values from Mono.env should have been merged into environment");
 
 				EnvironmentHelper.AssertValidEnvironmentSharedLibrary (intermediateOutputDir, AndroidSdkPath, AndroidNdkPath, supportedAbis);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -575,12 +575,12 @@ namespace Bug12935
 				IEnumerable<string> messages;
 				if (string.CompareOrdinal (manifestMerger, "legacy") == 0) {
 					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-					messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build succeeded."));
+					messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build succeeded.", StringComparison.Ordinal));
 				}
 				else {
 					builder.ThrowOnBuildFailure = false;
 					Assert.IsFalse (builder.Build (proj), "Build should have failed.");
-					messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build FAILED."));
+					messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal));
 				}
 				string warning = messages.FirstOrDefault (x => x.Contains ("warning XA1010:"));
 				Assert.IsNotNull (warning, "Warning should be XA1010");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Android.Build.Tests
 						proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				CompressionMethod method = compressNativeLibraries ? CompressionMethod.Deflate : CompressionMethod.Store;
 				using (var zip = ZipHelper.OpenZip (apk)) {
-					var libFiles = zip.Where (x => x.FullName.StartsWith("lib/") && !x.FullName.Equals("lib/", StringComparison.InvariantCultureIgnoreCase));
+					var libFiles = zip.Where (x => x.FullName.StartsWith("lib/", StringComparison.Ordinal) && !x.FullName.Equals("lib/", StringComparison.InvariantCultureIgnoreCase));
 					var abiPaths = new string[] { "lib/x86/" };
 					foreach (var file in libFiles) {
 						Assert.IsTrue (abiPaths.Any (x => file.FullName.Contains (x)), $"Apk contains an unnesscary lib file: {file.FullName}");
@@ -208,7 +208,7 @@ namespace Xamarin.Android.Build.Tests
 
 			using (var zip = ZipHelper.OpenZip (apk)) {
 				foreach (var entry in zip) {
-					if (entry.FullName.EndsWith (".so")) {
+					if (entry.FullName.EndsWith (".so", StringComparison.Ordinal)) {
 						AssertCompression (entry, compressed: false);
 					}
 				}
@@ -245,7 +245,7 @@ namespace Xamarin.Android.Build.Tests
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					foreach (var entry in zip) {
-						if (entry.FullName.EndsWith (".so") || entry.FullName.EndsWith (".bar")) {
+						if (entry.FullName.EndsWith (".so", StringComparison.Ordinal) || entry.FullName.EndsWith (".bar", StringComparison.Ordinal)) {
 							AssertCompression (entry, compressed: true);
 						}
 					}
@@ -262,7 +262,7 @@ namespace Xamarin.Android.Build.Tests
 				FileAssert.Exists (apk);
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					foreach (var entry in zip) {
-						if (entry.FullName.EndsWith (".so") || entry.FullName.EndsWith (".bar")) {
+						if (entry.FullName.EndsWith (".so", StringComparison.Ordinal) || entry.FullName.EndsWith (".bar", StringComparison.Ordinal)) {
 							AssertCompression (entry, compressed: false);
 						}
 					}
@@ -950,7 +950,7 @@ public class Test
 					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					foreach (var entry in zip) {
-						if (entry.FullName.EndsWith (".so")) {
+						if (entry.FullName.EndsWith (".so", StringComparison.Ordinal)) {
 							AssertCompression (entry, compressed: true);
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Build.Tests
 		ITaskItem CreateTaskItemForResourceFile (string root, string dir, string file)
 		{
 			string ext = Path.GetExtension (file);
-			if (dir.StartsWith ("values"))
+			if (dir.StartsWith ("values", StringComparison.Ordinal))
 				ext = ".arsc";
 			return new TaskItem (Path.Combine (root, dir, file), new Dictionary<string, string> { { "_FlatFile", $"{dir}_{Path.GetFileNameWithoutExtension (file)}{ext}.flat" } } );
 		}
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			string ext = Path.GetExtension (file);
 			string dir = Path.GetFileName (Path.GetDirectoryName (file));
-			if (dir.StartsWith ("values"))
+			if (dir.StartsWith ("values", StringComparison.Ordinal))
 				ext = ".arsc";
 			return new TaskItem (file, new Dictionary<string, string> { { "_FlatFile", $"{dir}_{Path.GetFileNameWithoutExtension (file)}{ext}.flat" } } );
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ValidateJavaVersionTests.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Android.Build.Tests
 			validateJavaVersion.JavaSdkPath = javaPath;
 
 			Assert.IsTrue (validateJavaVersion.Execute (), "second Execute should succeed!");
-			Assert.IsFalse (messages.Any (m => m.Message.StartsWith ("Using cached value for")), "`java -version` should *not* be cached!");
+			Assert.IsFalse (messages.Any (m => m.Message.StartsWith ("Using cached value for", StringComparison.Ordinal)), "`java -version` should *not* be cached!");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -463,7 +463,7 @@ namespace Xamarin.Android.Build.Tests
 		// https://github.com/xamarin/xamarin-android-tools/blob/683f37508b56c76c24b3287a5687743438625341/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs#L108-L132
 		void CreateShellScript (string path, string contents)
 		{
-			if (IsWindows && string.Compare (Path.GetExtension (path), ".dll", true) != 0)
+			if (IsWindows && string.Compare (Path.GetExtension (path), ".dll", StringComparison.OrdinalIgnoreCase) != 0)
 				path += ".cmd";
 			using (var script = new StreamWriter (path)) {
 				if (IsWindows) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -312,7 +312,7 @@ namespace Xamarin.Android.Build.Tests
 		static string AssertIsAssemblerString (string file, string value, int lineNumber)
 		{
 			string v = value.Trim ();
-			Assert.IsTrue (v.StartsWith ("\"") && v.EndsWith("\""), $"Field value is not a valid assembler string in '{file}:{lineNumber}': {v}");
+			Assert.IsTrue (v.StartsWith ("\"", StringComparison.Ordinal) && v.EndsWith("\"", StringComparison.Ordinal), $"Field value is not a valid assembler string in '{file}:{lineNumber}': {v}");
 			return v.Trim ('"');
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
@@ -39,7 +39,7 @@ namespace Xamarin.ProjectTools
 
 		public string TargetFrameworkDirectory {
 			get {
-				int index = TargetFrameworks.IndexOf (";");
+				int index = TargetFrameworks.IndexOf (";", StringComparison.Ordinal);
 				if (index != -1) {
 					return TargetFrameworks.Substring (0, TargetFrameworks.Length - index).ToLowerInvariant ();
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 						var name = ((CodeTypeDeclaration) g.Members [g.Members.Count-1]).Name;
 						var f = new CodeMemberField (typeof (int), GetResourceName (name, m.Groups[1].Value, map)) {
 								Attributes      = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
-								InitExpression  = new CodePrimitiveExpression (ToInt32 (m.Groups [2].Value, m.Groups [2].Value.IndexOf ("0x") == 0 ? 16 : 10)),
+								InitExpression  = new CodePrimitiveExpression (ToInt32 (m.Groups [2].Value, m.Groups [2].Value.IndexOf ("0x", StringComparison.Ordinal) == 0 ? 16 : 10)),
 								Comments = {
 									new CodeCommentStatement ("aapt resource value: " + m.Groups [2].Value),
 								},

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -160,7 +160,7 @@ namespace Xamarin.Android.Tasks {
 
 		string ToFullyQualifiedName (string typeName)
 		{
-			if (typeName.StartsWith ("."))
+			if (typeName.StartsWith (".", StringComparison.Ordinal))
 				return PackageName + typeName;
 			if (typeName.Contains ("."))
 				return typeName;
@@ -662,7 +662,7 @@ namespace Xamarin.Android.Tasks {
 				switch (el.Name.LocalName) {
 				case "provider":
 					var autho = el.Attribute (androidNs.GetName ("authorities"));
-					if (autho != null && autho.Value.EndsWith (".__mono_init__"))
+					if (autho != null && autho.Value.EndsWith (".__mono_init__", StringComparison.Ordinal))
 						continue;
 					goto case "activity";
 				case "activity":
@@ -720,7 +720,7 @@ namespace Xamarin.Android.Tasks {
 
 		XElement ActivityFromTypeDefinition (TypeDefinition type, string name, int targetSdkVersion)
 		{
-			if (name.StartsWith ("_"))
+			if (name.StartsWith ("_", StringComparison.Ordinal))
 				throw new InvalidActivityNameException (string.Format ("Activity name '{0}' is invalid, because activity namespaces may not begin with an underscore.", type.FullName));
 
 			return ToElement (type, name,

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 					// e.g. $prefix/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0.
 					// Trim off the version.
 					.Select (p => Path.GetDirectoryName (p.TrimEnd (Path.DirectorySeparatorChar)))
-					.Any (p => assembly.StartsWith (p, StringComparison.Ordinal));
+					.Any (p => assembly.StartsWith (p, StringComparison.OrdinalIgnoreCase));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 					// e.g. $prefix/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0.
 					// Trim off the version.
 					.Select (p => Path.GetDirectoryName (p.TrimEnd (Path.DirectorySeparatorChar)))
-					.Any (p => assembly.StartsWith (p));
+					.Any (p => assembly.StartsWith (p, StringComparison.Ordinal));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Android.Tasks
 
 		public static bool IsEmbeddedReferenceJar (string jar)
 		{
-			return jar.StartsWith ("__reference__");
+			return jar.StartsWith ("__reference__", StringComparison.Ordinal);
 		}
 
 		public static void LogWarning (object log, string msg, params object [] args)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkTools.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkTools.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Android.Tasks
 		public string GetNdkToolPrefixForAOT (AndroidTargetArch arch, int apiLevel)
 		{
 			string path = GetToolPath (NdkToolKind.Assembler, arch, apiLevel);
-			return path.Substring (0, path.LastIndexOf ("-") + 1);;
+			return path.Substring (0, path.LastIndexOf ("-", StringComparison.Ordinal) + 1);;
 		}
 
 		// Work around for a bug in NDK r19 before its 'c' release. See NdkToolsWithClangWithPlatforms.ctor

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -20,6 +20,8 @@
     <GenerateResxSource>true</GenerateResxSource>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <!-- Causes issues with linker files imported from Mono -->
+    <NoWarn>$(NoWarn);CA1310</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.JavadocImporter/DocumentElement.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/DocumentElement.cs
@@ -309,7 +309,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 		public override IEnumerable<XNode> GetTypeSummaryNodes (XElement jd)
 		{
 			var classDataComment = jd.DescendantNodes ()
-				.Where (n => n.NodeType == XmlNodeType.Comment && ((XComment)n).Value.IndexOf ("======== START OF CLASS DATA ========") > 0)
+				.Where (n => n.NodeType == XmlNodeType.Comment && ((XComment)n).Value.IndexOf ("======== START OF CLASS DATA ========", StringComparison.Ordinal) > 0)
 				.FirstOrDefault ();
 			if (classDataComment == null)
 				yield break;
@@ -323,7 +323,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 				// The next comment node is the end of this CLASS SUMMARY. It could be different comments
 				if (n.NodeType == XmlNodeType.Comment) {
 					var c = (XComment)n;
-					if (c.Value.IndexOf (" SUMMARY ========") > 0)
+					if (c.Value.IndexOf (" SUMMARY ========", StringComparison.Ordinal) > 0)
 						yield break;
 				} else if (n is XText) {
 					// FIXME: we don't use HAP for JavaDoc6 anymore, so we don't need such a mess.
@@ -339,7 +339,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 					// Sometimes this NESTED CLASS SUMMARY node could come *inside* a <p> tag. I think it is wrong, but
 					// 1) I don't trust SgmlReader, and 2) I don't trust javadoc/doclet.
 					var e = n as XElement;
-					if (e != null && e.Nodes ().Any (x => x.NodeType == XmlNodeType.Comment && ((XComment)x).Value.IndexOf (" SUMMARY ========") > 0))
+					if (e != null && e.Nodes ().Any (x => x.NodeType == XmlNodeType.Comment && ((XComment)x).Value.IndexOf (" SUMMARY ========", StringComparison.Ordinal) > 0))
 						yield break;
 					// skip empty <P> tag.
 					if (e == null || e.Name.LocalName != "p" || e.Nodes ().Any ())

--- a/src/Xamarin.Android.Tools.JavadocImporter/HtmlLoader.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/HtmlLoader.cs
@@ -231,7 +231,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 
 		public string GetJavaDocPath (string name)
 		{
-			if (name.StartsWith ("mono/", StringComparison.Ordinal)) {
+			if (name.StartsWith ("mono/", StringComparison.OrdinalIgnoreCase)) {
 				// generator.exe-generated type; there are no docs
 				return null;
 			}

--- a/src/Xamarin.Android.Tools.JavadocImporter/HtmlLoader.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/HtmlLoader.cs
@@ -231,7 +231,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 
 		public string GetJavaDocPath (string name)
 		{
-			if (name.StartsWith ("mono/")) {
+			if (name.StartsWith ("mono/", StringComparison.Ordinal)) {
 				// generator.exe-generated type; there are no docs
 				return null;
 			}

--- a/src/Xamarin.Android.Tools.JavadocImporter/MdocHelper.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/MdocHelper.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 			if (!m.Success)
 				return string.Format ("!:BadHref:{0}", href);
 			string jniTypeName = m.Groups ["type"].Value.Replace ('.', '$');
-			if (jniTypeName.EndsWith ("package-summary"))
+			if (jniTypeName.EndsWith ("package-summary", StringComparison.Ordinal))
 				return CreateNamespaceCref (jniTypeName);
 			Type type = GetAvailableTypes ()
 				.FirstOrDefault (t => {
@@ -201,10 +201,10 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 			if (href == null)
 				return "";
 			var cref = CrefFromHref (href.Value);
-			if (!cref.StartsWith ("!:BadHref"))
+			if (!cref.StartsWith ("!:BadHref", StringComparison.Ordinal))
 				return new XElement ("see",
 						new XAttribute ("cref", cref));
-			int packageStart = href.Value.LastIndexOf ("../");
+			int packageStart = href.Value.LastIndexOf ("../", StringComparison.Ordinal);
 			if (packageStart < 0)
 				return "";
 			var url = href.Value.Substring (packageStart + "../".Length);

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(LinkerSourceFullPath)\analyzer\common\Mono.Options\Options.cs">
-      <Link>Options.cs</Link>
-    </Compile>
     <Compile Include="..\..\external\Java.Interop\src\utils\StringRocks.cs">
       <Link>StringRocks.cs</Link>
     </Compile>
@@ -53,6 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.14" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
 

--- a/src/Xamarin.Android.Tools.JavadocImporter/samples.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/samples.cs
@@ -28,7 +28,7 @@ public class SampleRepository
 	Dictionary<string, SampleDesc> index = new Dictionary<string, SampleDesc> ();
 	Dictionary<string, string>     updates = new Dictionary<string, string> ();
 
-	public SampleRepository (string name) : this (ZipArchive.Open (name.EndsWith (".zip", StringComparison.Ordinal) ? name : name + ".zip", FileMode.Open))
+	public SampleRepository (string name) : this (ZipArchive.Open (name.EndsWith (".zip", StringComparison.OrdinalIgnoreCase) ? name : name + ".zip", FileMode.Open))
 	{
 		
 	}

--- a/src/Xamarin.Android.Tools.JavadocImporter/samples.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/samples.cs
@@ -28,7 +28,7 @@ public class SampleRepository
 	Dictionary<string, SampleDesc> index = new Dictionary<string, SampleDesc> ();
 	Dictionary<string, string>     updates = new Dictionary<string, string> ();
 
-	public SampleRepository (string name) : this (ZipArchive.Open (name.EndsWith (".zip") ? name : name + ".zip", FileMode.Open))
+	public SampleRepository (string name) : this (ZipArchive.Open (name.EndsWith (".zip", StringComparison.Ordinal) ? name : name + ".zip", FileMode.Open))
 	{
 		
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -102,14 +102,14 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			// Try to see if *successive* lines match expected output
 			var remaining   = expectedLogcatOutput;
 			return line => {
-				if (line.IndexOf (remaining) >= 0) {
+				if (line.IndexOf (remaining, StringComparison.Ordinal) >= 0) {
 					Reset ();
 					return true;
 				}
 				int count   = Math.Min (line.Length, remaining.Length);
 				for ( ; count > 0; count--) {
 					var startMatch = remaining.Substring (0, count);
-					if (line.IndexOf (startMatch) >= 0) {
+					if (line.IndexOf (startMatch, StringComparison.Ordinal) >= 0) {
 						remaining = remaining.Substring (count);
 						return false;
 					}

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Build.Tests
 				bool foundHeader = false;
 				while (!reader.EndOfStream) {
 					var line = reader.ReadLine ();
-					if (line.StartsWith ("#") || string.IsNullOrWhiteSpace (line)) {
+					if (line.StartsWith ("#", StringComparison.Ordinal) || string.IsNullOrWhiteSpace (line)) {
 						continue;
 					}
 					var split = line.Split (',');


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6271

Making culture-aware string comparisons when not intended can result in very hard to diagnose bugs.  (See https://github.com/xamarin/xamarin-android/issues/6271)

Like we added in JI (https://github.com/xamarin/java.interop/pull/879), we should use the appropriate Roslyn code analyzers set to `Error` severity to ensure that we fix current issues and do not introduce any new issues in the future.

One complication with enabling these rules is that the .NET 6+ version of these rules are stricter and require overloads that do not exist in .NET Framework or .NET Standard to fix the violations. Enabling these rules in `.editorconfig` affects all `$(TargetFrameworkMoniker)`s; we will instead use `Configuration.props` to only enable them for non-.NET 6+ builds.

Also tweaks and reuses the existing Roslyn Analyzers logic to exclude external code, as many libraries that are used for testing (like `Mono.Debugg[ing|er].Soft)` have issues surfaced by these analyzers.

Note that some non-test comparisons on filenames/paths were switch from case-sensitive to case-insensitive compares.