### PR TITLE
[Mono.Android] Enable api-since metadata for API-32.

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1670,6 +1670,8 @@
   <attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-R.xml.in')]" name="no-alternatives">true</attr>
   <attr api-since="31" path="/api/package/interface[contains(@merge.SourceFile,'api-31.xml.in')]" name="no-alternatives">true</attr>
   <attr api-since="31" path="/api/package/interface[contains(@merge.SourceFile,'api-S.xml.in')]" name="no-alternatives">true</attr>
+  <attr api-since="32" path="/api/package/interface[contains(@merge.SourceFile,'api-32.xml.in')]" name="no-alternatives">true</attr>
+  <attr api-since="32" path="/api/package/interface[contains(@merge.SourceFile,'api-Sv2.xml.in')]" name="no-alternatives">true</attr>
 
   <!-- Set ApiSince based on merge sourcefile. -->
   <attr api-since="22" path="/api//*[contains(@merge.SourceFile,'api-22.xml.in')]" name="api-since">22</attr>
@@ -1684,4 +1686,6 @@
   <attr api-since="30" path="/api//*[contains(@merge.SourceFile,'api-R.xml.in')]" name="api-since">30</attr>
   <attr api-since="31" path="/api//*[contains(@merge.SourceFile,'api-31.xml.in')]" name="api-since">31</attr>
   <attr api-since="31" path="/api//*[contains(@merge.SourceFile,'api-S.xml.in')]" name="api-since">31</attr>
+  <attr api-since="32" path="/api//*[contains(@merge.SourceFile,'api-32.xml.in')]" name="api-since">32</attr>
+  <attr api-since="32" path="/api//*[contains(@merge.SourceFile,'api-Sv2.xml.in')]" name="api-since">32</attr>
 </metadata>


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android/pull/6452  we did not add the required per-API-level `metadata` that enables the `ApiSince` (and thus `[SupportedOSPlatform]`) annotations.  This means that these APIs show as being available on all API levels.

Adding the required `metadata` produces the expected annotations:

```csharp
// Metadata.xml XPath method reference: path="/api/package[@name='android.app']/class[@name='WallpaperInfo']/method[@name='shouldUseDefaultDeviceStateChangeTransition' and count(parameter)=0]"
[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android32.0")]
[Register ("shouldUseDefaultDeviceStateChangeTransition", "()Z", "", ApiSince = 32)]
public unsafe bool ShouldUseDefaultDeviceStateChangeTransition ()
{
	const string __id = "shouldUseDefaultDeviceStateChangeTransition.()Z";
	try {
		var __rm = _members.InstanceMethods.InvokeAbstractBooleanMethod (__id, this, null);
		return __rm;
	} finally {
	}
}
```

This is correctly listed in the [documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/HowToAddNewApiLevel.md#building-the-new-monoandroid) but was missed.