### PR TITLE
[Microsoft.Android.Templates] Add preview language

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Android" ],
+  "classifications": [ "Android", "Mobile" ],
   "name": "Android Activity template",
   "description": "An Android Activity class",
   "tags": {

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Android" ],
+  "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidBinding",
-  "name": "Android Java Library Binding",
-  "description": "A project for creating an Android class library that binds to a native Java library",
+  "name": "Android Java Library Binding (Preview)",
+  "description": "A project for creating a .NET 6 Android class library that binds to a native Java library",
   "shortName": "android-bindinglib",
   "tags": {
     "language": "C#",

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Android" ],
+  "classifications": [ "Android", "Mobile" ],
   "name": "Android Layout template",
   "description": "An Android layout (XML) file",
   "tags": {

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Android" ],
+  "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidApp",
-  "name": "Android Application",
-  "description": "A project for creating an Android application",
+  "name": "Android Application (Preview)",
+  "description": "A project for creating a .NET 6 Android application",
   "shortName": "android",
   "tags": {
     "language": "C#",

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "Android" ],
+  "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidLib",
-  "name": "Android Class library",
-  "description": "A project for creating an Android class library",
+  "name": "Android Class Library (Preview)",
+  "description": "A project for creating a .NET 6 Android class library",
   "shortName": "androidlib",
   "tags": {
     "language": "C#",


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6373

Update our .NET 6 project templates to include "(Preview)" in the title
and include the "Mobile" classification.  The phrase ".NET 6" has also
been added to the description to help them stand out from the regular
Xamarin templates.