### PR TITLE
[illink] fix XA2000 warning, again

### DIFF
--- a/Documentation/guides/messages/il6200.md
+++ b/Documentation/guides/messages/il6200.md
@@ -1,9 +1,9 @@
 ---
-title: Xamarin.Android warning XA2000
-description: XA2000 warning code
-ms.date: 1/13/2019
+title: Xamarin.Android warning IL6200
+description: IL6200 warning code
+ms.date: 11/1/2021
 ---
-# Xamarin.Android warning XA2000
+# Xamarin.Android warning IL6200
 
 ## Example messages
 
@@ -11,7 +11,7 @@ ms.date: 1/13/2019
 Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 6 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.
 ```
 
-_Note: this error maps to [`IL6200`](il6200.md]) in .NET 6 and higher._
+_Note: this error maps to [`XA2000`](xa2000.md]) in Xamarin.Android._
 
 ## Solution
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Android.Tasks
 					AssemblyDefinition? assemblyDefinition = null;
 					if (!UsingAndroidNETSdk) {
 						assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
-						fixAbstractMethodsStep.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogMessageFromText (msg, MessageImportance.High));
+						fixAbstractMethodsStep.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogCodedWarning ("XA2000", msg));
 					}
 
 					// Only run the step on "MonoAndroid" assemblies


### PR DESCRIPTION
Context: https://github.com/dotnet/linker/issues/2333

In testing 10b97206, I found that the XA2000 warning didn't actually
appear when consuming a class library with `AppDomain` usage in .NET 6.

After some discussion on dotnet/linker#2333, the only way to log a
warning from a custom trimmer step is:

    Context.LogMessage (MessageContainer.CreateCustomWarningMessage (Context, msg, 6200, new MessageOrigin (), WarnVersion.ILLink5))

Where the code must be 6001 or higher, and it will automatically be
prefixed with `IL`. I mapped `XA2000`, to `IL6200`, to just have the
number *similar*? We can chooose something else, let me know.

Once the warning was working, I got *many* warnings for the same
assembly. It turns out we were emitting it in .NET 6 for every type!

    protected void ProcessType (TypeDefinition type)
    {
        var assembly = type.Module.Assembly;
        if (!CheckShouldProcessAssembly (assembly))
            return;
    //...
    bool CheckShouldProcessAssembly (AssemblyDefinition assembly)
    {
        if (!Annotations.HasAction (assembly))
            Annotations.SetAction (assembly, AssemblyAction.Skip);
        if (IsProductOrSdkAssembly (assembly))
            return false;
        // Called for each type!
        CheckAppDomainUsage (assembly, (string msg) =>

To solve this issue, I created a new `HashSet<string>` of assembly
names. This way we will only log this warning once per assembly.

I updated a test for this scenario.