### PR TITLE
[One .NET] properly set $(UseAppHost) to false

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -9,6 +9,9 @@ This file contains targets specific for Android application projects.
 <Project>
 
   <PropertyGroup>
+    <UseAppHost>false</UseAppHost>
+    <!-- see: https://github.com/xamarin/xamarin-macios/blob/a6eb528197854c074d9dd5847328c096890337be/dotnet/targets/Xamarin.Shared.Sdk.props#L38-L52 -->
+    <_RuntimeIdentifierUsesAppHost>false</_RuntimeIdentifierUsesAppHost>
     <RunCommand>dotnet</RunCommand>
     <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -20,7 +20,6 @@ _ResolveAssemblies MSBuild target.
     <ItemGroup>
       <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
       <PackageDownload Remove="Microsoft.AspNetCore.App.Runtime.%(_ProblematicRIDs.Identity)" />
-      <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/19891
Context: https://github.com/xamarin/xamarin-macios/blob/a6eb528197854c074d9dd5847328c096890337be/dotnet/targets/Xamarin.Shared.Sdk.props#L38-L52

We currently have a small hack in place to prevent Linux packages from
being used in .NET 6 builds:

    <!-- HACK: workaround for: https://github.com/dotnet/sdk/issues/19891 -->
    <Target Name="_RemoveLinuxFrameworkReferences"
        AfterTargets="ProcessFrameworkReferences">
      <ItemGroup>
        <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
        <PackageDownload Remove="Microsoft.AspNetCore.App.Runtime.%(_ProblematicRIDs.Identity)" />
        <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />
      </ItemGroup>
    </Target>

The Xamarin.iOS team found if you set this late during
`$(AfterMicrosoftNETSdkTargets)`:

    <_RuntimeIdentifierUsesAppHost>false</_RuntimeIdentifierUsesAppHost>
    <UseAppHost>false</UseAppHost>

Then `Microsoft.NETCore.App.Host.*` packs won't be brought in.

After making this change, I can remove this line from the workaround:

    <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />

The final solution for dotnet/sdk#19891, will be a future change that
makes `Microsoft.AspNetCore.App.Runtime` have a way to ignore
unsupported platforms.