### PR TITLE
[relnote-gen] Add Release Notes Generator Helper

### DIFF
--- a/Documentation/release-notes/README.md
+++ b/Documentation/release-notes/README.md
@@ -81,15 +81,15 @@ any custom release notes.
 
   For other changes, choose from the following headings:
 
-  - `#### Application and library build and deployment`
-  - `#### Application behavior on device and emulator`
-  - `#### Application Mono Framework behavior on device and emulator`
-  - `#### Application publishing`
-  - `#### Android API bindings`
-  - `#### Bindings projects`
-  - `#### Design-time build process`
-  - `#### Xamarin.Android SDK installation`
-  - `#### IDE compatibility`
+  - `### Application and library build and deployment`
+  - `### Application behavior on device and emulator`
+  - `### Application Mono Framework behavior on device and emulator`
+  - `### Application publishing`
+  - `### Android API bindings`
+  - `### Bindings projects`
+  - `### Design-time build process`
+  - `### Xamarin.Android SDK installation`
+  - `### IDE compatibility`
 
 - Write a list item to go under the heading.  Start the item with one of the
   following, in order of preference:
@@ -111,7 +111,7 @@ Examples:
 ```
 
 ```markdown
-#### Application behavior on device and emulator
+### Application behavior on device and emulator
 
 - [Developer Community 743965](https://developercommunity.visualstudio.com/content/problem/743965/newtonsoftjsonjsonreaderexception-unexpected-chara.html),
   [GitHub Issue 3626](https://github.com/xamarin/xamarin-android/issues/3626):

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -152,6 +152,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "assembly-store-reader", "to
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.JavaTypeSystem", "external\Java.Interop\src\Java.Interop.Tools.JavaTypeSystem\Java.Interop.Tools.JavaTypeSystem.csproj", "{4EFCED6E-9A6B-453A-94E4-CE4B736EC684}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "relnote-gen", "tools\relnote-gen\relnote-gen.csproj", "{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 5
@@ -420,6 +422,10 @@ Global
 		{4EFCED6E-9A6B-453A-94E4-CE4B736EC684}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{4EFCED6E-9A6B-453A-94E4-CE4B736EC684}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{4EFCED6E-9A6B-453A-94E4-CE4B736EC684}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -489,6 +495,7 @@ Global
 		{DA50FC92-7FE7-48B5-BDB6-CDA57B37BB51} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{4EFCED6E-9A6B-453A-94E4-CE4B736EC684} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17} = {864062D3-A415-4A6F-9324-5820237BA058}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/tools/relnote-gen/App.cs
+++ b/tools/relnote-gen/App.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xamarin.Android.Tools.ReleaseNotes;
+
+enum State {
+	None,
+	LookingForSummary,
+	InBody,
+	InDiff,
+	InReleaseNotesDiff,
+}
+
+static class App {
+
+	const string XamarinAndroidCommitBase   = "http://github.com/xamarin/xamarin-android/commit/";
+	const string XamarinAndroidPullBase     = "http://github.com/xamarin/xamarin-android/pull/";
+	const string XamarinAndroidIssuesBase   = "http://github.com/xamarin/xamarin-android/issues/";
+
+	static readonly Regex SummaryParser = new Regex (
+		@"^\s*(\[(?<component>[^]]+)\]\s+)?" +
+		@"(?<summary>.*?)" +
+		@"\s*(\((?<pr>#.*)\))?$"
+	);
+	static readonly Regex FixesParser = new Regex (
+		@"^\s*Fixes(:)?\s*(?<url>.*)$"
+	);
+
+	public static void Main (string[] args)
+	{
+		var commits = new Dictionary<string, List<CommitInfo>>(StringComparer.OrdinalIgnoreCase);
+
+		var commit = (CommitInfo?) null;
+		var state = State.None;
+		var line = (string?) null;
+		while ((line = Console.ReadLine ()) != null) {
+			if (line.StartsWith ("commit ", StringComparison.OrdinalIgnoreCase)) {
+				commit = new CommitInfo (line.Substring ("commit ".Length));
+				state = State.LookingForSummary;
+				continue;
+			}
+			if (line.StartsWith ("Author:", StringComparison.OrdinalIgnoreCase)) {
+				continue;
+			}
+			if (line.StartsWith ("Date:", StringComparison.OrdinalIgnoreCase)) {
+				continue;
+			}
+			// Console.WriteLine ($"# jonp: state={state}; line={line}");
+			switch (state) {
+			case State.LookingForSummary:
+				Debug.Assert (commit != null);
+				if (string.IsNullOrEmpty (line)) {
+					continue;
+				}
+				var (component, pr, summary) = GetSummaryInfo (line);
+				commit.Summary  = summary;
+				commit.PR       = pr;
+				if (!commits.TryGetValue (component, out var list)) {
+					commits.Add (component, list = new());
+				}
+				list.Add (commit);
+				state = State.InBody;
+				break;
+			case State.InBody:
+				Debug.Assert (commit != null);
+				var m = FixesParser.Match (line);
+				if (m.Success && m.Groups ["url"].Value is string u && !string.IsNullOrEmpty (u)) {
+					commit.Fixes.Add (u);
+					continue;
+				}
+				if (line.StartsWith ("diff", StringComparison.Ordinal)) {
+					state = State.InDiff;
+					continue;
+				}
+				commit.CommitMessage.Add (line);
+				break;
+			case State.InDiff:
+				if (line.StartsWith ("+++ b/Documentation/release-notes/", StringComparison.OrdinalIgnoreCase)) {
+					state = State.InReleaseNotesDiff;
+					continue;
+				}
+				break;
+			case State.InReleaseNotesDiff:
+				Debug.Assert (commit != null);
+				if (line.StartsWith ("@@ -0", StringComparison.Ordinal)) {
+					continue;
+				}
+				if (line.StartsWith (@"\ No newline at end of file", StringComparison.Ordinal) ||
+						line.StartsWith ("diff", StringComparison.Ordinal)) {
+					state = State.InDiff;
+					continue;
+				}
+				commit.ReleaseNotes.Add (line.Substring (1));
+				break;
+			default:
+				break;
+			}
+		}
+
+		foreach (var component in commits.Keys.OrderBy (k => k)) {
+			var c = component;
+			if (c == "") {
+				c = "Miscellaneous";
+			}
+			Console.WriteLine ($"- [{c}](#{c})");
+		}
+
+		foreach (var e in commits.OrderBy (e => e.Key)) {
+			Console.WriteLine ();
+			var component = e.Key;
+			if (component == "") {
+				component = "Miscellaneous";
+			}
+			Console.WriteLine ($"<a name=\"{component}\"></a>");
+			Console.WriteLine ($"### {component}");
+			foreach (var c in ((IEnumerable<CommitInfo>)e.Value).Reverse ()) {
+				Console.WriteLine ();
+				WriteCommit (c);
+			}
+		}
+	}
+
+	static (string component, string? pr, string summary) GetSummaryInfo (string line)
+	{
+		var m = SummaryParser.Match (line);
+		if (!m.Success) {
+			return ("", null, line);
+		}
+
+		var x = (
+			component: m.Groups ["component"].Value?.Trim () ?? "",
+			pr: m.Groups ["pr"].Value?.Trim (),
+			summary: m.Groups ["summary"].Value?.Trim () ?? "");
+		return x;
+	}
+
+	static void WriteCommit (CommitInfo c)
+	{
+		var links = c.Fixes.Select (f => GetLinkFromUrl (f)).ToList ();
+		links.Sort ();
+		if (!string.IsNullOrEmpty (c.PR)) {
+			links.Add ($"[PR {c.PR}]({XamarinAndroidPullBase}{c.PR})");
+		}
+		links.Add ($"[Commit {c.CommitHash.Substring (0, 8)}]({XamarinAndroidCommitBase}{c.CommitHash})");
+		var linkIndent = string.Join (",\n  ", links);
+		Console.WriteLine ($"- {c.Summary}  ");
+		Console.WriteLine ($"  ({linkIndent})");
+		if (c.ReleaseNotes.Count > 0) {
+			Console.WriteLine ();
+			Console.WriteLine ($"  {string.Join ("\n  ", c.ReleaseNotes)}");
+		}
+		if (c.CommitMessage.Count > 0) {
+			Console.WriteLine ($"  <!-- begin {c.CommitHash} commit message");
+			foreach (var m in c.CommitMessage) {
+				var v = m;
+				if (v?.Length > 2) {
+					v = v.Substring (2);
+				}
+				Console.WriteLine (v);
+			}
+			Console.WriteLine ($"  end {c.CommitHash} commit message -->");
+			Console.WriteLine ("");
+		}
+	}
+
+	static string GetLinkFromUrl (string url)
+	{
+		int s = url.LastIndexOf ('/');
+		if (s <= 0) {
+			return $"[Issue #{url}]({XamarinAndroidIssuesBase + url})";
+		}
+		return $"[Issue #{url.Substring (s+1)}]({url})";
+	}
+}
+
+
+
+
+
+
+
+

--- a/tools/relnote-gen/CommitInfo.cs
+++ b/tools/relnote-gen/CommitInfo.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Xamarin.Android.Tools.ReleaseNotes {
+
+	record CommitInfo (string CommitHash) {
+		public  string?         Summary;
+		public  string?         PR;
+		public  IList<string>   CommitMessage   = new List<string>();
+		public  IList<string>   Fixes           = new List<string>();
+		public  IList<string>   ReleaseNotes    = new List<string>();
+	}
+}

--- a/tools/relnote-gen/README.md
+++ b/tools/relnote-gen/README.md
@@ -1,0 +1,75 @@
+# Release Notes Generator
+
+Parses `git log` output to produce Xamarin.Android release notes fragments.
+
+Usage:
+
+```zsh
+(cd ~/Developer/src/xamarin/xamarin-android ;
+  git log -p --cherry-pick --right-only FROM...TO) \
+| dotnet run \
+| pbcopy
+```
+
+Use of `git log -p` allows for extraction of `Documentation/release-notes` blobs.
+
+Given a `git log` "block" of:
+
+```
+commit COMMIT
+Author: …
+Date:   …
+
+    [COMPONENT] SUMMARY (#PR)
+
+    Fixes: URL/NUMBER
+
+    Commit Message Body
+```
+
+Then the output of `renote-gen` will be:
+
+```markdown
+### COMPONENT
+
+  - Summary
+    ([#NUMBER](URL/NUMBER),
+    [PR #PR](http://github.com/xamarin/xamarin-android/pull/PR),
+    [Commit COMMIT](http://github.com/xamarin/xamarin-android/commit/COMMIT))
+```
+
+# API Diffs?
+
+[`Microsoft.DotNet.AsmDiff`](https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.AsmDiff)
+can be used to produce API diffs.
+
+First, "obtain" the two assemblies to compare, e.g.
+
+	curl -o Xamarin.Android.Sdk-11.3.0.4.vsix \
+	  https://bosstoragemirror.azureedge.net/vsts-devdiv/Xamarin.Android/public/4829460/d16-10/ae14cafda4befc69867db19eee0728efec9cf71b/signed/Xamarin.Android.Sdk-11.3.0.4.vsix
+	unzip Xamarin.Android.Sdk-11.3.0.4.vsix \
+	  '$ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v11.0/Mono.Android.dll'
+	  -d v11.3.0.4
+
+	curl -o Xamarin.Android.Sdk-12.0.0.3.vsix \
+	  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/5160375/d16-11/f0e3c2d1d269d311bc83d6875ffec3bfe5d17edb/signed/Xamarin.Android.Sdk-12.0.0.3.vsix
+	unzip Xamarin.Android.Sdk-12.0.0.3.vsix \
+	  '$ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v12.0/Mono.Android.dll'
+	  -d v12.0.0.3
+
+Next, build `Microsoft.DotNet.AsmDiff`:
+
+	git clone --depth 1 https://github.com/dotnet/arcade.git
+	dotnet build arcade/src/Microsoft.DotNet.AsmDiff
+
+Run `Microsoft.DotNet.AsmDiff` to produce API diffs.  We like Markdown diffs:
+
+	dotnet arcade/artifacts/bin/Microsoft.DotNet.AsmDiff/Debug/netcoreapp3.1/Microsoft.DotNet.AsmDiff.dll \
+	  --OldSet 'v11.3.0.4/$ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v11.0/Mono.Android.dll' \
+	  --NewSet 'v12.0.0.3/$ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v12.0/Mono.Android.dll' \
+	  --OldSetName 'Mono.Android.dll `$(TargetFrameworkVersion)`=v11.0' \
+	  --NewSetName '`$(TargetFrameworkVersion)`=v12.0' \
+	  --AlwaysDiffMembers \
+	  --IncludeTableOfContents \
+	  --DiffWriter Markdown \
+	  --OutFile Mono.Android_30-31-all.md

--- a/tools/relnote-gen/relnote-gen.csproj
+++ b/tools/relnote-gen/relnote-gen.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>Xamarin.Android.Tools.ReleaseNotes</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Context: ae6c42745038b22d525c6c5378e7b643ca99c25f
Context: https://docs.microsoft.com/xamarin/android/release-notes/12/12.1

Add a utility to *assist* with writing release notes:

	git log -p --cherry-pick --right-only 46e867efc69ac5b62881277e2580d1b6e0347b52...d7ce643351b248777a50ea63b3b13b54d95aa6c5 \
	| dotnet run --project tools/relnote-gen

`tools/relnote-gen` parses the `git log -p` output, looking for:

  * The `commit COMMIT` header
  * The commit message "summary", which optionally contains a
    "component" (b9ba3763) and PR number
  * The commit message text, which may contain `Fixes: ` URLs
  * Release notes (via `git log -p`; any additions to the
    `Documentation/release-notes` directory)

All commits with the same component are coalesced, and
Markdown-formatted text is written containing:

  * The components found, as a `### Component` header.
  * The commits, as a `-` bulleted list.
  * For each commit, links to the Fixes, PR, and commit.
  * The commit message body within an HTML <!-- … --> comment block

This kinda/sorta allows editing *all* commits at once, with most
relevant information, in one stream.  This is "grist" for the commit
message, to be edited down before final publishing.

Update `Documentation/release-notes/README.md`, to reduce the number
of `#`s used for section headers.  We're aiming for a smaller number
of sub-sections, as e.g. an `<h4/>` is nigh-invisible.

Current release notes template (kinda/sorta):

	## Xamarin.Android Version [Version Number]

	> Released [release date], included in Visual Studio [version]

	- [Component](#component))
	- …

	<a name="component"></a>
	### Component

	- …