### PR TITLE
[Mono.Android] Update F# API docs

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -317,6 +317,7 @@
       <_FxMoniker>xamarin-android-sdk-12</_FxMoniker>
       <_RootFxDir>$(BaseIntermediateOutputPath)docs-gen-temp/</_RootFxDir>
       <_FxConfig>-fx "$(_RootFxDir)"</_FxConfig>
+      <_Lang>--lang fsharp</_Lang>
       <!-- $(FrameworksXmlContent) describes the docs versions found at android-api-docs/tree/master/docs/Mono.Android/en/FrameworksIndex/
             and https://docs.microsoft.com/en-us/dotnet/api/android?view=xamarin-android-sdk-9 -->
       <FrameworksXmlContent>
@@ -341,7 +342,7 @@
         Lines="$(FrameworksXmlContent)"
     />
     <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig)"
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_Lang)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>


### PR DESCRIPTION
The `--lang` parameter will now be passed to `mdoc.exe` when updating
external API docs.  This should fix a `<TypeSignature />` ordering
issue.  If this parameter is not specified, some `F#` doc entries will
end up being listed before `C#` entries when updating existing docs that
contain `F#` data.