### PR TITLE
[Xamarin.Android.Build.Tasks] improve incremental design-time builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -205,8 +205,7 @@ namespace Xamarin.Android.Tasks
 		{
 			CodeDomProvider provider = CodeDomProvider.CreateProvider (language);
 
-			string code = null;
-			using (var o = new StringWriter ()) {
+			using (var o = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				var options = new CodeGeneratorOptions () {
 					BracingStyle = "C",
 					IndentString = "\t",
@@ -240,11 +239,12 @@ namespace Xamarin.Android.Tasks
 				if (isCSharp)
 					provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit("#pragma warning restore 1591"), o, options);
 
-				code = o.ToString ();
-			}
-
-			if (Files.CopyIfStringChanged (code, file)) {
-				Log.LogDebugMessage ($"Writing to: {file}");
+				o.Flush ();
+				if (Files.CopyIfStreamChanged (o.BaseStream, file)) {
+					Log.LogDebugMessage ($"Writing to: {file}");
+				} else {
+					Log.LogDebugMessage ($"Up to date: {file}");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -987,6 +987,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceFlagFile="$(_AndroidResFlagFile)"
 		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
+	<Touch Condition="Exists ('$(_AndroidManagedResourceDesignerFile)')" Files="$(_AndroidManagedResourceDesignerFile)" />
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == 'Resources\Resource.designer.cs'"/>


### PR DESCRIPTION
I was testing .NET MAUI projects inside Visual Studio, and noticed on
solution load two sets of builds run for each `$(TargetFramework)`:

1. `CollectPackageReferences;CollectFrameworkReferences;CollectUpToDateCheckBuiltDesignTime;CollectPackageDownloads;GenerateSupportedTargetFrameworkAlias;CollectAnalyzersDesignTime;CollectUpToDateCheckInputDesignTime;CollectUpToDateCheckOutputDesignTime;CollectSuggestedWorkloads;CollectCentralPackageVersions;CompileDesignTime;CollectResolvedCompilationReferencesDesignTime`
2. `ResolveFrameworkReferencesDesignTime;ResolveProjectReferencesDesignTime2;CollectResolvedSDKReferencesDesignTime;ResolveComReferencesDesignTime;ResolveAssemblyReferencesDesignTime;ResolvePackageDependenciesDesignTime;CollectSuggestedWorkloads`

1) net6.0-maccatalyst 0.344s
1) net6.0-ios         0.353s
1) net6.0-android     1.466s
2) net6.0-maccatalyst 0.063s
2) net6.0-ios         0.059s
2) net6.0-android     1.424s

![image](https://user-images.githubusercontent.com/840039/137990018-40254b32-ecef-4758-95b6-6740001e914a.png)

Android is the worst in both cases, due to:

    GenerateResourceDesigner 737ms
    GenerateResourceDesigner 766ms

I'm not sure how I got in this state, but the
`_ManagedUpdateAndroidResgen` MSBuild target *never* skips for me:

    Building target "_ManagedUpdateAndroidResgen" completely.
    Input file "C:\Program Files\dotnet\sdk-manifests\6.0.100\microsoft.net.sdk.maui\WorkloadManifest.targets" is newer than output file "obj\Debug\net6.0-android\designtime\Resource.designer.cs".

Reviewing the `<GenerateResourceDesigner/>` MSBuild task, there is a
case it doesn't update the timestamp on the `Resource.designer.cs`
output file. I added a `<Touch/>` call to solve this issue:

    <Touch Condition="Exists ('$(_AndroidManagedResourceDesignerFile)')" Files="$(_AndroidManagedResourceDesignerFile)" />

This is a nice solution, as it is localized to the MSBuild target where the
`Inputs` and `Outputs` are.

While I was at it, I switched from using a `new StreamWriter()` to
`MemoryStreamPool`. `MemoryStreamPool` usage saw a modest improvement:

    Before:
    GenerateResourceDesigner 491ms
    After:
    GenerateResourceDesigner 480ms

Overall these changes should improve all design-time builds by ~11ms,
and some incremental design-time builds will properly skip: saving up
to ~766ms.