### PR TITLE
Bump to NDK r23b

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "23";
-		public const string AndroidNdkPkgRevision = "23.0.7599858";
+		public const string AndroidNdkVersion = "23b";
+		public const string AndroidNdkPkgRevision = "23.1.7779620";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r23#r23b

The most important changes for us:

  * Bumped compiler toolchain to LLVM 12
    * Uses universal binaries on M1 Macs
  * Assorted cmake fixes