### PR TITLE
[ci] Fix DetermineApplicableTests build step

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -151,6 +151,7 @@ stages:
         arguments: --s=DetermineApplicableTests
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
         displayName: determine which test stages to run
+        name: TestConditions
         condition: and(succeeded(), eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR'))
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.

--- a/build-tools/automation/yaml-templates/run-xaprepare.yaml
+++ b/build-tools/automation/yaml-templates/run-xaprepare.yaml
@@ -1,5 +1,6 @@
 parameters:
   displayName: run xaprepare
+  name:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
   framework: net6.0
@@ -9,6 +10,7 @@ parameters:
 steps:
 - task: DotNetCoreCLI@2
   displayName: ${{ parameters.displayName }}
+  name: ${{ parameters.name }}
   condition: ${{ parameters.condition }}
   inputs:
     command: run


### PR DESCRIPTION
The test stages that run in a given PR are selected dynamically after
checking which files have changed in the PR.  This behavior relies on
the [output variables][0] Azure Pipelines feature.  In order to access
the output variable containing test stage information in in other
stages, the step that sets it must use the `name:` key.

Fix output variable setting from the xaprepare yaml template by adding
an option `name` parameter.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#use-output-variables-from-tasks