### PR TITLE
Fix `mono_log_mask` parsing and add property docs

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -42,6 +42,7 @@
   * [OSS Build Artifacts](workflow/OSSBuildArtifacts.md)
   * [Development tips and native debugging](workflow/DevelopmentTips.md)
   * [Localization](workflow/Localization.md)
+  * [Custom system properties](workflow/SystemProperties.md)
 
 
 # Coding Guidelines

--- a/Documentation/workflow/DevelopmentTips.md
+++ b/Documentation/workflow/DevelopmentTips.md
@@ -477,7 +477,13 @@ $ adb shell setprop debug.mono.log mono_log_level=debug,mono_log_mask=aot
 
 You could use `mono_log_mask=all` to enable all logging. See the [Mono
 documentation][mono-logging] for more information about
-`MONO_LOG_LEVEL` and `MONO_LOG_MASK`.
+`MONO_LOG_LEVEL` and `MONO_LOG_MASK`.  You can specify more than one
+category as the value of `mono_log-mask`, in which case individual
+categories need to be separated with `:`, for instance:
+
+```bash
+$ adb shell setprop debug.mono.log mono_log_level=debug,mono_log_mask=gc:asm:dll
+```
 
 There is further logging produced by `libmonodroid.so` you can enable with:
 

--- a/Documentation/workflow/SystemProperties.md
+++ b/Documentation/workflow/SystemProperties.md
@@ -1,0 +1,167 @@
+# Custom Android system properties used by Xamarin.Android
+
+## Introduction
+
+Xamarin.Android uses a number of custom Android system properties to
+communicate settings to application at the run time.  Each property
+value can be no longer than 91 characters (as per Android OS limits)
+and can be set from the command line using the following syntax:
+
+```bash
+$ adb shell setprop property_name property_value
+```
+
+To unset any of the properties, the following syntax needs to be used:
+
+```bash
+$ adb shell setprop property_name "''"
+```
+
+## Known properties
+
+### debug.mono.connect
+
+Used mostly by the IDEs to set arguments for the remote debugger
+connection required to attach the debugger to application running on
+device.  Arguments must be specified as a comma-separated list without
+any whitespace. Known arguments:
+
+  * `port=PORT`
+    Debugger port (a short integer)
+  * `timeout=VALUE`
+    Debugger session start timeout (in milliseconds)
+
+### debug.mono.debug
+
+Indicates that Mono debug session needs to be initialized.  Property
+value doesn't matter, only its presence is checked.
+
+### debug.mono.env
+
+Specifies a list of environment properties to set.  Property is only
+used in Debug builds of Xamarin.Android applications.  Its value
+is a list of `NAME=VALUE` pairs separated with the pipe character
+(`|`), without any whitespace surrounding each of the pipe separators.
+
+### debug.mono.extra
+
+Contains a whitespace separated list of additional command line
+arguments to pass to the Mono runtime initialization function.
+
+### debug.mono.gc
+
+Enable GC logging if set to any non-empty value.  Property is only
+used in Debug builds of Xamarin.Android applications.
+
+### debug.mono.gdb
+
+Set additional parameters when starting a Xamarin.Android application
+under GDB.  Each argument follows the `NAME:VALUE` format.  Supported
+arguments:
+
+  * `wait:TIMESTAMP`
+   `TIMESTAMP` should be the output of date +%s in the android shell.
+   If this property is set, wait for a native debugger to attach by
+   spinning in a loop.  If the current time is later than
+   `TIMESTAMP` + 10s, the property is ignored.
+
+### debug.mono.log
+
+Configure the Xamarin.Android runtime categories.  By default only the
+`default` category is enabled, which logs a handful of messages during
+application startup and operation.  This property enables all the
+messages logged below the `info` level for any of the categories.
+Value of the property is a comma-separated list of `NAME[=VALUE]`
+categories:
+
+  * `assembly`
+    Log all messages related to embedded assembly activities
+    (lookup, typemaps, loading etc).
+  * `bundle`
+    Log all messages related to bundled app processing.
+  * `debugger-log-level=LEVEL`
+    Set the Mono soft debugger logging level.
+  * `debugger`
+    Log all messages related to setting up the Mono soft debugger.
+  * `default`
+    Enable messages that don't belong to any of the other, more
+    specific, categories.
+  * `gc`
+    Log garbage collector messages.
+  * `gref-`
+    Enable global reference logging but without writing the logged
+    messages to a file.
+  * `gref=FILE`
+    Enable global reference logging and write messages to the
+    specified `FILE`
+  * `gref`
+    Enable global reference logging and log messages to the default
+    `grefs.txt` file.
+  * `lref-`
+    Enable local reference logging but without writing the logged
+    messages to a file.
+  * `lref=FILE`
+    Enable global reference logging and write messages to the
+    specified `FILE`
+  * `lref`
+    Enable global reference logging and log messages to the default
+    `lrefs.txt` file, unless `gref` or `gref=` are also present, in
+    which case messages will be logged to the `gref` file.
+  * `mono_log_level=LEVEL`
+    Set Mono runtime log level.  The default value is `error` to log
+    only errors, unless `gc` or `assembly` log categories are enabled,
+    in which case the default value for this property is `info`.
+  * `mono_log_mask=MASK`
+    Set Mono runtime log mask.  Value of this argument is a list of
+    categories separated with `:`, without any whitespace surrounding
+    the separator.  Full list of categories is [available here](https://www.mono-project.com/docs/advanced/runtime/logging-runtime-events/#trace-filters)
+  * `netlink`
+    Enable logging of low-level Linux `netlink` device used to
+    enumerate network interfaces and their associated IP addresses.
+  * `network`
+    Enable logging for messages related to network activity.
+  * `timing=bare`
+    Enable logging of native code performance information, without
+    logging method execution timing information to a file.
+  * `timing`
+    Enable logging of native code performance information, including
+    method execution timing which is written to a file named
+    `methods.txt`.  `timing=bare` should be used in preference to this
+    category.
+
+### debug.mono.max_grefc
+
+If set, override the number of maximum global references.  The number
+defaults to `2000` if the application is running in an emulator and
+`51200` otherwise.
+
+### debug.mono.profile
+
+In "legacy" Xamarin.Android applications (that is not NET6+ ones),
+value of this property specifies argument to the Mono logging
+profiler.
+
+In NET6+ applications, the only accepted value is `[aot:]PORTS` where
+`PORTS` becomes value of the `DOTNET_DiagnosticPorts` environment
+variable used by the NET6+ profiling infrastructure to configure the
+client/server ports.
+
+### debug.mono.runtime_args
+
+Additional arguments passed to the Mono's `mono_jit_parse_options`
+function.
+
+### debug.mono.soft_breakpoints
+
+If set to `0`, disable Mono debugger's soft breakpoints.  By default
+breakpoints are enabled.
+
+### debug.mono.trace
+
+Set Mono JIT trace options, passed to the Mono's
+`mono_jit_set_trace_options` function.
+
+### debug.mono.wref
+
+Configures use of Java (value `java`) or JNI (value `jni`) weak
+references.

--- a/Documentation/workflow/SystemProperties.md
+++ b/Documentation/workflow/SystemProperties.md
@@ -1,3 +1,24 @@
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Custom Android system properties used by Xamarin.Android](#custom-android-system-properties-used-by-xamarinandroid)
+    - [Introduction](#introduction)
+    - [Known properties](#known-properties)
+        - [debug.mono.connect](#debugmonoconnect)
+        - [debug.mono.debug](#debugmonodebug)
+        - [debug.mono.env](#debugmonoenv)
+        - [debug.mono.extra](#debugmonoextra)
+        - [debug.mono.gc](#debugmonogc)
+        - [debug.mono.gdb](#debugmonogdb)
+        - [debug.mono.log](#debugmonolog)
+        - [debug.mono.max_grefc](#debugmonomax_grefc)
+        - [debug.mono.profile](#debugmonoprofile)
+        - [debug.mono.runtime_args](#debugmonoruntime_args)
+        - [debug.mono.soft_breakpoints](#debugmonosoft_breakpoints)
+        - [debug.mono.trace](#debugmonotrace)
+        - [debug.mono.wref](#debugmonowref)
+
+<!-- markdown-toc end -->
 # Custom Android system properties used by Xamarin.Android
 
 ## Introduction

--- a/src/monodroid/jni/debug-constants.cc
+++ b/src/monodroid/jni/debug-constants.cc
@@ -11,7 +11,6 @@ const char Debug::DEBUG_MONO_ENV_PROPERTY[]          = "debug.mono.env";
 const char Debug::DEBUG_MONO_EXTRA_PROPERTY[]        = "debug.mono.extra";
 const char Debug::DEBUG_MONO_GC_PROPERTY[]           = "debug.mono.gc";
 const char Debug::DEBUG_MONO_GDB_PROPERTY[]          = "debug.mono.gdb";
-const char Debug::DEBUG_MONO_GDBPORT_PROPERTY[]      = "debug.mono.gdbport";
 const char Debug::DEBUG_MONO_LOG_PROPERTY[]          = "debug.mono.log";
 const char Debug::DEBUG_MONO_MAX_GREFC[]             = "debug.mono.max_grefc";
 const char Debug::DEBUG_MONO_PROFILE_PROPERTY[]      = "debug.mono.profile";

--- a/src/monodroid/jni/debug.hh
+++ b/src/monodroid/jni/debug.hh
@@ -35,7 +35,6 @@ namespace xamarin::android
 		static const char DEBUG_MONO_EXTRA_PROPERTY[];
 		static const char DEBUG_MONO_GC_PROPERTY[];
 		static const char DEBUG_MONO_GDB_PROPERTY[];
-		static const char DEBUG_MONO_GDBPORT_PROPERTY[];
 		static const char DEBUG_MONO_LOG_PROPERTY[];
 		static const char DEBUG_MONO_MAX_GREFC[];
 		static const char DEBUG_MONO_PROFILE_PROPERTY[];

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -228,7 +228,7 @@ namespace xamarin::android::internal
 #if defined (ANDROID)
 		static void mono_log_handler (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
 		static void mono_log_standard_streams_handler (const char *str, mono_bool is_stdout);
-		void setup_mono_tracing (char const* const& mono_log_mask);
+		void setup_mono_tracing (char const* const& mono_log_mask, bool have_log_assembly, bool have_log_gc);
 		void install_logging_handlers ();
 #endif // def ANDROID
 

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -228,7 +228,9 @@ namespace xamarin::android::internal
 #if defined (ANDROID)
 		static void mono_log_handler (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
 		static void mono_log_standard_streams_handler (const char *str, mono_bool is_stdout);
-		void setup_mono_tracing (char const* const& mono_log_mask, bool have_log_assembly, bool have_log_gc);
+
+		// A reference to unique_ptr is not the best practice ever, but it's faster this way
+		void setup_mono_tracing (std::unique_ptr<char[]> const& mono_log_mask, bool have_log_assembly, bool have_log_gc);
 		void install_logging_handlers ();
 #endif // def ANDROID
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2050,11 +2050,12 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
                                                           jboolean haveSplitApks)
 {
 	char *mono_log_mask_raw = nullptr;
-	char *mono_log_level = nullptr;
+	char *mono_log_level_raw = nullptr;
 
-	init_logging_categories (mono_log_mask_raw, mono_log_level);
+	init_logging_categories (mono_log_mask_raw, mono_log_level_raw);
 
 	std::unique_ptr<char[]> mono_log_mask (mono_log_mask_raw);
+	std::unique_ptr<char[]> mono_log_level (mono_log_level_raw);
 
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
@@ -2122,11 +2123,10 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	bool have_log_assembly = (log_categories & LOG_ASSEMBLY) != 0;
 	bool have_log_gc = (log_categories & LOG_GC) != 0;
 
-	if (mono_log_level == nullptr || *mono_log_level == '\0') {
+	if (mono_log_level == nullptr || *mono_log_level.get () == '\0') {
 		mono_trace_set_level_string ((have_log_assembly || have_log_gc) ? "info" : "error");
 	} else {
-		// `mono_log_level` cannot be freed here, Mono VM stores it internally
-		mono_trace_set_level_string (mono_log_level);
+		mono_trace_set_level_string (mono_log_level.get ());
 	}
 
 	setup_mono_tracing (mono_log_mask, have_log_assembly, have_log_gc);

--- a/src/monodroid/jni/strings.hh
+++ b/src/monodroid/jni/strings.hh
@@ -413,6 +413,21 @@ namespace xamarin::android::internal
 			buffer.get ()[idx] = NUL;
 		}
 
+		force_inline string_base& replace (const TChar c1, const TChar c2) noexcept
+		{
+			if (empty ()) {
+				return *this;
+			}
+
+			for (size_t i = 0; i < length (); i++) {
+				if (buffer.get ()[i] == c1) {
+					buffer.get ()[i] = c2;
+				}
+			}
+
+			return *this;
+		}
+
 		force_inline string_base& append (const TChar* s, size_t length) noexcept
 		{
 			if (s == nullptr || length == 0)


### PR DESCRIPTION
From the `how did I miss it?!` department.

The main purpose of this commit is to fix parsing of the `mono_log_mask`
component of the `debug.mono.log` property.  The component is set to a
list of Mono logging categories (e.g. `asm`, `gc` or `dll`) which, so
far, were supposed to be a comma-separated list.  However...
`debug.mono.log` **itself** uses commas to separate components, so using
the following:

```shell
$ adb shell setprop debug.mono.log mono_log_mask=asm,gc,dll
```

would **not** set the `MONO_LOG_MASK` environment variable to the
expected value of `asm,gc,dll` but instead it would end up being just
`asm`, as the other values would be considered to be `debug.mono.log`
components instead.  To fix this, this commit changes the
`mono_log_mask` separator to `:`, so the above command line will now be:

```shell
$ adb shell setprop debug.mono.log mono_log_mask=asm:gc:dll
```

Additionally, document all the `debug.mono.*` properties and remove the
`DEBUG_MONO_GDBPORT_PROPERTY` constant, since it's not used anywhere.

Also, when `assembly` or `gc` logging is enabled, we now set the Mono
tracing level to `info` instead of the default `error`.  This makes
tracking assembly loader and garbage collector issues easier by showing
more info from the Mono runtime, not just from Xamarin.Android.