### PR TITLE
Logcat All the Things

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/KillProcess.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/KillProcess.cs
@@ -19,7 +19,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			Log.LogMessage(MessageImportance.Low, $"  {nameof (ProcessId)}: {ProcessId}");
 
 			using (var p = Process.GetProcessById (ProcessId)) {
-				p.Kill ();
+				if (!p.HasExited)
+					p.Kill ();
 			}
 
 			return !Log.HasLoggedErrors;

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public			string		Arguments	{get; set;}
 		public                  string          ToolPath        {get; set;}
 		public                  string          ToolExe         {get; set;}
+		public                  string          LogcatFile      {get; set;}
 
 		public override bool Execute ()
 		{
@@ -68,7 +69,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"{Arguments ?? string.Empty} -verbose -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
+			var arguments = $"{Arguments ?? string.Empty} -verbose -logcat-output \"{LogcatFile}\" -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" -avd {ImageName}{port}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -26,6 +26,7 @@
     <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">5</AvdLaunchTimeoutMinutes>
     <AvdLaunchTimeoutSeconds>$([MSBuild]::Multiply($(AvdLaunchTimeoutMinutes), 60))</AvdLaunchTimeoutSeconds>
     <AvdLaunchTimeoutMS>$([MSBuild]::Multiply($(AvdLaunchTimeoutSeconds), 1000))</AvdLaunchTimeoutMS>
+    <_LogcatFilename>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)-full.log</_LogcatFilename>
   </PropertyGroup>
 
   <ItemGroup>
@@ -68,6 +69,7 @@
         AvdManagerHome="$(AvdManagerHome)"
         Arguments="$(TestEmulatorArguments)"
         ImageName="$(TestAvdName)"
+        LogcatFile="$(_LogcatFilename)"
         Port="$(_AdbEmulatorPort)"
         ToolExe="$(EmulatorToolExe)"
         ToolPath="$(EmulatorToolPath)">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Build.Tests
 			TestContext.Out.WriteLine ($"Trying to restart Emulator");
 			// shell out to msbuild and start the emulator again
 			using (var builder = new Builder ()) {
-				var out1 = RunProcessWithExitCode (builder.BuildTool, $"{project} /restore /t:AcquireAndroidTarget", timeoutInSeconds: 120);
+				var out1 = RunProcessWithExitCode (builder.BuildTool, $"{(Builder.UseDotNet ? "build" : "")} {project} /restore /t:AcquireAndroidTarget", timeoutInSeconds: 120);
 				TestContext.Out.WriteLine ($"{out1}");
 			}
 		}


### PR DESCRIPTION
Lets make use of the `emulator` `-logcat-output` argument to log ALL output from `adb` to a file while the emulator is running. 
The resulting file `logcat-$(Configuration)-full.log` will be included in the test `xa-build-status*` zip archives which are saved at the end of a test run.

Also fix a bug in the `RestartDevice` method where if it ran using `dotnet` we could get the following error

```
 RunProcess: /Users/runner/Library/Android/dotnet/dotnet /Users/runner/work/1/s/bin/TestRelease/Emulator.csproj /restore /t:AcquireAndroidTarget
 (1, , Could not execute because the specified command or file was not found.
```

This was because we were missing the `build` command. 