### PR TITLE
[build] Use dotnet build for make prepare

### DIFF
--- a/build-tools/automation/yaml-templates/install-apkdiff.yaml
+++ b/build-tools/automation/yaml-templates/install-apkdiff.yaml
@@ -1,5 +1,5 @@
 parameters:
-  version: '0.0.14'
+  version: '0.0.15'
   condition: succeeded()
   continueOnError: true
 

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -49,9 +49,9 @@ define MSBUILD_BINLOG
 		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/$(if $(3),$(3),Build)$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 
-# $(call DOTNET_BINLOG,name,dotnet=$(DOTNET_TOOL)) build=$(DOTNET_VERB)
+# $(call DOTNET_BINLOG,name,build=$(DOTNET_VERB),dotnet=$(DOTNET_TOOL))
 define DOTNET_BINLOG
-	$(if $(2),$(2),$(DOTNET_TOOL)) $(DOTNET_VERB) -c $(CONFIGURATION) -v:n \
+	$(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -c $(CONFIGURATION) -v:n \
 		-bl:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Prepare
 			new HomebrewProgram ("ccache"),
 			new HomebrewProgram ("cmake"),
 
-			new HomebrewProgram ("git", new Uri("https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/git.rb"), "/usr/local/bin/git") {
+			new HomebrewProgram ("git") {
 				MinimumVersion = "2.20.0",
 			},
 

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_CopyExtraResultFilesForCI.cs
@@ -7,13 +7,13 @@ namespace Xamarin.Android.Prepare
 	{
 		public Scenario_CopyExtraResultFilesForCI () 
 			: base ("CopyExtraResultFilesForCI", "Copy extra result files to artifact directory")
-		{
-			// Do not create a log that we would attempt to copy during this scenario.
-			Log.Instance.SetLogFile (Path.Combine (Context.Instance.LogDirectory, $"package-results-{Context.Instance.BuildTimeStamp}.txt"));
-		}
+		{}
 
 		protected override void AddSteps (Context context)
 		{
+			// Do not write to a log that we would attempt to copy during this scenario.
+			Log.Instance.SetLogFile (Path.Combine (context.LogDirectory, $"package-results-{context.BuildTimeStamp}.txt"));
+
 			Steps.Add (new Step_CopyExtraResultFilesForCI ());
 
 			// disable installation of missing programs...

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -19,18 +19,12 @@ namespace Xamarin.Android.Prepare
 			dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
 			var dotnetTool = Path.Combine (dotnetPath, "dotnet");
 			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion);
-			var dotnetTestRuntimeVersion = Configurables.Defaults.DotNetTestRuntimeVersion;
 
 			// Always delete the ~/android-toolchain/dotnet/ directory
 			Utilities.DeleteDirectory (dotnetPath);
 
 			if (!await InstallDotNetAsync (context, dotnetPath, dotnetPreviewVersion)) {
 				Log.ErrorLine ($"Installation of dotnet SDK {dotnetPreviewVersion} failed.");
-				return false;
-			}
-
-			if (!await InstallDotNetAsync (context, dotnetPath, dotnetTestRuntimeVersion, runtimeOnly: true)) {
-				Log.ErrorLine ($"Installation of dotnet runtime {dotnetTestRuntimeVersion} failed.");
 				return false;
 			}
 


### PR DESCRIPTION
The prepare related make targets have been updated to use `dotnet` over
`msbuild` or `mono`.

Includes an `apkdiff` bump to allow the tool to run against newer
versions of .NET, which will allow us to stop provisioning the .NET core
3.1 runtime.

Homebrew provisioning of `git` has been updated as installing
from a URL is no longer supported.

A small fix has been made in xaprepare to prevent log files from being
named renamed to `package-results-*` when running a different scenario.