### PR TITLE
[TEST] See if fs-level compression works in .pkg

### DIFF
--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -139,8 +139,6 @@
       <PkgBuildArgs Include="--version $(XAVersion)"/>
       <PkgBuildArgs Include="--install-location &quot;$(PkgInstallDir)&quot; "/>
       <PkgBuildArgs Include="--scripts &quot;$(PkgScriptsDir)&quot; "/>
-      <PkgBuildArgs Include="--min-os-version 10.12" />
-      <PkgBuildArgs Include="--compression latest" />
       <PkgBuildArgs Include="&quot;$(PkgOutputPath)/xamarin.android.pkg&quot; "/>
     </ItemGroup>
     <Exec Command="pkgbuild @(PkgBuildArgs, ' ')" />


### PR DESCRIPTION
Also tell `pkgbuild` we're targeting macOS 10.12 or newer and let it use
better compression methods for the package.