### PR TITLE
[build] set $DOTNET_MULTILEVEL_LOOKUP to 0

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -119,7 +119,7 @@
     </PropertyGroup>
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
-      <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\*$(AndroidLatestUnstableApiLevel)*.nupkg" />
+      <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android-aot" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
@@ -128,7 +128,11 @@
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
     </ItemGroup>
     <MakeDir Directories="$(_TempDirectory)" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install @(_InstallArguments, ' ')"
+        WorkingDirectory="$(_TempDirectory)"
+        EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
+    />
     <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -42,7 +42,7 @@
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; restore maui.proj -p:MauiVersion=$(MauiVersion)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
-        EnvironmentVariables="NUGET_PACKAGES=$(_TempDirectory)"
+        EnvironmentVariables="NUGET_PACKAGES=$(_TempDirectory);DOTNET_MULTILEVEL_LOOKUP=0"
     />
 
     <!-- Copy WorkloadManifest.* files-->
@@ -58,7 +58,11 @@
       <_InstallArguments Include="--configfile &quot;$(XamarinAndroidSourcePath)NuGet.config&quot;" />
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
     </ItemGroup>
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; workload install maui-android @(_InstallArguments, ' ')" WorkingDirectory="$(_TempDirectory)" />
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install maui-android @(_InstallArguments, ' ')"
+        WorkingDirectory="$(_TempDirectory)"
+        EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
+    />
     <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
   <Target Name="BuildDotNetPreviewApiLevel">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -347,6 +347,9 @@ namespace Xamarin.ProjectTools
 			if (!Builder.UseDotNet && !TestEnvironment.IsWindows) {
 				psi.SetEnvironmentVariable ("MSBUILD_EXE_PATH", null);
 			}
+			if (Builder.UseDotNet) {
+				psi.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
+			}
 
 			psi.Arguments = args.ToString ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -52,6 +52,7 @@ namespace Xamarin.ProjectTools
 				p.StartInfo.UseShellExecute = false;
 				p.StartInfo.RedirectStandardOutput = true;
 				p.StartInfo.RedirectStandardError = true;
+				p.StartInfo.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
 				// Ensure any variable alteration from DotNetXamarinProject.Construct is cleared.
 				if (!Builder.UseDotNet && !TestEnvironment.IsWindows) {
 					p.StartInfo.SetEnvironmentVariable ("MSBUILD_EXE_PATH", null);


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/install/windows#download-and-manually-install

I have VS main installed, and my system has:

    > dotnet --version
    6.0.200-preview.21573.3

And so any built-in `~\android-toolchain\dotnet\dotnet.exe` commands
would actually run my system `dotnet` because it is newer than the
version our build provisions. In this case, my `C:\Program
Files\dotnet\dotnet.exe` was attempting to install my local build.

We can use `$DOTNET_MULTILEVEL_LOOKUP` to force
`~\android-toolchain\dotnet\dotnet.exe` to be always used. I couldn't
find many docs on this, but it is used in various dotnet repos, such as:

https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/dotnet.cmd#L16-L17

I also fixed the wildcard match for `@(_PreviewPacks)`, which matched
a commit distance of 132!

    Microsoft.Android.Ref.31.31.0.101-ci.pr.gh6555.132.nupkg

It is intended to only match:

    Microsoft.Android.Ref.32.*.nupkg