### PR TITLE
[xaprepare] Suppress NRT warnings.

### DIFF
--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Xamarin.Android.Prepare</RootNamespace>
     <AssemblyName>xaprepare</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4294

We enabled NRT warnings for `xaprepare` in https://github.com/xamarin/xamarin-android/pull/4294, however we never fixed the warnings and they pollute our build logs.

By switching to `<Nullable>annotations</Nullable>` we can continue to use NRT syntax to annotate our code, but warnings will not be produced when null safety cannot be proven by the compiler.

Reduces warnings building `xaprepare` from 169 to 21.