### PR TITLE
[One .NET] add "preview" packs for API 32

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -33,6 +33,10 @@
     <AndroidLatestStableApiLevel Condition="'$(AndroidLatestStableApiLevel)' == ''">31</AndroidLatestStableApiLevel>
     <AndroidLatestStablePlatformId Condition="'$(AndroidLatestStablePlatformId)' == ''">$(AndroidLatestStableApiLevel)</AndroidLatestStablePlatformId>
     <AndroidLatestStableFrameworkVersion Condition="'$(AndroidLatestStableFrameworkVersion)'==''">v12.0</AndroidLatestStableFrameworkVersion>
+    <!-- *Latest* *unstable* API level binding that we support; this can be the same as *stable* -->
+    <AndroidLatestUnstableApiLevel Condition="'$(AndroidLatestUnstableApiLevel)' == ''">32</AndroidLatestUnstableApiLevel>
+    <AndroidLatestUnstablePlatformId Condition="'$(AndroidLatestUnstablePlatformId)' == ''">Sv2</AndroidLatestUnstablePlatformId>
+    <AndroidLatestUnstableFrameworkVersion Condition="'$(AndroidLatestUnstableFrameworkVersion)'==''">v12.0.99</AndroidLatestUnstableFrameworkVersion>
     <!-- The API level and TargetFrameworkVersion for the default Mono.Android.dll build -->
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">$(AndroidLatestStableApiLevel)</AndroidApiLevel>
     <AndroidPlatformId Condition=" '$(AndroidPlatformId)' == '' ">$(AndroidLatestStablePlatformId)</AndroidPlatformId>
@@ -52,7 +56,7 @@
     <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
     <_XABinRelativeInstallPrefix>lib\xamarin.android</_XABinRelativeInstallPrefix>
     <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)bin\$(Configuration)\$(_XABinRelativeInstallPrefix)\</XAInstallPrefix>
-    <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0\</_MonoAndroidNETOutputDir>
+    <_MonoAndroidNETOutputDir>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidApiLevel)\</_MonoAndroidNETOutputDir>
     <MingwDependenciesRootDirectory Condition=" '$(MingwDependenciesRootDirectory)' == '' ">$(MSBuildThisFileDirectory)\bin\Build$(Configuration)\mingw-deps</MingwDependenciesRootDirectory>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx64)</HostCxx>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -52,9 +52,21 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CreateAllPacks"
-      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo">
+  <Target Name="_CleanNuGetDirectory">
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
+  </Target>
+
+  <Target Name="_CreatePreviewPacks"
+      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+  </Target>
+
+  <Target Name="CreateAllPacks"
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks">
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -107,13 +119,16 @@
     </PropertyGroup>
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
+      <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\*$(AndroidLatestUnstableApiLevel)*.nupkg" />
+      <_InstallArguments Include="android-aot" />
+      <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />
       <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
     </ItemGroup>
     <MakeDir Directories="$(_TempDirectory)" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install android-aot @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
     <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
 

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -2,7 +2,7 @@
 ***********************************************************************************************
 Microsoft.Android.Ref.proj
 
-This project file is used to create the Microsoft.Android.Ref NuGet, which is the
+This project file is used to create the Microsoft.Android.[API].Ref NuGet, which is the
 targeting pack containing reference assemblies and other compile time assets required
 by projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
@@ -10,8 +10,8 @@ by projects that use the Microsoft.Android framework in .NET 5.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <PackageId>Microsoft.Android.Ref</PackageId>
-    <Description>Microsoft.Android reference assemblies. Please do not reference directly.</Description>
+    <PackageId>Microsoft.Android.$(AndroidApiLevel).Ref</PackageId>
+    <Description>Microsoft.Android reference assemblies for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRefPackAssemblyPath>ref\net6.0</_AndroidRefPackAssemblyPath>
   </PropertyGroup>
 
@@ -33,7 +33,8 @@ by projects that use the Microsoft.Android framework in .NET 5.
     <ItemGroup>
       <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net6.0\ref\Java.Interop.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.dll" />
-      <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputDir)ref\Mono.Android.Export.dll" />
+      <!-- Always include stable Mono.Android.Export.dll -->
+      <_AndroidRefPackAssemblies Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestStableApiLevel)\ref\Mono.Android.Export.dll" />
       <FrameworkListFileClass Include="@(_AndroidRefPackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />
     </ItemGroup>
 
@@ -43,7 +44,6 @@ by projects that use the Microsoft.Android framework in .NET 5.
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)Mono.Android.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputDir)mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(_MonoAndroidNETOutputDir)AndroidApiInfo.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
     </ItemGroup>
   </Target>
 

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -2,7 +2,7 @@
 ***********************************************************************************************
 Microsoft.Android.Runtime.proj
 
-This project file is used to create Microsoft.Android.Runtime NuGets, which are
+This project file is used to create Microsoft.Android.[API].Runtime NuGets, which are
 runtime packs that contain the assets required for a self-contained publish of
 projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
@@ -12,8 +12,8 @@ projects that use the Microsoft.Android framework in .NET 5.
   <PropertyGroup>
     <AndroidRID Condition=" '$(AndroidRID)' == '' ">android-arm64</AndroidRID>
     <AndroidABI Condition=" '$(AndroidABI)' == '' ">arm64-v8a-net6</AndroidABI>
-    <PackageId>Microsoft.Android.Runtime.$(AndroidRID)</PackageId>
-    <Description>Microsoft.Android runtime components. Please do not reference directly.</Description>
+    <PackageId>Microsoft.Android.$(AndroidApiLevel).Runtime.$(AndroidRID)</PackageId>
+    <Description>Microsoft.Android runtime components for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\net6.0</_AndroidRuntimePackAssemblyPath>
     <_AndroidRuntimePackNativePath>runtimes\$(AndroidRID)\native</_AndroidRuntimePackNativePath>
   </PropertyGroup>
@@ -34,9 +34,10 @@ projects that use the Microsoft.Android framework in .NET 5.
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputDir)Java.Interop.dll" />
+      <_AndroidRuntimePackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net6.0\Java.Interop.dll" />
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputDir)Mono.Android.dll" />
-      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputDir)Mono.Android.Export.dll" />
+      <!-- Always include stable Mono.Android.Export.dll -->
+      <_AndroidRuntimePackAssemblies Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />
       <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.debug.so" />
       <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.release.so" />
       <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libxamarin-debug-app-helper.so" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -62,6 +62,8 @@ core workload SDK packs imported by WorkloadManifest.targets.
     />
 
     <ItemGroup>
+      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" />
+      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml" Condition="Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml')" />
       <!-- Microsoft.Android.Sdk.ILLink output -->
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.dll" PackagePath="tools" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.pdb" PackagePath="tools" />
@@ -78,6 +80,7 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" PackagePath="PreserveLists" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\**" PackagePath="targets" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\dotnet.aotprofile" PackagePath="targets" />
+      <_PackageFiles Include="@(_AndroidApiInfo)" DirectoryName="$([System.IO.Path]::GetDirectoryName ('%(Identity)'))" PackagePath="data\$([System.IO.Path]::GetFileName ('%(_PackageFiles.DirectoryName)'))" />
       <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <None Include="$(MSBuildThisFileDirectory)SignList.xml" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
@@ -112,6 +115,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <AndroidNETSdkVersion>$(AndroidPackVersionLong)</AndroidNETSdkVersion>
     <XamarinAndroidVersion>$(AndroidPackVersionLong)</XamarinAndroidVersion>
+    <_AndroidRuntimePackId Condition=" '%24(TargetPlatformVersion)' != '$(AndroidLatestUnstableApiLevel).0' ">$(AndroidLatestStableApiLevel)</_AndroidRuntimePackId>
+    <_AndroidRuntimePackId Condition=" '%24(TargetPlatformVersion)' == '$(AndroidLatestUnstableApiLevel).0' ">$(AndroidLatestUnstableApiLevel)</_AndroidRuntimePackId>
   </PropertyGroup>
   <ItemGroup>
     <KnownFrameworkReference
@@ -120,9 +125,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         RuntimeFrameworkName="Microsoft.Android"
         DefaultRuntimeFrameworkVersion="**FromWorkload**"
         LatestRuntimeFrameworkVersion="**FromWorkload**"
-        TargetingPackName="Microsoft.Android.Ref"
+        TargetingPackName="Microsoft.Android.%24(_AndroidRuntimePackId).Ref"
         TargetingPackVersion="**FromWorkload**"
-        RuntimePackNamePatterns="Microsoft.Android.Runtime.**RID**"
+        RuntimePackNamePatterns="Microsoft.Android.%24(_AndroidRuntimePackId).Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
         Profile="Android"
     />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -61,4 +61,17 @@
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install maui-android @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
     <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
+  <Target Name="BuildDotNetPreviewApiLevel">
+    <ItemGroup>
+      <_DotNetPreviewProperties Include="TargetFramework=net6.0" />
+      <_DotNetPreviewProperties Include="AndroidApiLevel=$(AndroidLatestUnstableApiLevel)" />
+      <_DotNetPreviewProperties Include="AndroidPlatformId=$(AndroidLatestUnstablePlatformId)" />
+      <_DotNetPreviewProperties Include="AndroidFrameworkVersion=$(AndroidLatestUnstableFrameworkVersion)" />
+      <_DotNetPreviewProperties Include="AndroidPreviousFrameworkVersion=$(AndroidLatestStableFrameworkVersion)" />
+    </ItemGroup>
+    <MSBuild
+        Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
+        Properties="@(_DotNetPreviewProperties)"
+    />
+  </Target>
 </Project>

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
 
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <!-- Only build for net6.0 for $(AndroidLatestStableFrameworkVersion) -->
-    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(AndroidFrameworkVersion)' == '$(AndroidLatestStableFrameworkVersion)' ">monoandroid10;net6.0</TargetFrameworks>
+    <TargetFrameworks>monoandroid10;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoStdLib>true</NoStdLib>
     <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
@@ -19,11 +19,10 @@
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
     <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\</OutputPath>
+    <OutputPath>$(_MonoAndroidNETOutputDir)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
@@ -53,12 +52,14 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <!-- Only build the 'net6.0' version of 'Mono.Android.Export.dll' for the latest stable Android version or higher. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidLatestStableApiLevel)' ">
+    <BuildDependsOn></BuildDependsOn>
+  </PropertyGroup>
 
 </Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -33,7 +33,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\$(TargetFramework)\</OutputPath>
+    <DefineConstants Condition=" '$(AndroidApiLevel)' &gt; '$(AndroidLatestStableApiLevel)' ">$(DefineConstants);ANDROID_UNSTABLE</DefineConstants>
+    <OutputPath>$(_MonoAndroidNETOutputDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IncludeAndroidJavadoc)' == 'True' ">
@@ -376,8 +377,8 @@
   <Target Name="GetTargetPath" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <!-- Only build the 'net6.0' version of 'Mono.Android.dll' once for the latest stable Android version. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidFrameworkVersion)' != '$(AndroidLatestStableFrameworkVersion)' ">
+  <!-- Only build the 'net6.0' version of 'Mono.Android.dll' for the latest stable Android version or higher. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidLatestStableApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
 

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -58,7 +58,7 @@
     <ReplaceFileContents
         SourceFile="Properties\AssemblyInfo.cs.in"
         DestinationFile="$(IntermediateOutputPath)AssemblyInfo.cs"
-        Replacements="@PACKAGE_VERSION@=$(_PackageVersion);@PACKAGE_VERSION_BUILD@=$(_PackageVersionBuild);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch)">
+        Replacements="@PACKAGE_VERSION@=$(_PackageVersion);@PACKAGE_VERSION_BUILD@=$(_PackageVersionBuild);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch);@API_LEVEL@=$(AndroidApiLevel);@MIN_API_LEVEL@=$(AndroidMinimumDotNetApiLevel)">
     </ReplaceFileContents>
   </Target>
   <PropertyGroup>

--- a/src/Mono.Android/Properties/AssemblyInfo.cs.in
+++ b/src/Mono.Android/Properties/AssemblyInfo.cs.in
@@ -9,6 +9,7 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 [assembly: AssemblyInformationalVersion ("@PACKAGE_VERSION@.@PACKAGE_VERSION_BUILD@; git-rev-head:@PACKAGE_HEAD_REV@; git-branch:@PACKAGE_HEAD_BRANCH@")]
 [assembly: AssemblyTitle ("Mono.Android.dll")]
@@ -17,6 +18,13 @@ using System.Runtime.CompilerServices;
 // [assembly: AssemblyCopyright ("Copyright 2011-2014 Xamarin Inc.")]
 [assembly: AssemblyCompany ("Microsoft Corporation")]
 [assembly: AssemblyMetadata ("IsTrimmable", "True")]
+#if ANDROID_UNSTABLE
+[assembly: RequiresPreviewFeatures("This is an unstable Android API level. Opt into preview features by adding <EnablePreviewFeatures>True</EnablePreviewFeatures> to your project file.")]
+#endif
+#if !MONOANDROID1_0
+[assembly: TargetPlatform("Android@API_LEVEL@.0")]
+[assembly: SupportedOSPlatform("Android@MIN_API_LEVEL@.0")]
+#endif
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.Color))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.ColorConverter))]

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Tooling.targets
@@ -31,6 +31,7 @@ called for "legacy" projects in Xamarin.Android.Legacy.targets.
     </ValidateJavaVersion>
     <ResolveAndroidTooling
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+        TargetPlatformVersion="$(TargetPlatformVersion)"
         AndroidApiLevel="$(AndroidApiLevel)"
         AndroidApplication="$(AndroidApplication)"
         AndroidSdkPath="$(_AndroidSdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,15 +6,27 @@
       "packs": [
         "Microsoft.Android.Sdk",
         "Microsoft.Android.Sdk.BundleTool",
-        "Microsoft.Android.Ref",
-        "Microsoft.Android.Runtime.android-arm",
-        "Microsoft.Android.Runtime.android-arm64",
-        "Microsoft.Android.Runtime.android-x86",
-        "Microsoft.Android.Runtime.android-x64",
+        "Microsoft.Android.31.Ref",
+        "Microsoft.Android.31.Runtime.android-arm",
+        "Microsoft.Android.31.Runtime.android-arm64",
+        "Microsoft.Android.31.Runtime.android-x86",
+        "Microsoft.Android.31.Runtime.android-x64",
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "microsoft-net-runtime-android" ]
+    },
+    "android-32": {
+      "description": "Preview support for Android API-32.",
+      "packs": [
+        "Microsoft.Android.32.Ref",
+        "Microsoft.Android.32.Runtime.android-arm",
+        "Microsoft.Android.32.Runtime.android-arm64",
+        "Microsoft.Android.32.Runtime.android-x86",
+        "Microsoft.Android.32.Runtime.android-x64"
+      ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
+      "extends" : [ "android" ]
     },
     "android-aot": {
       "description": ".NET SDK Workload for building Android applications with AOT support.",
@@ -38,23 +50,43 @@
       "kind": "sdk",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.Ref": {
+    "Microsoft.Android.31.Ref": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.Runtime.android-arm": {
+    "Microsoft.Android.31.Runtime.android-arm": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.Runtime.android-arm64": {
+    "Microsoft.Android.31.Runtime.android-arm64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.Runtime.android-x86": {
+    "Microsoft.Android.31.Runtime.android-x86": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.Runtime.android-x64": {
+    "Microsoft.Android.31.Runtime.android-x64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.32.Ref": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.32.Runtime.android-arm": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.32.Runtime.android-arm64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.32.Runtime.android-x86": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.32.Runtime.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RAT";
 
+		public string TargetPlatformVersion { get; set; }
+
 		public string AndroidSdkPath { get; set; }
 
 		public string AndroidSdkBuildToolsVersion { get; set; }
@@ -73,7 +75,12 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			AndroidApiLevel = GetMaxStableApiLevel ().ToString ();
+			// This should be 31.0, 32.0, etc.
+			if (Version.TryParse (TargetPlatformVersion, out Version v)) {
+				AndroidApiLevel = v.Major.ToString ();
+			} else {
+				AndroidApiLevel = GetMaxStableApiLevel ().ToString ();
+			}
 
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -42,6 +42,10 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RSD";
 
+		/// <summary>
+		/// In Xamarin.Android, this is the path to ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v*.*\ that contains Mono.Android.dll
+		/// In .NET 6, this is dotnet\packs\Microsoft.Android.Sdk.Windows|Darwin\*\data\net6.0-android*\. Only contains AndroidApiInfo.xml
+		/// </summary>
 		public string [] ReferenceAssemblyPaths { get; set; }
 
 		public string CommandLineToolsVersion { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -773,11 +773,15 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void MauiTargetFramework ([Values ("net6.0-android", "net6.0-android31", "net6.0-android31.0")] string targetFramework)
+		public void MauiTargetFramework ([Values ("net6.0-android", "net6.0-android31", "net6.0-android31.0", "net6.0-android32.0")] string targetFramework)
 		{
 			var library = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
 			};
+			bool preview = targetFramework.Contains("32");
+			if (preview) {
+				library.SetProperty ("EnablePreviewFeatures", "true");
+			}
 			library.Sources.Clear ();
 			library.Sources.Add (new BuildItem.Source ("Foo.cs") {
 				TextContent = () =>
@@ -798,7 +802,10 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 
 			var dotnet = CreateDotNetBuilder (library);
 			Assert.IsTrue (dotnet.Build (), $"{library.ProjectName} should succeed");
-			dotnet.AssertHasNoWarnings ();
+			// NOTE: Preview API levels emit XA4211
+			if (!preview) {
+				dotnet.AssertHasNoWarnings ();
+			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -172,11 +172,6 @@ namespace Xamarin.ProjectTools
 
 		public string LatestTargetFrameworkVersion (out string apiLevel) {
 			GetTargetFrameworkVersionRange (out string _, out string _, out apiLevel, out string lastFrameworkVersion, out string [] _);
-			// TODO: We aren't sure how to support preview bindings in .NET6 yet.
-			if (UseDotNet && apiLevel == "32") {
-				apiLevel = "31";
-				return "v12.0";
-			}
 			return lastFrameworkVersion;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -7,6 +7,7 @@
   <UsingTask AssemblyFile="$(PrepTasksAssembly)"      TaskName="Xamarin.Android.BuildTools.PrepTasks.Which" />
 
   <Import Project="..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems')" />
+  <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
   <PropertyGroup>
     <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
@@ -217,17 +218,11 @@
         Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@NDK_ARMEABI_V7_API@=$(AndroidNdkApiLevel_ArmV7a);@NDK_ARM64_V8A_API@=$(AndroidNdkApiLevel_ArmV8a);@NDK_X86_API@=$(AndroidNdkApiLevel_X86);@NDK_X86_64_API@=$(AndroidNdkApiLevel_X86_64);@BUNDLETOOL_VERSION@=$(XABundleToolVersion)">
     </ReplaceFileContents>
   </Target>
-  <Target Name="_FindAndroidApiInfo">
-    <ItemGroup>
-      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\*\AndroidApiInfo.xml" />
-    </ItemGroup>
-  </Target>
   <Target Name="_GenerateSupportedPlatforms"
-      DependsOnTargets="_FindAndroidApiInfo"
-      Inputs="$(BootstrapTasksAssembly);$(MSBuildThisFile);@(_AndroidApiInfo)"
+      Inputs="$(BootstrapTasksAssembly);$(MSBuildThisFile);..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems"
       Outputs="Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.SupportedPlatforms.targets">
     <GenerateSupportedPlatforms
-        AndroidApiInfo="@(_AndroidApiInfo)"
+        AndroidApiInfo="@(AndroidApiInfo)"
         MinimumApiLevel="$(AndroidMinimumDotNetApiLevel)"
         OutputFile="Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.SupportedPlatforms.targets"
     />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -54,8 +54,13 @@ projects.
           `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.6.20264.1\ref\net5.0\`
          See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
     -->
-    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
+    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
+      <_AndroidApiInfo Include="$(MSBuildThisFileDirectory)..\data\*\AndroidApiInfo.xml" />
+      <_AndroidApiInfoDirectories Include="@(_AndroidApiInfo->'%(RootDir)%(Directory)')" />
       <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' != 'true' ">
+      <_AndroidApiInfoDirectories Include="$(_XATargetFrameworkDirectories)" />
     </ItemGroup>
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
@@ -69,7 +74,7 @@ projects.
         JavaSdkPath="$(JavaSdkDirectory)"
         MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
         LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
-        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+        ReferenceAssemblyPaths="@(_AndroidApiInfoDirectories)">
       <Output TaskParameter="CommandLineToolsPath"      PropertyName="_AndroidToolsDirectory" />
       <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6176
Fixes: https://github.com/xamarin/xamarin-android/issues/6501

After some discussion with Daniel Plaisted, we think the best approach
for setting up API 31 packs is to have multiple packs:

* `Microsoft.Android.31.Ref`
* `Microsoft.Android.31.Runtime.[RID]`
* `Microsoft.Android.32.Ref`
* `Microsoft.Android.32.Runtime.[RID]`

We can check `$(TargetPlatformVersion)` to decide which pack to
list in `@(KnownFrameworkReference)` during builds.

These will all be versioned to match all other Android workload packs.
We'll continue to use `**FromWorkload**` to define their versions in
MSBuild.

I created a `android-32` workload, that installs additional API 32
packs. However, this workload doesn't necessarily need to exist as
targeting and runtime packs can also be resolved from NuGet.org. It is
nice to install `android-32` -- from then on builds will work offline.

One problem I hit was the need for `AndroidApiInfo.xml` for all
supported API levels. I moved these files to the
`Microsoft.Android.Sdk.[Platform]` packs, so I could include both 31
and 32 `AndroidApiInfo.xml` files.

All these changes I tried to do in a way where they are based on the
following new properties in `Configuration.props`:

    <AndroidLatestUnstableApiLevel Condition="'$(AndroidLatestUnstableApiLevel)' == ''">32</AndroidLatestUnstableApiLevel>
    <AndroidLatestUnstablePlatformId Condition="'$(AndroidLatestUnstablePlatformId)' == ''">Sv2</AndroidLatestUnstablePlatformId>
    <AndroidLatestUnstableFrameworkVersion Condition="'$(AndroidLatestUnstableFrameworkVersion)'==''">v12.0.99</AndroidLatestUnstableFrameworkVersion>
    <BuildDotNetPreviewApiLevel Condition=" '$(BuildDotNetPreviewApiLevel)' == '' And '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' ">true</BuildDotNetPreviewApiLevel>

Going forward, we should be able to just update these numbers. The
only decision we'll need to make is what to do about packs.

In the future, if API 32 is "stable" but is not the default:

1. We don't have to keep building & shipping API 31. We can hardcode
   the version for stable `Microsoft.Android.31.Ref/Runtime` packages
   on NuGet.org.

2. Users will have to opt into `net6.0-android32`.

In the future, if API 32 is "stable" and we can just make it default:

2. We get rid of `Microsoft.Android.31.Ref/Runtime` packages
   completely, and `net6.0-android` is `net6.0-android32` by default.