### PR TITLE
[build] use dotnet/runtime packs from the ".NET 6 MAUI" channel

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>d0662ed8db919642177ddfd06a1c33895a69015f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.1-mauipre.1.21602.7">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+      <Sha>3992fc3841133e15ad322842d35adb8c249a824f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MicrosoftNETILLinkTasksPackageVersion>6.0.100-1.21519.4</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.20181.7</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.1-mauipre.1.21602.7</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NOTE: temporarily hardcode 6.0.100, until we have new branding on dotnet/runtime packs -->


### PR DESCRIPTION
Changes: https://github.com/dotnet/runtime/compare/4822e3c3aa77eb82b2fb33c9321f923cf11ddde6...3992fc3841133e15ad322842d35adb8c249a824f

We are in a situation where:

1. .NET MAUI is still in preview.

2. We need dotnet/runtime fixes for MAUI, but we don't necessarily
   want all fixes going into .NET 6 service releases.

Since we are relying on optional workload packs from dotnet/runtime
anyway, we can simply use "different" builds.

An initial set of builds is coming from the ".NET 6 MAUI" channel on
Maestro. To update, we will need to drop the `CoherentParentDependency`
for dotnet/runtime.

After this change goes in, I can configure a subscription to update
daily/weekly, or whichever we decide is best.