### PR TITLE
[One .NET] prefer /manifest/@android:versionCode

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -282,9 +282,10 @@ namespace Xamarin.Android.Tasks
 				NeedsInternet = NeedsInternet,
 				InstantRunEnabled = InstantRunEnabled
 			};
-			// Only set manifest.VersionCode if it is not blank.
-			// We do not want to override the existing manifest in this case.
-			if (!string.IsNullOrEmpty (VersionCode)) {
+			// Only set manifest.VersionCode if there is no existing value in AndroidManifest.xml.
+			if (manifest.HasVersionCode) {
+				Log.LogDebugMessage ($"Using existing versionCode in: {ManifestTemplate}");
+			} else if (!string.IsNullOrEmpty (VersionCode)) {
 				manifest.VersionCode = VersionCode;
 			}
 			manifest.Assemblies.AddRange (userAssemblies.Values);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
@@ -125,6 +125,10 @@ namespace Xamarin.Android.Build.Tests
 			if (!Builder.UseDotNet) {
 				proj.SetProperty ("GenerateApplicationManifest", "true");
 			}
+			proj.SetProperty ("ApplicationId", "com.i.should.not.be.used");
+			proj.SetProperty ("ApplicationTitle", "I should not be used");
+			proj.SetProperty ("ApplicationVersion", "21");
+			proj.SetProperty ("ApplicationDisplayVersion", "1.1.1.1");
 
 			using var b = CreateApkBuilder ();
 			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
@@ -108,5 +108,35 @@ namespace Xamarin.Android.Build.Tests
 				Assert.AreEqual (versionNumber, assemblyFileVersion.ConstructorArguments [0].Value);
 			}
 		}
+
+		[Test]
+		public void AndroidManifestValuesWin ()
+		{
+			var packageName = "com.xamarin.singleproject";
+			var applicationLabel = "My Sweet App";
+			var versionName = "99.0";
+			var versionCode = "99";
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidManifest = proj.AndroidManifest
+				.Replace ("package=\"${PACKAGENAME}\"", $"package=\"{packageName}\"")
+				.Replace ("android:label=\"${PROJECT_NAME}\"", $"android:label=\"{applicationLabel}\"")
+				.Replace ("android:versionName=\"1.0\"", $"android:versionName=\"{versionName}\"")
+				.Replace ("android:versionCode=\"1\"", $"android:versionCode=\"{versionCode}\"");
+			if (!Builder.UseDotNet) {
+				proj.SetProperty ("GenerateApplicationManifest", "true");
+			}
+
+			using var b = CreateApkBuilder ();
+			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			var manifest = b.Output.GetIntermediaryPath ("android/AndroidManifest.xml");
+			FileAssert.Exists (manifest);
+
+			using var stream = File.OpenRead (manifest);
+			var doc = XDocument.Load (stream);
+			Assert.AreEqual (packageName, doc.Root.Attribute ("package")?.Value);
+			Assert.AreEqual (versionName, doc.Root.Attribute (AndroidAppManifest.AndroidXNamespace + "versionName")?.Value);
+			Assert.AreEqual (versionCode, doc.Root.Attribute (AndroidAppManifest.AndroidXNamespace + "versionCode")?.Value);
+			Assert.AreEqual (applicationLabel, doc.Root.Element ("application").Attribute (AndroidAppManifest.AndroidXNamespace + "label")?.Value);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Android.Tasks {
 
 		static XNamespace androidNs = AndroidXmlNamespace;
 		static XNamespace androidToolsNs = AndroidXmlToolsNamespace;
+		static readonly XName versionCodeAttributeName = androidNs + "versionCode";
 
 		XDocument doc;
 
@@ -101,7 +102,7 @@ namespace Xamarin.Android.Tasks {
 		/// </summary>
 		public string VersionCode {
 			get {
-				XAttribute attr = doc.Root.Attribute (androidNs + "versionCode");
+				XAttribute attr = doc.Root.Attribute (versionCodeAttributeName);
 				if (attr != null) {
 					string code = attr.Value;
 					if (!string.IsNullOrEmpty (code))
@@ -110,9 +111,11 @@ namespace Xamarin.Android.Tasks {
 				return "1";
 			}
 			set {
-				doc.Root.SetAttributeValue (androidNs + "versionCode", versionCode = value);
+				doc.Root.SetAttributeValue (versionCodeAttributeName, versionCode = value);
 			}
 		}
+
+		public bool HasVersionCode => doc.Root.Attribute (versionCodeAttributeName) != null;
 
 		public string GetMinimumSdk () {
 			int defaultMinSdkVersion = MonoAndroidHelper.SupportedVersions.MinStableVersion.ApiLevel;
@@ -270,8 +273,8 @@ namespace Xamarin.Android.Tasks {
 
 			manifest.SetAttributeValue (XNamespace.Xmlns + "android", "http://schemas.android.com/apk/res/android");
 
-			if (manifest.Attribute (androidNs + "versionCode") == null) {
-				manifest.SetAttributeValue (androidNs + "versionCode",
+			if (manifest.Attribute (versionCodeAttributeName) == null) {
+				manifest.SetAttributeValue (versionCodeAttributeName,
 					string.IsNullOrEmpty (versionCode) ? "1" : versionCode);
 			}
 			if (manifest.Attribute (androidNs + "versionName") == null) {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6384
Fixes: https://github.com/dotnet/sdk/issues/21614

In .NET 6, you can't currently put `versionCode` in
`AndroidManifest.xml`, as it is always overwritten by a default:

    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>

We should actually check if the value is present in
`AndroidManifest.xml` and only set if blank.

The other new MSBuild properties don't appear to suffer from this
problem:

* `$(ApplicationId)`
* `$(ApplicationTitle)`
* `$(ApplicationDisplayVersion)`

This is because we don't default these properties to a value when they
are blank.

I added a new test for this scenario.