### PR TITLE
[tests] remove $MONO_LOG_LEVEL debug

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -388,8 +388,6 @@ $@"<Project>
 				RedirectStandardError = true,
 				RedirectStandardOutput = true,
 			};
-			//TODO: possibly remove this later?
-			psi.SetEnvironmentVariable ("MONO_LOG_LEVEL", "debug");
 			Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
 			using (var process = new Process {
 				StartInfo = psi,


### PR DESCRIPTION
I was looking at a build log and noticed:

    Mono: AOT: FOUND method System.Threading.Thread:GetCurrentCultureNoAppX () [0x1120b7eb0 - 0x1120b7f82 0x1124d0e98]
    Mono: AOT: FOUND method System.Globalization.CultureInfo:get_UserDefaultCulture () [0x1123d0750 - 0x1123d0772 0x1124e2be7]
    Mono: AOT: FOUND method System.Globalization.CultureInfo:ConstructCurrentCulture () [0x1123ca740 - 0x1123ca88c 0x1124e286c]
    Mono: AOT NOT FOUND: (wrapper managed-to-native) System.Globalization.CultureInfo:get_current_locale_name ().

It seems like if Mono is set to log all of this information, it would
slow down our CI times?

I found an instance we set `MONO_LOG_LEVEL=debug` for MSBuild tests,
added in:

https://github.com/xamarin/xamarin-android/commit/b8c30f9e5329bfb4f1bf7ac3ade4131ffd067654

It was probably just here to temporarily diagnose issues in a Mono bump.