### PR TITLE
[Xamarin.Android.Build.Tasks] Bump XA0113 warning to 30.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -59,7 +59,7 @@ ms.date: 01/24/2020
 + [XA0109](xa0109.md): Unsupported or invalid `$(TargetFrameworkVersion)` value of 'v4.5'.
 + [XA0111](xa0111.md): Could not get the `aapt2` version. Please check it is installed correctly.
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
-+ [XA0113](xa0113.md): Google Play requires that new applications and updates must use a TargetFrameworkVersion of v10.0 (API level 29) or above.
++ [XA0113](xa0113.md): Google Play requires that new applications and updates must use a TargetFrameworkVersion of v11.0 (API level 30) or above.
 + [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties to remove the old value. If the properties page does not show an 'armeabi' checkbox, un-check and re-check one of the other ABIs and save the changes.
 + [XA0116](xa0116.md): Unable to find `EmbeddedResource` named `{ResourceName}`.
 + [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -7,13 +7,13 @@ ms.date: 02/28/2019
 
 ## Issue
 
-As of November 2nd 2020, new applications and application updates uploaded
-to the Google Play store need to target v10.0 (API 29) or above.
+As of November 1st 2021, new applications and application updates uploaded
+to the Google Play store need to target v11.0 (API 30) or above.
 
 ## Solution
 
 If you are seeing this warning, you should update the
-`$(TargetFrameworkVersion)` of your projects to be v10.0 or above.
+`$(TargetFrameworkVersion)` of your projects to be v11.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
 warnings, you can make use of the `/warnasmessage:XA0113` command line

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Legacy/ResolveAndroidTooling.cs
@@ -45,8 +45,8 @@ namespace Xamarin.Android.Tasks.Legacy
 
 			int apiLevel;
 			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
-				if (apiLevel < 29)
-					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, "v10.0", "29", TargetFrameworkVersion, AndroidApiLevel);
+				if (apiLevel < 30)
+					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113, "v11.0", "30", TargetFrameworkVersion, AndroidApiLevel);
 				if (apiLevel < 21)
 					Log.LogCodedWarning ("XA0117", Properties.Resources.XA0117, TargetFrameworkVersion);
 			}


### PR DESCRIPTION
Context: https://support.google.com/googleplay/android-developer/answer/9859152?#targetsdk

We currently warn if `$(TargetFrameworkVersion)` is less than 29:

    Google Play requires that new applications and updates must use a TargetFrameworkVersion of v10.0 (API level 29) or above.

Since November 1, 2021, Google Play requires API 30, so we need to
update this warning.