### PR TITLE
[GitHub] Don't use checkboxes in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -7,14 +7,17 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this report! Please make sure to add as much detail as you can, preferably with a reproduction if possible. This will help us diagnose the issue faster and thus resolve it quicker.
-  - type: checkboxes
+  - type: dropdown
     id: android-type
     attributes:
       label: Android application type
-      description: In what type of Android application do you see this issue?
+      description: In what type(s) of Android application(s) do you see this issue?
+      multiple: true
       options:
-      - label: Classic Xamarin.Android (MonoAndroid11.0, MonoAndroid12.0, etc.)
-      - label: Android for .NET (net6.0-android, etc.)
+      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
+      - Android for .NET (net6.0-android, etc.)
+    validations:
+      required: true
   - type: input
     id: platform-versions
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -7,14 +7,17 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this report! Please make sure to add as much detail as you can, preferably with a reproduction if possible. This will help us diagnose the issue faster and thus resolve it quicker.
-  - type: checkboxes
+  - type: dropdown
     id: android-type
     attributes:
       label: Android application type
-      description: In what type of Android application do you see this issue?
+      description: In what type(s) of Android application(s) do you see this issue?
+      multiple: true
       options:
-      - label: Classic Xamarin.Android (MonoAndroid11.0, MonoAndroid12.0, etc.)
-      - label: Android for .NET (net6.0-android, etc.)
+      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
+      - Android for .NET (net6.0-android, etc.)
+    validations:
+      required: true
   - type: input
     id: platform-versions
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -12,14 +12,17 @@ body:
 
         [Microsoft Q&A](https://docs.microsoft.com/en-us/answers/topics/dotnet-android.html)
         [Stack Overflow](https://stackoverflow.com)
-  - type: checkboxes
+  - type: dropdown
     id: android-type
     attributes:
       label: Android application type
-      description: In what type of Android application do you see this issue?
+      description: In what type(s) of Android application(s) do you see this issue?
+      multiple: true
       options:
-      - label: Classic Xamarin.Android (MonoAndroid11.0, MonoAndroid12.0, etc.)
-      - label: Android for .NET (net6.0-android, etc.)
+      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
+      - Android for .NET (net6.0-android, etc.)
+    validations:
+      required: true
   - type: input
     id: platform-versions
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -9,14 +9,17 @@ body:
         Documentation for how to troubleshoot issues with binding projects, as well as common issues and how to solve them, is available [here](https://github.com/xamarin/java.interop/wiki/Troubleshooting-Android-Bindings-Issues).
 
         If you get stuck troubleshooting an issue, please make sure to add as much detail as you can, preferably with a reproduction if possible. This will help us diagnose the issue faster and thus resolve it quicker.
-  - type: checkboxes
+  - type: dropdown
     id: android-type
     attributes:
       label: Android application type
-      description: In what type of Android application do you see this issue?
+      description: In what type(s) of Android application(s) do you see this issue?
+      multiple: true
       options:
-      - label: Classic Xamarin.Android (MonoAndroid11.0, MonoAndroid12.0, etc.)
-      - label: Android for .NET (net6.0-android, etc.)
+      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
+      - Android for .NET (net6.0-android, etc.)
+    validations:
+      required: true
   - type: input
     id: platform-versions
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -7,14 +7,17 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this report! Please make sure to add as much detail as you can, preferably with a reproduction if possible. This will help us diagnose the issue faster and thus resolve it quicker.
-  - type: checkboxes
+  - type: dropdown
     id: android-type
     attributes:
       label: Android application type
-      description: In what type of Android application do you see this issue?
+      description: In what type(s) of Android application(s) do you see this issue?
+      multiple: true
       options:
-      - label: Classic Xamarin.Android (MonoAndroid11.0, MonoAndroid12.0, etc.)
-      - label: Android for .NET (net6.0-android, etc.)
+      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
+      - Android for .NET (net6.0-android, etc.)
+    validations:
+      required: true
   - type: input
     id: platform-versions
     attributes:


### PR DESCRIPTION
In our new YML issue templates, we use checkboxes for users to choose if their issues applies to Classic XA, .NET XA, or both.

However, these checkboxes are converted to "issue tasks" and show up as "1 of 2 tasks". ([example])(https://github.com/xamarin/xamarin-android/issues/6545)

This feedback has been filed to [GitHub](https://github.com/github/feedback/discussions/5238).

For now, switch to a dropdown that allows multiple selections.