### PR TITLE
[Tests] Fix `uname` usage on macOS

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -68,7 +68,13 @@ namespace Xamarin.Android.Tasks
 				os = e.Data.Trim ();
 			};
 			DataReceivedEventHandler error = (o, e) => {};
-			int r = RunProcess ("uname", "-s", output, error);
+
+			string uname = "/usr/bin/uname";
+			if (!File.Exists (uname)) {
+				uname = "uname";
+			}
+
+			int r = RunProcess (uname, "-s", output, error);
 			if (r == 0)
 				return os;
 			return null;


### PR DESCRIPTION
Recently we've seen a lot of failures on the macOS build bots caused by
the inability to find `uname(1)`, resulting in the following exception
being thrown:

    Xamarin.Android.Tooling.targets(64,5): error XARSD7000: System.ComponentModel.Win32Exception (0x80004005): ApplicationName='uname', CommandLine='-s', CurrentDirectory='', Native error= Cannot find the specified file
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at System.Diagnostics.Process.StartWithCreateProcess (System.Diagnostics.ProcessStartInfo startInfo) [0x0029f] in <ab9a187a50e54f8cb6a2692756ca03ac>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at System.Diagnostics.Process.Start () [0x0003a] in <ab9a187a50e54f8cb6a2692756ca03ac>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at (wrapper remoting-invoke-with-check) System.Diagnostics.Process.Start()
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at Xamarin.Android.Tasks.MonoAndroidHelper.RunProcess (System.String name, System.String args, System.Diagnostics.DataReceivedEventHandler onOutput, System.Diagnostics.DataReceivedEventHandler onError, System.Collections.Generic.Dictionary`2[TKey,TValue] environmentVariables) [0x0008e] in <86c291cf525b4df3b5f5ddcd2e7d4df1>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at Xamarin.Android.Tasks.MonoAndroidHelper.GetOSBinDirName () [0x00047] in <86c291cf525b4df3b5f5ddcd2e7d4df1>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at System.Lazy`1[T].PublicationOnlyViaFactory (System.LazyHelper initializer) [0x00011] in <08f46039e5064c628bf7795f9b970b7b>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at System.Lazy`1[T].CreateValue () [0x00059] in <08f46039e5064c628bf7795f9b970b7b>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at System.Lazy`1[T].get_Value () [0x0000a] in <08f46039e5064c628bf7795f9b970b7b>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at Xamarin.Android.Tasks.MonoAndroidHelper.GetOSBinPath () [0x0001e] in <86c291cf525b4df3b5f5ddcd2e7d4df1>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at Xamarin.Android.Tasks.ResolveSdks.RunTask () [0x0002c] in <86c291cf525b4df3b5f5ddcd2e7d4df1>:0
    Xamarin.Android.Tooling.targets(64,5): error XARSD7000:   at Microsoft.Android.Build.Tasks.AndroidTask.Execute () [0x00000] in <a01aa22f822341d9b923ecca0eca2261>:0

Check whether `/usr/bin/uname` exists and use it, if it does, falling
back to `uname`