### PR TITLE
[One .NET] use file scoped namespaces in templates

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/Activity1.cs
+++ b/src/Microsoft.Android.Templates/android-activity/Activity1.cs
@@ -1,13 +1,12 @@
-namespace AndroidApp1
-{
-    [Activity(Label = "@string/app_name", MainLauncher = true)]
-    public class Activity1 : Activity
-    {
-        protected override void OnCreate(Bundle? savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
+namespace AndroidApp1;
 
-            // Create your application here
-        }
+[Activity(Label = "@string/app_name", MainLauncher = true)]
+public class Activity1 : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        // Create your application here
     }
 }

--- a/src/Microsoft.Android.Templates/android/MainActivity.cs
+++ b/src/Microsoft.Android.Templates/android/MainActivity.cs
@@ -1,14 +1,13 @@
-namespace AndroidApp1
-{
-    [Activity(Label = "@string/app_name", MainLauncher = true)]
-    public class MainActivity : Activity
-    {
-        protected override void OnCreate(Bundle? savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
+namespace AndroidApp1;
 
-            // Set our view from the "main" layout resource
-            SetContentView(Resource.Layout.activity_main);
-        }
+[Activity(Label = "@string/app_name", MainLauncher = true)]
+public class MainActivity : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        // Set our view from the "main" layout resource
+        SetContentView(Resource.Layout.activity_main);
     }
 }

--- a/src/Microsoft.Android.Templates/androidlib/Class1.cs
+++ b/src/Microsoft.Android.Templates/androidlib/Class1.cs
@@ -1,6 +1,5 @@
-namespace AndroidLib1
+namespace AndroidLib1;
+
+public class Class1
 {
-    public class Class1
-    {
-    }
 }


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-10#file-scoped-namespace-declaration

In 7fb7c814, I implemented most C# 10 features in templates, but I forgot about file scoped namespaces.

To match the other .NET 6 templates, we should have:

    namespace AndroidApp1;

And remove one level of indentation from these files.