### PR TITLE
[build] specify path for self checkouts

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -125,6 +125,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+      path: s/xamarin-android
 
     - template: yaml-templates/install-microbuild-tooling.yaml
       parameters:
@@ -409,6 +410,7 @@ stages:
     - checkout: self
       clean: true
       submodules: recursive
+      path: s/xamarin-android
 
     - checkout: monodroid
       clean: true
@@ -1518,6 +1520,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+      path: s/xamarin-android
 
     - checkout: release_scripts
       clean: true

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -9,6 +9,8 @@ steps:
 - checkout: self
   clean: true
   submodules: recursive
+  ${{ if ne(parameters.xaSourcePath, variables['System.DefaultWorkingDirectory']) }}:
+    path: s/xamarin-android
 
 - ${{ if eq(parameters.updateVS, true) }}:
   - template: update-vs.yaml


### PR DESCRIPTION
We have a private mirror, for servicing security fixes, or testing
builds of .NET with security fixes.

By default, the private mirror, `xamarin-android-private` is checking
out into:

    Finishing: Checkout xamarin/xamarin-android-private@main to s/xamarin-android-private

Which causes the build to fail on a later step:

    Could not find a part of the path '/Users/builder/azdo/_work/7/s/xamarin-android/build-tools/provisioning/xcode.csx'

Specify the path when checking out `self` to solve this issue.