### PR TITLE
[tests] update to latest GPS packages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -532,8 +532,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nCrashlytics.Crashlytics.HandleManagedExceptions();");
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Crashlytics_2_9_4);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric_1_4_3);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				builder.Target = "Restore";
 				Assert.IsTrue (builder.Build (proj), "Restore should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -534,7 +534,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nCrashlytics.Crashlytics.HandleManagedExceptions();");
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Crashlytics_2_9_4);
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric_1_4_3);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				builder.Target = "Restore";
 				Assert.IsTrue (builder.Build (proj), "Restore should have succeeded.");
@@ -1661,7 +1661,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				},
 				PackageReferences = {
 					KnownPackages.Acr_UserDialogs,
-					KnownPackages.Xamarin_Build_Download_0_4_11,
+					KnownPackages.Xamarin_Build_Download,
 				}
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -531,7 +531,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nCrashlytics.Crashlytics.HandleManagedExceptions();");
-			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Crashlytics_2_9_4);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Crashlytics);
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric);
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -527,14 +527,13 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		}
 
 		[Test]
-		[Category ("DotNetIgnore")] // Xamarin.Build.Download needs updated $(TargetFramework) checks
 		public void ExtraAaptManifest ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nCrashlytics.Crashlytics.HandleManagedExceptions();");
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Crashlytics_2_9_4);
 			proj.PackageReferences.Add (KnownPackages.Xamarin_Android_Fabric_1_4_3);
-			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Build_Download_0_4_11);
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				builder.Target = "Restore";
 				Assert.IsTrue (builder.Build (proj), "Restore should have succeeded.");
@@ -1661,7 +1660,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				},
 				PackageReferences = {
 					KnownPackages.Acr_UserDialogs,
-					KnownPackages.Xamarin_Build_Download,
+					KnownPackages.Xamarin_Build_Download_0_4_11,
 				}
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -450,23 +450,23 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
-		public static Package Xamarin_Android_Crashlytics_2_9_4 = new Package {
+		public static Package Xamarin_Android_Crashlytics = new Package {
 			Id = "Xamarin.Android.Crashlytics",
-			Version = "2.9.4",
+			Version = "2.9.4.4",
 			TargetFramework = "MonoAndroid60",
 			References = {
 				new BuildItem.Reference("Xamarin.Android.Crashlytics") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Crashlytics.2.9.4\\lib\\MonoAndroid60\\Xamarin.Android.Crashlytics.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Crashlytics.2.9.4.4\\lib\\MonoAndroid60\\Xamarin.Android.Crashlytics.dll"
 				}
 			}
 		};
-		public static Package Xamarin_Android_Fabric_1_4_3 = new Package {
+		public static Package Xamarin_Android_Fabric = new Package {
 			Id = "Xamarin.Android.Fabric",
-			Version = "1.4.3",
+			Version = "1.4.3.4",
 			TargetFramework = "MonoAndroid60",
 			References = {
 				new BuildItem.Reference("Xamarin.Android.Fabric") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Fabric.1.4.3\\lib\\MonoAndroid60\\Xamarin.Android.Fabric.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Fabric.1.4.3.4\\lib\\MonoAndroid60\\Xamarin.Android.Fabric.dll"
 				}
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -480,19 +480,19 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_GooglePlayServices_Base = new Package {
 			Id = "Xamarin.GooglePlayServices.Base",
-			Version = "117.1.0",
+			Version = "117.6.0.2",
 		};
 		public static Package Xamarin_GooglePlayServices_Basement = new Package {
 			Id = "Xamarin.GooglePlayServices.Basement",
-			Version = "117.1.0",
+			Version = "117.6.0.3",
 		};
 		public static Package Xamarin_GooglePlayServices_Tasks = new Package {
 			Id = "Xamarin.GooglePlayServices.Tasks",
-			Version = "117.0.0",
+			Version = "117.2.1.2",
 		};
 		public static Package Xamarin_GooglePlayServices_Maps = new Package {
 			Id = "Xamarin.GooglePlayServices.Maps",
-			Version = "117.0.0",
+			Version = "117.0.1.2",
 		};
 		public static Package Acr_UserDialogs = new Package {
 			Id = "Acr.UserDialogs",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -470,9 +470,9 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
-		public static Package Xamarin_Build_Download_0_4_11 = new Package {
+		public static Package Xamarin_Build_Download = new Package {
 			Id = "Xamarin.Build.Download",
-			Version = "0.4.11",
+			Version = "0.11.0",
 		};
 		public static Package NuGet_Build_Packaging = new Package {
 			Id = "NuGet.Build.Packaging",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -474,6 +474,11 @@ namespace Xamarin.ProjectTools
 			Id = "Xamarin.Build.Download",
 			Version = "0.11.0",
 		};
+		// NOTE: old version required for some tests
+		public static Package Xamarin_Build_Download_0_4_11 = new Package {
+			Id = "Xamarin.Build.Download",
+			Version = "0.4.11",
+		};
 		public static Package NuGet_Build_Packaging = new Package {
 			Id = "NuGet.Build.Packaging",
 			Version = "0.2.2",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -48,7 +48,7 @@ namespace Xamarin.ProjectTools
       ""client_info"": {
         ""mobilesdk_app_id"": ""1:1041063143217:android:ffbe6976403db935"",
         ""android_client_info"": {
-          ""package_name"": ""com.xamarin.sample""
+          ""package_name"": """ + packageName + @"""
         }
       },
       ""oauth_client"": [
@@ -56,7 +56,7 @@ namespace Xamarin.ProjectTools
           ""client_id"": ""1041063143217-rve97omgqivvs3qcne1ljso137k3t6po.apps.googleusercontent.com"",
           ""client_type"": 1,
           ""android_info"": {
-            ""package_name"": ""com.xamarin.sample"",
+            ""package_name"": """ + packageName + @""",
             ""certificate_hash"": ""84949BBD3F34C8290A55AC9B66AD0A701EBA67AC""
           }
         },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -23,6 +23,7 @@ namespace Xamarin.ProjectTools
 				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
 				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Maps);
 				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
+				PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
 
 				//TODO: temporary fix for <Import/> ordering breakage and workloads
 				SetProperty ("AndroidApplication", "True");


### PR DESCRIPTION
We recently discovered the following doesn't work in .NET 6:

* `dotnet new android`
* Add `<PackageReference Include="Xamarin.Google.MLKit.BarcodeScanning" Version="116.1.2.2" />`

`dotnet build` fails with many `javac` errors:

    obj\Debug\net6.0-android\android\src\crc6434af9c19aa01b597\GoogleApiClientConnectionCallbacksImpl.java(8,52): error JAVAC0000:  error: package com.google.android.gms.common.api.GoogleApiClient does not exist

`Xamarin.Build.Download` didn't actually download the Java libraries.

If you make this change to Xamarin.Build.Download locally, it solves
the issue:

https://github.com/xamarin/XamarinComponents/commit/faf04b389ea3e1b9a57d9f9bd5ba57f0ad2f87fa

We never shipped this fix!

This is resolved now with [Xamarin.Build.Download 0.11.0][0]. So
adding this to the original `.csproj` solves the problem:

    <PackageReference Include="Xamarin.Build.Download" Version="0.11.0" />

Let's update tests that would have caught this issue. I found I could
reproduce the issue with newer Google Play Services NuGet packages,
while the old ones we used in tests worked fine.

[0]: https://www.nuget.org/packages/Xamarin.Build.Download/0.11.0