### PR TITLE
[ci] Fix xaprepare usage for nightly tests.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -146,10 +146,12 @@ stages:
         solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         artifactName: Build Results - macOS
 
-    - script: mono $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=DetermineApplicableTests --no-emoji --run-mode=CI
-      displayName: determine which test stages to run
-      name: TestConditions
-      condition: and(succeeded(), eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR'))
+    - template: yaml-templates/run-xaprepare.yaml
+      parameters:
+        arguments: --s=DetermineApplicableTests
+        xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
+        displayName: determine which test stages to run
+        condition: and(succeeded(), eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR'))
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 # Check - "Xamarin.Android (Windows Build and Test)"

--- a/build-tools/automation/yaml-templates/run-systemapp-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-systemapp-tests.yaml
@@ -12,8 +12,9 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
 
-    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
-      displayName: install emulator
+    - template: run-xaprepare.yaml
+      parameters:
+        arguments: --s=EmulatorTestDependencies
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -15,8 +15,9 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
 
-    - script: mono $(System.DefaultWorkingDirectory)/build-tools/xaprepare/xaprepare/bin/$(XA.Build.Configuration)/xaprepare.exe --s=EmulatorTestDependencies --no-emoji --run-mode=CI
-      displayName: install emulator
+    - template: run-xaprepare.yaml
+      parameters:
+        arguments: --s=EmulatorTestDependencies
 
     - task: DownloadPipelineArtifact@2
       inputs:


### PR DESCRIPTION
Some of the nightly pipelines tests are failing because they need the recent "run `xaprepare` on .NET6" [changes](https://github.com/xamarin/xamarin-android/pull/6369) applied to them.  

```
Cannot open assembly '/Users/runner/work/1/s/build-tools/xaprepare/xaprepare/bin/Release/xaprepare.exe': No such file or directory.
```

A search of the repo shows these should be the final remaining instances still using `mono xaprepare`.