### PR TITLE
Bump Mono

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:main@5b0fab478fa4682034dbbc0cce06748c7dc51474
-mono/mono:2020-02@b8d7525156acaecf311ba468147caa74d8c190f6
+mono/mono:2020-02@a5d1934898bfdf06662cee5799782b09ce8afe5a


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6546
Context: https://github.com/mono/mono/pull/21391
Changes:

  * transform sgen_get_descriptor to parallel safe version in
    job_major_mod_union_preclean (#21391)