### PR TITLE
[monodroid] Add new `gref+`, `lref+` log options

### DIFF
--- a/Documentation/workflow/SystemProperties.md
+++ b/Documentation/workflow/SystemProperties.md
@@ -118,16 +118,30 @@ categories:
   * `gref`
     Enable global reference logging and log messages to the default
     `grefs.txt` file.
+  * `gref+`
+    Enable global reference logging, writing messages to `adb logcat`.
+    ***Note***: this will spam `adb logcat`, possibly impacting app
+    performance, and Android might not preserve all messages.
+    This is provided as a "last ditch effort", and is not as reliable
+    as the normal `gref` or `gref=` options which write to a file.
+    Added in Xamarin.Android 12.2.
   * `lref-`
     Enable local reference logging but without writing the logged
     messages to a file.
   * `lref=FILE`
-    Enable global reference logging and write messages to the
+    Enable local reference logging and write messages to the
     specified `FILE`
   * `lref`
-    Enable global reference logging and log messages to the default
+    Enable local reference logging and log messages to the default
     `lrefs.txt` file, unless `gref` or `gref=` are also present, in
     which case messages will be logged to the `gref` file.
+  * `lref+`
+    Enable local reference logging, writing messages to `adb logcat`.
+    ***Note***: this will spam `adb logcat`, possibly impacting app
+    performance, and Android might not preserve all messages.
+    This is provided as a "last ditch effort", and is not as reliable
+    as the normal `lref` or `lref=` options which write to a file.
+    Added in Xamarin.Android 12.2.
   * `mono_log_level=LEVEL`
     Set Mono runtime log level.  The default value is `error` to log
     only errors, unless `gc` or `assembly` log categories are enabled,

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -215,6 +215,11 @@ init_logging_categories (char*& mono_log_mask, char*& mono_log_level)
 			continue;
 		}
 
+		if (set_category ("gref+", param, LOG_GREF)) {
+			gref_to_logcat = true;
+			continue;
+		}
+
 		constexpr char CAT_LREF_EQUALS[] = "lref=";
 		constexpr size_t CAT_LREF_EQUALS_LEN = sizeof(CAT_LREF_EQUALS) - 1;
 		if (set_category (CAT_LREF_EQUALS, param, LOG_LREF, true /* arg_starts_with_name */)) {
@@ -224,6 +229,11 @@ init_logging_categories (char*& mono_log_mask, char*& mono_log_level)
 
 		if (set_category ("lref-", param, LOG_LREF)) {
 			light_lref = true;
+			continue;
+		}
+
+		if (set_category ("lref+", param, LOG_LREF)) {
+			lref_to_logcat = true;
 			continue;
 		}
 

--- a/src/monodroid/jni/monodroid-glue.hh
+++ b/src/monodroid/jni/monodroid-glue.hh
@@ -24,4 +24,6 @@ JNIEnv* get_jnienv (void);
 
 extern  FILE  *gref_log;
 extern  FILE  *lref_log;
+extern  bool    gref_to_logcat;
+extern  bool    lref_to_logcat;
 #endif /* __MONODROID_GLUE_H */

--- a/src/monodroid/jni/osbridge.hh
+++ b/src/monodroid/jni/osbridge.hh
@@ -135,7 +135,7 @@ namespace xamarin::android::internal
 		int _monodroid_gref_inc ();
 		int _monodroid_gref_dec ();
 		char* _get_stack_trace_line_end (char *m);
-		void _write_stack_trace (FILE *to, const char *from);
+		void _write_stack_trace (FILE *to, char *from, LogCategories = LOG_NONE);
 		mono_bool take_global_ref_2_1_compat (JNIEnv *env, MonoObject *obj);
 		mono_bool take_weak_global_ref_2_1_compat (JNIEnv *env, MonoObject *obj);
 		mono_bool take_global_ref_jni (JNIEnv *env, MonoObject *obj);


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/25/25443/bug.html#c23
Context: https://github.com/xamarin/monodroid/commit/bf9dc9ee270002ab02f6339640ad80f1b0bdf7c1

Once upon a time, JNI Global Reference (GREF) and
JNI Local Reference (LREF) logging was written only to `adb logcat`.
This worked, until it didn't work; around Android 5.0,
[`__android_log_print()`][0] appeared to become "less reliable", and
`adb logcat` would no longer "reliably" contain all GREF messages.
We "fixed" this in xamarin/monodroid@bf9dc9ee (2015-Feb-6) by writing
GREF messages to `grefs.txt`.

While this improved reliability, there was a "usability" cost:
`grefs.txt` can only be accessed if the app is ["debuggable"][1],
which isn't necessarily easy (requires rebuilding from source), and
hinders diagnosis and review.

Add new `gref+` and `lref+` options, which re-introduce spamming
`adb logcat` with GREF and LREF messages:

	adb shell setprop debug.mono.log gref+,lref+

This will allow non-debuggable apps to produce accessible GREF logs:

	adb logcat > log.txt &
	msbuild /t:StartAndroidActivity App.csproj

…and (again!) *spam* logcat:

	monodroid-gref: +g+ grefc 5 gwrefc 0 obj-handle 0x7fc13ebc70/I -> new-handle 0x29e6/G from thread '(null)'(1)
	monodroid-gref:   at Android.Runtime.AndroidObjectReferenceManager.CreateGlobalReference (Java.Interop.JniObjectReference value) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Java.Interop.JniObjectReference.NewGlobalRef () [0x00000] in <66190dc38bc34d07af752fceda80105a>:0
	monodroid-gref:   at Android.Runtime.JNIEnv.NewGlobalRef (System.IntPtr jobject) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.Runtime.AndroidValueManager.AddPeer (Java.Interop.IJavaPeerable value, System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer, System.IntPtr& handleField) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Java.Lang.Object.SetHandle (System.IntPtr value, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Java.Lang.Object..ctor (System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.Content.Context..ctor (System.IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.Content.ContextWrapper..ctor (System.IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.Views.ContextThemeWrapper..ctor (System.IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.App.Activity..ctor () [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at HelloWorld.MainActivity..ctor () [0x00000] in <01eae2bf5ab14181a2c9706cec17ab4e>:0
	monodroid-gref:   at Android.Runtime.DynamicMethodNameCounter.3 (System.IntPtr , System.Object[] ) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Java.Interop.TypeManager.Activate (Java.Interop.IJavaPeerable o, System.IntPtr jobject, System.Reflection.ConstructorInfo cinfo, System.Object[] parms) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Java.Interop.TypeManager.n_Activate (System.IntPtr jnienv, System.IntPtr jclass, System.IntPtr typename_ptr, System.IntPtr signature_ptr, System.IntPtr jobject, System.IntPtr parameters_ptr) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref:   at Android.Runtime.DynamicMethodNameCounter.2 (System.IntPtr , System.IntPtr , System.IntPtr , System.IntPtr , System.IntPtr , System.IntPtr ) [0x00000] in <31a674ae732f498eaa71dc8ffa7c6f81>:0
	monodroid-gref: handle 0x29e6; key_handle 0xc2ad59d: Java Type: `example/MainActivity`; MCW type: `HelloWorld.MainActivity`

The new `gref+` and `lref+` log categories should not be considered
to be "reliable"; message delivery is up to `adb logcat`, which has a
known history of skipping messages.  That said, this may be better
than nothing, which was the previous alternative.

[0]: https://developer.android.com/ndk/reference/group/logging#__android_log_print
[1]: https://developer.android.com/guide/topics/manifest/application-element#debug