### PR TITLE
[ci] override schedule for Xamarin.Android nightly

### DIFF
--- a/Documentation/guides/HowToBranch.md
+++ b/Documentation/guides/HowToBranch.md
@@ -30,11 +30,15 @@ See [eng/README.md][2] for details on `darc` commands.
    `$(AndroidPackVersionSuffix)` in `Directory.Build.props` is
    incremented to the *next* version: `preview.43`. You may also need
    to update `$(AndroidPackVersion)` if `main` needs to target a new
-   .NET version band. In the same PR, update `azure-pipelines-nightly.yaml`
-   to build the new release branch.
+   .NET version band.
 
 Note that release candidates will use values such as `rc.1`, `rc.2`, etc.
+
+7. Update the [Xamarin.Android Nightly job][3], so the schedule only
+   runs on desired branches. We likely only need a single .NET 6+
+   branch to be on this schedule at a time.
 
 [0]: https://github.com/dotnet/maui/issues/598
 [1]: https://github.com/dotnet/installer
 [2]: ../../eng/README.md
+[3]: https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=14072&view=Tab_Triggers

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -8,16 +8,6 @@ trigger:
 pr:
   - none
 
-schedules:
-- cron: "0 3 * * *"
-  displayName: Run daily at 3:00 UTC
-  branches:
-    include:
-    - main
-    - d16-11
-    - d17-0
-    - release/6.0.1xx-preview10
-
 # External sources, scripts, tests, and yaml template files.
 resources:
   repositories:


### PR DESCRIPTION
We noticed the Xamarin.Android nightly job is running against old
branches like:

* `release/6.0.1xx-preview3`
* `release/6.0.1xx-preview4`
* `release/6.0.1xx-preview5`
* `release/6.0.1xx-preview6`
* `release/6.0.1xx-preview7`

xamarin-android/main does *not* have a schedule setup for these
branches... Meaning, we would have to go update the trigger on each
branch?

Instead, let's define the schedule in Azure DevOps UI. I've updated
`HowToBranch.md` with the new instructions.

I removed the schedule from `azure-pipelines-nightly.yaml`. After this
is merged, we may have to cherry-pick the schedule removal to each
branch. After this is merged, we'll find out.