### PR TITLE
[ci] Move Linux tests to separate stage

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -341,15 +341,15 @@ stages:
 
     - template: yaml-templates\fail-on-issue.yaml
 
-# Check - "Xamarin.Android (Linux Build and Smoke Test)"
-- stage: linux_build_test
+# Check - "Xamarin.Android (Linux Build)"
+- stage: linux_build
   displayName: Linux
   dependsOn: []
   jobs:
-  - job: linux_build_test
-    displayName: Build and Smoke Test
+  - job: linux_build_create_sdk_pack
+    displayName: Build
     pool: android-devdiv-ubuntu-vmss
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
     workspace:
       clean: all
@@ -387,13 +387,9 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make jenkins
 
-    - task: DotNetCoreCLI@2
-      displayName: extract workload packs
-      inputs:
-        projects: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        arguments: >-
-          -t:CreateAllPacks,ExtractWorkloadPacks -c $(XA.Build.Configuration)
-          -bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/create-all-packs.binlog
+    - script: make create-nupkgs CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make create-nupkgs
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
@@ -408,29 +404,18 @@ stages:
         artifactName: nuget-linux-unsigned
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
-    - template: yaml-templates/install-apkdiff.yaml
-
-    - template: yaml-templates/run-nunit-tests.yaml
-      parameters:
-        useDotNet: true
-        testRunTitle: Xamarin.Android.Build.Tests - Linux .NET 6 Smoke Tests
-        testAssembly: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Test$(XA.Build.Configuration)/net6.0/Xamarin.Android.Build.Tests.dll
-        dotNetTestExtraArgs: --filter CheckSignApk  # TODO: Add more tests (e.g. "TestCategory = SmokeTests $(DotNetNUnitCategories)" )
-        testResultsFile: TestResult-NET6SmokeMSBuildTests-Linux-$(XA.Build.Configuration).xml
-
     - template: yaml-templates/upload-results.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
         artifactName: Build Results - Linux
         includeBuildResults: true
 
-    - template: yaml-templates\fail-on-issue.yaml
+    - template: yaml-templates/fail-on-issue.yaml
 
 - stage: smoke_tests
   displayName: Smoke Tests
   dependsOn: mac_build
   jobs:
-
   # Check - "Xamarin.Android (Smoke Tests APKs Legacy - macOS)"
   - job: mac_apk_tests_legacy
     displayName: APKs Legacy - macOS
@@ -863,6 +848,44 @@ stages:
     - template: yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild Smoke With Emulator - macOS
+
+    - template: yaml-templates/fail-on-issue.yaml
+
+- stage: linux_tests
+  displayName: Linux Tests
+  dependsOn:
+  - mac_build
+  - linux_build
+  jobs:
+  # Check - "Xamarin.Android (Linux Tests MSBuild Smoke)"
+  - job: linux_tests_smoke
+    displayName: MSBuild Smoke
+    pool: android-devdiv-ubuntu-vmss
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/setup-ubuntu.yaml
+
+    - template: yaml-templates/setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        useDotNet: true
+        testRunTitle: Xamarin.Android.Build.Tests - Linux .NET 6 Smoke Tests
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/net6.0/Xamarin.Android.Build.Tests.dll
+        dotNetTestExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
+        testResultsFile: TestResult-NET6SmokeMSBuildTests-Linux-$(XA.Build.Configuration).xml
+
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        artifactName: Test Results - MSBuild Smoke - Linux
 
     - template: yaml-templates/fail-on-issue.yaml
 

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -28,6 +28,7 @@ steps:
     }
     Write-Host "##vso[task.setvariable variable=XA.Provisionator.Args]$installer"
   displayName: find installer and set provisionator variable
+  condition: and(succeeded(), ne(variables['agent.os'], 'Linux'))
 
 - task: provisionator@2
   inputs:
@@ -35,3 +36,4 @@ steps:
     github_token: $(GitHub.Token)
     provisioning_script: $(XA.Provisionator.Args)
     provisioning_extra_args: ${{ parameters.provisionExtraArgs }}
+  condition: and(succeeded(), ne(variables['agent.os'], 'Linux'))

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -28,6 +28,12 @@ steps:
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: |
+    echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/${{ parameters.jdkTestFolder }}"
+    echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]$HOME/anroid-toolchain/dotnet/dotnet"
+  displayName: set JI_JAVA_HOME
+  condition: and(succeeded(), eq(variables['agent.os'], 'Linux'))
+
+- script: |
     echo ##vso[task.setvariable variable=JI_JAVA_HOME]%USERPROFILE%\android-toolchain\${{ parameters.jdkTestFolder }}
     echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]%USERPROFILE%\android-toolchain\dotnet\dotnet.exe
   displayName: set JI_JAVA_HOME
@@ -48,38 +54,36 @@ steps:
     arguments: --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes
     condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
     xaSourcePath: ${{ parameters.xaSourcePath }}
-  
+
 - template: run-xaprepare.yaml
   parameters:
     arguments: --s=AndroidTestDependencies
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
-- task: MSBuild@1
-  displayName: nuget restore Xamarin.Android.Build.Tasks.sln
+- task: DotNetCoreCLI@2
+  displayName: restore NUnit.Console
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/Xamarin.Android.Build.Tasks.sln
-    configuration: ${{ parameters.configuration }}
-    msbuildArguments: /t:Restore /p:RestoreConfigFile=${{ parameters.xaSourcePath }}/NuGet.config /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tasks.binlog
+    command: restore
+    projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+    restoreArguments: --configfile ${{ parameters.xaSourcePath }}/NuGet.config -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
 
-- task: MSBuild@1
-  displayName: nuget restore Xamarin.Android-Tests.sln
-  inputs:
-    solution: ${{ parameters.xaSourcePath }}/Xamarin.Android-Tests.sln
-    configuration: ${{ parameters.configuration }}
-    msbuildArguments: /t:Restore /p:RestoreConfigFile=${{ parameters.xaSourcePath }}/NuGet.config /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android-Tests.binlog
-
-- task: MSBuild@1
+- task: DotNetCoreCLI@2
   displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
   inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-    configuration: ${{ parameters.configuration }}
-    msbuildArguments: /restore /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
+    projects: ${{ parameters.xaSourcePath }}/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+    arguments: -c ${{ parameters.configuration }} -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
 
 # Download and install .NET nupkgs
 - task: DownloadPipelineArtifact@2
   inputs:
     artifactName: $(NuGetArtifactName)
     downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/$(NuGetArtifactName)
+
+- task: DownloadPipelineArtifact@2
+  inputs:
+    artifactName: nuget-linux-unsigned
+    downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/$(NuGetArtifactName)
+  condition: and(succeeded(), eq(variables['agent.os'], 'Linux'))
 
 - task: DotNetCoreCLI@2
   displayName: extract workload packs

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -394,10 +394,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				AndroidClassParser = "class-parse",
 			};
 			using (var bbuilder = CreateDllBuilder (Path.Combine (path, "BuildWithExternalJavaLibraryBinding"))) {
-				string multidex_path = TestEnvironment.IsRunningOnCI ?
-					TestEnvironment.MonoAndroidToolsDirectory :
-					Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
-				string multidex_jar = Path.Combine (multidex_path, "android-support-multidex.jar");
+				string multidex_jar = Path.Combine (bbuilder.AndroidMSBuildDirectory, "android-support-multidex.jar");
 				binding.Jars.Add (new AndroidItem.InputJar (() => multidex_jar));
 
 				Assert.IsTrue (bbuilder.Build (binding), "Binding build should succeed.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xamarin.Android.Tools.VSWhere;
 
@@ -94,6 +95,26 @@ namespace Xamarin.ProjectTools
 				} else {
 					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
 				}
+			}
+		}
+
+		static string _dotNetAndroidSdkDirectory;
+		public static string DotNetAndroidSdkDirectory {
+			get {
+				if (!string.IsNullOrEmpty (_dotNetAndroidSdkDirectory)) {
+					return _dotNetAndroidSdkDirectory;
+				}
+				var sdkName = IsMacOS ? "Microsoft.Android.Sdk.Darwin"
+					: TestEnvironment.IsWindows ? "Microsoft.Android.Sdk.Windows"
+					: "Microsoft.Android.Sdk.Linux";
+
+				return _dotNetAndroidSdkDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", sdkName)).LastOrDefault ();
+			}
+		}
+
+		public static string DotNetAndroidSdkToolsDirectory {
+			get {
+				return Path.Combine (DotNetAndroidSdkDirectory, "tools");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -104,9 +104,9 @@ namespace Xamarin.ProjectTools
 				if (!string.IsNullOrEmpty (_dotNetAndroidSdkDirectory)) {
 					return _dotNetAndroidSdkDirectory;
 				}
-				var sdkName = IsMacOS ? "Microsoft.Android.Sdk.Darwin"
-					: TestEnvironment.IsWindows ? "Microsoft.Android.Sdk.Windows"
-					: "Microsoft.Android.Sdk.Linux";
+				var sdkName = IsMacOS ? "Microsoft.Android.Sdk.Darwin" :
+					IsWindows ? "Microsoft.Android.Sdk.Windows" :
+					"Microsoft.Android.Sdk.Linux";
 
 				return _dotNetAndroidSdkDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", sdkName)).LastOrDefault ();
 			}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5701

Adds a Linux test stage to exercise the `Microsoft.Android.Sdk.Linux`
.nupkg produced by the Linux build.  This stage contains one job that
runs the `SmokeTests` category of our MSBuild tests.

A couple of updates have been made to `Xamarin.ProjectTools` to support
test environments that do not have a system-wide installation of classic
Xamarin.Android.  This effort was focused on getting the `SmokeTests`
category to run, however more test harness changes will be needed in 
in this area in the future.