### PR TITLE
[ci] PKG notarization still needs .NET Core 3.1.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1526,8 +1526,13 @@ stages:
     - checkout: release_scripts
       clean: true
 
-    - template: yaml-templates/use-dot-net.yaml
-
+    # Doesn't support .NET 6 yet
+    - task: UseDotNet@2
+      displayName: Use .NET Core 3.1
+      inputs:
+        packageType: runtime
+        version: 3.1.405
+    
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(InstallerArtifactName)


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android/pull/6369 we removed .NET Core 3.1 from our CI.  However, it is still needed by the `pkg` notarization step, which only runs on `main`/`release` branches so it didn't show as a failure on the initial PR.

Add .NET Core 3.1 back for this CI job only.