### PR TITLE
[Xamarin.Android.Build.Tasks] Don't use -XX:-UseSplitVerifier

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -91,9 +91,6 @@ namespace Xamarin.Android.Tasks
 			// N can be in the form of Nm or NGB (e.g 100m or 1GB ) 
 			cmd.AppendSwitchIfNotNull("-Xmx", JavaMaximumHeapSize);
 
-			// See https://bugzilla.xamarin.com/show_bug.cgi?id=21096
-			cmd.AppendSwitch ("-XX:-UseSplitVerifier");
-
 			// Arguments sent to java.exe
 			cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (MonoAndroidToolsDirectory, "jar2xml.jar"));
 


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=21096 [a 404 :-(]
Context: http://github.com/xamarin/monodroid/commit/df479c296720ee8fd2f19b12d2ff58d2b7474141
Context: https://github.com/xamarin/xamarin-android/issues/6524

(Behold the perils of *not* copying "important contextual bug info"
into commit messages, and the original bug was "private", and now
nobody can access the bug…)

Way back in 2014, we updated `<JarToXml/>` to *disable* use of the
[new type checker with StackMapTable attributes][0]:

	java -XX:-UseSplitVerifier -jar /path/to/jar2xml.jar …

This was presumably to work around a bug with [asm][1], which was
probably fixed by [bumping to asm 5.0.3][2].

Unfortunately, using `-XX:-UseSplitVerifier` *fails* on JDK-11:

	% path/to/jdk-11/java -XX:-UseSplitVerifier -jar /path/to/jar2xml.jar …
	Unrecognized VM option 'UseSplitVerifier'
	Error: Could not create the Java Virtual Machine.
	Error: A fatal exception has occurred. Program will exit.

This means it's currently impossible to use `jar2xml` with JDK-11.

Update the `<JarToXml/>` task to no longer use
`-XX:-UseSplitVerifier`.  It's no longer necessary as of
xamarin/jar2xml@d414d5b4, and it can't be used with JDK-11.

[0]: https://www.oracle.com/java/technologies/javase/vmoptions-jsp.html
[1]: https://asm.ow2.io/
[2]: https://github.com/xamarin/jar2xml/commit/d414d5b45e91e9ebb73639b163ab2bd418642f96