### PR TITLE
Bump NDK to r24

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -51,9 +51,9 @@ namespace Xamarin.Android.Prepare
 		public const string AndroidX86_64_NET6 = AbiNames.TargetJit.AndroidX86_64 + "_NET6";
 
 		public static readonly Dictionary<string, uint> NdkMinimumAPI = new Dictionary<string, uint> {
-			{ AbiNames.TargetJit.AndroidArmV7a, 16 }, { AndroidArmV7a_NET6, 21 },
+			{ AbiNames.TargetJit.AndroidArmV7a, 19 }, { AndroidArmV7a_NET6, 21 },
 			{ AbiNames.TargetJit.AndroidArmV8a, 21 }, { AndroidArmV8a_NET6, 21 },
-			{ AbiNames.TargetJit.AndroidX86,    16 }, { AndroidX86_NET6, 21 },
+			{ AbiNames.TargetJit.AndroidX86,    19 }, { AndroidX86_NET6, 21 },
 			{ AbiNames.TargetJit.AndroidX86_64, 21 }, { AndroidX86_64_NET6, 21 },
 		};
 	}

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "23b";
-		public const string AndroidNdkPkgRevision = "23.1.7779620";
+		public const string AndroidNdkVersion = "24-beta1";
+		public const string AndroidNdkPkgRevision = "24.0.7856742-beta1";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "24-rc1";
-		public const string AndroidNdkPkgRevision = "24.0.8079956-rc1";
+		public const string AndroidNdkVersion = "24";
+		public const string AndroidNdkPkgRevision = "24.0.8215888";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "24-beta1";
-		public const string AndroidNdkPkgRevision = "24.0.7856742-beta1";
+		public const string AndroidNdkVersion = "24-beta2";
+		public const string AndroidNdkPkgRevision = "24.0.7956693-beta2";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "24-beta2";
-		public const string AndroidNdkPkgRevision = "24.0.7956693-beta2";
+		public const string AndroidNdkVersion = "24-rc1";
+		public const string AndroidNdkPkgRevision = "24.0.8079956-rc1";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -137,17 +137,13 @@ namespace Xamarin.Android.Tasks
 			int level;
 			if (manifest?.MinSdkVersion != null) {
 				level       = manifest.MinSdkVersion.Value;
-				Log.LogDebugMessage ($"NDK API level read from manifest");
 			} else if (int.TryParse (MinimumSupportedApiLevel, out level)) {
-				Log.LogDebugMessage ("NDK API level taken from MinimumSupportedApiLevel");
 				// level already set
 			} else if (int.TryParse (AndroidApiLevel, out level)) {
-				Log.LogDebugMessage ("NDK API level taken from AndroidApiLevel");
 				// level already set
 			} else {
 				// Probably not ideal!
 				level       = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
-				Log.LogDebugMessage ("NDK API level taken from MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel");
 			}
 
 			// Some Android API levels do not exist on the NDK level. Workaround this my mapping them to the
@@ -161,7 +157,6 @@ namespace Xamarin.Android.Tasks
 
 			// API levels below level 21 do not provide support for 64-bit architectures.
 			if (ndk.IsNdk64BitArch (arch) && level < 21) {
-				Log.LogDebugMessage ("NDK API level raised to 21, required for 64-bit support");
 				level = 21;
 			}
 
@@ -177,7 +172,6 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			Log.LogDebugMessage ($"Using NDK API level {level}");
 			return level;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -137,13 +137,17 @@ namespace Xamarin.Android.Tasks
 			int level;
 			if (manifest?.MinSdkVersion != null) {
 				level       = manifest.MinSdkVersion.Value;
+				Log.LogDebugMessage ($"NDK API level read from manifest");
 			} else if (int.TryParse (MinimumSupportedApiLevel, out level)) {
+				Log.LogDebugMessage ("NDK API level taken from MinimumSupportedApiLevel");
 				// level already set
 			} else if (int.TryParse (AndroidApiLevel, out level)) {
+				Log.LogDebugMessage ("NDK API level taken from AndroidApiLevel");
 				// level already set
 			} else {
 				// Probably not ideal!
 				level       = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+				Log.LogDebugMessage ("NDK API level taken from MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel");
 			}
 
 			// Some Android API levels do not exist on the NDK level. Workaround this my mapping them to the
@@ -157,6 +161,7 @@ namespace Xamarin.Android.Tasks
 
 			// API levels below level 21 do not provide support for 64-bit architectures.
 			if (ndk.IsNdk64BitArch (arch) && level < 21) {
+				Log.LogDebugMessage ("NDK API level raised to 21, required for 64-bit support");
 				level = 21;
 			}
 
@@ -172,6 +177,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
+			Log.LogDebugMessage ($"Using NDK API level {level}");
 			return level;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -207,9 +207,9 @@ namespace Xamarin.Android.Build.Tests
 					// Since we overrode minSdkVersion=16, that means we should use libc.so from android-16.
 					if (ndk22OrNewer) {
 						// NDK r22 or newer store libc in [toolchain]/sysroot/usr/lib/[ARCH]/[API]/libc.so
-						StringAssertEx.ContainsRegex (@"\s*\[aot-compiler stdout].*sysroot.*.usr.lib.*16.libc\.so", b.LastBuildOutput, "AOT+LLVM should use libc.so from minSdkVersion!");
+						StringAssertEx.ContainsRegex (@"\s*\[aot-compiler stdout].*sysroot.*.usr.lib.*19.libc\.so", b.LastBuildOutput, "AOT+LLVM should use libc.so from minSdkVersion!");
 					} else {
-						StringAssertEx.ContainsRegex (@"\s*\[aot-compiler stdout].*android-16.arch-.*.usr.lib.libc\.so", b.LastBuildOutput, "AOT+LLVM should use libc.so from minSdkVersion!");
+						StringAssertEx.ContainsRegex (@"\s*\[aot-compiler stdout].*android-19.arch-.*.usr.lib.libc\.so", b.LastBuildOutput, "AOT+LLVM should use libc.so from minSdkVersion!");
 					}
 				}
 				foreach (var abi in supportedAbis.Split (new char [] { ';' })) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MakeBundleTests.cs
@@ -159,7 +159,7 @@ namespace Xamarin.Android.Build.Tests
 			string sonameField;
 
 			if (elfReaderLlvm) {
-				arguments = "-dynamic-table";
+				arguments = "--dynamic-table";
 				sonameField = "SONAME";
 			} else {
 				arguments = "-d";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -440,7 +440,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{versionCode:000}",
 				/* props */ null,
 				/* shouldBuild */ true,
-				/* expected */ "219012;316012",
+				/* expected */ "219012;319012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -450,7 +450,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{versionCode:000}",
 				/* props */ "screen=24",
 				/* shouldBuild */ true,
-				/* expected */ "21924012;31624012",
+				/* expected */ "21924012;31924012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -460,7 +460,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:0}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ true,
-				/* expected */ "219241012;316241012",
+				/* expected */ "219241012;319241012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -470,7 +470,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:00}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ false,
-				/* expected */ "2192401012;3162401012",
+				/* expected */ "2192401012;3192401012",
 			},
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -440,7 +440,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{versionCode:000}",
 				/* props */ null,
 				/* shouldBuild */ true,
-				/* expected */ "216012;316012",
+				/* expected */ "219012;316012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -450,7 +450,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{versionCode:000}",
 				/* props */ "screen=24",
 				/* shouldBuild */ true,
-				/* expected */ "21624012;31624012",
+				/* expected */ "21924012;31624012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -460,7 +460,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:0}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ true,
-				/* expected */ "216241012;316241012",
+				/* expected */ "219241012;316241012",
 			},
 			new object[] {
 				/* seperateApk */ true,
@@ -470,7 +470,7 @@ namespace Bug12935
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:00}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ false,
-				/* expected */ "2162401012;3162401012",
+				/* expected */ "2192401012;3162401012",
 			},
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				Assert.IsTrue (ndk.ValidateNdkPlatform (arch, enableLLVM: false));
 				Assert.AreEqual (0, errors.Count, "NdkTools.ValidateNdkPlatform should not have returned false.");
 				int level = ndk.GetMinimumApiLevelFor (arch);
-				int expected = 16;
+				int expected = 19;
 				Assert.AreEqual (expected, level, $"Min Api Level for {arch} should be {expected}.");
 				var compilerNoQuotes = ndk.GetToolPath (NdkToolKind.CompilerC, arch, level);
 				Assert.AreEqual (0, errors.Count, "NdkTools.GetToolPath should not have errored.");

--- a/tests/Mono.Android-Tests/Properties/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_Tests">
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 	<application android:debuggable="true" android:label="Xamarin.Android.RuntimeTests" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>

--- a/tests/Mono.Android-Tests/Runtime-AppBundle/Properties/AndroidManifest.xml
+++ b/tests/Mono.Android-Tests/Runtime-AppBundle/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_TestsAppBundle">
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 	<application android:label="Xamarin.Android.RuntimeTestsAppBundle" android:name="android.apptests.App" android:usesCleartextTraffic="true">
 		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
 	</application>


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r24#changes

The most interesting changes from Xamarin.Android's point of view:

 * GDB has been removed. Use LLDB instead. Note that ndk-gdb uses 
   LLDB by default, and Android Studio has only ever supported LLDB.
 * Jelly Bean (APIs 16, 17, and 18) is no longer supported. The
   minimum OS supported by the NDK is KitKat (API level 19).
 * Non-Neon devices are no longer supported. A very small number of
   very old devices do not support Neon so most apps will not notice
   aside from the performance improvement.
 * Additional Apple M1 support: 
   * LLVM tools are now universal binaries. 