### PR TITLE
$(AndroidPackVersionSuffix)=preview.13; net6 is 31.0.200.preview.13

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,8 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>31.0.101</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.12</AndroidPackVersionSuffix>
+    <AndroidPackVersion>31.0.200</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.13</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: http://aka.ms/maui-schedule

Update our version number to 31.0.200 to match the 6.0.200 .NET SDK.

We branched xamarin-android/release/6.0.2xx-preview12, to reflect the
next release of .NET MAUI Preview 12.

xamarin-android/main becomes Preview 13.