### PR TITLE
A handful of tiny improvements for the native runtime

### DIFF
--- a/src/monodroid/jni/basic-utilities.hh
+++ b/src/monodroid/jni/basic-utilities.hh
@@ -217,6 +217,15 @@ namespace xamarin::android
 			return strdup_new (s, strlen (s));
 		}
 
+		char *strdup_new (xamarin::android::internal::string_segment const& s, size_t from_index = 0) noexcept
+		{
+			if (from_index >= s.length ()) {
+				return nullptr;
+			}
+
+			return strdup_new (s.start () + from_index, s.length () - from_index);
+		}
+
 		template<typename CharType = char, typename ...Strings>
 		char* string_concat (const char *s1, const CharType* s2, Strings... strings)
 		{
@@ -285,8 +294,6 @@ namespace xamarin::android
 		}
 
 	private:
-		void  add_to_vector (char ***vector, size_t size, char *token);
-
 		template<typename CharType>
 		static constexpr void assert_char_type ()
 		{

--- a/src/monodroid/jni/cpp-util.hh
+++ b/src/monodroid/jni/cpp-util.hh
@@ -39,7 +39,7 @@ do_abort_unless (bool condition, const char* fmt, ...)
 }
 
 #define abort_unless(_condition_, _fmt_, ...) do_abort_unless (_condition_, "%s:%d (%s): " _fmt_, __FILE__, __LINE__, __FUNCTION__, ## __VA_ARGS__)
-#define abort_if_invalid_pointer_argument(_ptr_) abort_unless ((_ptr_) != NULL, "Parameter '%s' must be a valid pointer", #_ptr_)
+#define abort_if_invalid_pointer_argument(_ptr_) abort_unless ((_ptr_) != nullptr, "Parameter '%s' must be a valid pointer", #_ptr_)
 #define abort_if_negative_integer_argument(_arg_) abort_unless ((_arg_) > 0, "Parameter '%s' must be larger than 0", #_arg_)
 
 namespace xamarin::android

--- a/src/monodroid/jni/strings.hh
+++ b/src/monodroid/jni/strings.hh
@@ -76,6 +76,12 @@ namespace xamarin::android::internal
 			return memcmp (_start, s, length ()) == 0;
 		}
 
+		template<size_t Size>
+		force_inline bool equal (const char (&s)[Size]) noexcept
+		{
+			return equal (s, Size - 1);
+		}
+
 		force_inline bool starts_with_c (const char *s) const noexcept
 		{
 			if (s == nullptr)

--- a/src/monodroid/jni/xxhash.hh
+++ b/src/monodroid/jni/xxhash.hh
@@ -52,7 +52,7 @@ namespace xamarin::android
 		force_inline static constexpr uint32_t hash (const char *input, size_t len) noexcept
 		{
 			return finalize (
-				(len >= 16 ? h16bytes<Seed> (input, len) : Seed + PRIME5) + len,
+				(len >= 16 ? h16bytes<Seed> (input, len) : Seed + PRIME5) + static_cast<uint32_t>(len),
 				(input) + (len & ~0xFU),
 				len & 0xF
 			);


### PR DESCRIPTION
  * Rewrite `BasicUtilities::monodroid_strsplit`
    Instead of reallocating the vector on each new token, pre-calculate
    the number of tokens and allocate enough memory for the entire
    vector at once.
  * Rewrite `init_logging_categories`
    Eliminate memory allocation by not using `monodroid_strsplit`,
    instead do all the processing using on-stack strings and their
    tokenizer.  Also, replace the `CATEGORY` preprocessor macro with a
    template function.