### PR TITLE
[ci] Fix nightly ci by comparing 'XAShouldAnalyzeAssembly' as string instead of bool

### DIFF
--- a/build-tools/scripts/RoslynAnalyzers.projitems
+++ b/build-tools/scripts/RoslynAnalyzers.projitems
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition=" $(XAShouldAnalyzeAssembly) == 'True' ">
+  <ItemGroup Condition=" '$(XAShouldAnalyzeAssembly)' == 'True' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/build-tools/scripts/RoslynAnalyzers.projitems
+++ b/build-tools/scripts/RoslynAnalyzers.projitems
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition=" $(XAShouldAnalyzeAssembly) ">
+  <ItemGroup Condition=" $(XAShouldAnalyzeAssembly) == 'True' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The nightly pipeline is failing with:
```
/Users/builder/azdo/_work/4/s/xamarin-android/build-tools/scripts/RoslynAnalyzers.projitems(3,14): error MSB4113: Specified condition " $(XAShouldAnalyzeAssembly) " evaluates to "" instead of a boolean. [/Users/builder/azdo/_work/4/s/xamarin-android
```

We should update this comparison to a string compare so that it still works if `$(XAShouldAnalyzeAssembly)` doesn't get set at all.