### PR TITLE
[One .NET] rework .NET 6 AOT support

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -53,14 +53,17 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         AndroidApiLevel="$(_AndroidApiLevel)"
         MinimumSupportedApiLevel="$(AndroidMinimumSupportedApiLevel)"
         AndroidSequencePointsMode="$(_SequencePointsMode)"
-        AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
         TargetName="$(TargetName)"
         ResolvedAssemblies="@(_AndroidAotInputs)"
         AotOutputDirectory="$(_AndroidAotBinDirectory)"
         RuntimeIdentifier="$(RuntimeIdentifier)"
         EnableLLVM="$(EnableLLVM)"
-        UsingAndroidNETSdk="true"
         Profiles="@(AndroidAotProfile)">
+      <Output PropertyName="_Triple"     TaskParameter="Triple" />
+      <Output PropertyName="_ToolPrefix" TaskParameter="ToolPrefix" />
+      <Output PropertyName="_MsymPath"   TaskParameter="MsymPath" />
+      <Output PropertyName="_LdName"     TaskParameter="LdName" />
+      <Output PropertyName="_LdFlags"    TaskParameter="LdFlags" />
       <Output ItemName="_MonoAOTAssemblies" TaskParameter="ResolvedAssemblies" />
     </GetAotAssemblies>
     <PropertyGroup>
@@ -69,7 +72,10 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath)aot\" />
     <MonoAOTCompiler
-        Assemblies="@(_MonoAOTAssemblies->'%(FullPath)')"
+        Triple="$(_Triple)"
+        ToolPrefix="$(_ToolPrefix)"
+        MsymPath="$(_MsymPath)"
+        Assemblies="@(_MonoAOTAssemblies)"
         CompilerBinaryPath="$(_MonoAOTCompilerPath)"
         DisableParallelAot="$(_DisableParallelAot)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
@@ -79,7 +85,11 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         OutputType="Library"
         UseAotDataFile="false"
         UseLLVM="$(EnableLLVM)"
-        LLVMPath="$(_LLVMPath)">
+        LLVMPath="$(_LLVMPath)"
+        LdName="$(_LdName)"
+        LdFlags="$(_LdFlags)"
+        WorkingDirectory="$(MSBuildProjectDirectory)"
+        AotArguments="$(AndroidAotAdditionalArguments)">
       <Output TaskParameter="CompiledAssemblies" ItemName="_AotCompiledAssemblies" />
       <Output TaskParameter="FileWrites"         ItemName="FileWrites" />
     </MonoAOTCompiler>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Android.Tasks
 
 		public string ExtraAotOptions { get; set; }
 
+		public string AotAdditionalArguments { get; set; }
+
 		[Output]
 		public string[] NativeLibrariesReferences { get; set; }
 
@@ -137,11 +139,27 @@ namespace Xamarin.Android.Tasks
 					string tempDir = Path.Combine (outdir, Path.GetFileName (assembly.ItemSpec));
 					Directory.CreateDirectory (tempDir);
 
-					var aotOptions = GetAotOptions (ndk, arch, level, outdir, mtriple, toolPrefix);
+					GetAotOptions (ndk, arch, level, outdir, toolPrefix);
 					// NOTE: ordering seems to matter on Windows
-					aotOptions.Insert (0, $"outfile={outputFile}");
-					aotOptions.Insert (0, $"llvm-path={SdkBinDirectory}");
-					aotOptions.Insert (0, $"temp-path={tempDir}");
+					var aotOptions = new List<string> ();
+					aotOptions.Add ("asmwriter");
+					aotOptions.Add ($"mtriple={mtriple}");
+					aotOptions.Add ($"tool-prefix={toolPrefix}");
+					aotOptions.Add ($"outfile={outputFile}");
+					aotOptions.Add ($"llvm-path={SdkBinDirectory}");
+					aotOptions.Add ($"temp-path={tempDir}");
+					if (!string.IsNullOrEmpty (AotAdditionalArguments)) {
+						aotOptions.Add (AotAdditionalArguments);
+					}
+					if (!string.IsNullOrEmpty (MsymPath)) {
+						aotOptions.Add ($"msym-dir={MsymPath}");
+					}
+					if (!string.IsNullOrEmpty (LdName)) {
+						aotOptions.Add ($"ld-name={LdName}");
+					}
+					if (!string.IsNullOrEmpty (LdFlags)) {
+						aotOptions.Add ($"ld-flags={LdFlags}");
+					}
 					if (Profiles != null && Profiles.Length > 0) {
 						if (Path.GetFileNameWithoutExtension (assembly.ItemSpec) == TargetName) {
 							LogDebugMessage ($"Not using profile(s) for main assembly: {assembly.ItemSpec}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/AbiUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/AbiUtils.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Xamarin.ProjectTools
+{
+	public static class AbiUtils
+	{
+		public static string AbiToRuntimeIdentifier (string androidAbi)
+		{
+			if (androidAbi == "armeabi-v7a") {
+				return "android-arm";
+			} else if (androidAbi == "arm64-v8a") {
+				return "android-arm64";
+			} else if (androidAbi == "x86") {
+				return "android-x86";
+			} else if (androidAbi == "x86_64") {
+				return "android-x64";
+			}
+			throw new InvalidOperationException ($"Unknown abi: {androidAbi}");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -31,30 +31,14 @@ namespace Xamarin.ProjectTools
 
 		public static void SetRuntimeIdentifier (this IShortFormProject project, string androidAbi)
 		{
-			if (androidAbi == "armeabi-v7a") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-arm");
-			} else if (androidAbi == "arm64-v8a") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-arm64");
-			} else if (androidAbi == "x86") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-x86");
-			} else if (androidAbi == "x86_64") {
-				project.SetProperty (KnownProperties.RuntimeIdentifier, "android-x64");
-			}
+			project.SetProperty (KnownProperties.RuntimeIdentifier, AbiUtils.AbiToRuntimeIdentifier (androidAbi));
 		}
 
 		public static void SetRuntimeIdentifiers (this IShortFormProject project, string [] androidAbis)
 		{
 			var abis = new List<string> ();
 			foreach (var androidAbi in androidAbis) {
-				if (androidAbi == "armeabi-v7a") {
-					abis.Add ("android-arm");
-				} else if (androidAbi == "arm64-v8a") {
-					abis.Add ("android-arm64");
-				} else if (androidAbi == "x86") {
-					abis.Add ("android-x86");
-				} else if (androidAbi == "x86_64") {
-					abis.Add ("android-x64");
-				}
+				abis.Add (AbiUtils.AbiToRuntimeIdentifier (androidAbi));
 			}
 			project.SetProperty (KnownProperties.RuntimeIdentifiers, string.Join (";", abis));
 		}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6520
Context: https://github.com/dotnet/runtime/issues/56163
Context: https://github.com/dotnet/runtime/pull/62725

This fixes AOT builds for project names like `foo Ümläüts`, and
LLVM-related options are no longer space delimited.

Previously, `<MonoAOTCompiler/>` managed its own `WorkingDirectory` to
the location that `.dll` input files were located. The problem with
this, is that *other* paths like `temp-path`, etc. would then need to
be full paths. Full paths containing characters like `Ümläüts` would
break!

Additionally, `%(AotArguments)` metadata is split on `;` and joined on
`,`. And since `ld-flags` contains a `;`, we would lose it. So we
delimited by the space character, which also breaks if directories
contain a space!

To solve these issues:

* Added strongly-typed properties to the `<MonoAOTCompiler/>` MSBuild
  task. We no longer have to put as many things in `%(AotArguments)`
  on each assembly. Only assembly-specific settings go there now, like
  the path to AOT profiles. Right now the "main assembly" has no
  profile at all, and the rest get built-in profiles.

* Added a `WorkingDirectory` property, which we pass in
  `$(MSBuildProjectDirectory)` for the current project directory.

After these changes, I could remove many temporary comments around
dotnet/runtime#56163, as the tests work properly now.