### PR TITLE
[CI] Run macOS test jobs on macOS 11

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -22,7 +22,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-10.15
+  value: macOS-11
 - name: HostedWinVS2019
   value: Hosted Windows 2019 with VS2019
 - name: 1ESWindowsPool


### PR DESCRIPTION
Now that macOS 12 Monterey is publicly available, it seems like a good
time to upgrade our macOS test machines to last years macOS 11 Big Sur
release.
