### PR TITLE
[Mono.Android] Pass frameworks.xml file to mdoc

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -311,6 +311,7 @@
       <_AssemblyBasename>$(OutputPath)Mono.Android</_AssemblyBasename>
       <_ImportXml>-i "$(_AssemblyBasename).xml"</_ImportXml>
       <_Assembly>$(_AssemblyBasename).dll</_Assembly>
+      <_JIAssembly>$(OutputPath)../v1.0/Java.Interop.dll</_JIAssembly>
       <_Output>-o "$(MSBuildThisFileDirectory)../../external/android-api-docs/docs/Mono.Android/en"</_Output>
       <_DocTypeArgs Condition=" '$(DocTypeName)' != '' ">--type=$(DocTypeName)</_DocTypeArgs>
       <_FxMoniker>xamarin-android-sdk-12</_FxMoniker>
@@ -327,12 +328,12 @@
       </FrameworksXmlContent>
     </PropertyGroup>
     <!-- Create a temporary directory which contains frameworks.xml and our framework assembly.
-         Copy Mono.Android.dll to the %(Source) path described in frameworks.xml (e.g. xamarin-android-sdk-12) -->
+         Copy Mono.Android.dll and Java.Interop.dll to the %(Source) path described in frameworks.xml (e.g. xamarin-android-sdk-12) -->
     <RemoveDir Directories="$(_RootFxDir)" />
     <MakeDir Directories="$(_RootFxDir)" />
     <MakeDir Directories="$(_RootFxDir)$(_FxMoniker)" />
     <Copy
-        SourceFiles="$(_Assembly)"
+        SourceFiles="$(_Assembly);$(_JIAssembly)"
         DestinationFolder="$(_RootFxDir)$(_FxMoniker)"
     />
     <WriteLinesToFile

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="mdoc"
-        PackageVersion="5.8.0"
+        Version="5.8.5"
         GeneratePathProperty="True"
         ReferenceOutputAssembly="False"
         SkipGetTargetFrameworkProperties="True"
@@ -313,7 +313,7 @@
       <_Assembly>$(_AssemblyBasename).dll</_Assembly>
       <_Output>-o "$(MSBuildThisFileDirectory)../../external/android-api-docs/docs/Mono.Android/en"</_Output>
       <_DocTypeArgs Condition=" '$(DocTypeName)' != '' ">--type=$(DocTypeName)</_DocTypeArgs>
-      <_LatestFxMoniker>xamarin-android-sdk-12</_LatestFxMoniker>
+      <_FxMoniker>xamarin-android-sdk-12</_FxMoniker>
       <_RootFxDir>$(BaseIntermediateOutputPath)docs-gen-temp/</_RootFxDir>
       <_FxConfig>-fx "$(_RootFxDir)"</_FxConfig>
       <!-- $(FrameworksXmlContent) describes the docs versions found at android-api-docs/tree/master/docs/Mono.Android/en/FrameworksIndex/
@@ -321,8 +321,7 @@
       <FrameworksXmlContent>
 <![CDATA[
 <Frameworks>
-  <Framework Name="$(_LatestFxMoniker)" Source="$(_LatestFxMoniker)" />
-  <Framework Name="xamarin-android-sdk-9" Source="xamarin-android-sdk-9" />
+  <Framework Name="$(_FxMoniker)" Source="$(_FxMoniker)" />
 </Frameworks>
 ]]>
       </FrameworksXmlContent>
@@ -331,10 +330,10 @@
          Copy Mono.Android.dll to the %(Source) path described in frameworks.xml (e.g. xamarin-android-sdk-12) -->
     <RemoveDir Directories="$(_RootFxDir)" />
     <MakeDir Directories="$(_RootFxDir)" />
-    <MakeDir Directories="$(_RootFxDir)$(_LatestFxMoniker)" />
+    <MakeDir Directories="$(_RootFxDir)$(_FxMoniker)" />
     <Copy
         SourceFiles="$(_Assembly)"
-        DestinationFolder="$(_RootFxDir)$(_LatestFxMoniker)"
+        DestinationFolder="$(_RootFxDir)$(_FxMoniker)"
     />
     <WriteLinesToFile
         File="$(_RootFxDir)frameworks.xml"

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -310,12 +310,38 @@
       <_Libdir>-L "$(OutputPath)../v1.0"</_Libdir>
       <_AssemblyBasename>$(OutputPath)Mono.Android</_AssemblyBasename>
       <_ImportXml>-i "$(_AssemblyBasename).xml"</_ImportXml>
-      <_Assembly>"$(_AssemblyBasename).dll"</_Assembly>
+      <_Assembly>$(_AssemblyBasename).dll</_Assembly>
       <_Output>-o "$(MSBuildThisFileDirectory)../../external/android-api-docs/docs/Mono.Android/en"</_Output>
       <_DocTypeArgs Condition=" '$(DocTypeName)' != '' ">--type=$(DocTypeName)</_DocTypeArgs>
+      <_LatestFxMoniker>xamarin-android-sdk-12</_LatestFxMoniker>
+      <_RootFxDir>$(BaseIntermediateOutputPath)docs-gen-temp/</_RootFxDir>
+      <_FxConfig>-fx "$(_RootFxDir)"</_FxConfig>
+      <!-- $(FrameworksXmlContent) describes the docs versions found at android-api-docs/tree/master/docs/Mono.Android/en/FrameworksIndex/
+            and https://docs.microsoft.com/en-us/dotnet/api/android?view=xamarin-android-sdk-9 -->
+      <FrameworksXmlContent>
+<![CDATA[
+<Frameworks>
+  <Framework Name="$(_LatestFxMoniker)" Source="$(_LatestFxMoniker)" />
+  <Framework Name="xamarin-android-sdk-9" Source="xamarin-android-sdk-9" />
+</Frameworks>
+]]>
+      </FrameworksXmlContent>
     </PropertyGroup>
+    <!-- Create a temporary directory which contains frameworks.xml and our framework assembly.
+         Copy Mono.Android.dll to the %(Source) path described in frameworks.xml (e.g. xamarin-android-sdk-12) -->
+    <RemoveDir Directories="$(_RootFxDir)" />
+    <MakeDir Directories="$(_RootFxDir)" />
+    <MakeDir Directories="$(_RootFxDir)$(_LatestFxMoniker)" />
+    <Copy
+        SourceFiles="$(_Assembly)"
+        DestinationFolder="$(_RootFxDir)$(_LatestFxMoniker)"
+    />
+    <WriteLinesToFile
+        File="$(_RootFxDir)frameworks.xml"
+        Lines="$(FrameworksXmlContent)"
+    />
     <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_Assembly) "
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>


### PR DESCRIPTION
A `frameworks.xml` file will now be passed to `mdoc.exe` when updating
external API docs.  This file contains the metadata required to find
and update or create [FrameworksIndex files][0].

The version of `Mono.Android.dll` used to generate docs will no longer
be passed to `mdoc.exe`.  Instead, it will be copied to the relative
`%(Source)` directory described in `frameworks.xml` to be resolved
automatically.

The `mdoc` package version has also been fixed, and we'll now use
`5.8.0` instead of `5.0.0.25`.

Includes the following Java.Interop update:
https://github.com/xamarin/java.interop/compare/dcdcce13220d98a848ae3d3598b9b87b22a62c84...087684a70bb71a84c0afb7423c27b50bafb74fb2

[0]: https://github.com/xamarin/android-api-docs/tree/cd414a93057b6f61afcdd3db6ff44391fb166246/docs/Mono.Android/en/FrameworksIndex