### PR TITLE
[One .NET] default to Profiled AOT for Release builds

### DIFF
--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -176,6 +176,28 @@ property, as `$(AotAssemblies)` will eventually be deprecated.
 
 [blazor]: https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-4/#blazor-webassembly-ahead-of-time-aot-compilation
 
+We want to choose the optimal settings for startup time and app size.
+By default `Release` builds will default to:
+
+```xml
+<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <RunAOTCompilation>true</RunAOTCompilation>
+  <AndroidEnableProfiledAot>true</AndroidEnableProfiledAot>
+</PropertyGroup>
+```
+This is the behavior when `$(RunAOTCompilation)` and
+`$(AndroidEnableProfiledAot)` are blank.
+
+So if you would like to *disable* AOT, you would need to explicitly
+turn these settings off:
+
+```xml
+<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <RunAOTCompilation>false</RunAOTCompilation>
+  <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+</PropertyGroup>
+```
+
 ## dotnet cli
 
 There are currently a few "verbs" we are aiming to get working in

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -112,14 +112,14 @@
       <Output TaskParameter="Result" ItemName="_NuGetSources" />
     </XmlPeek>
 
-    <!-- dotnet workload install android-aot -->
+    <!-- dotnet workload install android -->
     <PropertyGroup>
       <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
     </PropertyGroup>
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
-      <_InstallArguments Include="android-aot" />
+      <_InstallArguments Include="android" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -10,7 +10,6 @@
       <Replacement>@PACK_VERSION_SHORT@</Replacement>
     </ShortNames>
     <ComponentResources Include="android" Version="@WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Android" Description=".NET SDK Workload for building Android applications."/>
-    <ComponentResources Include="android-aot" Version="@WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Android with AOT" Description=".NET SDK Workload for building Android applications with AOT support."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Android.Manifest*.nupkg" Version="@WORKLOAD_VERSION@" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -71,9 +71,12 @@
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' and Exists ('Properties\AndroidManifest.xml') and !Exists ('AndroidManifest.xml') ">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition=" '$(AndroidManifest)' == '' ">AndroidManifest.xml</AndroidManifest>
     <GenerateApplicationManifest Condition=" '$(GenerateApplicationManifest)' == '' ">true</GenerateApplicationManifest>
+    <!-- Default to AOT in Release mode -->
+    <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == '' and '$(Configuration)' == 'Release' ">true</RunAOTCompilation>
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == 'true' ">true</RunAOTCompilation>
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' ">false</RunAOTCompilation>
     <AotAssemblies>$(RunAOTCompilation)</AotAssemblies>
+    <AndroidEnableProfiledAot Condition=" '$(AndroidEnableProfiledAot)' == '' and '$(RunAOTCompilation)' == 'true' ">true</AndroidEnableProfiledAot>
 
     <!--
       Runtime libraries feature switches defaults

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -14,12 +14,7 @@
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
-      "extends" : [ "microsoft-net-runtime-android" ]
-    },
-    "android-aot": {
-      "description": ".NET SDK Workload for building Android applications with AOT support.",
-      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
-      "extends" : [ "android", "microsoft-net-runtime-android-aot" ]
+      "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ]
     }
   },
   "packs": {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -132,6 +132,9 @@ namespace Xamarin.Android.Build.Tests
 				new XamarinAndroidApplicationProject ();
 			proj.ProjectName = testName;
 			proj.IsRelease = true;
+			// TODO: AOT fails https://github.com/xamarin/xamarin-android/issues/6685
+			// .NET 6 uses AOT by default for Release
+			proj.AotAssemblies = false;
 			if (forms) {
 				proj.PackageReferences.Clear ();
 				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -75,6 +75,7 @@ namespace Xamarin.Android.Build.Tests
 				new XamarinFormsAndroidApplicationProject () :
 				new XamarinAndroidApplicationProject ();
 			proj.IsRelease = true;
+			proj.AotAssemblies = false; // Release defaults to Profiled AOT for .NET 6
 			proj.SetAndroidSupportedAbis ("arm64-v8a");
 			proj.SetProperty ("LinkerDumpDependencies", "True");
 			proj.SetProperty ("AndroidUseAssemblyStore", "False");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -532,9 +532,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace (": Activity", ": AndroidX.AppCompat.App.AppCompatActivity");
 			proj.SetProperty ("AndroidUseAssemblyStore", usesAssemblyStore.ToString ());
-			if (aot) {
-				proj.SetProperty ("RunAOTCompilation", "true");
-			}
+			proj.SetProperty ("RunAOTCompilation", aot.ToString ());
 			proj.OtherBuildItems.Add (new AndroidItem.InputJar ("javaclasses.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestJar,
 			});
@@ -633,6 +631,10 @@ namespace Xamarin.Android.Build.Tests
 					helper.AssertContainsEntry ($"assemblies/{abi}/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
 				} else {
 					helper.AssertContainsEntry ("assemblies/System.Private.CoreLib.dll",        shouldContainEntry: expectEmbeddedAssembies);
+				}
+				if (aot) {
+					helper.AssertContainsEntry ($"lib/{abi}/libaot-{proj.ProjectName}.dll.so");
+					helper.AssertContainsEntry ($"lib/{abi}/libaot-System.Linq.dll.so");
 				}
 			}
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Android.Build.Tests
 			var bytes = new byte [1024];
 			app = new XamarinFormsMapsApplicationProject {
 				IsRelease = true,
+				AotAssemblies = false, // Release defaults to Profiled AOT for .NET 6
 				PackageName = "com.xamarin.bundletooltests",
 			};
 			app.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("foo.bar") {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -614,6 +614,7 @@ using System.Runtime.Serialization.Json;
 
 			proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
+				AotAssemblies = false, // Release defaults to Profiled AOT for .NET 6
 			};
 			var abis = new string[] { "armeabi-v7a", "arm64-v8a", "x86", "x86_64" };
 			proj.SetAndroidSupportedAbis (abis);


### PR DESCRIPTION
To improve startup performance for `Release` builds:

1. Default `$(RunAOTCompilation)` to `true`

2. Default `$(AndroidEnableProfiledAot)` to `true`.

Going forward, you would have to explicitly turn these off if you want
them to be off.

We also can drop the `android-aot` workload, and just include the
dotnet/runtime packs in the `android` workload:

https://github.com/dotnet/runtime/blob/c7adf5598f27e59644030ddae4e382cbda74e41e/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in#L29-L40

These packs are already inserted into Visual Studio, so we can rely on
them.

Since the new project options screen evaluates MSBuild, we don't
appear to need to do anything on the UI side:

![image](https://user-images.githubusercontent.com/840039/144901348-de5cdad4-babc-4349-908f-4a9dc2ea187b.png)
