### PR TITLE
[Xamarin.Android.Build.Tasks] Profiled AOT can Full AOT the main assembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -30,7 +30,7 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
     <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64" />
   </ImportGroup>
 
-  <UsingTask TaskName="Xamarin.Android.Tasks.GetAotArguments" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.GetAotAssemblies" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <Target Name="_AndroidAotInputs">
     <ItemGroup>
@@ -43,7 +43,10 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
       DependsOnTargets="_AndroidAotInputs"
       Inputs="@(_AndroidAotInputs)"
       Outputs="$(_AndroidStampDirectory)_AndroidAot.stamp">
-    <GetAotArguments
+    <ItemGroup>
+      <AndroidAotProfile Include="$(MSBuildThisFileDirectory)dotnet.aotprofile" Condition=" '$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' != 'false' " />
+    </ItemGroup>
+    <GetAotAssemblies
         AndroidAotMode="$(AndroidAotMode)"
         AndroidNdkDirectory="$(_AndroidNdkDirectory)"
         AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
@@ -51,31 +54,23 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         MinimumSupportedApiLevel="$(AndroidMinimumSupportedApiLevel)"
         AndroidSequencePointsMode="$(_SequencePointsMode)"
         AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
+        TargetName="$(TargetName)"
+        ResolvedAssemblies="@(_AndroidAotInputs)"
         AotOutputDirectory="$(_AndroidAotBinDirectory)"
         RuntimeIdentifier="$(RuntimeIdentifier)"
         EnableLLVM="$(EnableLLVM)"
         UsingAndroidNETSdk="true"
-        Profiles="@(_AotProfiles)">
-      <Output PropertyName="_AotArguments" TaskParameter="Arguments" />
-      <Output PropertyName="_AotOutputDirectory" TaskParameter="OutputDirectory" />
-    </GetAotArguments>
+        Profiles="@(AndroidAotProfile)">
+      <Output ItemName="_MonoAOTAssemblies" TaskParameter="ResolvedAssemblies" />
+    </GetAotAssemblies>
     <PropertyGroup>
       <_MonoAOTCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', '$(RuntimeIdentifier)'))</_MonoAOTCompilerPath>
       <_LLVMPath Condition=" '$(EnableLLVM)' == 'true' ">$([System.IO.Path]::GetDirectoryName ('$(_MonoAOTCompilerPath)'))</_LLVMPath>
     </PropertyGroup>
-    <ItemGroup>
-      <_MonoAOTAssemblies
-          Include="@(_AndroidAotInputs->'%(FullPath)')"
-          TempDirectory="$([MSBuild]::EnsureTrailingSlash($(_AotOutputDirectory)))%(FileName)"
-          AotArguments="$(_AotArguments),temp-path=$([System.IO.Path]::GetFullPath(%(_MonoAOTAssemblies.TempDirectory)))"
-      />
-      <AndroidAotProfile Include="$(MSBuildThisFileDirectory)dotnet.aotprofile" Condition=" '$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' != 'false' " />
-    </ItemGroup>
-    <MakeDir Directories="$(IntermediateOutputPath)aot\;@(_MonoAOTAssemblies->'%(TempDirectory)')" />
+    <MakeDir Directories="$(IntermediateOutputPath)aot\" />
     <MonoAOTCompiler
-        Assemblies="@(_MonoAOTAssemblies)"
+        Assemblies="@(_MonoAOTAssemblies->'%(FullPath)')"
         CompilerBinaryPath="$(_MonoAOTCompilerPath)"
-        AotProfilePath="@(AndroidAotProfile->'%(FullPath)')"
         DisableParallelAot="$(_DisableParallelAot)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
         LibraryFormat="So"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -32,9 +32,6 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "AOT";
 
-		[Required]
-		public ITaskItem[] ResolvedAssemblies { get; set; }
-
 		// Which ABIs to include native libs for
 		[Required]
 		public string [] SupportedAbis { get; set; }
@@ -145,6 +142,17 @@ namespace Xamarin.Android.Tasks
 					aotOptions.Insert (0, $"outfile={outputFile}");
 					aotOptions.Insert (0, $"llvm-path={SdkBinDirectory}");
 					aotOptions.Insert (0, $"temp-path={tempDir}");
+					if (Profiles != null && Profiles.Length > 0) {
+						if (Path.GetFileNameWithoutExtension (assembly.ItemSpec) == TargetName) {
+							LogDebugMessage ($"Not using profile(s) for main assembly: {assembly.ItemSpec}");
+						} else {
+							aotOptions.Add ("profile-only");
+							foreach (var p in Profiles) {
+								var fp = Path.GetFullPath (p.ItemSpec);
+								aotOptions.Add ($"profile={fp}");
+							}
+						}
+					}
 
 					// we need to quote the entire --aot arguments here to make sure it is parsed
 					// on windows as one argument. Otherwise it will be split up into multiple

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Android.Build.Tasks;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Called in .NET 6+ to populate %(AotArguments) metadata in the ResolvedAssemblies [Output] property.
+	/// </summary>
+	public class GetAotAssemblies : GetAotArguments
+	{
+		public override string TaskPrefix => "GAOT";
+
+		public override Task RunTaskAsync ()
+		{
+			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
+			if (ndk == null) {
+				return Task.CompletedTask; // NdkTools.Create will log appropriate error
+			}
+
+			bool hasValidAotMode = GetAndroidAotMode (AndroidAotMode, out AotMode);
+			if (!hasValidAotMode) {
+				LogCodedError ("XA3002", Properties.Resources.XA3002, AndroidAotMode);
+				return Task.CompletedTask;
+			}
+
+			if (AotMode == AotMode.Interp) {
+				LogDebugMessage ("Interpreter AOT mode enabled");
+				return Task.CompletedTask;
+			}
+
+			TryGetSequencePointsMode (AndroidSequencePointsMode, out SequencePointsMode);
+
+			SdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
+
+			var abi = AndroidRidAbiHelper.RuntimeIdentifierToAbi (RuntimeIdentifier);
+			if (string.IsNullOrEmpty (abi)) {
+				Log.LogCodedError ("XA0035", Properties.Resources.XA0035, RuntimeIdentifier);
+				return Task.CompletedTask;
+			}
+
+			(_, string outdir, string mtriple, AndroidTargetArch arch) = GetAbiSettings (abi);
+			string toolPrefix = GetToolPrefix (ndk, arch, out int level);
+
+			var aotOptions = GetAotOptions (ndk, arch, level, outdir, mtriple, toolPrefix);
+
+			var aotProfiles = new StringBuilder ();
+			if (Profiles != null && Profiles.Length > 0) {
+				aotProfiles.Append (",profile-only");
+				foreach (var p in Profiles) {
+					var fp = Path.GetFullPath (p.ItemSpec);
+					aotProfiles.Append (",profile=");
+					aotProfiles.Append (fp);
+				}
+			}
+
+			var arguments = string.Join (",", aotOptions);
+			foreach (var assembly in ResolvedAssemblies) {
+				var temp = Path.GetFullPath (Path.Combine (outdir, Path.GetFileNameWithoutExtension (assembly.ItemSpec)));
+				Directory.CreateDirectory (temp);
+				if (Path.GetFileNameWithoutExtension (assembly.ItemSpec) == TargetName) {
+					LogDebugMessage ($"Not using profile(s) for main assembly: {assembly.ItemSpec}");
+					assembly.SetMetadata ("AotArguments", $"{arguments},temp-path={temp}");
+				} else {
+					assembly.SetMetadata ("AotArguments", $"{arguments},temp-path={temp}{aotProfiles}");
+				}
+			}
+
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -700,6 +700,7 @@ projects. .NET 5 projects will not import this file.
         AndroidSequencePointsMode="$(_SequencePointsMode)"
         AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
         ExtraAotOptions="$(AndroidExtraAotOptions)"
+        TargetName="$(TargetName)"
         ResolvedAssemblies="@(_ShrunkAssemblies)"
         AotOutputDirectory="$(_AndroidAotBinDirectory)"
         IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
@@ -245,7 +245,7 @@
       "Size": 13656
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 10648
+      "Size": 260040
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
       "Size": 1333820
@@ -389,7 +389,7 @@
       "Size": 21520
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 14488
+      "Size": 178024
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
       "Size": 1182700
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 17233092
+  "PackageSize": 17417412
 }


### PR DESCRIPTION
When using the built-in profiles for Profiled AOT, one drawback is the
user's code isn't AOT'd. We only AOT types that are called in the BCL,
`Java.Interop.dll`, `Mono.Android.dll`, etc.

To make this better, we can full AOT the "main" assembly. Most code in
users' main assembly would likely get called on startup. This should
have a minor impact to `.apk` size, but gain us a better startup boost
by default.

When testing, I can see more methods AOT'd:

    11-11 09:01:01.441 16386 16386 D Mono    : AOT: FOUND method foo.MainActivity:OnCreate (Android.OS.Bundle) [0x7c050e8e20f0 - 0x7c050e8e213b 0x7c050e8e2673]

## Results ##

A `dotnet new android` app, built with:

    > dotnet build -c Release -p:AndroidEnableProfiledAot=true -p:RunAOTCompilation=true -r android-arm64 -p:AndroidPackageFormat=apk

File size:

    > apkdiff -f before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +       5,632 lib/arm64-v8a/libaot-foo.dll.so
    +           5 assemblies/assemblies.blob
    Summary:
    +           5 Other entries 0.00% (of 787,048)
    +           0 Dalvik executables 0.00% (of 345,340)
    +       5,632 Shared libraries 0.09% (of 6,008,168)
    +           0 Package size difference 0.00% (of 3,169,571)

10 runs on a Pixel 5 was an average of 193ms before, and 192ms after
(the `Activity Displayed` time). There may, in fact, not be a
difference for `dotnet new android`.

Next I installed .NET MAUI 6.0.101-preview.11.2149, and tried a
`dotnet new maui` app:

File size:

    > apkdiff -f before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +      67,144 lib/arm64-v8a/libaot-foo.dll.so
    Summary:
    +           0 Other entries 0.00% (of 7,765,174)
    +           0 Dalvik executables 0.00% (of 6,443,152)
    +      67,144 Shared libraries 0.50% (of 13,388,688)
    +      20,480 Package size difference 0.14% (of 14,272,332)

10 runs on a Pixel 5:

    Before:
    Activity: Displayed     656ms
    Activity: Displayed     635ms
    Activity: Displayed     623ms
    Activity: Displayed     633ms
    Activity: Displayed     660ms
    Activity: Displayed     655ms
    Activity: Displayed     634ms
    Activity: Displayed     646ms
    Activity: Displayed     628ms
    Activity: Displayed     646ms
    Activity: Displayed     630ms
    -------------------------------
    Average                 641ms

    After:
    Activity: Displayed     679ms
    Activity: Displayed     644ms
    Activity: Displayed     607ms
    Activity: Displayed     620ms
    Activity: Displayed     623ms
    Activity: Displayed     615ms
    Activity: Displayed     619ms
    Activity: Displayed     623ms
    Activity: Displayed     617ms
    Activity: Displayed     631ms
    Activity: Displayed     623ms
    -------------------------------
    Average                 627ms

I think this might help startup by ~14ms in a `dotnet new maui` app.
It would likely improve more depending on the app.