### PR TITLE
[Xamarin.Android.Build.Tasks] Remove Java.Interop.dll reference.

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -135,13 +135,9 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java-source-utils.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\javadoc-to-mdoc.exe" ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\javadoc-to-mdoc.pdb" ExcludeFromAndroidNETSdk="true" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Localization.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Localization.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll.config" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Export.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Export.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Cecil.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Cecil.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Diagnostics.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -329,6 +329,7 @@ namespace MonoDroid.Tuner {
 			return false;
 		}
 
+		// Keep in sync with: https://github.com/xamarin/java.interop/blob/8ccb8374d242490d8d1b032f2c8ca7a813fd40f3/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs#L405-L421
 		public static string GetMarshalMethodName (string name, string signature)
 		{
 			if (name == null)

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -316,7 +316,7 @@ namespace MonoDroid.Tuner {
 			if (marshalType == null || !marshalType.HasMethods)
 				return false;
 
-			var marshalMethodName = MarshalMemberBuilder.GetMarshalMethodName (nativeMethod, signature);
+			var marshalMethodName = GetMarshalMethodName (nativeMethod, signature);
 			if (marshalMethodName == null)
 				return false;
 
@@ -327,6 +327,24 @@ namespace MonoDroid.Tuner {
 				}
 
 			return false;
+		}
+
+		public static string GetMarshalMethodName (string name, string signature)
+		{
+			if (name == null)
+				throw new ArgumentNullException (nameof(name));
+
+			if (signature == null)
+				throw new ArgumentNullException (nameof(signature));
+
+			var idx1 = signature.IndexOf ('(');
+			var idx2 = signature.IndexOf (')');
+			var arguments = signature;
+
+			if (idx1 >= 0 && idx2 >= idx1)
+				arguments = arguments.Substring (idx1 + 1, idx2 - idx1 - 1);
+
+			return $"n_{name}{(string.IsNullOrEmpty (arguments) ? "" : "_")}{arguments?.Replace ('/', '_')?.Replace (';', '_')}";
 		}
 
 		public static Instruction CreateLoadArraySizeOrOffsetInstruction (int intValue)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -445,8 +445,6 @@
     </ProjectReference>
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj" />
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
   </ItemGroup>
 
   <!-- Import Microsoft.NET.Sdk targets before our targets so we can override behavior -->


### PR DESCRIPTION
Commit 3e6a6232d904acfc95017eeae58408787b0f8dc9
Context: https://discord.com/channels/732297728826277939/732297837953679412/898675755779768330

An unfortunate unexpected breakage occurred due to commit 3e6a6232:
the version of `Java.Interop.dll` changed -- which we *should* have
expected but completely overlooked & forgot -- which in turn meant
that *everything* which depends upon it -- which is everything --
started breaking due to the version change, e.g.

	error CS1705: Assembly 'Microsoft.Maui' with identity 'Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
	uses 'Java.Interop, Version=0.1.6.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'
	which has a higher version than referenced assembly
	'Java.Interop' with identity 'Java.Interop, Version=0.1.2.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'

The primary motivation with 3e6a6232 was to improve the use of
*MSBuild* task assemblies, however `Java.Interop.dll` is *not* really a *MSBuild*
assembly.  It is simply a dependency pulled in for `Java.Interop.Export.dll` which was
itself pulled in for a single small static method `MarshalMemberBuilder.GetMarshalMethodName (...)`.

As such, let's remove both `Java.Interop.dll` and `Java.Interop.Export.dll` from `Xamarin.Android.Build.Tasks`
and simple copy the needed method.

This means we do not need to continuously update the version number of JI/JIE, which will allow
assemblies created with newer versions of XA to continue working on earlier releases where JI has a
version number of `0.1.0.0`.

Additionally, remove `Java.Interop.dll` and `Java.Interop.Export.dll` from the `lib\xamarin.android\xbuild\Xamarin\Android` directory in the installer.  `Java.Interop.dll` should only be consumed via the framework profiles.  `Java.Interop.Export.dll` was experientable and is not in active use.