### PR TITLE
[xaprepare] Fix all nullable reference types warnings

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
+++ b/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Prepare
 				string rev = parts [1].Trim ();
 				NDKRevision = rev;
 
-				if (!Utilities.ParseAndroidPkgRevision (rev, out Version? ver, out string tag)) {
+				if (!Utilities.ParseAndroidPkgRevision (rev, out Version? ver, out string? tag) || ver == null) {
 					Log.ErrorLine ($"Unable to parse NDK revision '{rev}' as a valid version string");
 					return false;
 				}
@@ -68,7 +68,7 @@ namespace Xamarin.Android.Prepare
 				NDKVersionMajor = ver.Major.ToString ();
 				NDKVersionMinor = ver.Minor.ToString ();
 				NDKVersionMicro = ver.Build.ToString ();
-				NDKVersionTag = tag;
+				NDKVersionTag = tag ?? String.Empty;
 				break;
 			}
 

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -356,9 +356,9 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public bool IsRunningOnHostedAzureAgent {
 			get {
-				string agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
+				string? agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
 				bool hasHostedAgentName = !string.IsNullOrEmpty (agentNameValue) && agentNameValue.ToUpperInvariant ().Contains ("AZURE PIPELINES");
-				string serverTypeValue = Environment.GetEnvironmentVariable ("SYSTEM_SERVERTYPE");
+				string? serverTypeValue = Environment.GetEnvironmentVariable ("SYSTEM_SERVERTYPE");
 				bool isHostedServerType = !string.IsNullOrEmpty (serverTypeValue) && serverTypeValue.ToUpperInvariant ().Contains ("HOSTED");
 				return hasHostedAgentName || isHostedServerType;
 			}
@@ -421,7 +421,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		void PropertiesChanged (object sender, PropertiesChangedEventArgs args)
+		void PropertiesChanged (object? sender, PropertiesChangedEventArgs args)
 		{
 			if (String.Compare (KnownProperties.AndroidSupportedTargetJitAbis, args.Name, StringComparison.Ordinal) == 0) {
 				targetJitAbis = null;

--- a/build-tools/xaprepare/xaprepare/Application/EssentialTools.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/EssentialTools.MacOS.cs
@@ -4,8 +4,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class EssentialTools : AppObject
 	{
-		string brewPath;
-		string pkgutilPath;
+		string brewPath = String.Empty;
+		string pkgutilPath = String.Empty;
 
 		public string BrewPath {
 			get => GetRequiredValue (brewPath, "brew");

--- a/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
@@ -8,32 +8,32 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly char[] lineSplit = new [] { '\n' };
 
-		string cachedVersionOutput;
+		string? cachedVersionOutput;
 		bool brewNeedsSudo = false;
 		bool multipleVersionsPickle = false;
-		
+
 		public override bool NeedsSudoToInstall => brewNeedsSudo;
-		public string HomebrewTapName           { get; }
-		public Uri HomebrewFormulaUrl           { get; }
+		public string HomebrewTapName           { get; } = String.Empty;
+		public Uri? HomebrewFormulaUrl           { get; }
 		public bool Pin                         { get; set; }
 
-		public HomebrewProgram (string homebrewPackageName, string executableName = null)
+		public HomebrewProgram (string homebrewPackageName, string? executableName = null)
 			: this (homebrewPackageName, homebrewTap: null, executableName: executableName)
 		{}
 
-		public HomebrewProgram (string homebrewPackageName, Uri homebrewFormulaUrl, string executableName = null)
+		public HomebrewProgram (string homebrewPackageName, Uri homebrewFormulaUrl, string? executableName = null)
 			: this (homebrewPackageName, homebrewTap: null, executableName: executableName)
 		{
 			HomebrewFormulaUrl = homebrewFormulaUrl ?? throw new ArgumentNullException (nameof (homebrewFormulaUrl));
 		}
 
-		public HomebrewProgram (string homebrewPackageName, string homebrewTap, string executableName)
+		public HomebrewProgram (string homebrewPackageName, string? homebrewTap, string? executableName)
 		{
 			if (String.IsNullOrEmpty (homebrewPackageName))
 				throw new ArgumentException ("must not be null or empty", nameof (homebrewPackageName));
 			Name = homebrewPackageName;
-			HomebrewTapName = homebrewTap?.Trim ();
-			ExecutableName = executableName?.Trim ();
+			HomebrewTapName = homebrewTap?.Trim () ?? String.Empty;
+			ExecutableName = executableName?.Trim () ?? String.Empty;
 		}
 
 		public override async Task<bool> Install ()
@@ -50,10 +50,10 @@ namespace Xamarin.Android.Prepare
 				Log.InfoLine ($"{Name} has multiple versions installed, let's get out of this pickle");
 				// 1. unpin
 				success = await runner.UnPin (Name);
-				
+
 				// 2. unlink
 				success = await runner.Unlink (Name);
-				
+
 				// 3. uninstall --ignore-dependencies
 				success = await runner.Uninstall (Name, ignoreDependencies: true, force: true);
 				install = true;
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Prepare
 			return multipleVersionsPickle;
 		}
 
-		protected override bool ParseVersion (string version, out Version ver)
+		protected override bool ParseVersion (string? version, out Version? ver)
 		{
 			if (base.ParseVersion (version, out ver))
 				return true;
@@ -105,14 +105,14 @@ namespace Xamarin.Android.Prepare
 			//
 			// We need to handle it here *and* on install time (see Install above)
 
-			int pos = version.IndexOf (' ');
+			int pos = version!.IndexOf (' ');
 			if (pos > 0) {
 				Log.DebugLine ($"Brew reported more than one version of {Name} is installed: {version}");
 				multipleVersionsPickle = true;
 				var versions = new List<Version> ();
 				foreach (string v in version.Split (' ')) {
 					string cvs = GetCleanedUpVersion (v);
-					if (Version.TryParse (cvs, out Version tempVer)) {
+					if (Version.TryParse (cvs, out Version? tempVer) && tempVer != null) {
 						versions.Add (tempVer);
 					}
 				}
@@ -159,7 +159,7 @@ namespace Xamarin.Android.Prepare
 					return false;
 			}
 
-			string[] parts = cachedVersionOutput.Split (new [] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
+			string[] parts = cachedVersionOutput!.Split (new [] { ' ' }, 2, StringSplitOptions.RemoveEmptyEntries);
 			if (parts.Length != 2) {
 				Log.DebugLine ($"Unable to parse {Name} version from Homebrew output: '{cachedVersionOutput}'");
 				return false;

--- a/build-tools/xaprepare/xaprepare/Application/Log.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Log.cs
@@ -88,12 +88,16 @@ namespace Xamarin.Android.Prepare
 		public void Todo (string text)
 		{
 			var caller = new StackFrame (1, true);
-			MethodBase method = caller.GetMethod ();
+			MethodBase? method = caller.GetMethod ();
 
 			var sb = new StringBuilder ();
-			sb.Append (method.DeclaringType.FullName);
-			sb.Append ('.');
-			sb.Append (method.Name);
+			if (method != null) {
+				sb.Append (method.DeclaringType?.FullName ?? "UnknownType");
+				sb.Append ('.');
+				sb.Append (method.Name);
+			} else {
+				sb.Append ("Unknown Method");
+			}
 
 			if (!String.IsNullOrEmpty (caller.GetFileName ())) {
 				int lineNumber = caller.GetFileLineNumber ();

--- a/build-tools/xaprepare/xaprepare/Application/MonoPkgProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoPkgProgram.MacOS.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 {
 	class MonoPkgProgram : PkgProgram
 	{
-		public MonoPkgProgram (string name, string packageId, Uri packageUrl = null)
+		public MonoPkgProgram (string name, string packageId, Uri? packageUrl = null)
 			: base (name, packageId, packageUrl)
 		{
 			ExecutableName = "mono";

--- a/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Android.Prepare
 			if (bf.ExcludeDebugSymbols)
 				return (destFile, String.Empty);
 
-			return (destFile, Path.Combine (destDir, Path.GetFileName (bf.DebugSymbolsPath)));
+			return (destFile, Path.Combine (destDir, Path.GetFileName (bf.DebugSymbolsPath) ?? String.Empty));
 		}
 
 		public static (string assembly, string debugSymbols) GetDestinationPaths (TestAssembly tasm)
@@ -146,7 +146,7 @@ namespace Xamarin.Android.Prepare
 
 			string destDir;
 			if (tasm.Name.IndexOf (Path.DirectorySeparatorChar) >= 0)
-				destDir = Path.Combine (BCLTestsDestinationDir, Path.GetDirectoryName (tasm.Name));
+				destDir = Path.Combine (BCLTestsDestinationDir, Path.GetDirectoryName (tasm.Name) ?? String.Empty);
 			else
 				destDir = BCLTestsDestinationDir;
 

--- a/build-tools/xaprepare/xaprepare/Application/NullableAttributes.cs
+++ b/build-tools/xaprepare/xaprepare/Application/NullableAttributes.cs
@@ -1,3 +1,4 @@
+#if !NETCOREAPP
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -9,3 +10,4 @@ namespace System.Diagnostics.CodeAnalysis
 	internal sealed class MaybeNullAttribute : Attribute
 	{ }
 }
+#endif

--- a/build-tools/xaprepare/xaprepare/Application/PkgProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/PkgProgram.MacOS.cs
@@ -8,10 +8,10 @@ namespace Xamarin.Android.Prepare
 	{
 		public override bool NeedsSudoToInstall => false;
 		public string PackageId                { get; }
-		public Uri PackageUrl                  { get; set; }
+		public Uri? PackageUrl                 { get; set; }
 		protected bool SkipPkgUtilVersionCheck { get; set; }
 
-		public PkgProgram (string name, string packageId, Uri packageUrl = null)
+		public PkgProgram (string name, string packageId, Uri? packageUrl = null)
 		{
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Prepare
 
 			var runner = new PkgutilRunner (Context.Instance);
 
-			Version ver = await GetVersion (echoError: true);
+			Version? ver = await GetVersion (echoError: true);
 			if (ver == null)
 				return false;
 
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		async Task<Version> GetVersion (bool echoError)
+		async Task<Version?> GetVersion (bool echoError)
 		{
 			var runner = new PkgutilRunner (Context.Instance);
 			return await runner.GetPackageVersion (PackageId, echoError: echoError);

--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Android.Prepare
 		///   than the default one (created when <see cref="EchoStandardOutput"/> is set to <c>true</c>) or the one
 		///   specified by the caller by setting the <see cref="StandardErrorEchoWrapper" />.
 		/// </summary>
-		public void WriteStderrLine (string line)
+		public void WriteStderrLine (string? line)
 		{
 			if (StandardErrorEchoWrapper != null) {
 				StandardErrorEchoWrapper.WriteLine (line);
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Prepare
 			if (guardCache == null)
 				guardCache = new Dictionary<TextWriter, WriterGuard> ();
 
-			if (guardCache.TryGetValue (writer, out WriterGuard ret) && ret != null)
+			if (guardCache.TryGetValue (writer, out WriterGuard? ret) && ret != null)
 				return ret;
 
 			ret = new WriterGuard (writer);

--- a/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
@@ -36,20 +36,20 @@ namespace Xamarin.Android.Prepare
 
 	    public ProcessStandardStreamWrapper (IFormatProvider formatProvider)
 		    : base (formatProvider)
-        {}
+	    {}
 
-	    public override void WriteLine (string value)
+	    public override void WriteLine (string? value)
 	    {
 		    DoWrite (value, true);
 	    }
 
-	    protected virtual string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
+	    protected virtual string? PreprocessMessage (string? message, ref bool writeLine, out bool ignoreLine)
 	    {
 		    ignoreLine = false;
 		    return message;
 	    }
 
-	    void DoWrite (string message, bool writeLine)
+	    void DoWrite (string? message, bool writeLine)
 	    {
 		    Action<string, ConsoleColor, bool, string> writer;
 		    ConsoleColor color;

--- a/build-tools/xaprepare/xaprepare/Application/Program.ArchLinux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.ArchLinux.cs
@@ -41,8 +41,12 @@ namespace Xamarin.Android.Prepare
 		protected override bool DeterminePackageVersion()
 		{
 			var output = Utilities.GetStringFromStdout ("pacman", "-Q", PackageName).Split(' ');
-			CurrentVersion = output.Length == 2 ? output[1] : null;
-			return !String.IsNullOrEmpty (CurrentVersion);
+			if (output.Length == 2) {
+				CurrentVersion = output[1];
+				return true;
+			}
+
+			return false;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Prepare
 				LoggingLevel = ProcessStandardStreamWrapper.LogLevel.Message;
 			}
 
-			protected override string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
+			protected override string? PreprocessMessage (string? message, ref bool writeLine, out bool ignoreLine)
 			{
 				ignoreLine = false;
 				// apt-get calls `dpkg` which can't be persuaded to not show any progress and it shows the progress by
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Prepare
 				// line to us... So in order to keep the display straight we need to reset the cursor position blindly
 				// here.
 				Console.CursorLeft = 1;
-				return message.TrimEnd ();
+				return message?.TrimEnd ();
 			}
 		}
 

--- a/build-tools/xaprepare/xaprepare/Application/Program.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Android.Prepare
 {
 	abstract class Program : AppObject
 	{
-		const string DefaultCurrentVersion = "0.0.0";
+		protected const string DefaultCurrentVersion = "0.0.0";
 
 		bool? installed;
 

--- a/build-tools/xaprepare/xaprepare/Application/Properties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 
 		public int Count => properties.Count;
 		public bool IsDefined (string propertyName) => properties.ContainsKey (EnsureName (propertyName));
-		public bool IsEmpty (string propertyName) => IsDefined (propertyName) && properties.TryGetValue (propertyName, out string v) && v != null;
+		public bool IsEmpty (string propertyName) => IsDefined (propertyName) && properties.TryGetValue (propertyName, out string? v) && v != null;
 		public string? this [string name] => GetValue (name);
 
 		public Properties ()
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Prepare
 
 		public string? GetValue (string propertyName, string? defaultValue = null)
 		{
-			if (!properties.TryGetValue (EnsureName (propertyName), out string value))
+			if (!properties.TryGetValue (EnsureName (propertyName), out string? value))
 				return defaultValue;
 
 			return value;

--- a/build-tools/xaprepare/xaprepare/Application/Runtime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Runtime.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Android.Prepare
 {
 	abstract class Runtime : AppObject
 	{
-		string displayName;
+		string displayName = String.Empty;
 		Func<Context, bool> enabledCheck;
 
 		/// <summary>
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public string DisplayName {
 			get => String.IsNullOrEmpty (displayName) ? Name : displayName;
-			set => displayName = value;
+			set => displayName = value ?? String.Empty;
 		}
 
 		/// <summary>

--- a/build-tools/xaprepare/xaprepare/Application/Scenario.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Scenario.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Prepare
 			if (log != null)
 				Log = log;
 			foreach (Step step in Steps) {
-				context.Banner (step.Description ?? step.GetType ().FullName);
+				context.Banner (step.Description ?? step.GetType ().FullName ?? "Unnamed Step");
 
 				bool success;
 				Exception? stepEx = null;

--- a/build-tools/xaprepare/xaprepare/Application/ThumbTwiddler.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ThumbTwiddler.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Android.Prepare
 		};
 
 		readonly Context context;
-		readonly string[] twiddler;
+		readonly string[]? twiddler;
 		readonly long twiddleInterval;
 		readonly int twiddleSteps;
 		readonly bool dullMode;
@@ -99,9 +99,9 @@ namespace Xamarin.Android.Prepare
 				WriteTwiddler ("        ", showElapsed: false);
 		}
 
-		void Twiddle (object state)
+		void Twiddle (object? state)
 		{
-			if (dullMode) {
+			if (dullMode || twiddler == null) {
 				string wittyMessage = alternateTwiddlerMessages[random!.Next (0, alternateTwiddlerMessages.Count - 1)];
 				Log.StatusLine ($"{wittyMessage}... {GetElapsedTime ()}", ConsoleColor.Gray, skipLogFile: true);
 				return;

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -430,8 +430,6 @@ namespace Xamarin.Android.Prepare
 			static string? mingw64CmakeTemplatePath;
 			static string? monoRuntimesEnabledAbisCachePath;
 			static string? frameworkListInstallPath;
-			static string? correttoCacheDir;
-			static string? correttoInstallDir;
 			static string? profileAssembliesProjitemsPath;
 			static string? bclTestsSourceDir;
 			static string? installHostBCLDir;

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Prepare
 			}
 
 			return
-				version.IndexOf ("bullseye", StringComparison.OrdinalIgnoreCase) >= 0 ||
+				version!.IndexOf ("bullseye", StringComparison.OrdinalIgnoreCase) >= 0 ||
 				version.IndexOf ("bookworm", StringComparison.OrdinalIgnoreCase) >= 0 ||
 				version.IndexOf ("sid", StringComparison.OrdinalIgnoreCase) >= 0;
 		}
@@ -86,13 +86,12 @@ namespace Xamarin.Android.Prepare
 				// VERSION_ID and VERSION_CODENAME from /etc/os-release, so we need to
 				// fake it
 				debian_version = ReadDebianVersion ();
-				if (IsBookwormSidOrNewer (debian_version) && DebianUnstableVersionMap.TryGetValue (debian_version!, out string unstable_version)) {
+				if (IsBookwormSidOrNewer (debian_version) && DebianUnstableVersionMap.TryGetValue (debian_version!, out string? unstable_version) && unstable_version != null) {
 					Release = unstable_version;
 				};
 			}
 
-			Version debianRelease;
-			if (!Version.TryParse (Release, out debianRelease)) {
+			if (!Version.TryParse (Release, out Version? debianRelease) || debianRelease == null) {
 				if (Int32.TryParse (Release, out int singleNumberVersion)) {
 					debianRelease = new Version (singleNumberVersion, 0);
 				} else {
@@ -102,6 +101,7 @@ namespace Xamarin.Android.Prepare
 					}
 
 					IsTesting = true;
+					debianRelease = new Version (12, 0); // Assume testing is newer than bullseye (11)
 				}
 			}
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Ubuntu.cs
@@ -40,8 +40,7 @@ namespace Xamarin.Android.Prepare
 
 		protected override bool EnsureVersionInformation (Context context)
 		{
-			Version ubuntuRelease;
-			if (!Version.TryParse (Release, out ubuntuRelease)) {
+			if (!Version.TryParse (Release, out Version? ubuntuRelease) || ubuntuRelease == null) {
 				if (Int32.TryParse (Release, out int singleNumberVersion)) {
 					ubuntuRelease = new Version (singleNumberVersion, 0);
 				} else {

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Android.Prepare
 			if (String.Compare (cfName, Configurables.Defaults.DefaultCompressionFormat.Name, StringComparison.OrdinalIgnoreCase) == 0)
 				return true;
 
-			if (!Configurables.Defaults.CompressionFormats.TryGetValue (cfName, out CompressionFormat cf)) {
+			if (!Configurables.Defaults.CompressionFormats.TryGetValue (cfName, out CompressionFormat? cf)) {
 				Log.Instance.ErrorLine ($"Unknown compression format name: {cfName}");
 				return false;
 			}

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
@@ -165,8 +165,9 @@ and re-enable it after building with the following command:
 			if (String.IsNullOrEmpty (id))
 				return false;
 
-			if (!distroIdMap.TryGetValue (id, out string val))
+			if (!distroIdMap.TryGetValue (id, out string? val) || val == null) {
 				return false;
+			}
 
 			distro = val;
 			return true;
@@ -228,9 +229,9 @@ and re-enable it after building with the following command:
 			if (usingBaseDistro)
 				Log.Instance.InfoLine ($"Distribution supported via its base distribution: {idLike}");
 
-			Func<Context, Linux> creator;
-			if (!distroMap.TryGetValue (distro, out creator))
+			if (!distroMap.TryGetValue (distro, out Func<Context, Linux>? creator) || creator == null) {
 				throw new InvalidOperationException ($"Your Linux distribution ({name} {release}) is not supported at this time.");
+			}
 
 			Linux linux = creator (context);
 			linux.Name = name;

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/MacOS.cs
@@ -24,7 +24,7 @@ After all the issues are fixed, please re-run the bootstrapper.
 
 		public Version Version         { get; }
 		public string Build            { get; }
-		public Version HomebrewVersion { get; private set; }
+		public Version? HomebrewVersion { get; private set; }
 		public bool HomebrewErrors     { get; set; }
 
 		bool processIsTranslated;
@@ -45,7 +45,7 @@ After all the issues are fixed, please re-run the bootstrapper.
 				Build = build;
 				Release = $"{release} ({build})";
 
-				if (!Version.TryParse (release, out Version ver)) {
+				if (!Version.TryParse (release, out Version? ver) || ver == null) {
 					Log.WarningLine ($"Unable to parse macOS version: {release}");
 					Version = new Version (0, 0, 0);
 				} else
@@ -94,7 +94,7 @@ After all the issues are fixed, please re-run the bootstrapper.
 			HomebrewPrefix = Utilities.GetStringFromStdout (brewPath, "--prefix");
 
 			(bool success, string bv) = Utilities.GetProgramVersion (brewPath);
-			if (!success || !Version.TryParse (bv, out Version brewVersion)) {
+			if (!success || !Version.TryParse (bv, out Version? brewVersion) || brewVersion == null) {
 				Log.ErrorLine ("Failed to obtain Homebrew version");
 				return false;
 			}
@@ -105,7 +105,7 @@ After all the issues are fixed, please re-run the bootstrapper.
 			// `HostHomebrewPrefix` property which is defined in `Configuration.OperatingSystem.props` but we're here to
 			// *generate* the latter file, so when the bootstrapper is built `HostHomebrewPrefix` is empty and we can't
 			// access mingw utilities. So, we need to cheat here.
-			string mxePath = Context.Instance.Properties.GetValue (KnownProperties.AndroidMxeFullPath);
+			string? mxePath = Context.Instance.Properties.GetValue (KnownProperties.AndroidMxeFullPath);
 			if (String.IsNullOrEmpty (mxePath))
 				Context.Instance.Properties.Set (KnownProperties.AndroidMxeFullPath, HomebrewPrefix);
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Prepare
 		{
 			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim () ?? String.Empty;
 			if (String.IsNullOrEmpty (JavaHome)) {
-				var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim ();
+				var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim () ?? String.Empty;
 				JavaHome = Path.Combine (androidToolchainDirectory, Configurables.Defaults.JdkFolder);
 			}
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Prepare
 		public override string Which (string programPath, bool required = true)
 		{
 			if (String.Compare ("7za", programPath, StringComparison.OrdinalIgnoreCase) == 0) {
-				string packagePath = Context.Instance.Properties.GetValue (KnownProperties.Pkg7Zip_CommandLine);
+				string? packagePath = Context.Instance.Properties.GetValue (KnownProperties.Pkg7Zip_CommandLine);
 				if (String.IsNullOrEmpty (packagePath)) {
 					packagePath = Path.Combine (Configurables.Paths.XAPackagesDir, "7-zip.commandline", "18.1.0");
 				}
@@ -119,11 +119,11 @@ namespace Xamarin.Android.Prepare
 
 		string GetHomeDir ()
 		{
-			string homeDir = Environment.GetEnvironmentVariable ("USERPROFILE");
+			string? homeDir = Environment.GetEnvironmentVariable ("USERPROFILE");
 			if (!String.IsNullOrEmpty (homeDir))
 				return homeDir;
 
-			string homeDrive = Environment.GetEnvironmentVariable ("HOMEDRIVE");
+			string? homeDrive = Environment.GetEnvironmentVariable ("HOMEDRIVE");
 			if (String.IsNullOrEmpty (homeDrive))
 				throw new InvalidOperationException ("Unable to determine user's home directory, missing HOMEDRIVE environment variable");
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
@@ -224,15 +224,15 @@ namespace Xamarin.Android.Prepare
 					throw new InvalidOperationException ($"Unsupported BCL file type {bcf.Type}");
 
 				AssemblyName aname = AssemblyName.GetAssemblyName (fullFilePath);
-				string version = bcf.Version ?? String.Empty;
-				if (String.IsNullOrEmpty (version) && !Runtimes.FrameworkListVersionOverrides.TryGetValue (bcf.Name, out version))
-					version = aname.Version.ToString ();
+				string? version = bcf.Version ?? String.Empty;
+				if (String.IsNullOrEmpty (version) && !Runtimes.FrameworkListVersionOverrides.TryGetValue (bcf.Name, out version) || version == null)
+					version = aname.Version?.ToString () ?? "0.0.0";
 
 				return new XElement (
 					"File",
-					new XAttribute ("AssemblyName", aname.Name),
+					new XAttribute ("AssemblyName", aname.Name ?? "Unknown"),
 					new XAttribute ("Version", version),
-					new XAttribute ("PublicKeyToken", String.Join (String.Empty, aname.GetPublicKeyToken ().Select (b => b.ToString ("x2")))),
+					new XAttribute ("PublicKeyToken", String.Join (String.Empty, aname.GetPublicKeyToken ()?.Select (b => b.ToString ("x2")) ?? new string[]{})),
 					new XAttribute ("ProcessorArchitecture", aname.ProcessorArchitecture.ToString ())
 				);
 			}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ChangeLibMonoSgenDylibID.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ChangeLibMonoSgenDylibID.MacOS.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Prepare
 					continue;
 				}
 
-				if (!ChangeID (libPath)) {
+				if (!await ChangeID (libPath)) {
 					Log.StatusLine ("    failed", ConsoleColor.Magenta);
 					result = false;
 				}
@@ -37,12 +37,14 @@ namespace Xamarin.Android.Prepare
 
 			return result;
 
-			bool ChangeID (string path)
+			Task<bool> ChangeID (string path)
 			{
-				Log.DebugLine ($"Changing dylib id for {path}");
-				Log.StatusLine ($"  {context.Characters.Bullet} {Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, path)}");
-				var runner = new ProcessRunner (xcrun, "install_name_tool", "-id", "@loader_path/libmonosgen-2.0.dylib", path);
-				return runner.Run ();
+				return Task.Run(() => {
+					Log.DebugLine ($"Changing dylib id for {path}");
+					Log.StatusLine ($"  {context.Characters.Bullet} {Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, path)}");
+					var runner = new ProcessRunner (xcrun, "install_name_tool", "-id", "@loader_path/libmonosgen-2.0.dylib", path);
+					return runner.Run ();
+				});
 			}
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -19,8 +19,10 @@ namespace Xamarin.Android.Prepare
 			if (!Directory.Exists (rootDir))
 				return false;
 
-			CopyExtraTestFiles (Path.Combine (rootDir, $"Test{context.Configuration}"), context);
-			CopyExtraBuildFiles (Path.Combine (rootDir, $"Build{context.Configuration}"), context);
+			await Task.Run (() => {
+				CopyExtraTestFiles (Path.Combine (rootDir, $"Test{context.Configuration}"), context);
+				CopyExtraBuildFiles (Path.Combine (rootDir, $"Build{context.Configuration}"), context);
+			});
 			return true;
 		}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Android.Prepare
 
 			var runAllTestsLoggingCommand = "##vso[task.setvariable variable=TestAreas;isOutput=true]MSBuild,MSBuildDevice,BCL,Designer";
 
-			string commitRevision = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION");
-			string commitMessage = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSIONMESSAGE");
+			string? commitRevision = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSION");
+			string? commitMessage = Environment.GetEnvironmentVariable ("BUILD_SOURCEVERSIONMESSAGE");
 			if (string.IsNullOrEmpty (commitRevision) || string.IsNullOrEmpty (commitMessage)) {
 				Log.WarningLine ("One or more source version variable values were empty:");
 				Log.WarningLine ($"BUILD_SOURCEVERSION='{commitRevision}' BUILD_SOURCEVERSIONMESSAGE='{commitMessage}'.");

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateCGManifest.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateCGManifest.cs
@@ -147,8 +147,8 @@ namespace Xamarin.Android.Prepare
 
 		public  override    string      Type    => "Git";
 
-		public  string      RepositoryUrl   {get; private set;}
-		public  string      CommitHash      {get; private set;}
+		public  string      RepositoryUrl   {get; private set;} = String.Empty;
+		public  string      CommitHash      {get; private set;} = String.Empty;
 
 		GitSubmoduleInfo ()
 		{
@@ -162,13 +162,17 @@ namespace Xamarin.Android.Prepare
 
 		const string Submodule = "submodule.external/";
 
-		public static IEnumerable<GitSubmoduleInfo> GetGitSubmodules (List<string> config, List<string> submoduleStatus)
+		public static IEnumerable<GitSubmoduleInfo> GetGitSubmodules (List<string>? config, List<string>? submoduleStatus)
 		{
+			if (config == null) {
+				yield return CreateEmptySubmoduleInfo ();
+			}
+
 			string? entryId = null;
 			string? path = null;
 			string? url = null;
 
-			foreach (var line in config) {
+			foreach (var line in config!) {
 				if (!line.StartsWith (Submodule, StringComparison.Ordinal))
 					continue;
 
@@ -208,6 +212,10 @@ namespace Xamarin.Android.Prepare
 
 			GitSubmoduleInfo CreateSubmoduleInfo (string url, string path)
 			{
+				if (submoduleStatus == null) {
+					return CreateEmptySubmoduleInfo ();
+				}
+
 				string? hash = null;
 				foreach (var e in submoduleStatus) {
 					int pi  = e.IndexOf (path, StringComparison.OrdinalIgnoreCase);
@@ -218,7 +226,15 @@ namespace Xamarin.Android.Prepare
 				}
 				return new GitSubmoduleInfo () {
 					RepositoryUrl   = url,
-					CommitHash      = hash,
+					CommitHash      = hash ?? String.Empty,
+				};
+			}
+
+			GitSubmoduleInfo CreateEmptySubmoduleInfo ()
+			{
+				return new GitSubmoduleInfo {
+					RepositoryUrl = String.Empty,
+					CommitHash = String.Empty,
 				};
 			}
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 		public Step_Get_Android_BuildTools ()
 			: base ("Downloading build-tools archive")
 		{
-			string XABuildToolsVersion     = Context.Instance.Properties [KnownProperties.XABuildToolsVersion];
+			string XABuildToolsVersion     = Context.Instance.Properties [KnownProperties.XABuildToolsVersion] ?? String.Empty;
 			string XABuildToolsPackagePrefixMacOS = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixMacOS] ?? string.Empty;
 			string XABuildToolsPackagePrefixWindows = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixWindows] ?? string.Empty;
 			string XABuildToolsPackagePrefixLinux = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefixLinux] ?? string.Empty;

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Android.Prepare
 						return false;
 					}
 
-					if (!neededFiles.TryGetValue (cdh.FileName, out string destinationFileName))
+					if (!neededFiles.TryGetValue (cdh.FileName, out string? destinationFileName))
 						continue;
 
 					foundFiles.Add (cdh.FileName);
@@ -315,7 +315,11 @@ namespace Xamarin.Android.Prepare
 
 		void Extract (string compressedFilePath, uint crc32FromHeader)
 		{
-			string outputFile = Path.Combine (Path.GetDirectoryName (compressedFilePath), Path.GetFileNameWithoutExtension (compressedFilePath));
+			if (String.IsNullOrEmpty (compressedFilePath)) {
+				throw new ArgumentException ("must not be null or empty", nameof (compressedFilePath));
+			}
+
+			string outputFile = Path.Combine (Path.GetDirectoryName (compressedFilePath) ?? String.Empty, Path.GetFileNameWithoutExtension (compressedFilePath) ?? String.Empty);
 			using (var fs = File.OpenRead (compressedFilePath)) {
 				using (var dfs = File.OpenWrite (outputFile)) {
 					Extract (fs, dfs, crc32FromHeader);
@@ -571,7 +575,7 @@ namespace Xamarin.Android.Prepare
 
 			if (cdh.FileCommentLength > 0) {
 				bytes = ReadBytes (cdr, cdh.FileCommentLength, dataLength, ref nread, out worked);
-				if (!worked) {
+				if (!worked || bytes == null) {
 					goto failed;
 				}
 				cdh.FileComment = Encoding.ASCII.GetString (bytes);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
@@ -44,9 +44,9 @@ namespace Xamarin.Android.Prepare
 			}
 
 			string jdkInstallDir = JdkInstallDir;
-			if (OpenJDKExistsAndIsValid (jdkInstallDir, out string installedVersion)) {
+			if (OpenJDKExistsAndIsValid (jdkInstallDir, out string? installedVersion)) {
 				Log.Status ($"{ProductName} version ");
-				Log.Status (installedVersion, ConsoleColor.Yellow);
+				Log.Status (installedVersion ?? "Unknown", ConsoleColor.Yellow);
 				Log.StatusLine (" already installed in: ", jdkInstallDir, tailColor: ConsoleColor.Cyan);
 				return true;
 			}
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		bool OpenJDKExistsAndIsValid (string installDir, out string installedVersion)
+		bool OpenJDKExistsAndIsValid (string installDir, out string? installedVersion)
 		{
 			installedVersion = null;
 			if (!Directory.Exists (installDir)) {
@@ -175,7 +175,7 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			string cv = null;
+			string? cv = null;
 			foreach (string l in lines) {
 				string line = l.Trim ();
 				if (!line.StartsWith ("JAVA_VERSION=", StringComparison.Ordinal)) {
@@ -213,7 +213,7 @@ namespace Xamarin.Android.Prepare
 
 			installedVersion = $"{cv} r{rv}";
 
-			if (!Version.TryParse (cv, out Version cversion)) {
+			if (!Version.TryParse (cv, out Version? cversion) || cversion == null) {
 				Log.DebugLine ($"Unable to parse {ProductName} version from: {cv}");
 				return false;
 			}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
@@ -237,15 +237,15 @@ namespace Xamarin.Android.Prepare
 					throw new InvalidOperationException ($"Unsupported BCL file type {bcf.Type}");
 
 				AssemblyName aname = AssemblyName.GetAssemblyName (fullFilePath);
-				string version = bcf.Version ?? String.Empty;
-				if (String.IsNullOrEmpty (version) && !Runtimes.FrameworkListVersionOverrides.TryGetValue (bcf.Name, out version))
-					version = aname.Version.ToString ();
+				string? version = bcf.Version ?? String.Empty;
+				if (String.IsNullOrEmpty (version) && !Runtimes.FrameworkListVersionOverrides.TryGetValue (bcf.Name, out version) || version == null)
+					version = aname.Version?.ToString () ?? "0.0.0";
 
 				return new XElement (
 					"File",
-					new XAttribute ("AssemblyName", aname.Name),
+					new XAttribute ("AssemblyName", aname.Name ?? "Unknown"),
 					new XAttribute ("Version", version),
-					new XAttribute ("PublicKeyToken", String.Join (String.Empty, aname.GetPublicKeyToken ().Select (b => b.ToString ("x2")))),
+					new XAttribute ("PublicKeyToken", String.Join (String.Empty, aname.GetPublicKeyToken ()?.Select (b => b.ToString ("x2")) ?? new string[]{})),
 					new XAttribute ("ProcessorArchitecture", aname.ProcessorArchitecture.ToString ())
 				);
 			}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalGitDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalGitDependencies.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Prepare
 
 		async Task<string> GetGitHubURL (ExternalGitDependency egd, GitRunner git)
 		{
-			string ghToken = Environment.GetEnvironmentVariable("GH_AUTH_SECRET");
+			string? ghToken = Environment.GetEnvironmentVariable("GH_AUTH_SECRET");
 			if (!String.IsNullOrEmpty (ghToken)) {
 				return  $"https://{ghToken}@github.com:/{egd.Owner}/{egd.Name}";
 			} else {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
@@ -102,8 +102,8 @@ implication, estoppel or otherwise."			}
 			if (licenses.Count == 0)
 				return;
 
-			string blurb;
-			if (!tpnBlurbs.TryGetValue (licenseType, out blurb))
+			string? blurb;
+			if (!tpnBlurbs.TryGetValue (licenseType, out blurb) || blurb == null)
 				throw new InvalidOperationException ($"Unknown license type {licenseType}");
 
 			using (StreamWriter sw = Utilities.OpenStreamWriter (outputPath)) {

--- a/build-tools/xaprepare/xaprepare/ToolRunners/BrewRunner.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/BrewRunner.MacOS.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Prepare
 
 		string BrewPath => Context.Instance?.Tools?.BrewPath ?? "brew";
 
-		public BrewRunner (Context context, Log log = null, string toolPath = null)
+		public BrewRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (30);
@@ -121,17 +121,17 @@ namespace Xamarin.Android.Prepare
 			return await RunBrew (echoOutput, echoError, "unpin", packageName);;
 		}
 
-		public bool List (string packageName, out List<string> lines)
+		public bool List (string packageName, out List<string>? lines)
 		{
 			if (String.IsNullOrEmpty (packageName))
 				throw new ArgumentException ("must not be null or empty", nameof (packageName));
 
 			lines = null;
-			string listing = CaptureBrewOutput ("ls", packageName)?.Trim ();
+			string? listing = CaptureBrewOutput ("ls", packageName)?.Trim ();
 			if (String.IsNullOrEmpty (listing))
 				return false;
 
-			lines = new List <string> (listing.Split (lineSplit, StringSplitOptions.RemoveEmptyEntries));
+			lines = new List <string> (listing!.Split (lineSplit, StringSplitOptions.RemoveEmptyEntries));
 			return true;
 		}
 
@@ -156,6 +156,9 @@ namespace Xamarin.Android.Prepare
 			bool success = await RunTool (() => runner.Run ());
 			if (!success) {
 				var os = Context.Instance.OS as MacOS;
+				if (os == null) {
+					throw new InvalidOperationException ("Context.Instance.OS is not MacOS!");
+				}
 				os.HomebrewErrors = true;
 			}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.OutputSink.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 				: base (log, logFilePath)
 			{}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				base.WriteLine (value);
 			}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Prepare
 			// Contents of the changed line
 			public string Line                              { get; private set; } = String.Empty;
 
-			public bool ProcessLine (string line)
+			public bool ProcessLine (string? line)
 			{
 				if (String.IsNullOrEmpty (line))
 					return false;
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Prepare
 					return false;
 				}
 
-				if (line [0] == '\t') {
+				if (line! [0] == '\t') {
 					Line = line.Substring (1);
 					// Means we've parsed the last line in the record and our job is done
 					return true;
@@ -146,9 +146,13 @@ namespace Xamarin.Android.Prepare
 				}
 			}
 
-			void ParseCommit (string line)
+			void ParseCommit (string? line)
 			{
-				string[] parts = line.Split (FieldSeparator, StringSplitOptions.RemoveEmptyEntries);
+				if (String.IsNullOrEmpty (line)) {
+					return;
+				}
+
+				string[] parts = line!.Split (FieldSeparator, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length < 3)
 					throw new InvalidOperationException ($"Unexpected commit line format (not enough fields): {line}");
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.OutputSink.cs
@@ -6,14 +6,14 @@ namespace Xamarin.Android.Prepare
 	{
 		class OutputSink : ToolRunner.ToolOutputSink
 		{
-			public Action<string>? LineCallback { get; set; }
+			public Action<string?>? LineCallback { get; set; }
 
 			public OutputSink (Log log, string? logFilePath = null)
 				: base (log, logFilePath)
 			{
 			}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				base.WriteLine (value);
 				LineCallback?.Invoke (value);

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
@@ -12,11 +12,11 @@ namespace Xamarin.Android.Prepare
 		{
 			public readonly List<string> Messages = new List<string> ();
 
-			protected override string PreprocessMessage (string message, ref bool writeLine, out bool ignoreLine)
+			protected override string? PreprocessMessage (string? message, ref bool writeLine, out bool ignoreLine)
 			{
 				ignoreLine = true;
 
-				if (message.Length == 0)
+				if (message == null || message.Length == 0)
 					return message;
 
 				Messages.Add (message);
@@ -84,8 +84,8 @@ namespace Xamarin.Android.Prepare
 			if (String.IsNullOrEmpty (destinationDirectoryPath))
 				throw new ArgumentException ("must not be null or empty", nameof (destinationDirectoryPath));
 
-			string parentDir = Path.GetDirectoryName (destinationDirectoryPath);
-			string dirName = Path.GetFileName (destinationDirectoryPath);
+			string? parentDir = Path.GetDirectoryName (destinationDirectoryPath);
+			string? dirName = Path.GetFileName (destinationDirectoryPath);
 			Utilities.CreateDirectory (parentDir);
 			var runner = CreateGitRunner (parentDir, useCustomStderrWrapper: true);
 			runner.AddArgument ("clone");
@@ -108,7 +108,7 @@ namespace Xamarin.Android.Prepare
 			bool success = await RunTool (
 				() => {
 					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
-						outputSink.LineCallback = (string line) => lines.Add (line);
+						outputSink.LineCallback = (string? line) => lines.Add (line ?? String.Empty);
 						return runner.Run ();
 					}
 				}
@@ -147,10 +147,10 @@ namespace Xamarin.Android.Prepare
 
 			string hash = String.Empty;
 			using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
-				outputSink.LineCallback = (string line) => {
+				outputSink.LineCallback = (string? line) => {
 					if (!String.IsNullOrEmpty (hash))
 						return;
-					hash = line.Trim ();
+					hash = line?.Trim () ?? String.Empty;
 				};
 
 				if (!runner.Run ())
@@ -189,7 +189,7 @@ namespace Xamarin.Android.Prepare
 			bool success = await RunTool (
 				() => {
 					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
-						outputSink.LineCallback = (string line) => ParseBlameLine (line, parserState);
+						outputSink.LineCallback = (string? line) => ParseBlameLine (line, parserState);
 						runner.WorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
 						return runner.Run ();
 					}
@@ -215,7 +215,7 @@ namespace Xamarin.Android.Prepare
 			bool success = await RunTool (
 				() => {
 					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
-						outputSink.LineCallback = (string line) => lines.Add (line);
+						outputSink.LineCallback = (string? line) => lines.Add (line ?? String.Empty);
 						return runner.Run ();
 					}
 				}
@@ -242,8 +242,8 @@ namespace Xamarin.Android.Prepare
 			bool success = await RunTool (
 				() => {
 					using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
-						outputSink.LineCallback = (string line) => {
-							containsHttps = !string.IsNullOrEmpty (line) && line.Contains ("https://");
+						outputSink.LineCallback = (string? line) => {
+							containsHttps = !string.IsNullOrEmpty (line) && line!.Contains ("https://");
 						};
 						runner.WorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
 						return runner.Run ();
@@ -257,7 +257,7 @@ namespace Xamarin.Android.Prepare
 			return containsHttps;
 		}
 
-		public async Task<List<string>> RunCommandForOutputAsync (string workingDirectory, params string[] args)
+		public async Task<List<string>?> RunCommandForOutputAsync (string workingDirectory, params string[] args)
 		{
 			if (!Directory.Exists (workingDirectory))
 				throw new ArgumentException ("must exist", nameof (workingDirectory));
@@ -267,13 +267,13 @@ namespace Xamarin.Android.Prepare
 			return await RunForOutputAsync (runner);
 		}
 
-		async Task<List<string>> RunForOutputAsync (ProcessRunner runner)
+		async Task<List<string>?> RunForOutputAsync (ProcessRunner runner)
 		{
 			var lines = new List<string> ();
 			bool success = await RunTool (
 				() => {
 					using (var outputSink = (OutputSink) SetupOutputSink (runner)) {
-						outputSink.LineCallback = (string line) => lines.Add (line);
+						outputSink.LineCallback = (string? line) => lines.Add (line ?? String.Empty);
 						return runner.Run ();
 					}
 				}
@@ -322,7 +322,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		void ParseBlameLine (string line, BlameParserState state)
+		void ParseBlameLine (string? line, BlameParserState state)
 		{
 			if (state.CurrentEntry == null)
 				state.CurrentEntry = new BlamePorcelainEntry ();

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.OutputSink.cs
@@ -13,11 +13,6 @@ namespace Xamarin.Android.Prepare
 				: base (log, logFilePath)
 			{
 			}
-
-			public override void WriteLine (string value)
-			{
-				base.WriteLine (value);
-			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.MacOS.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Android.Prepare
 {
 	partial class MakeRunner
 	{
-		static string executableName;
+		static string executableName = String.Empty;
 
 		protected override string DefaultToolExecutableName => EnsureExecutableName ();
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.OutputSink.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.OutputSink.Unix.cs
@@ -9,11 +9,6 @@ namespace Xamarin.Android.Prepare
 			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{}
-
-			public override void WriteLine (string value)
-			{
-				base.WriteLine (value);
-			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.Unix.cs
@@ -18,8 +18,11 @@ namespace Xamarin.Android.Prepare
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (60);
 			string vs = VersionString.Trim ();
-			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out version))
+			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out Version? ver) || ver == null) {
 				version = new Version (0, 0);
+			} else {
+				version = ver;
+			}
 		}
 
 		public async Task<bool> Run (string logTag, string? workingDirectory = null, List<string>? arguments = null)

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.OutputSink.cs
@@ -14,11 +14,11 @@ namespace Xamarin.Android.Prepare
 				: base (log, logFilePath)
 			{}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				base.WriteLine (value);
 
-				if (!writeToStderr && value.StartsWith ("FAILED:", StringComparison.Ordinal)) {
+				if (!writeToStderr && value != null && value.StartsWith ("FAILED:", StringComparison.Ordinal)) {
 					writeToStderr = true;
 				}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.OutputSink.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Prepare
 				packageBullet = Context.Instance.Characters.Package;
 			}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				const string RestoringPackagePrefix = "Restoring NuGet package";
 				const string AllPackagesRestoredPrefix = "All packages listed in";
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Prepare
 					return;
 
 				string? consoleMessage = null;
-				if (value.StartsWith (RestoringPackagePrefix, StringComparison.OrdinalIgnoreCase)) {
+				if (value!.StartsWith (RestoringPackagePrefix, StringComparison.OrdinalIgnoreCase)) {
 					consoleMessage = $"{packageBullet} {value.Substring (RestoringPackagePrefix.Length).Trim ().TrimEnd ('.')}";
 				} else if (value.StartsWith (AllPackagesRestoredPrefix, StringComparison.OrdinalIgnoreCase)) {
 					consoleMessage = value.Trim ();

--- a/build-tools/xaprepare/xaprepare/ToolRunners/PkgutilRunner.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/PkgutilRunner.MacOS.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => GetToolExecutableName ();
 		protected override string ToolName                  => "PkgUtil";
 
-		public PkgutilRunner (Context context, Log log = null, string toolPath = null)
+		public PkgutilRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath)
 		{}
 
@@ -22,16 +22,16 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		public async Task<Version> GetPackageVersion (string packageId, bool echoOutput = false, bool echoError = true)
+		public async Task<Version?> GetPackageVersion (string packageId, bool echoOutput = false, bool echoError = true)
 		{
 			if (String.IsNullOrEmpty (packageId))
 				throw new ArgumentException ("must not be null or empty", nameof (packageId));
 
-			string output = Utilities.GetStringFromStdout (GetRunner (echoOutput, echoError, "--pkg-info", packageId))?.Trim ();
+			string output = Utilities.GetStringFromStdout (GetRunner (echoOutput, echoError, "--pkg-info", packageId)).Trim ();
 			if (String.IsNullOrEmpty (output))
 				return null;
 
-			string v = null;
+			string? v = null;
 			foreach (string l in output.Split ('\n')) {
 				if (GetFieldValue (l.Trim (), "version:", out v))
 					break;
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Prepare
 				return null;
 			}
 
-			if (!Version.TryParse (v, out Version pkgVer)) {
+			if (!Version.TryParse (v, out Version? pkgVer) || pkgVer == null) {
 				Log.ErrorLine ($"Failed to parse package {packageId} version from '{v}'");
 				return null;
 			}
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Prepare
 		}
 #pragma warning restore CS1998
 
-		bool GetFieldValue (string line, string name, out string v)
+		bool GetFieldValue (string line, string name, out string? v)
 		{
 			v = null;
 			if (String.IsNullOrEmpty (line))
@@ -83,7 +83,7 @@ namespace Xamarin.Android.Prepare
 
 		string GetToolExecutableName ()
 		{
-			EssentialTools tools = Context.Instance?.Tools;
+			EssentialTools? tools = Context.Instance?.Tools;
 
 			if (tools != null && tools.IsInitialized)
 				return tools.PkgutilPath;

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.OutputSink.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 				: base (log, logFilePath)
 			{}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				base.WriteLine (value);
 				if (String.IsNullOrEmpty (value))

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
@@ -21,8 +21,11 @@ namespace Xamarin.Android.Prepare
 			ProcessTimeout = TimeSpan.FromMinutes (DefaultTimeout);
 
 			string vs = VersionString.Trim ();
-			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out version))
+			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out Version? ver) || ver == null) {
 				version = new Version (0, 0);
+			} else {
+				version = ver;
+			}
 		}
 
 		public async Task<bool> Extract (string archivePath, string outputDirectory, List<string>? extraArguments = null)

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.OutputSink.cs
@@ -12,11 +12,6 @@ namespace Xamarin.Android.Prepare
 				: base (log, logFilePath)
 			{
 			}
-
-			public override void WriteLine (string value)
-			{
-				base.WriteLine (value);
-			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.OutputSink.cs
@@ -14,13 +14,6 @@ namespace Xamarin.Android.Prepare
 			{
 				Log.Todo ("Implement parsing, if necessary");
 			}
-
-			public override void WriteLine (string value)
-			{
-				base.WriteLine (value);
-				if (String.IsNullOrEmpty (value))
-					return;
-			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.OutputSink.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Prepare
 					Writer = new StreamWriter (File.Open (logFilePath, FileMode.Create, FileAccess.Write), Utilities.UTF8NoBOM);
 			}
 
-			public override void WriteLine (string value)
+			public override void WriteLine (string? value)
 			{
 				Writer?.WriteLine (value ?? String.Empty);
 			}

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Xamarin.Android.Prepare</RootNamespace>
     <AssemblyName>xaprepare</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/tools/vswhere/MSBuildLocator.cs
+++ b/tools/vswhere/MSBuildLocator.cs
@@ -54,8 +54,8 @@ namespace Xamarin.Android.Tools.VSWhere
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
 			using (var p = Process.Start (info)) {
-				p.WaitForExit ();
-				return p.StandardOutput.ReadToEnd ().Trim ();
+				p?.WaitForExit ();
+				return p?.StandardOutput.ReadToEnd ().Trim () ?? String.Empty;
 			}
 		}
 	}


### PR DESCRIPTION
Context: 94c2a3d86a2e0e74863b57e3c5c61dbd29daa9ea

94c2a3d8 suppressed NRT warnings in order to stop polluting build logs
with them.  Fix all the warnings and remove the suppression flag.