### PR TITLE
[ci] Use .NET 6 RC 2 and use shared variables

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -33,17 +33,7 @@ resources:
 
 # Global variables
 variables:
-  RunningOnCI: true
-  XA.Build.Configuration: Release
-  XA.Jdk11.Folder: jdk-11
-  XA.Jdk8.Folder: jdk-1.8
-  NuGetArtifactName: nuget-unsigned
-  InstallerArtifactName: installers-unsigned
-  TestAssembliesArtifactName: test-assemblies
-  DotNet6Version: 6.0.100-preview.3.21202.5
-  HostedMacImage: macOS-10.15
-  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
-  NUnit.NumberOfTestWorkers: 4
+- template: yaml-templates/variables.yaml
 
 stages:
 - stage: mac_build

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -19,15 +19,11 @@ pr:
 # Predefined variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
 # https://dev.azure.com/xamarin/public/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=48&view=Tab_Variables
 variables:
-  XA.Jdk8.Folder: jdk-1.8
-  XA.Jdk11.Folder: jdk-11
-  XA.Build.Configuration: Release
-  NuGetArtifactName: nuget-unsigned
-  InstallerArtifactName: installers-unsigned
-  EXTRA_MSBUILD_ARGS: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
-  PREPARE_FLAGS: PREPARE_CI=1 PREPARE_CI_PR=1
-  DotNet6Version: 6.0.100-preview.3.21202.5
-  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
+- template: yaml-templates/variables.yaml
+- name: EXTRA_MSBUILD_ARGS
+  value: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
+- name: PREPARE_FLAGS
+  value: PREPARE_CI=1 PREPARE_CI_PR=1
 
 stages:
 - stage: mac_stage

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -33,34 +33,29 @@ resources:
 
 # Global variables
 variables:
-  XA.Jdk8.Folder: jdk-1.8
-  XA.Jdk11.Folder: jdk-11
-  NuGetArtifactName: nuget-unsigned
-  InstallerArtifactName: installers-unsigned
-  TestAssembliesArtifactName: test-assemblies
-  NUnitConsoleVersion: 3.11.1
-  DotNet6Version: 6.0.100-preview.3.21202.5
-  HostedMacImage: macOS-10.15
-  HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: android-win-2019
-  VSEngMicroBuild2019: VSEngSS-MicroBuild2019-1ES
+- template: yaml-templates/variables.yaml
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
-  IsMonoBranch: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
-  RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  DotNetNUnitCategories: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
-  NUnit.NumberOfTestWorkers: 4
-  GitHub.Token: $(github--pat--vs-mobiletools-engineering-service2)
-  CONVERT_JAVADOC_TO_XMLDOC: $[ne(variables['Build.DefinitionName'], 'Xamarin.Android-PR')]
-  ${{ if and(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    MicroBuildSignType: Real
-    VSEngMacBuildPool: VSEng-Xamarin-RedmondMac-Android-Trusted
-  ${{ if or(ne(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-    MicroBuildSignType: Test
-    VSEngMacBuildPool: VSEng-Xamarin-RedmondMac-Android-Untrusted
-  TeamName: XamarinAndroid
+- name: IsMonoBranch
+  value: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
+- name: RunAllTests
+  value: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
+- name: DotNetNUnitCategories
+  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
+- name: CONVERT_JAVADOC_TO_XMLDOC
+  value: $[ne(variables['Build.DefinitionName'], 'Xamarin.Android-PR')]
+- ${{ if and(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: MicroBuildSignType
+    value: Real
+  - name: VSEngMacBuildPool
+    value: VSEng-Xamarin-RedmondMac-Android-Trusted
+- ${{ if or(ne(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: MicroBuildSignType
+    value: Test
+  - name: VSEngMacBuildPool
+    value: VSEng-Xamarin-RedmondMac-Android-Untrusted
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:

--- a/build-tools/automation/yaml-templates/setup-ubuntu.yaml
+++ b/build-tools/automation/yaml-templates/setup-ubuntu.yaml
@@ -1,8 +1,10 @@
 steps:
-- template: use-dot-net.yaml
 
 - script: sudo rm /etc/apt/sources.list.d/treasure-data.list || true
   displayName: remove invalid treasure-data source
+
+- script: echo "##vso[task.setvariable variable=XDG_CONFIG_HOME]$HOME/.config"
+  displayName: update XDG_CONFIG_HOME
 
 - script: >
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF &&
@@ -11,10 +13,12 @@ steps:
     sudo apt install -y --no-install-recommends mono-complete nuget msbuild
   displayName: install mono preview
 
+- script: sudo apt upgrade
+  displayName: update packages
+
+- template: use-dot-net.yaml
+
 - task: NuGetToolInstaller@1
   displayName: Use NuGet 5.x
   inputs:
     versionSpec: 5.x
-
-- script: echo "##vso[task.setvariable variable=XDG_CONFIG_HOME]$HOME/.config"
-  displayName: update XDG_CONFIG_HOME

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -1,0 +1,33 @@
+variables:
+- name: RunningOnCI
+  value: true
+- name: XA.Build.Configuration
+  value: Release
+- name: XA.Jdk8.Folder
+  value: jdk-1.8
+- name: XA.Jdk11.Folder
+  value: jdk-11
+- name: NuGetArtifactName
+  value: nuget-unsigned
+- name: InstallerArtifactName
+  value: installers-unsigned
+- name: TestAssembliesArtifactName
+  value: test-assemblies
+- name: NUnitConsoleVersion
+  value: 3.11.1
+- name: NUnit.NumberOfTestWorkers
+  value: 4
+- name: DotNet6Version
+  value: 6.0.100-rc.2.21505.57
+- name: GitHub.Token
+  value: $(github--pat--vs-mobiletools-engineering-service2)
+- name: HostedMacImage
+  value: macOS-10.15
+- name: HostedWinVS2019
+  value: Hosted Windows 2019 with VS2019
+- name: VSEngWinVS2019
+  value: android-win-2019
+- name: VSEngMicroBuild2019
+  value: VSEngSS-MicroBuild2019-1ES
+- name: TeamName
+  value: XamarinAndroid


### PR DESCRIPTION
Updates CI to use .NET 6.0.100-rc.2 instead of the much older preview 3
version that we've been building against.  Shared variables (including
`DotNet6Version`) have been moved to a new variables.yaml template file.