### PR TITLE
[Xamarin.Android.Build.Tasks] Use class-parse.exe out of MSBuild process

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -69,6 +69,9 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.pdb" PackagePath="tools" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\%(_LocalizationLanguages.Identity)\Microsoft.Android.Sdk.ILLink.resources.dll" PackagePath="tools\%(_LocalizationLanguages.Identity)" />
       <_PackageFiles Include="$(ToolsSourceDir)**" PackagePath="tools" />
+      <_PackageFiles Include="$(NetCoreAppToolsSourceDir)class-parse.dll" PackagePath="tools" />
+      <_PackageFiles Include="$(NetCoreAppToolsSourceDir)class-parse.pdb" PackagePath="tools" />
+      <_PackageFiles Include="$(NetCoreAppToolsSourceDir)class-parse.runtimeconfig.json" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.dll" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.pdb" PackagePath="tools" />
       <_PackageFiles Include="$(NetCoreAppToolsSourceDir)generator.runtimeconfig.json" PackagePath="tools" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
@@ -31,6 +31,7 @@ This file is only used by binding projects.
         OutputFile="$(ApiOutputFile).class-parse"
         SourceJars="@(EmbeddedJar);@(InputJar)"
         DocumentationPaths="@(_AndroidDocumentationPath)"
+        ToolPath="$(MonoAndroidToolsDirectory)"
     />
     <BindingsGenerator
         OnlyRunXmlAdjuster="true"
@@ -45,6 +46,13 @@ This file is only used by binding projects.
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
     />
+
+    <ItemGroup>
+      <!-- Created by <ClassParse /> -->
+      <FileWrites Include="$(IntermediateOutputPath)class-parse.rsp" />
+      <!-- Created by <BindingGenerator /> -->
+      <FileWrites Condition="Exists ('$(IntermediateOutputPath)java-resolution-report.log')" Include="$(IntermediateOutputPath)java-resolution-report.log" />
+    </ItemGroup>    
   </Target>
 
   <Target Name="_GetJavaSourceJarJavadocFiles"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -415,7 +415,6 @@
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj" />
-    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj" />
     <!--
       Mono.Android.csproj needs to be built first because this project
       references files *generated* and contained within the Mono.Android project.


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/499

There are potentially some conflicts with using `Xamarin.Android.Tools.Bytecode` directly in the MSBuild process, as it now imports `protobuf-net` which is a commonly used library.

To ensure it isn't running in-process, switch our targets to shell out to `class-parse[.exe/.dll]`.

Additionally add `class-parse.dll`, etc. to the .NET 6 install pack.  We are already shipping `class-parse.exe`, etc. in the Classic installer even though it wasn't used, so no additional installer changes are needed there.

As expected, moving this out-of-process is slightly slower, but still acceptable.

```
Before
292 ms  ClassParse                                 1 calls

After
425 ms  ClassParse                                 1 calls
```

Additionally adds `java-resolution-report.log` to `<FileWrites />` which was added in https://github.com/xamarin/java.interop/pull/849.