### PR TITLE
[One .NET] fix AOT builds with different settings

### DIFF
--- a/Documentation/guides/messages/xa0119.md
+++ b/Documentation/guides/messages/xa0119.md
@@ -27,14 +27,21 @@ Remove the following options from `Debug` configurations:
 * App Bundles
   * `<AndroidPackageFormat>aab</AndroidPackageFormat>`
 
+Remove the following from `Release` configurations:
+
+* Hot Reload support
+  * `<UseInterpreter>true</UseInterpreter>`
+
 *DO* use the following options for `Debug` configurations:
 
 * `<AndroidLinkMode>None</AndroidLinkMode>`
 * `<EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>`
+* `<UseInterpreter>true</UseInterpreter>`
 
 *DO* use the following options for `Release` configurations:
 
 * `<EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>`
+* `<AotAssemblies>True</AotAssemblies>` or in .NET 6 `<RunAOTCompilation>True</RunAOTCompilation>`
 
 Consider submitting a [bug][bug] if you are getting one of these
 warnings under normal circumstances.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -40,7 +40,7 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
 
   <Target Name="_AndroidAot"
       Condition=" '$(AotAssemblies)' == 'true' and '$(RuntimeIdentifier)' != '' "
-      DependsOnTargets="_AndroidAotInputs"
+      DependsOnTargets="_CreatePropertiesCache;_AndroidAotInputs"
       Inputs="@(_AndroidAotInputs)"
       Outputs="$(_AndroidStampDirectory)_AndroidAot.stamp">
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -296,6 +296,10 @@ The term "lock file" comes from NuGet. For example, search for "UnauthorizedLock
     <value>Using fast deployment and a code shrinker at the same time is not recommended. Use fast deployment for Debug configurations and a code shrinker for Release configurations.</value>
     <comment>The following are literal names and should not be translated: Debug, Release.</comment>
   </data>
+  <data name="XA0119_Interpreter" xml:space="preserve">
+    <value>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</value>
+    <comment>The following are literal names and should not be translated: AOT, Debug, Release.</comment>
+  </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>
     <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -33,6 +33,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>
 {0} - The Java SDK version number</note>
       </trans-unit>
+      <trans-unit id="XA0119_Interpreter">
+        <source>Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</source>
+        <target state="new">Disabling the interpreter; using the interpreter and AOT at the same time is not supported. Use the interpreter for hot reload support in Debug configurations and AOT for Release configurations.</target>
+        <note>The following are literal names and should not be translated: AOT, Debug, Release.</note>
+      </trans-unit>
       <trans-unit id="XA0125">
         <source>'{0}' is using a deprecated debug information level.
 Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1741,6 +1741,21 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		public void XA0119Interpreter ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetProperty ("UseInterpreter", "true");
+			proj.SetProperty ("AotAssemblies", "true");
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "XA0119"), "Output should contain XA0119 warnings");
+			}
+		}
+
+		[Test]
 		public void FastDeploymentDoesNotAddContentProvider ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -865,6 +865,37 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			builder.AssertHasNoWarnings ();
 		}
 
+		static readonly object [] SettingCombinationsSource = new object [] {
+			// Interpreter + AOT
+			new object [] {
+				/* isRelease */      true,
+				/* useInterpreter */ true,
+				/* publishTrimmed */ true,
+				/* aot */            true,
+			},
+			// Debug + AOT
+			new object [] {
+				/* isRelease */      false,
+				/* useInterpreter */ false,
+				/* publishTrimmed */ true,
+				/* aot */            true,
+			},
+		};
+
+		[Test]
+		[TestCaseSource (nameof (SettingCombinationsSource))]
+		public void SettingCombinations (bool isRelease, bool useInterpreter, bool publishTrimmed, bool aot)
+		{
+			var proj = new XASdkProject {
+				IsRelease = isRelease,
+			};
+			proj.SetProperty ("UseInterpreter", useInterpreter.ToString ());
+			proj.SetProperty ("PublishTrimmed", publishTrimmed.ToString ());
+			proj.SetProperty ("RunAOTCompilation", aot.ToString ());
+			var builder = CreateDotNetBuilder (proj);
+			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
+		}
+
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)
 		{
 			if (string.IsNullOrEmpty (relativeProjectDir)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -190,7 +190,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 	<!-- Ahead-of-time compilation properties -->
 	<AotAssemblies Condition=" '$(AndroidEnableProfiledAot)' == 'True' ">True</AotAssemblies>
-	<AndroidAotMode Condition=" '$(AndroidUseInterpreter)' != 'False' ">Interpreter</AndroidAotMode>
+	<AndroidAotMode Condition=" '$(AotAssemblies)' != 'True' And '$(AndroidUseInterpreter)' == 'True' ">Interpreter</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' ">None</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' And '$(AndroidAotMode)' != 'Interpreter' ">True</AotAssemblies>
@@ -444,6 +444,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_AAB"
       Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AndroidPackageFormat)' == 'aab' "
+  />
+  <AndroidWarning Code="XA0119"
+      ResourceName="XA0119_Interpreter"
+      Condition=" '$(AndroidUseInterpreter)' == 'True' And '$(AotAssemblies)' == 'True' "
   />
   <AndroidWarning Code="XA1027"
       ResourceName="XA1027"


### PR DESCRIPTION
Building a .NET 6 `Release` app with `UseInterpreter=true` and
`RunAOTCompilation=true` would fail with:

    Microsoft.Android.Sdk.Aot.targets(71,5): Unknown Mode value: Interpreter. 'Mode' must be one of: Normal,JustInterp,Full,FullInterp,Hybrid,LLVMOnly,LLVMOnlyInterp

Reviewing the code:

https://github.com/dotnet/runtime/blob/60edc0bdafce1849fec19e3ec4f766074de50fc3/src/tasks/AotCompilerTask/MonoAOTCompiler.cs#L1064-L1073

There does not appear to be a mode of `Normal` + `Interp`. So let's
just make AOT take precendence over `$(UseInterpreter)`. On Android
`$(UseInterpreter)` is a Debug-mode setting for Hot Reload.

Building a .NET 6 `Debug` app `RunAOTCompilation=true` would fail with:

    Microsoft.Android.Sdk.Aot.targets(49,5): error MSB4044: The "GetAotAssemblies" task was not given a value for the required parameter "AndroidApiLevel".

This is because the linker was skipped, particularly this target:

    <Target Name="_PrepareLinking"
        Condition=" '$(PublishTrimmed)' == 'true' "
        AfterTargets="ComputeResolvedFilesToPublishList"
        DependsOnTargets="GetReferenceAssemblyPaths;_CreatePropertiesCache">

`_CreatePropertiesCache` doesn't run, and so we have some empty
properties in this case. We can simply add `_CreatePropertiesCache` to
the `_AndroidAot` MSBuild target's `DependsOnTargets` to solve this
issue.