### PR TITLE
[ci] Install .NET Core 3.1.19 runtime to notarize

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1531,7 +1531,7 @@ stages:
       displayName: Use .NET Core 3.1
       inputs:
         packageType: runtime
-        version: 3.1.405
+        version: 3.1.19
     
     - task: DownloadPipelineArtifact@2
       inputs:


### PR DESCRIPTION
It appears that we were previously trying to install a .NET Core 3 SDK
version as a runtime, using the latest runtime version should fix that.