### PR TITLE
[Xamarin.Android.Build.Tests] Update Microsoft_Azure_EventHubs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -901,12 +901,14 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				} else {
 					app.Packages.Add (KnownPackages.Microsoft_Azure_EventHubs);
 				}
-				Assert.IsFalse (appBuilder.Build (app), "Build should have failed.");
+
+				bool shouldBuild = usePackageReference;
+				Assert.AreEqual (shouldBuild ,appBuilder.Build (app), $"Build should have {(shouldBuild ? "built" : "failed")}.");
 
 				//NOTE: we get a different message when using <PackageReference /> due to automatically getting the Microsoft.Azure.Amqp (and many other) transient dependencies
 				if (usePackageReference) {
-					Assert.IsTrue (appBuilder.LastBuildOutput.ContainsText ($"{error} `Microsoft.Azure.Services.AppAuthentication`, referenced by `Microsoft.Azure.EventHubs`. Please add a NuGet package or assembly reference for `Microsoft.Azure.Services.AppAuthentication`, or remove the reference to `Microsoft.Azure.EventHubs`."),
-						$"Should recieve '{error}' regarding `Microsoft.Azure.Services.AppAuthentication`!");
+					Assert.IsFalse (appBuilder.LastBuildOutput.ContainsText ($"{error} `Microsoft.Azure.Services.AppAuthentication`, referenced by `Microsoft.Azure.EventHubs`. Please add a NuGet package or assembly reference for `Microsoft.Azure.Services.AppAuthentication`, or remove the reference to `Microsoft.Azure.EventHubs`."),
+						$"Should not recieve '{error}' regarding `Microsoft.Azure.Services.AppAuthentication`!");
 				} else {
 					Assert.IsTrue (appBuilder.LastBuildOutput.ContainsText ($"{error} `Microsoft.Azure.Amqp`, referenced by `Microsoft.Azure.EventHubs`. Please add a NuGet package or assembly reference for `Microsoft.Azure.Amqp`, or remove the reference to `Microsoft.Azure.EventHubs`."),
 						$"Should recieve '{error}' regarding `Microsoft.Azure.Services.Amqp`!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -392,11 +392,11 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Microsoft_Azure_EventHubs = new Package {
 			Id = "Microsoft.Azure.EventHubs",
-			Version = "2.0.0",
+			Version = "2.2.1",
 			TargetFramework = "netstandard2.0",
 			References = {
 				new BuildItem.Reference("Microsoft.Azure.EventHubs") {
-					MetadataValues = "HintPath=..\\packages\\Microsoft.Azure.EventHubs.2.0.0\\lib\\netstandard2.0\\Microsoft.Azure.EventHubs.dll"
+					MetadataValues = "HintPath=..\\packages\\Microsoft.Azure.EventHubs.2.2.1\\lib\\netstandard2.0\\Microsoft.Azure.EventHubs.dll"
 				}
 			}
 		};


### PR DESCRIPTION
We are seeing a Component Governance error for `System.Net.WebSockets.Client`.
This is because one of our tests uses `Microsoft.Azure.EventHubs`. This
is pulling in an old version of `System.Net.WebSockets.Client`.

So we need to upgrade the NuGet to make sure we pull in the newer version.
Interestingly, with the newer version we no longer get the expected
failure when using `PackageReference`. This is probably due to them fixing
the NuGet. So we have to update the test to reflect that change.