### PR TITLE
[ClassParse.targets] Pass in temporary MSBuild flag `$(_AndroidUseJavaLegacyResolver)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
@@ -44,7 +44,7 @@ This file is only used by binding projects.
         ToolExe="$(BindingsGeneratorToolExe)"
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
-     />
+    />
   </Target>
 
   <Target Name="_GetJavaSourceJarJavadocFiles"


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android/pull/6436 we added the `$(_AndroidUseJavaLegacyResolver)` MSBuild flag to the `<BindingsGenerator>` task to allow users to opt out of any issues caused by the new Java type resolver system added in https://github.com/xamarin/java.interop/pull/849.

However, we call `generator` twice during the build (once for ApiXmlAdjuster and once to generate C# code) and we only added this flag to one of them.  This adds the flag to the `ApiXmlAdjuster` case, which is where it primarily is needed.