### PR TITLE
[NET6] Pass required properties to MonoVM

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.RuntimeConfig.targets
@@ -26,6 +26,8 @@ See: https://github.com/dotnet/runtime/blob/b13715b6984889a709ba29ea8a1961db469f
     <_RuntimeConfigReservedProperties Include="NATIVE_DLL_SEARCH_DIRECTORIES"/>
     <_RuntimeConfigReservedProperties Include="PLATFORM_RESOURCE_ROOTS"/>
     <_RuntimeConfigReservedProperties Include="PINVOKE_OVERRIDE"/>
+    <_RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER"/>
+    <_RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY"/>
   </ItemGroup>
 
   <Target Name="_ParseRuntimeConfigFiles"

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -42,6 +42,10 @@ public class MonoPackageManager {
 				String dataDir      = getNativeLibraryPath (context);
 				ClassLoader loader  = context.getClassLoader ();
 				String runtimeDir = getNativeLibraryPath (runtimePackage);
+
+				//
+				// Should the order change here, src/monodroid/jni/SharedConstants.hh must be updated accordingly
+				//
 				String[] appDirs = new String[] {filesDir, cacheDir, dataDir};
 				boolean haveSplitApks = false;
 

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -519,6 +519,7 @@ endif()
 
 if(ANDROID AND ENABLE_NET6)
   list(APPEND XAMARIN_MONODROID_SOURCES
+    ${SOURCES_DIR}/monovm-properties.cc
     ${SOURCES_DIR}/pinvoke-override-api.cc
     ${SOURCES_DIR}/java_interop_api.c
     ${JAVA_INTEROP_SRC_PATH}/java-interop-util.cc

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -15,14 +15,14 @@ const char* BasicAndroidSystem::built_for_abi_name = nullptr;
 void
 BasicAndroidSystem::detect_embedded_dso_mode (jstring_array_wrapper& appDirs) noexcept
 {
-	// appDirs[2] points to the native library directory
-	std::unique_ptr<char> libmonodroid_path {utils.path_combine (appDirs[2].get_cstr (), "libmonodroid.so")};
+	// appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX] points to the native library directory
+	std::unique_ptr<char> libmonodroid_path {utils.path_combine (appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr (), "libmonodroid.so")};
 	log_debug (LOG_ASSEMBLY, "Checking if libmonodroid was unpacked to %s", libmonodroid_path.get ());
 	if (!utils.file_exists (libmonodroid_path.get ())) {
 		log_debug (LOG_ASSEMBLY, "%s not found, assuming application/android:extractNativeLibs == false", libmonodroid_path.get ());
 		set_embedded_dso_mode_enabled (true);
 	} else {
-		log_debug (LOG_ASSEMBLY, "Native libs extracted to %s, assuming application/android:extractNativeLibs == true", appDirs[2].get_cstr ());
+		log_debug (LOG_ASSEMBLY, "Native libs extracted to %s, assuming application/android:extractNativeLibs == true", appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 		set_embedded_dso_mode_enabled (false);
 	}
 }
@@ -34,8 +34,8 @@ BasicAndroidSystem::setup_app_library_directories (jstring_array_wrapper& runtim
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
 		BasicAndroidSystem::app_lib_directories_size = 1;
 		BasicAndroidSystem::app_lib_directories = new const char*[app_lib_directories_size]();
-		BasicAndroidSystem::app_lib_directories [0] = utils.strdup_new (appDirs[2].get_cstr ());
-		log_debug (LOG_ASSEMBLY, "Added filesystem DSO lookup location: %s", appDirs[2].get_cstr ());
+		BasicAndroidSystem::app_lib_directories [0] = utils.strdup_new (appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
+		log_debug (LOG_ASSEMBLY, "Added filesystem DSO lookup location: %s", appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	} else {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup directly in the APK");
 		BasicAndroidSystem::app_lib_directories_size = runtimeApks.get_length ();

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2100,9 +2100,12 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		total_time.mark_start ();
 	}
 
+	jstring_array_wrapper applicationDirs (env, appDirs);
+	jstring_wrapper &home = applicationDirs[SharedConstants::APP_DIRS_FILES_DIR_INDEX];
+
 #if defined (NET6)
 	{
-		MonoVMProperties monovm_props;
+		MonoVMProperties monovm_props { home };
 
 		// NOTE: the `const_cast` breaks the contract made to MonoVMProperties that the arrays it returns won't be
 		// modified, but it's "ok" since Mono doesn't modify them and by using `const char* const*` in MonoVMProperties
@@ -2118,8 +2121,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	}
 #endif // def NET6
 
-	jstring_array_wrapper applicationDirs (env, appDirs);
-
 	android_api_level = apiLevel;
 	androidSystem.detect_embedded_dso_mode (applicationDirs);
 	androidSystem.set_running_in_emulator (isEmulator);
@@ -2133,8 +2134,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 
 	androidSystem.setup_environment ();
 
-	jstring_wrapper &home = applicationDirs[0];
-	set_environment_variable_for_directory ("TMPDIR", applicationDirs[1]);
+	set_environment_variable_for_directory ("TMPDIR", applicationDirs[SharedConstants::APP_DIRS_CACHE_DIR_INDEX]);
 	set_environment_variable_for_directory ("HOME", home);
 	create_xdg_directories_and_environment (home);
 	androidSystem.set_primary_override_dir (home);

--- a/src/monodroid/jni/monovm-properties.cc
+++ b/src/monodroid/jni/monovm-properties.cc
@@ -1,0 +1,13 @@
+#include "monovm-properties.hh"
+
+using namespace xamarin::android::internal;
+
+MonoVMProperties::property_array MonoVMProperties::_property_keys {
+	RUNTIME_IDENTIFIER_KEY,
+	APP_CONTEXT_BASE_DIRECTORY_KEY,
+};
+
+MonoVMProperties::property_array MonoVMProperties::_property_values {
+	SharedConstants::runtime_identifier,
+	nullptr,
+};

--- a/src/monodroid/jni/monovm-properties.hh
+++ b/src/monodroid/jni/monovm-properties.hh
@@ -4,29 +4,34 @@
 #if defined (NET6)
 #include <cstring>
 #include "monodroid-glue-internal.hh"
+#include "jni-wrappers.hh"
 
 namespace xamarin::android::internal
 {
 	class MonoVMProperties final
 	{
-		constexpr static size_t PROPERTY_COUNT = 0;
+		constexpr static size_t PROPERTY_COUNT = 2;
+
+		constexpr static char RUNTIME_IDENTIFIER_KEY[] = "RUNTIME_IDENTIFIER";
+		constexpr static size_t RUNTIME_IDENTIFIER_INDEX = 0;
+
+		constexpr static char APP_CONTEXT_BASE_DIRECTORY_KEY[] = "APP_CONTEXT_BASE_DIRECTORY";
+		constexpr static size_t APP_CONTEXT_BASE_DIRECTORY_INDEX = 1;
 
 		using property_array = const char*[PROPERTY_COUNT];
 
 	public:
-		explicit MonoVMProperties ()
+		explicit MonoVMProperties (jstring_wrapper& filesDir)
 		{
 			static_assert (PROPERTY_COUNT == N_PROPERTY_KEYS);
 			static_assert (PROPERTY_COUNT == N_PROPERTY_VALUES);
+
+			_property_values[APP_CONTEXT_BASE_DIRECTORY_INDEX] = strdup (filesDir.get_cstr ());
 		}
 
-		int property_count () const
+		constexpr int property_count () const
 		{
-			if constexpr (PROPERTY_COUNT != 0) {
-				return _property_count;
-			} else {
-				return 0;
-			}
+			return PROPERTY_COUNT;
 		}
 
 		const char* const* property_keys () const
@@ -48,23 +53,11 @@ namespace xamarin::android::internal
 		}
 
 	private:
-		template<size_t N_PROPERTIES, size_t P_INDEX>
-		force_inline void
-		add_init_property (const char* key)
-		{
-			static_assert (P_INDEX < N_PROPERTIES);
-			_property_keys[P_INDEX] = key;
-			_property_count++;
-		}
-
-	private:
-		property_array _property_keys = {};
+		static property_array _property_keys;
 		constexpr static size_t N_PROPERTY_KEYS = sizeof(_property_keys) / sizeof(const char*);
 
-		property_array _property_values = {};
+		static property_array _property_values;
 		constexpr static size_t N_PROPERTY_VALUES = sizeof(_property_values) / sizeof(const char*);
-
-		int _property_count = 0;
 	};
 }
 #endif // def NET6

--- a/src/monodroid/jni/shared-constants.hh
+++ b/src/monodroid/jni/shared-constants.hh
@@ -46,15 +46,26 @@ namespace xamarin::android::internal
 
 #if __arm__
 		static constexpr char android_abi[] = "armeabi_v7a";
+		static constexpr char runtime_identifier[] = "android-arm";
 #elif __aarch64__
 		static constexpr char android_abi[] = "arm64_v8a";
+		static constexpr char runtime_identifier[] = "android-arm64";
 #elif __x86_64__
 		static constexpr char android_abi[] = "x86_64";
+		static constexpr char runtime_identifier[] = "android-x64";
 #elif __i386__
 		static constexpr char android_abi[] = "x86";
+		static constexpr char runtime_identifier[] = "android-x86";
 #endif
 
 		static constexpr auto split_config_abi_apk_name = concat_const ("/split_config.", android_abi, ".apk");
+
+		//
+		// Indexes must match these of trhe `appDirs` array in src/java-runtime/mono/android/MonoPackageManager.java
+		//
+		static constexpr size_t APP_DIRS_FILES_DIR_INDEX = 0;
+		static constexpr size_t APP_DIRS_CACHE_DIR_INDEX = 1;
+		static constexpr size_t APP_DIRS_DATA_DIR_INDEX = 2;
 	};
 }
 #endif // __SHARED_CONSTANTS_HH


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6190

NET6+ BCL needs two `AppContext` properties to be defined and passed to
the runtime on initialization:

  * `RUNTIME_IDENTIFIER` which contains the RID
  * `APP_CONTEXT_BASE_DIRECTORY` which points to the app's "home"
    directory

Initialize and pass these properties to `monovm_initialize_preparsed`.