### PR TITLE
[One .NET] add %(Platform) to any global @(Using)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -21,9 +21,9 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
-    <Using Include="Android.App" />
-    <Using Include="Android.Widget" />
-    <Using Include="Android.OS.Bundle" Alias="Bundle" />
+    <Using Include="Android.App" Platform="Android" />
+    <Using Include="Android.Widget" Platform="Android" />
+    <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/3018#pullrequestreview-792369556

In order for the .NET MAUI workload to properly implement implicit
global usings:

1. The .NET MAUI workload will add many `@(Using)` entries that
   conflict with each platform's APIs.

2. We need *something* to identify `@(Using)` is for a specific
   platform, so we can use a new `%(Platform)` metadata for this.

3. Late in .NET MAUI's MSBuild targets, we can do:

```xml
<ItemGroup Condition=" '$(UseMaui)' == 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
  <Using Remove="@(Using->HasMetadata('Platform'))" />
</ItemGroup>
```

In .NET 7, we might have a nicer design around this, but for now this
is the plan for .NET 6.