### PR TITLE
$(AndroidPackVersionSuffix)=preview.12; net6 is 31.0.101.preview.12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>31.0.101</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.11</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.12</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/b04b9fda5c34b9edec10bc6fd65dd5b67fe8d52a/Documentation/guides/HowToBranch.md
Context: https://github.com/xamarin/xamarin-android/tree/release/6.0.1xx-preview11

We branched `xamarin-android` along with `xamarin-macios`. This will
reflect the next release of .NET MAUI Preview 11. xamarin-android/main
should become Preview 12.