### PR TITLE
[ci] Move to 1ES Windows VS 2022 pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -158,7 +158,7 @@ stages:
   jobs:
   - job: win_build_test
     displayName: Build and Smoke Test
-    pool: $(VSEngWinVS2019)
+    pool: $(1ESWindowsPool)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     steps:
@@ -277,7 +277,7 @@ stages:
 
   - job: win_dotnet_build_test
     displayName: Dotnet Build and Smoke Test
-    pool: $(VSEngWinVS2019)
+    pool: $(1ESWindowsPool)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     steps:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -13,11 +13,11 @@ parameters:
 jobs:
   - job: ${{ parameters.job_name }}
     displayName: MSBuild ${{ parameters.job_suffix }} - Windows-${{ parameters.node_id }}/${{ parameters.additional_node_id }}
-    pool: $(VSEngWinVS2019)
+    pool: $(1ESWindowsPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     variables:
-      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+      VSINSTALLDIR: C:\Program Files\Microsoft Visual Studio\2022\Enterprise
     steps:
     - script: netsh int ipv4 set global sourceroutingbehavior=drop
 

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -25,8 +25,8 @@ variables:
   value: macOS-10.15
 - name: HostedWinVS2019
   value: Hosted Windows 2019 with VS2019
-- name: VSEngWinVS2019
-  value: android-win-2019
+- name: 1ESWindowsPool
+  value: android-win-2022
 - name: VSEngMicroBuild2019
   value: VSEngSS-MicroBuild2019-1ES
 - name: TeamName

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -162,9 +162,9 @@ namespace Xamarin.Android.Build
 					Path.Combine (programFiles, "MSBuild", "Microsoft"),
 				};
 				SearchPathsOS            = "windows";
-				string nuget             = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "16.0");
+				string nuget             = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "17.0");
 				if (!Directory.Exists (nuget)) {
-					nuget = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "15.0");
+					nuget = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "16.0");
 				}
 				NuGetProps               = Path.Combine (nuget, "Microsoft.NuGet.props");
 				NuGetTargets             = Path.Combine (nuget, "Microsoft.NuGet.targets");


### PR DESCRIPTION
Context: https://aka.ms/1eshostedpools

I've created a new Windows VS 2022 pool to use for Windows build and
test jobs.  The azure resource for this pool can be [found here][0].

The base image of this pool is the Microsoft-hosted [windows-2022][1]
image, and our machines will stay in sync with any updates that happen
to that hosted pool moving foward.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourceGroups/devdiv-vm-scale-sets/providers/Microsoft.CloudTest/hostedpools/android-win-2022/overview
[1]: https://github.com/actions/virtual-environments/blob/ddaeaaa8fba88b009ab140001e63ee317dae52db/images/win/Windows2022-Readme.md