### PR TITLE
Fix heap overflow detected by a clang sanitizer

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -35,9 +35,16 @@ endif()
 
 option(ENABLE_CLANG_ASAN "Enable the clang AddressSanitizer support" OFF)
 option(ENABLE_CLANG_UBSAN "Enable the clang UndefinedBehaviorSanitizer support" OFF)
+
+if(ENABLE_CLANG_ASAN OR ENABLE_CLANG_UBSAN)
+  set(STRIP_DEBUG_DEFAULT OFF)
+else()
+  set(STRIP_DEBUG_DEFAULT ON)
+endif()
+
 option(ENABLE_NET6 "Enable compilation for .NET6" OFF)
 option(ENABLE_TIMING "Build with timing support" OFF)
-option(STRIP_DEBUG "Strip debugging information when linking" ON)
+option(STRIP_DEBUG "Strip debugging information when linking" ${STRIP_DEBUG_DEFAULT})
 option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
 option(USE_CCACHE "Use ccache, if found, to speed up recompilation" ${CCACHE_OPTION_DEFAULT})
 

--- a/src/monodroid/jni/basic-utilities.cc
+++ b/src/monodroid/jni/basic-utilities.cc
@@ -344,7 +344,7 @@ BasicUtilities::monodroid_strsplit (const char *str, const char *delimiter, size
 		vector = (char **) xmalloc (2 * sizeof (vector));
 		vector [0] = nullptr;
 	} else if (size > 0) {
-		vector[size - 1] = nullptr;
+		add_to_vector (&vector, size, nullptr);
 	}
 
 	return vector;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6420#issuecomment-951488194

Clang's AddressSanitizer detected the following:

    10-26 15:55:25.393  2488  2488 I Mono.Android_Tests: ==2488==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x8a600774 at pc 0xaeee9982 bp 0xbf98dc68 sp 0xbf98dc60
    10-26 15:55:25.394  2488  2488 I Mono.Android_Tests: WRITE of size 4 at 0x8a600774 thread T0
    10-26 15:55:25.398  2488  2488 I Mono.Android_Tests:     #0 0xaeee9981  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x38981)
    10-26 15:55:25.398  2488  2488 I Mono.Android_Tests:     #1 0xaeef92d9  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x482d9)
    10-26 15:55:25.398  2488  2488 I Mono.Android_Tests:     #2 0xaef009ae  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x4f9ae)
    10-26 15:55:25.398  2488  2488 I Mono.Android_Tests:     #3 0xaef06d14  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x55d14)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests: 0x8a600774 is located 0 bytes to the right of 4-byte region [0x8a600770,0x8a600774)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests: allocated by thread T0 here:
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests:     #0 0xaedbe925  (/data/app/Mono.Android_Tests-1/lib/x86/libclang_rt.asan-i686-android.so+0xb6925)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests:     #1 0xaeee9ae1  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x38ae1)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests:     #2 0xaeee9751  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x38751)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests:     #3 0xaeef92d9  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x482d9)
    10-26 15:55:25.399  2488  2488 I Mono.Android_Tests:     #4 0xaef009ae  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x4f9ae)
    10-26 15:55:25.400  2488  2488 I Mono.Android_Tests:     #5 0xaef06d14  (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x55d14)
    10-26 15:55:25.400  2488  2488 I Mono.Android_Tests:     #6 0xb30cb970  (/data/dalvik-cache/x86/data@app@Mono.Android_Tests-1@base.apk@classes.dex+0x5c970)
    10-26 15:55:25.400  2488  2488 I Mono.Android_Tests: SUMMARY: AddressSanitizer: heap-buffer-overflow (/data/app/Mono.Android_Tests-1/lib/x86/libmonodroid.so+0x38981)

Address of the offending region points to
`BasicUtilities::monodroid_strsplit` and is likely the line modified in
this commit.  Append terminating `nullptr` to vector instead of
overwriting the last element.