### PR TITLE
[monodroid] Fix `monodroid_dlopen()` to load arbitrary DSOs for legacy code

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1485,6 +1485,7 @@ MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, [[m
 	}
 
 	if (!utils.ends_with (name, ".dll.so") && !utils.ends_with (name, ".exe.so")) {
+		h = androidSystem.load_dso (name, dl_flags, true /* skip_existing_check */);
 		return monodroid_dlopen_log_and_return (h, err, name, name_needs_free);
 	}
 


### PR DESCRIPTION
Context: 3329243f734a28dfc4b86951f5329833f3703971

3329243f failed to apply the same fix to the "legacy" Xamarin.Android, fix
the omission.