### PR TITLE
[Xamarin.Andorid.Build.Tasks] Improve javac version parsing

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 		// `javac -version` will produce values such as:
 		//  javac 9.0.4
 		//  javac 1.8.0_77
-		internal static readonly Regex JavacVersionRegex = new Regex (@"(?<version>[\d\.]+)(_\d+)?");
+		internal static readonly Regex JavacVersionRegex = new Regex (@"javac (?<version>\d+\.[\d\.]+)(_\d+)?");
 
 		bool ValidateJava ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1556,5 +1556,26 @@ namespace App1
 				}
 			}
 		}
+
+		[Test]
+		[NonParallelizable] // Environment variables are global!
+		public void BuildWithJavaToolOptions ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true
+			};
+			var oldEnvVar = Environment.GetEnvironmentVariable ("JAVA_TOOL_OPTIONS");
+			try {
+				Environment.SetEnvironmentVariable ("JAVA_TOOL_OPTIONS",
+						"-Dcom.sun.jndi.ldap.object.trustURLCodebase=false -Dcom.sun.jndi.rmi.object.trustURLCodebase=false -Dcom.sun.jndi.cosnaming.object.trustURLCodebase=false -Dlog4j2.formatMsgNoLookups=true");
+				using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+					b.Target = "Build";
+					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+					b.AssertHasNoWarnings ();
+				}
+			} finally {
+				Environment.SetEnvironmentVariable ("JAVA_TOOL_OPTIONS", oldEnvVar);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -406,14 +406,14 @@ namespace Xamarin.Android.Build.Tests
 			return referencesDirectory;
 		}
 
-		protected string CreateFauxJavaSdkDirectory (string path, string javaVersion, out string javaExe, out string javacExe)
+		protected string CreateFauxJavaSdkDirectory (string path, string javaVersion, out string javaExe, out string javacExe, string[] extraPrefix = null)
 		{
 			javaExe = IsWindows ? "java.cmd" : "java";
 			javacExe  = IsWindows ? "javac.cmd" : "javac";
 
 			var javaPath = Path.Combine (Root, path);
 
-			CreateFauxJdk (javaPath, javaVersion, javaVersion, javaVersion);
+			CreateFauxJdk (javaPath, javaVersion, javaVersion, javaVersion, extraPrefix);
 
 			var jarSigner = IsWindows ? "jarsigner.exe" : "jarsigner";
 			var javaBinPath = Path.Combine (javaPath, "bin");
@@ -423,7 +423,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		// https://github.com/xamarin/xamarin-android-tools/blob/683f37508b56c76c24b3287a5687743438625341/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs#L60-L100
-		void CreateFauxJdk (string dir, string releaseVersion, string releaseBuildNumber, string javaVersion)
+		void CreateFauxJdk (string dir, string releaseVersion, string releaseBuildNumber, string javaVersion, string[] extraPrefix)
 		{
 			Directory.CreateDirectory (dir);
 
@@ -443,10 +443,15 @@ namespace Xamarin.Android.Build.Tests
 			Directory.CreateDirectory (jli);
 			Directory.CreateDirectory (jre);
 
+			string prefix = extraPrefix == null
+				? ""
+				: string.Join ("",
+					extraPrefix.Select (e => "echo " + e + Environment.NewLine));
+
 			string quote = IsWindows ? "" : "\"";
 			string java = IsWindows
-				? $"echo java version \"{javaVersion}\"{Environment.NewLine}"
-				: $"echo java version '\"{javaVersion}\"'{Environment.NewLine}";
+				? prefix + $"echo java version \"{javaVersion}\"{Environment.NewLine}"
+				: prefix + $"echo java version '\"{javaVersion}\"'{Environment.NewLine}";
 			java = java +
 				$"echo Property settings:{Environment.NewLine}" +
 				$"echo {quote}    java.home = {dir}{quote}{Environment.NewLine}" +
@@ -457,6 +462,7 @@ namespace Xamarin.Android.Build.Tests
 				$"echo {quote}        .{quote}{Environment.NewLine}";
 
 			string javac =
+				prefix +
 				$"echo javac {javaVersion}{Environment.NewLine}";
 
 			CreateShellScript (Path.Combine (bin, "jar"), "");


### PR DESCRIPTION
Context: https://en.wikipedia.org/wiki/Log4Shell
Context: https://nvd.nist.gov/vuln/detail/CVE-2021-45046
Context: https://twitter.com/hacks4pancakes/status/1470926736095391744
Context: https://twitter.com/Laughing_Mantis/status/1470412026119798786

Around 2021-Dec-10, the "Log4Shell" exploit became widely known.
For a brief moment (the weekend?), it appeared that the exploit could
be prevented -- or at least *minimized* -- by disabling certain JVM
features, a'la:

	export JAVA_TOOL_OPTIONS='-Dcom.sun.jndi.ldap.object.trustURLCodebase=false -Dcom.sun.jndi.rmi.object.trustURLCodebase=false -Dcom.sun.jndi.cosnaming.object.trustURLCodebase=false -Dlog4j2.formatMsgNoLookups=true'
	export _JAVA_OPTIONS="$JAVA_TOOL_OPTIONS"

Turns out™, this mitigation [doesn't actually work][0], but it was
attempted by some.

Funny thing about that mitigation: it potentially breaks
Xamarin.Android builds:

	export JAVA_TOOL_OPTIONS=…
	msbuild /restore /t:SignAndroidPackage /v:diag…
	…
	warning XA0033: Failed to get the Java SDK version because the returned value does not appear to contain a valid version number. `javac -version` returned: ```Picked up JAVA_TOOL_OPTIONS: …
	warning XA0033: _JAVA_OPTIONS=…
	warning XA0033: javac 11.0.10
	warning XA0033: ```
	…
	Task "ManifestMerger"
	  Task Parameter:OutputManifestFile=obj/Debug/android/AndroidManifest.xml
	  …
	  Task Parameter:
	      LibraryManifestFiles=
	          …
	  Task Parameter:AndroidManifest=obj/Debug/AndroidManifest.xml
	  -cp …/manifestmerger.jar com.xamarin.manifestmerger.Main obj/Debug/android/manifestmerger.rsp
	  /Users/jon/android-toolchain/jdk-11/bin/java -cp /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/manifestmerger.jar com.xamarin.manifestmerger.Main obj/Debug/android/manifestmerger.rsp
	…/Android/Xamarin.Android.Common.targets(1441,3): error AMM0000: Picked up JAVA_TOOL_OPTIONS: -Dcom.sun.jndi.ldap.object.trustURLCodebase=false -Dcom.sun.jndi.rmi.object.trustURLCodebase=false -Dcom.sun.jndi.cosnaming.object.trustURLCodebase=false -Dlog4j2.formatMsgNoLookups=true
	  Picked up JAVA_TOOL_OPTIONS: -Dcom.sun.jndi.ldap.object.trustURLCodebase=false -Dcom.sun.jndi.rmi.object.trustURLCodebase=false -Dcom.sun.jndi.cosnaming.object.trustURLCodebase=false -Dlog4j2.formatMsgNoLookups=true
	  The command exited with code -1.

The XA0033 warning could be an error if `/warnaserror` is used.
The AMM0000 error is unexpected, but doesn't appear to happen with
Xamarin.Android 12.2 (current main), but *does* happen with 12.0.

The XA0033 warning is emitted because the `javac -version` parsing
via `ValidateJavaVersion.JavacVersionRegex` is too lax; consider the
regex:

	Regex JavacVersionRegex = new Regex (@"(?<version>[\d\.]+)(_\d+)?");

vs. the command output:

	> JAVA_TOOL_OPTIONS="-Dcom.sun.jndi.ldap.object.trustURLCodebase=false" \
	    javac -version
	Picked up JAVA_TOOL_OPTIONS: -Dcom.sun.jndi.ldap.object.trustURLCodebase=false
	javac 11.0.10

`ValidateJavaVersion.JavacVersionRegex` only requires *one* `\d` *or*
`\.`, and thus matches the `.` in `-Dcom.sun…`.  The `version` group
is thus *only* `.`, which can't be parsed into a `Version` value.

Fix the XA0033 warning by improving the `javac -version` parsing, in
part by making the regex match stricter, by requiring `javac `.

[0]: https://twitter.com/Laughing_Mantis/status/1470412026119798786