### PR TITLE
Enable more 6.0 feature switches

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -92,6 +92,10 @@
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
     <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
+		<_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
+		<NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+		<BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>    
+
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">true</EnableSingleFileAnalyzer>
 
     <!-- XA feature switches defaults -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -92,9 +92,9 @@
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
     <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
-		<_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
-		<NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-		<BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>    
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>    
 
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">true</EnableSingleFileAnalyzer>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,34 +5,34 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 58251
+      "Size": 54784
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 83568
+      "Size": 78925
     },
     "assemblies/rc.bin": {
-      "Size": 946
+      "Size": 1045
     },
     "assemblies/System.Linq.dll": {
-      "Size": 11293
+      "Size": 10160
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 534128
+      "Size": 508197
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2832
+      "Size": 2412
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3539
+      "Size": 3551
     },
     "classes.dex": {
-      "Size": 345240
+      "Size": 345312
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 374408
+      "Size": 383792
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3180064
+      "Size": 3180144
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776216
@@ -41,10 +41,10 @@
       "Size": 84064
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 150024
+      "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 11824
+      "Size": 11912
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -53,7 +53,7 @@
       "Size": 2469
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2388
+      "Size": 2342
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 4762
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2705300
+  "PackageSize": 2676628
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,217 +8,217 @@
       "Size": 7251
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 65415
+      "Size": 61748
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 4826
+      "Size": 3840
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 476882
+      "Size": 437663
     },
     "assemblies/mscorlib.dll": {
-      "Size": 4191
+      "Size": 3850
     },
     "assemblies/netstandard.dll": {
-      "Size": 5909
+      "Size": 5538
     },
     "assemblies/rc.bin": {
-      "Size": 946
+      "Size": 1045
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 12611
+      "Size": 11590
     },
     "assemblies/System.Collections.dll": {
-      "Size": 20498
+      "Size": 19126
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 9467
+      "Size": 8483
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2873
+      "Size": 2008
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 3468
+      "Size": 2610
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 7198
+      "Size": 6017
     },
     "assemblies/System.Console.dll": {
-      "Size": 7589
+      "Size": 6598
     },
     "assemblies/System.Core.dll": {
-      "Size": 2373
+      "Size": 1973
     },
     "assemblies/System.Diagnostics.DiagnosticSource.dll": {
-      "Size": 3991
+      "Size": 3041
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 7675
+      "Size": 6804
     },
     "assemblies/System.dll": {
-      "Size": 2723
+      "Size": 2321
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2424
+      "Size": 2003
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 13123
+      "Size": 12246
     },
     "assemblies/System.Formats.Asn1.dll": {
-      "Size": 28017
+      "Size": 26857
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 12575
+      "Size": 11463
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 20004
+      "Size": 18840
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 12011
+      "Size": 10775
     },
     "assemblies/System.Linq.dll": {
-      "Size": 21013
+      "Size": 19514
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 187209
+      "Size": 182123
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 225096
+      "Size": 221429
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 14111
+      "Size": 13166
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 18733
+      "Size": 17590
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 43268
+      "Size": 41587
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 49177
+      "Size": 48005
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 4769
+      "Size": 3773
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 59070
+      "Size": 57713
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 55991
+      "Size": 54651
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 13174
+      "Size": 12015
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 813928
+      "Size": 779913
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 199090
+      "Size": 193971
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 45757
+      "Size": 43921
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 256188
+      "Size": 251557
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 18737
+      "Size": 17106
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1829
+      "Size": 1341
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2976
+      "Size": 2602
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 3903
+      "Size": 2919
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 25285
+      "Size": 24191
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 2346
+      "Size": 1942
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 3756
+      "Size": 2676
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 4766
+      "Size": 3983
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 44066
+      "Size": 42144
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 15079
+      "Size": 13834
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 10129
+      "Size": 8697
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 78987
+      "Size": 77129
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 78288
+      "Size": 76744
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 17966
+      "Size": 16872
     },
     "assemblies/System.Xml.dll": {
-      "Size": 2243
+      "Size": 1824
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 117240
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 6382
+      "Size": 6076
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6340
+      "Size": 6099
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 113258
+      "Size": 112593
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7060
+      "Size": 6816
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 16983
+      "Size": 16609
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 97329
+      "Size": 96724
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 14569
+      "Size": 14275
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 40367
+      "Size": 39933
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6452
+      "Size": 6139
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6843
+      "Size": 6595
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6934
+      "Size": 6675
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3530
+      "Size": 3275
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 12984
+      "Size": 12676
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 85161
+      "Size": 84690
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 5324
+      "Size": 5082
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10694
+      "Size": 10390
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 18347
+      "Size": 17994
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 528450
@@ -233,16 +233,16 @@
       "Size": 60774
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 40475
+      "Size": 40136
     },
     "classes.dex": {
       "Size": 3483980
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 380120
+      "Size": 383792
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3184240
+      "Size": 3180144
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776216
@@ -251,7 +251,7 @@
       "Size": 84064
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 150024
+      "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 134120
@@ -2009,5 +2009,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8730366
+  "PackageSize": 8587006
 }


### PR DESCRIPTION
to produce smaller output

_AggressiveAttributeTrimming - mostly attributes remove by current XA
NullabilityInfoContextSupport - saves a lot by trimming all C# compiler generated nullable information
BuiltInComInteropSupport - no COM support on Android