### PR TITLE
Revert "[tests] enable NoSymbolsArgShouldReduceAppSize test (#6544)"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -449,6 +449,10 @@ namespace "+ libName + @" {
 		[Category ("LLVM")]
 		public void NoSymbolsArgShouldReduceAppSize ([Values ("", "Hybrid")] string androidAotMode)
 		{
+			if (Builder.UseDotNet) {
+				Assert.Ignore ("https://github.com/dotnet/runtime/issues/57800");
+			}
+
 			AssertAotModeSupported (androidAotMode);
 
 			var proj = new XamarinAndroidApplicationProject () {


### PR DESCRIPTION
This reverts commit 5dcf2945e4cd7da50c5c8f76608e0d0266022b09.

Context: https://github.com/xamarin/xamarin-android/issues/6520
Context: https://github.com/xamarin/xamarin-android/pull/6560
Context: 5dcf2945e4cd7da50c5c8f76608e0d0266022b09
Context: c96d9f496675d177687273fb20bc65f6e5dc73cd

There was a "curious" interaction between 5dcf2945 (PR #6544) and
commit c96d9f49 (PR #6539): they both had green PRs, but each of
their PR build ran without the other existing.  Once both were merged,
all subsequent commits, and PRs based on c96d9f49, had a unit test
failure in `NoSymbolsArgShouldReduceAppSize`:

	Task "MonoAOTCompiler" requested 6 cores, acquired 6 cores, and now holds 6 cores total.
	[System.Private.CoreLib.dll] Running: C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64\6.0.1-mauipre.1.21602.7\Sdk\..\tools\mono-aot-cross.exe --response="C:\Users\cloudtest\AppData\Local\Temp\tmp4D48.tmp"
	[System.Private.CoreLib.dll] Using working directory: C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked
	[System.Private.CoreLib.dll] Setting environment variables for execution:
	[System.Private.CoreLib.dll] 	MONO_PATH = C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked;
	[System.Private.CoreLib.dll] 	MONO_ENV_OPTIONS =
	[System.Private.CoreLib.dll] Exit code: 1
	[System.Private.CoreLib.dll] Exec (with response file contents expanded) in C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked: MONO_PATH=C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked; MONO_ENV_OPTIONS= C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64\6.0.1-mauipre.1.21602.7\Sdk\..\tools\mono-aot-cross.exe --debug --llvm "--aot=asmwriter,mtriple=aarch64-linux-android,tool-prefix=C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-,ld-name=ld.EXE,ld-flags=-LC:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21 C:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libc.so C:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libm.so,temp-path=C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib,nodebug,llvm-path=C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64\6.0.1-mauipre.1.21602.7\Sdk\..\tools,outfile=C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\System.Private.CoreLib.dll.so,llvm-outfile=C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\System.Private.CoreLib.dll-llvm.o" "System
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find Files\: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find C:\Program\: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find Files\: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libc.so: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find C:\Program\: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find Files\: No such file or directory
	C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE: cannot find (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libm.so: No such file or directory
	AOT of image System.Private.CoreLib.dll failed.
	Mono Ahead of Time compiler - compiling assembly C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked\System.Private.CoreLib.dll
	AOTID EE73FF83-5340-500C-4239-56CE4D83F91B
	Executing opt: "C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64\6.0.1-mauipre.1.21602.7\Sdk\..\tools\opt" -f -O2 -disable-tail-calls -place-safepoints -spp-all-backedges -o "C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.opt.bc" "C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.bc"
	Executing llc: "C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64\6.0.1-mauipre.1.21602.7\Sdk\..\tools\llc"  -enable-implicit-null-checks -disable-fault-maps -march=aarch64 -asm-verbose=false -mtriple=aarch64-linux-android -disable-gnu-eh-frame -enable-mono-eh-frame -mono-eh-frame-symbol=mono_aot_corlib_eh_frame -disable-tail-calls -relocation-model=pic -filetype=obj -o "C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp-llvm.o" "C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.opt.bc"
	Compiled: 7440/7440
	Executing the native assembler: "C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-as"   -o C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.s.o C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.s
	Executing the native linker: "C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\tools\binutils\aarch64-linux-android-ld.EXE" -Bsymbolic -shared -o C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\System.Private.CoreLib.dll.so.tmp "C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp-llvm.o" C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\aot\arm64-v8a\System.Private.CoreLib\temp.s.o -LC:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21 C:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libc.so C:\Program\ Files\ (x86)\Android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\21\libm.so
	1:8>C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.12.134\targets\Microsoft.Android.Sdk.Aot.targets(71,5): error : Precompiling failed for C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\obj\Release\android-arm64\linked\System.Private.CoreLib.dll [C:\a\_work\1\a\TestRelease\12-09_14.48.54\temp\NoSymbolsArgShouldReduceAppSize\UnnamedProject.csproj]

This is the same error scenario as Issue #6520.

The "curious interaction" is as follows: the
`NoSymbolsArgShouldReduceAppSize` works under .NET 6 *so long as* the
NDK toolchain is installed into a directory that doesn't have spaces.
When #6544 ran, this was the case: it used the NDK provisioned by our
build process, located in `$HOME`.

Commit c96d9f49 / PR #6539 changed this: the NDK became optional
except when LLVM is required, because NDK tools located within the
Xamarin.Android install could be used instead.  As part of this
change, `$(AndroidNdkDirectory)` was *not* always set to the NDK
provisioned by the unit tests.  When an NDK *was* required, the
system-wide / VS-provided NDK was used instead, at:

	C:\Program Files (x86)\Android\android-sdk\ndk\23.1.7779620

Once both commits 5dcf2945 and c96d9f49 landed, the *now running*
`NoSymbolsArgShouldReduceAppSize` test failed, as it was trying to
use the system-wide NDK directory.

Revert commit 5dcf2945, disabling the
`NoSymbolsArgShouldReduceAppSize`.  We'll re-enable it once we fix
Issue #6520.