### PR TITLE
[ci] Build with stable .NET 6 release

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -18,7 +18,7 @@ variables:
 - name: NUnit.NumberOfTestWorkers
   value: 4
 - name: DotNet6Version
-  value: 6.0.100-rc.2.21505.57
+  value: 6.0.100
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage


### PR DESCRIPTION
Bumps the system .NET 6 install from RC 2 to the official stable build.