### PR TITLE
[tests] Ignore unstable API levels when creating test projects

### DIFF
--- a/build-tools/scripts/XABuildConfig.cs.in
+++ b/build-tools/scripts/XABuildConfig.cs.in
@@ -9,6 +9,7 @@ namespace Xamarin.Android.Tools
 		public const string NDKRevision = "@NDK_REVISION@";
 		public const string NDKRelease = "@NDK_RELEASE@";
 		public const int NDKMinimumApiAvailable = @NDK_MINIMUM_API_AVAILABLE@;
+		public const int AndroidLatestStableApiLevel = @ANDROID_LATEST_STABLE_API_LEVEL@;
 		public static readonly Version NDKVersion = new Version (@NDK_VERSION_MAJOR@, @NDK_VERSION_MINOR@, @NDK_VERSION_MICRO@);
 
 		public static readonly Dictionary <string, int> ArchAPILevels = new Dictionary <string, int> (StringComparer.Ordinal) {

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Android.Prepare
 		public const string AndroidCmakeUrlPrefix               = "AndroidCmakeUrlPrefix";
 		public const string AndroidCmakeVersion                 = "AndroidCmakeVersion";
 		public const string AndroidCmakeVersionPath             = "AndroidCmakeVersionPath";
+		public const string AndroidLatestStableApiLevel         = "AndroidLatestStableApiLevel";
 		public const string AndroidLatestStableFrameworkVersion = "AndroidLatestStableFrameworkVersion";
 		public const string AndroidMxeFullPath                  = "AndroidMxeFullPath";
 		public const string AndroidNdkDirectory                 = "AndroidNdkDirectory";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -9,6 +9,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.AndroidCmakeUrlPrefix,               StripQuotes ("@AndroidCmakeUrlPrefix@"));
 			properties.Add (KnownProperties.AndroidCmakeVersion,                 StripQuotes ("@AndroidCmakeVersion@"));
 			properties.Add (KnownProperties.AndroidCmakeVersionPath,             StripQuotes (@"@AndroidCmakeVersionPath@"));
+			properties.Add (KnownProperties.AndroidLatestStableApiLevel,         StripQuotes ("@AndroidLatestStableApiLevel@"));
 			properties.Add (KnownProperties.AndroidLatestStableFrameworkVersion, StripQuotes ("@AndroidLatestStableFrameworkVersion@"));
 			properties.Add (KnownProperties.AndroidMxeFullPath,                  StripQuotes (@"@AndroidMxeFullPath@"));
 			properties.Add (KnownProperties.AndroidNdkDirectory,                 StripQuotes (@"@AndroidNdkDirectory@"));

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -166,6 +166,7 @@ namespace Xamarin.Android.Prepare
 				{ "@NDK_X86_API@",               BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86].ToString () },
 				{ "@NDK_X86_64_API@",            BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86_64].ToString () },
 				{ "@XA_SUPPORTED_ABIS@",         context.Properties.GetRequiredValue (KnownProperties.AndroidSupportedTargetJitAbis).Replace (':', ';') },
+				{ "@ANDROID_LATEST_STABLE_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidLatestStableApiLevel) },
 			};
 
 			return new GeneratedPlaceholdersFile (

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -43,6 +43,7 @@
       <Replacement Include="@AndroidCmakeUrlPrefix@=$(AndroidCmakeUrlPrefix)" />
       <Replacement Include="@AndroidCmakeVersion@=$(AndroidCmakeVersion)" />
       <Replacement Include="@AndroidCmakeVersionPath@=$(AndroidCmakeVersionPath)" />
+      <Replacement Include="@AndroidLatestStableApiLevel@=$(AndroidLatestStableApiLevel)" />
       <Replacement Include="@AndroidMxeFullPath@=$(AndroidMxeFullPath)" />
       <Replacement Include="@AndroidNdkDirectory@=$(AndroidNdkDirectory)" />
       <Replacement Include="@AndroidNdkVersion@=$(AndroidNdkVersion)" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Xamarin.Android.Tools;
 
@@ -138,8 +136,6 @@ namespace Xamarin.ProjectTools
 			if (maxInstalled != null)
 				return maxInstalled.Value;
 
-			var supportedVersions = new AndroidVersions (GetAndroidApiInfoDirectories ());
-
 			string sdkPath = GetAndroidSdkPath ();
 			foreach (var dir in Directory.EnumerateDirectories (Path.Combine (sdkPath, "platforms"))) {
 				int version;
@@ -147,32 +143,12 @@ namespace Xamarin.ProjectTools
 				Console.WriteLine ($"GetMaxInstalledPlatform: Parsing {v}");
 				if (!int.TryParse (v, out version))
 					continue;
-				if (version < maxInstalled || version > supportedVersions.MaxStableVersion?.ApiLevel)
+				if (version < maxInstalled || version > XABuildConfig.AndroidLatestStableApiLevel)
 					continue;
 				Console.WriteLine ($"GetMaxInstalledPlatform: Setting maxInstalled to {version}");
 				maxInstalled = version;
 			}
 			return maxInstalled ?? 0;
 		}
-
-		static IEnumerable<string> GetAndroidApiInfoDirectories ()
-		{
-			var frameworkDirs = new List<string> {
-				TestEnvironment.MonoAndroidFrameworkDirectory,
-			};
-
-			var sdkName = TestEnvironment.IsMacOS ? "Microsoft.Android.Sdk.Darwin"
-				: TestEnvironment.IsWindows ? "Microsoft.Android.Sdk.Windows"
-				: "Microsoft.Android.Sdk.Linux";
-
-			var searchDir = Path.Combine (GetDotNetPreviewPath (), "packs", sdkName);
-			if (Directory.Exists (searchDir)) {
-				var dataDirs = Directory.GetDirectories (searchDir, "data", SearchOption.AllDirectories);
-				frameworkDirs.AddRange (dataDirs.Where (d => Directory.EnumerateFiles (d, "AndroidApiInfo.xml", SearchOption.AllDirectories).Any ()));
-			}
-
-			return frameworkDirs.Where (d => Directory.Exists (d));
-		}
-
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -12,6 +12,7 @@
   <Import Project="..\..\..\..\build-tools\scripts\NUnitReferences.projitems" />
   <ItemGroup>
     <Compile Remove="Resources\**\*.cs" />
+    <Compile Include="..\..\..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
     <EmbeddedResource Include="Resources\**\*" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/21751b5bc4292be4b23dd58577cb6cf9f01d82bb

Android API 32 is [now "final"][0], and is causing test failures on hosted
Azure Pipelines agents:

    "/Users/runner/work/1/a/TestRelease/12-15_16.53.22/temp/XA4310apk/UnnamedProject.csproj" (Build;SignAndroidPackage target) (1:7) ->
    (_CheckGoogleSdkRequirements target) -> 
      /Users/runner/Library/Android/dotnet/packs/Microsoft.Android.Sdk.Darwin/31.0.101-preview.12.144/targets/Microsoft.Android.Sdk.Tooling.targets(68,5): warning XA1008: The TargetFrameworkVersion (Android API level 31) is lower than the targetSdkVersion (32). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match. [/Users/runner/work/1/a/TestRelease/12-15_16.53.22/temp/XA4310apk/UnnamedProject.csproj]

Fix this by ignoring invalid or unstable android versions when
[determining which `targetSdkVersion` to use][1] in the manifest files
of our test projects.

[0]: https://developer.android.com/about/versions/12/12L/overview#timeline
[1]: https://github.com/xamarin/xamarin-android/blob/7fb7c8149ec9df4e0445ebedfa26695f24775367/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs#L71
