### PR TITLE
Bump to xamarin/monodroid/main@5b0fab47

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@06ff96ddccf7d702ed413b85728459b639d5f1a3
+xamarin/monodroid:main@5b0fab478fa4682034dbbc0cce06748c7dc51474
 mono/mono:2020-02@b8d7525156acaecf311ba468147caa74d8c190f6


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/06ff96ddccf7d702ed413b85728459b639d5f1a3...5b0fab478fa4682034dbbc0cce06748c7dc51474

  * xamarin/monodroid@5b0fab478: Bump to xamarin/androidtools/main@772d2f0b (#1234)
  * xamarin/monodroid@16f8f7ea2: Bump xamarin-android (#1233)