### PR TITLE
[One .NET] rename Microsoft.Android.31.Ref -> Microsoft.Android.Ref.31

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -2,7 +2,7 @@
 ***********************************************************************************************
 Microsoft.Android.Ref.proj
 
-This project file is used to create the Microsoft.Android.[API].Ref NuGet, which is the
+This project file is used to create the Microsoft.Android.Ref.[API] NuGet, which is the
 targeting pack containing reference assemblies and other compile time assets required
 by projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
@@ -10,7 +10,7 @@ by projects that use the Microsoft.Android framework in .NET 5.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <PackageId>Microsoft.Android.$(AndroidApiLevel).Ref</PackageId>
+    <PackageId>Microsoft.Android.Ref.$(AndroidApiLevel)</PackageId>
     <Description>Microsoft.Android reference assemblies for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRefPackAssemblyPath>ref\net6.0</_AndroidRefPackAssemblyPath>
   </PropertyGroup>

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -2,7 +2,7 @@
 ***********************************************************************************************
 Microsoft.Android.Runtime.proj
 
-This project file is used to create Microsoft.Android.[API].Runtime NuGets, which are
+This project file is used to create Microsoft.Android.Runtime.[API].[RID] NuGets, which are
 runtime packs that contain the assets required for a self-contained publish of
 projects that use the Microsoft.Android framework in .NET 5.
 ***********************************************************************************************
@@ -12,7 +12,7 @@ projects that use the Microsoft.Android framework in .NET 5.
   <PropertyGroup>
     <AndroidRID Condition=" '$(AndroidRID)' == '' ">android-arm64</AndroidRID>
     <AndroidABI Condition=" '$(AndroidABI)' == '' ">arm64-v8a-net6</AndroidABI>
-    <PackageId>Microsoft.Android.$(AndroidApiLevel).Runtime.$(AndroidRID)</PackageId>
+    <PackageId>Microsoft.Android.Runtime.$(AndroidApiLevel).$(AndroidRID)</PackageId>
     <Description>Microsoft.Android runtime components for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\net6.0</_AndroidRuntimePackAssemblyPath>
     <_AndroidRuntimePackNativePath>runtimes\$(AndroidRID)\native</_AndroidRuntimePackNativePath>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -125,9 +125,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         RuntimeFrameworkName="Microsoft.Android"
         DefaultRuntimeFrameworkVersion="**FromWorkload**"
         LatestRuntimeFrameworkVersion="**FromWorkload**"
-        TargetingPackName="Microsoft.Android.%24(_AndroidRuntimePackId).Ref"
+        TargetingPackName="Microsoft.Android.Ref.%24(_AndroidRuntimePackId)"
         TargetingPackVersion="**FromWorkload**"
-        RuntimePackNamePatterns="Microsoft.Android.%24(_AndroidRuntimePackId).Runtime.**RID**"
+        RuntimePackNamePatterns="Microsoft.Android.Runtime.%24(_AndroidRuntimePackId).**RID**"
         RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
         Profile="Android"
     />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,11 +6,11 @@
       "packs": [
         "Microsoft.Android.Sdk",
         "Microsoft.Android.Sdk.BundleTool",
-        "Microsoft.Android.31.Ref",
-        "Microsoft.Android.31.Runtime.android-arm",
-        "Microsoft.Android.31.Runtime.android-arm64",
-        "Microsoft.Android.31.Runtime.android-x86",
-        "Microsoft.Android.31.Runtime.android-x64",
+        "Microsoft.Android.Ref.31",
+        "Microsoft.Android.Runtime.31.android-arm",
+        "Microsoft.Android.Runtime.31.android-arm64",
+        "Microsoft.Android.Runtime.31.android-x86",
+        "Microsoft.Android.Runtime.31.android-x64",
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
@@ -19,11 +19,11 @@
     "android-32": {
       "description": "Preview support for Android API-32.",
       "packs": [
-        "Microsoft.Android.32.Ref",
-        "Microsoft.Android.32.Runtime.android-arm",
-        "Microsoft.Android.32.Runtime.android-arm64",
-        "Microsoft.Android.32.Runtime.android-x86",
-        "Microsoft.Android.32.Runtime.android-x64"
+        "Microsoft.Android.Ref.32",
+        "Microsoft.Android.Runtime.32.android-arm",
+        "Microsoft.Android.Runtime.32.android-arm64",
+        "Microsoft.Android.Runtime.32.android-x86",
+        "Microsoft.Android.Runtime.32.android-x64"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "android" ]
@@ -50,43 +50,43 @@
       "kind": "sdk",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.31.Ref": {
+    "Microsoft.Android.Ref.31": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.31.Runtime.android-arm": {
+    "Microsoft.Android.Runtime.31.android-arm": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.31.Runtime.android-arm64": {
+    "Microsoft.Android.Runtime.31.android-arm64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.31.Runtime.android-x86": {
+    "Microsoft.Android.Runtime.31.android-x86": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.31.Runtime.android-x64": {
+    "Microsoft.Android.Runtime.31.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.32.Ref": {
+    "Microsoft.Android.Ref.32": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.32.Runtime.android-arm": {
+    "Microsoft.Android.Runtime.32.android-arm": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.32.Runtime.android-arm64": {
+    "Microsoft.Android.Runtime.32.android-arm64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.32.Runtime.android-x86": {
+    "Microsoft.Android.Runtime.32.android-x86": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },
-    "Microsoft.Android.32.Runtime.android-x64": {
+    "Microsoft.Android.Runtime.32.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },


### PR DESCRIPTION
When doing a Visual Studio insertion, we hit a build errors complaining
some packs don't have owners.

The rules matched patterns like:

    Microsoft.Android.Ref*
    Microsoft.Android.Runtime*
    Microsoft.Android.Sdk*

We decided to rename the packs to match the above patterns, as we
didn't like the names anyway:

* Microsoft.Android.31.Ref -> Microsoft.Android.Ref.31
* Microsoft.Android.31.Runtime.[RID] -> Microsoft.Android.Ref.31.[RID]
* Microsoft.Android.32.Ref -> Microsoft.Android.Ref.32
* Microsoft.Android.32.Runtime.[RID] -> Microsoft.Android.Ref.32.[RID]

I think the `[RID]` should still remain last, as that tends to be the
pattern with RID-specific packages like:

* https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.win-x64/
* https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.osx-x64/
* https://www.nuget.org/packages/Microsoft.NETCore.App.Runtime.linux-x64/

`@(KnownFrameworkReference)` changes to:

    <KnownFrameworkReference
        Include="Microsoft.Android"
        TargetFramework="net6.0"
        RuntimeFrameworkName="Microsoft.Android"
        DefaultRuntimeFrameworkVersion="**FromWorkload**"
        LatestRuntimeFrameworkVersion="**FromWorkload**"
        TargetingPackName="Microsoft.Android.Ref.$(_AndroidRuntimePackId)"
        TargetingPackVersion="**FromWorkload**"
        RuntimePackNamePatterns="Microsoft.Android.Runtime.$(_AndroidRuntimePackId).**RID**"
        RuntimePackRuntimeIdentifiers="android-arm;android-arm64;android-x86;android-x64"
        Profile="Android"
    />