### PR TITLE
Fix the `timing=bare` logging category

### DIFF
--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -228,6 +228,7 @@ init_logging_categories (char*& mono_log_mask, char*& mono_log_level)
 		}
 
 		if (param.starts_with ("timing=bare")) {
+			log_categories |= LOG_TIMING;
 			log_timing_categories |= LOG_TIMING_BARE;
 			continue;
 		}


### PR DESCRIPTION
917e1a94 rewrote the `init_logging_categories` function which parses the
`debug.mono.log` system property to eliminate memory allocation and
perform the parsing faster.  However, the conversion failed to set the
`LOG_TIMING` category when the `timing=bare` is used, which results in
the timing information not showing in the logs.

Fix the mistake by setting `LOG_TIMING` where appropriate.