### PR TITLE
[One .NET] 'dotnet publish' should support $(AndroidPackageFormats)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
@@ -21,7 +21,9 @@ This file contains the implementation for 'dotnet publish'.
 
   <Target Name="_CalculateAndroidFilesToPublish">
     <ItemGroup>
-      <_AndroidFilesToPublish Include="$(OutputPath)*.$(AndroidPackageFormat)" />
+      <_AllPackageFormats Include="$(AndroidPackageFormat);$(AndroidPackageFormats)" />
+      <_AndroidPackageFormats Include="@(_AllPackageFormats->Distinct())" />
+      <_AndroidFilesToPublish Include="$(OutputPath)*.%(_AndroidPackageFormats.Identity)" />
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
       <ResolvedFileToPublish Include="@(_AndroidFilesToPublish)" RelativePath="%(FileName)%(Extension)" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -646,24 +646,24 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Publish (), "first `dotnet publish` should succeed");
+			dotnet.AssertHasNoWarnings ();
 
 			var publishDirectory = Path.Combine (FullProjectDirectory, proj.OutputPath, runtimeIdentifier, "publish");
-			string ext = isRelease ? "aab" : "apk";
-			var apk = Path.Combine (publishDirectory, $"{proj.PackageName}.{ext}");
-			var apkSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.{ext}");
-			FileAssert.Exists (apk);
+			var apk = Path.Combine (publishDirectory, $"{proj.PackageName}.apk");
+			var apkSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.apk");
+			// NOTE: the unsigned .apk doesn't exist when $(AndroidPackageFormats) is `aab;apk`
+			if (!isRelease) {
+				FileAssert.Exists (apk);
+			}
 			FileAssert.Exists (apkSigned);
 
-			Assert.IsTrue (dotnet.Publish (parameters: new [] { "AndroidPackageFormat=aab" }), $"second `dotnet publish` should succeed");
-			var aab = Path.Combine (publishDirectory, $"{proj.PackageName}.aab");
-			var aabSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.aab");
+			// NOTE: $(AndroidPackageFormats) defaults to `aab;apk` in Release
 			if (isRelease) {
-				FileAssert.Exists (apkSigned);
-			} else {
-				FileAssert.DoesNotExist (apkSigned);
+				var aab = Path.Combine (publishDirectory, $"{proj.PackageName}.aab");
+				var aabSigned = Path.Combine (publishDirectory, $"{proj.PackageName}-Signed.aab");
+				FileAssert.Exists (aab);
+				FileAssert.Exists (aabSigned);
 			}
-			FileAssert.Exists (aab);
-			FileAssert.Exists (aabSigned);
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6393

We found that `dotnet build -c Release` doesn't copy `.apk` files to
`$(PublishDir)`.

In f9f879c7, `$(AndroidPackageFormats)` was changed to default to
`aab;apk`. However, the `dotnet publish` target was not updated for
this change.

I updated an existing test, and made changes so all
`$(AndroidPackageFormats)` files will be copied.