### PR TITLE
Don't count assemblies to be skipped when packaging

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -295,6 +295,10 @@ namespace Xamarin.Android.Tasks
 					return;
 				}
 
+				if (Boolean.TryParse (assembly.GetMetadata ("AndroidSkipAddToPackage"), out bool value) && value) {
+					return;
+				}
+
 				string abi = assembly.GetMetadata ("Abi");
 				if (String.IsNullOrEmpty (abi)) {
 					assemblyCount++;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -25,6 +25,34 @@ namespace Xamarin.Android.Build.Tests
 	{
 		[Test]
 		[Category ("SmokeTests")]
+		public void CheckAssemblyCounts ([Values (false, true)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				EmbedAssembliesIntoApk = true,
+			};
+
+			var abis = new [] { "armeabi-v7a", "x86" };
+			proj.SetAndroidSupportedAbis (abis);
+			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseAssemblyStore", "True");
+
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				string objPath = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+
+				List<string> envFiles = EnvironmentHelper.GatherEnvironmentFiles (objPath, String.Join (";", abis), true);
+				EnvironmentHelper.ApplicationConfig app_config = EnvironmentHelper.ReadApplicationConfig (envFiles);
+				Assert.That (app_config, Is.Not.Null, "application_config must be present in the environment files");
+
+				string apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+				var helper = new ArchiveAssemblyHelper (apk, useAssemblyStores: true);
+
+				Assert.IsTrue (app_config.number_of_assemblies_in_apk == (uint)helper.GetNumberOfAssemblies (), "Assembly count must be equal between ApplicationConfig and the archive contents");
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
 		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms)
 		{
 			var testName = "テスト";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -24,10 +24,11 @@ namespace Xamarin.Android.Build.Tests
 	public partial class BuildTest : BaseTest
 	{
 		[Test]
+		[NonParallelizable]
 		[Category ("SmokeTests")]
 		public void CheckAssemblyCounts ([Values (false, true)] bool isRelease)
 		{
-			var proj = new XamarinAndroidApplicationProject () {
+			var proj = new XamarinFormsAndroidApplicationProject () {
 				IsRelease = isRelease,
 				EmbedAssembliesIntoApk = true,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("SmokeTests")]
 		public void CheckAssemblyCounts ([Values (false, true)] bool isRelease)
 		{
-			var proj = new XamarinFormsAndroidApplicationProject () {
+			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 				EmbedAssembliesIntoApk = true,
 			};
@@ -39,6 +39,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.PackageReferences.Add (KnownPackages.AndroidXMediaRouter);
 			proj.PackageReferences.Add (KnownPackages.AndroidXLegacySupportV4);
 			proj.PackageReferences.Add (KnownPackages.AndroidXLifecycleLiveData);
+			proj.PackageReferences.Add (KnownPackages.XamarinGoogleAndroidMaterial);
 
 			var abis = new [] { "armeabi-v7a", "x86" };
 			proj.SetAndroidSupportedAbis (abis);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -31,6 +31,13 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 				EmbedAssembliesIntoApk = true,
 			};
+			proj.PackageReferences.Add (KnownPackages.AndroidXMigration);
+			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);
+			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompatResources);
+			proj.PackageReferences.Add (KnownPackages.AndroidXBrowser);
+			proj.PackageReferences.Add (KnownPackages.AndroidXMediaRouter);
+			proj.PackageReferences.Add (KnownPackages.AndroidXLegacySupportV4);
+			proj.PackageReferences.Add (KnownPackages.AndroidXLifecycleLiveData);
 
 			var abis = new [] { "armeabi-v7a", "x86" };
 			proj.SetAndroidSupportedAbis (abis);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
@@ -187,6 +187,12 @@ namespace Xamarin.Android.Build.Tests
 			return entries;
 		}
 
+		public int GetNumberOfAssemblies (bool forceRefresh = false)
+		{
+			List<string> contents = ListArchiveContents (assembliesRootDir, forceRefresh);
+			return contents.Where (x => x.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)).Count ();
+		}
+
 		public bool Exists (string entryPath, bool forceRefresh = false)
 		{
 			List<string> contents = ListArchiveContents (assembliesRootDir, forceRefresh);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Android.Build.Tests
 			foreach (var asm in explorer.Assemblies) {
 				string prefix = storeEntryPrefix;
 
-				if (haveMultipleRids &&!String.IsNullOrEmpty (asm.Store.Arch)) {
+				if (haveMultipleRids && !String.IsNullOrEmpty (asm.Store.Arch)) {
 					string arch = ArchToAbi[asm.Store.Arch];
 					prefix = $"{prefix}{arch}/";
 				}
@@ -187,10 +187,25 @@ namespace Xamarin.Android.Build.Tests
 			return entries;
 		}
 
-		public int GetNumberOfAssemblies (bool forceRefresh = false)
+		public int GetNumberOfAssemblies (bool countAbiAssembliesOnce = true, bool forceRefresh = false)
 		{
 			List<string> contents = ListArchiveContents (assembliesRootDir, forceRefresh);
-			return contents.Where (x => x.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)).Count ();
+			var dlls = contents.Where (x => x.EndsWith (".dll", StringComparison.OrdinalIgnoreCase));
+
+			if (!countAbiAssembliesOnce) {
+				return dlls.Count ();
+			}
+
+			var cache = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+			return dlls.Where (x => {
+				string name = Path.GetFileName (x);
+				if (cache.Contains (name)) {
+					return false;
+				}
+
+				cache.Add (name);
+				return true;
+			}).Count ();
 		}
 
 		public bool Exists (string entryPath, bool forceRefresh = false)

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -349,7 +349,7 @@ EmbeddedAssemblies::find_assembly_store_entry (hash_t hash, const AssemblyStoreH
 {
 #if !defined (__MINGW32__) || (defined (__MINGW32__) && __GNUC__ >= 10)
 	hash_t entry_hash;
-	const AssemblyStoreHashEntry *ret;
+	const AssemblyStoreHashEntry *ret = nullptr;
 
 	while (entry_count > 0) {
 		ret = entries + (entry_count / 2);
@@ -358,8 +358,7 @@ EmbeddedAssemblies::find_assembly_store_entry (hash_t hash, const AssemblyStoreH
 		} else {
 			entry_hash = ret->hash32;
 		}
-
-		std::strong_ordering result = hash <=> entry_hash;
+		auto result = hash <=> entry_hash;
 
 		if (result < 0) {
 			entry_count /= 2;


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/Xamarin-Forms-Android-App-crashes-on-sta/1578587
Context: c9270261

c9270261 added support for assembly stores which, in turn, depend on
knowing the exact number of assemblies packaged in the APK in order to
properly perform binary search on the tables of assembly name hashes.
This information is recorded by the `GeneratePackageManagerJava` task
in the `libxamarin-app.so` library on the build time and then used by
the assembly store code on the run time.

The code responsible for counting failed to skip assemblies which had
the `AndroidSkipAddToPackage` metadata, in our case the old Android
Support Library ones, replaced by AndroidX, with the metadata set on the
old assemblies by the AndroidX migration code.

Properly ignore skipped assemblies when counting.

Additionally, improve the `assembly-store-reader` utility to show the
hash tables stored in the blob as well as check whether they are
properly sorted.