### PR TITLE
[build] Use `dotnet run` to update Mono

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ PREPARE_BUILD_LOG = bin/Build$(CONFIGURATION)/bootstrap-build.binlog
 PREPARE_RESTORE_LOG = bin/Build$(CONFIGURATION)/bootstrap-restore.binlog
 PREPARE_SOURCE_DIR = build-tools/xaprepare
 PREPARE_SOLUTION = $(PREPARE_SOURCE_DIR)/xaprepare.sln
+PREPARE_PROJECT = $(PREPARE_SOURCE_DIR)/xaprepare/xaprepare.csproj
 PREPARE_EXE = $(PREPARE_SOURCE_DIR)/xaprepare/bin/$(CONFIGURATION)/xaprepare.exe
 PREPARE_COMMON_MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(PREPARE_MSBUILD_ARGS) $(MSBUILD_ARGS)
 PREPARE_MSBUILD_FLAGS = /binaryLogger:"$(PREPARE_BUILD_LOG)" $(PREPARE_COMMON_MSBUILD_FLAGS)
@@ -225,8 +226,8 @@ shutdown-compiler-server:
 	fi
 
 .PHONY: prepare-update-mono
-prepare-update-mono: prepare-build shutdown-compiler-server
-	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:UpdateMono
+prepare-update-mono: shutdown-compiler-server
+	dotnet run -c $(CONFIGURATION) -v:n --project "$(PREPARE_PROJECT)" --framework net6.0 -- "-s:UpdateMono" $(_PREPARE_ARGS)
 
 prepare-external-git-dependencies: prepare-build
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS) -s:PrepareExternalGitDependencies


### PR DESCRIPTION
We've seen a couple of PR builds fail recently with the following:

    "/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/xaprepare/xaprepare/xaprepare.csproj" (Build target) (2:3) ->
    (GetReferenceAssemblyPaths target) ->
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(1232,5): error MSB3971: The reference assemblies for ".NETFramework,Version=v6.0" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK. [/Users/builder/azdo/_work/2/s/xamarin-android/build-tools/xaprepare/xaprepare/xaprepare.csproj]

This appears to only be happening when the Mono installation on disk is
too old to support .NET 6.  We can fix this by using `dotnet` to update
Mono.