### PR TITLE
[Xamarin.Android.Build.Tasks] make $(AndroidNdkDirectory) optional

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -57,8 +57,8 @@ namespace Xamarin.Android.Tasks
 
 		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
-			if (ndk == null) {
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: EnableLLVM, log: Log);
+			if (Log.HasLoggedErrors) {
 				return; // NdkTools.Create will log appropriate error
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -694,8 +694,8 @@ namespace Xamarin.Android.Tasks
 				return;
 			}
 
-			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
-			if (ndk == null) {
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: false, log: Log);
+			if (Log.HasLoggedErrors) {
 				return; // NdkTools.Create will log appropriate error
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,50 +17,50 @@ namespace Xamarin.Android.Tasks
 	public abstract class GetAotArguments : AndroidAsyncTask
 	{
 		[Required]
-		public string AndroidApiLevel { get; set; }
+		public string AndroidApiLevel { get; set; } = "";
 
 		[Required]
-		public string AndroidAotMode { get; set; }
+		public string AndroidAotMode { get; set; } = "";
 
 		[Required]
-		public string AotOutputDirectory { get; set; }
+		public string AotOutputDirectory { get; set; } = "";
 
 		[Required]
-		public string AndroidBinUtilsDirectory { get; set; }
+		public string AndroidBinUtilsDirectory { get; set; } = "";
 
 		[Required]
-		public string TargetName { get; set; }
+		public string TargetName { get; set; } = "";
 
 		/// <summary>
 		/// Will be blank in .NET 6+
 		/// </summary>
-		public string ManifestFile { get; set; }
+		public string ManifestFile { get; set; } = "";
 
 		/// <summary>
 		/// $(AndroidMinimumSupportedApiLevel) in .NET 6+
 		/// </summary>
-		public string MinimumSupportedApiLevel { get; set; }
+		public string MinimumSupportedApiLevel { get; set; } = "";
 
-		public string RuntimeIdentifier { get; set; }
+		public string RuntimeIdentifier { get; set; } = "";
 
-		public string AndroidNdkDirectory { get; set; }
+		public string AndroidNdkDirectory { get; set; } = "";
 
 		public bool EnableLLVM { get; set; }
 
-		public string AndroidSequencePointsMode { get; set; }
+		public string AndroidSequencePointsMode { get; set; } = "";
 
-		public ITaskItem [] Profiles { get; set; }
+		public ITaskItem [] Profiles { get; set; } = Array.Empty<ITaskItem> ();
 
 		public bool UsingAndroidNETSdk { get; set; }
 
-		public string AotAdditionalArguments { get; set; }
+		public string AotAdditionalArguments { get; set; } = "";
 
 		[Required, Output]
-		public ITaskItem [] ResolvedAssemblies { get; set; }
+		public ITaskItem [] ResolvedAssemblies { get; set; } = Array.Empty<ITaskItem> ();
 
 		protected AotMode AotMode;
 		protected SequencePointsMode SequencePointsMode;
-		protected string SdkBinDirectory;
+		protected string SdkBinDirectory = "";
 
 		public static bool GetAndroidAotMode(string androidAotMode, out AotMode aotMode)
 		{
@@ -117,7 +118,7 @@ namespace Xamarin.Android.Tasks
 
 		int GetNdkApiLevel (NdkTools ndk, AndroidTargetArch arch)
 		{
-			AndroidAppManifest manifest = null;
+			AndroidAppManifest? manifest = null;
 			if (!string.IsNullOrEmpty (ManifestFile)) {
 				manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);
 			}
@@ -254,10 +255,6 @@ namespace Xamarin.Android.Tasks
 			var toolchainPath = toolPrefix.Substring (0, toolPrefix.LastIndexOf (Path.DirectorySeparatorChar));
 			var ldFlags = string.Empty;
 			if (EnableLLVM) {
-				if (string.IsNullOrEmpty (AndroidNdkDirectory)) {
-					return null;
-				}
-
 				string androidLibPath = string.Empty;
 				try {
 					androidLibPath = ndk.GetDirectoryPath (NdkToolchainDir.PlatformLib, arch, level);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
@@ -15,8 +15,8 @@ namespace Xamarin.Android.Tasks
 
 		public override Task RunTaskAsync ()
 		{
-			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
-			if (ndk == null) {
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: EnableLLVM, log: Log);
+			if (Log.HasLoggedErrors) {
 				return Task.CompletedTask; // NdkTools.Create will log appropriate error
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Android.Tasks
 
 		const string BundleSharedLibraryName = "libmonodroid_bundle_app.so";
 
-		[Required]
 		public string AndroidNdkDirectory { get; set; }
 
 		[Required]
@@ -57,8 +56,8 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			NdkTools? ndk = NdkTools.Create (AndroidNdkDirectory, Log);
-			if (ndk == null) {
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: true, log: Log);
+			if (Log.HasLoggedErrors) {
 				return false; // NdkTools.Create will log appropriate error
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -258,6 +258,7 @@ namespace Xamarin.Android.Build.Tests
 				AotAssemblies = true,
 				PackageName = "com.xamarin.buildaotappandbundlewithspecialchars",
 			};
+			proj.SetProperty ("AndroidNdkDirectory", AndroidNdkPath);
 			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
 			proj.SetAndroidSupportedAbis (supportedAbis);
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1003,6 +1003,7 @@ namespace UnamedProject
 		public void BuildMkBundleApplicationRelease ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
+			proj.SetProperty ("AndroidNdkDirectory", AndroidNdkPath);
 			using (var b = CreateApkBuilder ("temp/BuildMkBundleApplicationRelease", false)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
@@ -1029,6 +1030,7 @@ namespace UnamedProject
 		public void BuildMkBundleApplicationReleaseAllAbi ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
+			proj.SetProperty ("AndroidNdkDirectory", AndroidNdkPath);
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			using (var b = CreateApkBuilder ("temp/BuildMkBundleApplicationReleaseAllAbi", false)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 			using (var builder = new Builder ()) {
 				var ndkDir = AndroidNdkPath;
 				var sdkDir = AndroidSdkPath;
-				NdkTools ndk = NdkTools.Create (ndkDir, log);
+				NdkTools ndk = NdkTools.Create (ndkDir, log: log);
 				ndk.OSBinPath = SetUp.OSBinDirectory;
 				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir, AndroidSdkResolver.GetJavaSdkPath ());
 				var platforms = ndk.GetSupportedPlatforms ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
@@ -30,8 +30,6 @@ namespace Xamarin.ProjectTools
 				}
 			};
 
-			var sdkPath = AndroidSdkResolver.GetAndroidSdkPath ();
-			var ndkPath = AndroidSdkResolver.GetAndroidNdkPath ();
 			var jdkPath = AndroidSdkResolver.GetJavaSdkPath ();
 			JavacFullPath = Path.Combine (jdkPath, "bin", "javac");
 			JarFullPath = Path.Combine (jdkPath, "bin", "jar");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -311,10 +311,6 @@ namespace Xamarin.ProjectTools
 				if (Directory.Exists (sdkPath)) {
 					sw.WriteLine (" /p:AndroidSdkDirectory=\"{0}\" ", sdkPath);
 				}
-				string ndkPath = AndroidSdkResolver.GetAndroidNdkPath ();
-				if (Directory.Exists (ndkPath)) {
-					sw.WriteLine (" /p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
-				}
 				string jdkPath = AndroidSdkResolver.GetJavaSdkPath ();
 				if (Directory.Exists (jdkPath)) {
 					sw.WriteLine (" /p:JavaSdkDirectory=\"{0}\" ", jdkPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -13,7 +13,6 @@ namespace Xamarin.ProjectTools
 		public string ProcessLogFile { get; set; }
 		public string Verbosity { get; set; } = "diag";
 		public string AndroidSdkPath { get; set; } = AndroidSdkResolver.GetAndroidSdkPath ();
-		public string AndroidNdkPath { get; set; } = AndroidSdkResolver.GetAndroidNdkPath ();
 		public string JavaSdkPath { get; set; } = AndroidSdkResolver.GetJavaSdkPath ();
 
 		public string ProjectDirectory { get; private set; }
@@ -158,9 +157,6 @@ namespace Xamarin.ProjectTools
 			}
 			if (Directory.Exists (AndroidSdkPath)) {
 				arguments.Add ($"/p:AndroidSdkDirectory=\"{AndroidSdkPath}\"");
-			}
-			if (Directory.Exists (AndroidNdkPath)) {
-				arguments.Add ($"/p:AndroidNdkDirectory=\"{AndroidNdkPath}\"");
 			}
 			if (Directory.Exists (JavaSdkPath)) {
 				arguments.Add ($"/p:JavaSdkDirectory=\"{JavaSdkPath}\"");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NdkVersion.cs
@@ -7,6 +7,8 @@ namespace Xamarin.Android.Tasks
 		public Version Main { get; }
 		public string Tag { get; } = String.Empty;
 
+		public NdkVersion () => Main = new Version (0, 0);
+
 		public NdkVersion (string? version)
 		{
 			string? ver = version?.Trim ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NullNdkTools.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/NullNdkTools.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	class NullNdkTools : NdkTools
+	{
+		public NullNdkTools (TaskLoggingHelper? log = null) : base (new NdkVersion (), log)
+		{
+			log?.LogDebugMessage ("No Android NDK found");
+		}
+
+		public override int GetMinimumApiLevelFor (AndroidTargetArch arch) => throw new NotImplementedException ();
+
+		public override string GetToolPath (NdkToolKind kind, AndroidTargetArch arch, int apiLevel) => throw new NotImplementedException ();
+
+		public override string GetToolPath (string name, AndroidTargetArch arch, int apiLevel) => throw new NotImplementedException ();
+
+		public override bool ValidateNdkPlatform (Action<string> logMessage, Action<string, string> logError, AndroidTargetArch arch, bool enableLLVM) => throw new NotImplementedException ();
+
+		protected override string GetPlatformIncludeDirPath (AndroidTargetArch arch, int apiLevel) => throw new NotImplementedException ();
+	}
+}


### PR DESCRIPTION
It is possible for us to not require the Android NDK to be installed,
but we have checks in place that would emit errors, such as:

    error XA5104: Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.

To make it possible to build with AOT without the NDK:

1. Make a `NullNdkTools` class to use when an NDK is not found.

2. Make the NDK only actually required when `$(EnableLLVM)` is `true`.

3. Update our MSBuild tests so they leave `$(AndroidNdkDirectory)`
   blank.

After these changes, I'm able to build full and profiled AOT applications without
an Android NDK installed.

After this is merged, we might be able to make `Release` builds in .NET 6 default
to use profiled AOT.