### PR TITLE
[xaprepare] Fix Unicode detection when running on dotnet

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -398,11 +398,15 @@ namespace Xamarin.Android.Prepare
 			}
 
 			Properties.PropertiesChanged += PropertiesChanged;
-			canConsoleUseUnicode =
-				Console.OutputEncoding is UTF7Encoding ||
-				Console.OutputEncoding is UTF8Encoding ||
-				Console.OutputEncoding is UTF32Encoding ||
-				Console.OutputEncoding is UnicodeEncoding;
+			if (Console.OutputEncoding.EncodingName.IndexOf ("Unicode", StringComparison.OrdinalIgnoreCase) >= 0) {
+				canConsoleUseUnicode = true;
+			} else {
+				canConsoleUseUnicode =
+					Console.OutputEncoding is UTF7Encoding ||
+					Console.OutputEncoding is UTF8Encoding ||
+					Console.OutputEncoding is UTF32Encoding ||
+					Console.OutputEncoding is UnicodeEncoding;
+			}
 
 			Log.Todo ("better checks for interactive session (isatty?)");
 			InteractiveSession = !Console.IsOutputRedirected;


### PR DESCRIPTION
37dbc459 made `xaprepare` build and run using dotnet which
caused `xaprepare` to misdetect whether the current terminal
supports Unicode and, thus, not use emoji.  This cannot be! :D

The problem lies in the fact that dotnet sets `Console.OutputEncoding`
to an internal class wrapping `System.Encoding` and our check for
the known Unicode encoding types fails.  Before looking at the type
of `OutputEncoding`, check whether the encoding name contains the
word "Unicode".  This fixes the check on dotnet.