### PR TITLE
[One .NET] specify all RIDs by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -28,7 +28,6 @@ _ResolveAssemblies MSBuild target.
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>
     <PublishDir>$(OutputPath)</PublishDir>
-    <_AndroidLinkFlag>$(_OuterIntermediateOutputPath)link.flag</_AndroidLinkFlag>
     <BuildDependsOn>_RemoveLegacyDesigner;$(BuildDependsOn)</BuildDependsOn>
     <!-- We don't want IncrementalClean to run here, or files get deleted -->
     <CoreBuildDependsOn>
@@ -69,7 +68,6 @@ _ResolveAssemblies MSBuild target.
       <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
     </ItemGroup>
     <PropertyGroup>
-      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">;_ProguardProjectConfiguration=$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true
         ;AppendRuntimeIdentifierToOutputPath=true
@@ -77,7 +75,6 @@ _ResolveAssemblies MSBuild target.
         ;_OuterIntermediateAssembly=@(IntermediateAssembly)
         ;_OuterOutputPath=$(OutputPath)
         ;_OuterIntermediateOutputPath=$(IntermediateOutputPath)
-        $(_ProguardProjectConfiguration)
       </_AdditionalProperties>
       <_AndroidBuildRuntimeIdentifiersInParallel Condition=" '$(_AndroidBuildRuntimeIdentifiersInParallel)' == '' ">true</_AndroidBuildRuntimeIdentifiersInParallel>
     </PropertyGroup>
@@ -90,6 +87,12 @@ _ResolveAssemblies MSBuild target.
         Targets="_ComputeFilesToPublishForRuntimeIdentifiers">
       <Output TaskParameter="TargetOutputs" ItemName="ResolvedFileToPublish" />
     </MSBuild>
+    <!-- Properties produced by the inner build in Microsoft.Android.Sdk.ILLink.targets -->
+    <PropertyGroup>
+      <_InnerIntermediateOutputPath>$(IntermediateOutputPath)%(_RIDs.Identity)\</_InnerIntermediateOutputPath>
+      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(_InnerIntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
+      <_AndroidLinkFlag>$(_InnerIntermediateOutputPath)link.flag</_AndroidLinkFlag>
+    </PropertyGroup>
     <ItemGroup>
       <_ResolvedAssemblyFiles Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' " />
       <_ResolvedSymbolFiles   Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.pdb' " />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -66,7 +66,7 @@
     <TrimmerDefaultAction Condition=" '$(TrimmerDefaultAction)' == '' and '$(AndroidLinkMode)' == 'Full' ">link</TrimmerDefaultAction>
     <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
-    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
     <RuntimeIdentifier  Condition=" '$(RuntimeIdentifiers)' != '' And '$(RuntimeIdentifier)' != '' " />
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">AndroidManifest.xml</AndroidManifest>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -20,6 +20,7 @@ This file contains the .NET 5-specific targets to customize ILLink
         -->
       <_TrimmerDumpDependencies Condition=" '$(LinkerDumpDependencies)' == 'true' ">true</_TrimmerDumpDependencies>
       <_AndroidLinkerCustomStepAssembly>$(MSBuildThisFileDirectory)..\tools\Microsoft.Android.Sdk.ILLink.dll</_AndroidLinkerCustomStepAssembly>
+      <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Android.Runtime.AndroidEnvironment.VSAndroidDesignerIsEnabled"


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1413756
Fixes: https://github.com/xamarin/xamarin-android/issues/6353

The API 31 emulator no longer has 32-bit images and the x86_64 image
has dropped support for 32-bit architectures:

    > adb shell getprop | grep cpu
    [ro.product.cpu.abi]: [x86_64]
    [ro.product.cpu.abilist]: [x86_64,arm64-v8a]
    [ro.product.cpu.abilist32]: []
    [ro.product.cpu.abilist64]: [x86_64,arm64-v8a]

Compared to an API 30 x86_64 emulator:

    > adb shell getprop | grep cpu
    [ro.product.cpu.abi]: [x86_64]
    [ro.product.cpu.abilist]: [x86_64,x86,arm64-v8a,armeabi-v7a,armeabi]
    [ro.product.cpu.abilist32]: [x86,armeabi-v7a,armeabi]
    [ro.product.cpu.abilist64]: [x86_64,arm64-v8a]

The problem is our default RIDs are:

    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm64;android-x86</RuntimeIdentifiers>

And so you hit this error when trying to deploy a `dotnet new android`
app on an API 31 x86_64 emulator:

    error ADB0020: Mono.AndroidTools.IncompatibleCpuAbiExceptiopn: The package does not support the CPU architecture of this device.

To workaround this, you can add `android-x64` to your list of
`$(RuntimeIdentifiers)`.

To solve this issue, we can default `$(RuntimeIdentifiers)` to all 4
architectures. We have code that will select a single architecture for
Debug builds using "Fast Deployment". It seems better to have a
default here that will always work, and the only drawback would be the
additional architectures for Release builds.

After this change, I discovered an issue introduced in 33a6d1e52:

    ILLink error IL1012: IL Linker has encountered an unexpected error. Please report the issue at https://github.com/mono/linker/issues [C:\a\_work\1\s\bin\TestRelease\temp\BuildProguard Enabled Project(1)Trued8r8\UnnamedProject.csproj]
    ...
    Unhandled exception. System.IO.IOException: The process cannot access the file 'C:\a\_work\1\s\bin\TestRelease\temp\BuildProguard Enabled Project(1)Trued8r8\obj\Release\proguard\proguard_project_references.cfg' because it is being used by another process.

When we build each RID in parallel, each inner build was attempting to
write to the same file. I changed the path for this file to be:

    $(IntermediateOutputPath)%(_RIDs.Identity)\proguard\proguard_project_references.cfg

And then set `$(_ProguardProjectConfiguration)` appropriately after
the inner builds complete. This also needs to actually be a file path,
I don't see how the value was working before:

    <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">;_ProguardProjectConfiguration=$(IntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>

Then another related issue:

    (_TouchAndroidLinkFlag target) ->
    Microsoft.Android.Sdk.ILLink.targets(114,5): error MSB3371: The file "obj\Release\net6.0-android\link.flag" cannot be created. The process cannot access the file 'C:\a\_work\2\s\bin\TestRelease\temp\DotNetBuildandroid-armandroid-arm64android-x86android-x64TrueTrue\obj\Release\net6.0-android\link.flag' because it is being used by another process.

I setup `$(_AndroidLinkFlag)` the same as
`$(_ProguardProjectConfiguration)` to solve this issue.