### PR TITLE
[Xamarin.Android.Build.Tasks] skip C# binding-related targets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -29,7 +29,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
   </PropertyGroup>
 
   <Target Name="_SetAndroidGenerateManagedBindings"
-      Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' ">
+      Condition=" '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' ">
     <PropertyGroup>
       <!-- Used throughout to determine if C# binding-related targets should skip -->
       <_AndroidGenerateManagedBindings>true</_AndroidGenerateManagedBindings>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -596,6 +596,19 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 		}
 
 		[Test]
+		[TestCaseSource (nameof (ClassParseOptions))]
+		public void NothingToBind (string classParser)
+		{
+			var proj = new XamarinAndroidBindingProject {
+				AndroidClassParser = classParser,
+			};
+			using (var b = CreateDllBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.AssertHasNoWarnings ();
+			}
+		}
+
+		[Test]
 		[Category ("DotNetIgnore")] //TODO: @(LibraryProjectProperties) not supported yet in .NET 5+
 		public void BugzillaBug11964 ()
 		{


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1334066

In traditional Xamarin.Android, a File -> New binding project emits
the warning:

    BINDINGSGENERATOR warning BG8601: No '<package>' elements found.

This happens until you add a Java library to actually bind.

The warning doesn't happen in .NET 6 due to the `Condition`:

    <Target Name="_SetAndroidGenerateManagedBindings"
        Condition=" '$(UsingAndroidNETSdk)' != 'true' Or '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' ">
      <PropertyGroup>
        <!-- Used throughout to determine if C# binding-related targets should skip -->
        <_AndroidGenerateManagedBindings>true</_AndroidGenerateManagedBindings>
      </PropertyGroup>
    </Target>

The `$(UsingAndroidNETSdk)` check makes the value always true in
traditional Xamarin.Android. I think we can just remove this check, as
the `Condition` has been working well in .NET 6.

I added a new test for this scenario. The warning is gone now.