### PR TITLE
[Xamarin.Android.Build.Tasks] Add Support for bundletool meta-data

### DIFF
--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -38,6 +38,26 @@ Used to provide an AOT profile, for use with profile-guided AOT.
 It can be also used from Visual Studio by setting the `AndroidAotProfile`
 build action to a file containing an AOT profile.
 
+## AndroidAppBundleMetaDataFile
+
+Specifies a file that will be included as metadata in the Android App Bundle.
+The format of the flag value is `<bundle-path>:<physical-file>` where
+`bundle-path` denotes the file location inside the App Bundle's metadata
+directory, and `physical-file` is an existing file containing the raw data
+to be stored.
+
+```xml
+<ItemGroup>
+  <AndroidAppBundleMetaDataFile
+    Include="com.android.tools.build.obfuscation/proguard.map:$(OutputPath)mapping.txt"
+  />
+</ItemGroup>
+```
+
+See [bundletool](https://developer.android.com/studio/build/building-cmdline#build_your_app_bundle_using_bundletool) documentation for more details.
+
+Added in Xamarin.Android 12.3.
+
 ## AndroidBoundLayout
 
 Indicates that the layout file is to have code-behind generated for it in case when

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -300,6 +300,28 @@ should be created instead of having support for all ABIs in a single `.apk`.
 See also the [Building ABI-Specific APKs](~/android/deploy-test/building-apps/abi-specific-apks.md)
 guide.
 
+## AndroidCreateProguardMappingFile
+
+A boolean property that controls if a proguard mapping file is
+generated as part of the build process.
+
+Adding the following to your csproj will cause the file to be
+generated. This uses the [`AndroidProguardMappingFile`](#androidproguardmappingfile) property
+to control the location of the final mapping file.
+
+```
+<AndroidCreateProguardMappingFile>True</AndroidCreateProguardMappingFile>
+```
+
+Note that if you are using `.aab` files the mapping file with be
+automatically included in your package. So there is no need to upload
+it to the Google Play Store manually. If you are using `.apk` files
+you will need to manually upload the [`AndroidProguardMappingFile`](#androidproguardmappingfile).
+
+The default value is `True` when using `AndroidLinkTool=r8`.
+
+Added in Xamarin.Android 12.3.
+
 ## AndroidDebugKeyAlgorithm
 
 Specifies the default
@@ -987,7 +1009,18 @@ mean the `mapping.txt` file will be produced in the `$(OutputPath)`
 folder. This file can then be used when uploading packages to the
 Google Play Store.
 
-The default value is `$(OutputPath)mapping.txt`.
+By default this file is produced automatically when using `AndroidLinkTool=r8`
+and will generate the following file `$(OutputPath)mapping.txt`.
+
+If you do not want to generate this mapping file you can use the
+[`AndroidCreateProguardMappingFile`](#androidcreateproguardmappingfile) property to stop creating it .
+Add the following in your project
+
+```
+<AndroidCreateProguardMappingFile>False</AndroidCreateProguardMappingFile>
+```
+
+or use `-p:AndroidCreateProguardMappingFile=False` on the command line.
 
 This property was added in Xamarin.Android 11.2.
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Publish.targets
@@ -24,6 +24,7 @@ This file contains the implementation for 'dotnet publish'.
       <_AllPackageFormats Include="$(AndroidPackageFormat);$(AndroidPackageFormats)" />
       <_AndroidPackageFormats Include="@(_AllPackageFormats->Distinct())" />
       <_AndroidFilesToPublish Include="$(OutputPath)*.%(_AndroidPackageFormats.Identity)" />
+      <_AndroidFilesToPublish Include="$(AndroidProguardMappingFile)" Condition="Exists ('$(AndroidProguardMappingFile)')" />
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" />
       <ResolvedFileToPublish Include="@(_AndroidFilesToPublish)" RelativePath="%(FileName)%(Extension)" />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tasks
 {
 	/// <summary>
 	/// Invokes `bundletool` to create an Android App Bundle (.aab file)
-	/// 
+	///
 	/// Usage: bundletool build-bundle --modules=base.zip --output=foo.aab --config=BundleConfig.json
 	/// </summary>
 	public class BuildAppBundle : BundleTool
@@ -63,8 +63,10 @@ namespace Xamarin.Android.Tasks
 		public string BaseZip { get; set; }
 
 		public string CustomBuildConfigFile { get; set; }
-		
+
 		public string [] Modules { get; set; }
+
+		public ITaskItem [] MetaDataFiles { get; set; }
 
 		[Required]
 		public string Output { get; set; }
@@ -130,6 +132,9 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--modules ", string.Join (",", modules));
 			cmd.AppendSwitchIfNotNull ("--output ", Output);
 			cmd.AppendSwitchIfNotNull ("--config ", temp);
+			foreach (var file in MetaDataFiles ?? Array.Empty<ITaskItem> ()) {
+				cmd.AppendSwitch ($"--metadata-file={file.ItemSpec}");
+			}
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Android.Tasks
 					if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
 						xamcfg.WriteLine ("-keepattributes SourceFile");
 						xamcfg.WriteLine ("-keepattributes LineNumberTable");
-						xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+						xamcfg.WriteLine ($"-printmapping \"{Path.GetFullPath (ProguardMappingFileOutput)}\"");
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Tasks
 						if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
 							xamcfg.WriteLine ("-keepattributes SourceFile");
 							xamcfg.WriteLine ("-keepattributes LineNumberTable");
-							xamcfg.WriteLine ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+							xamcfg.WriteLine ($"-printmapping \"{Path.GetFullPath (ProguardMappingFileOutput)}\"");
 						}
 					}
 				}
@@ -125,7 +125,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (ProguardMappingFileOutput)) {
 					lines.Add ("-keepattributes SourceFile");
 					lines.Add ("-keepattributes LineNumberTable");
-					lines.Add ($"-printmapping {Path.GetFullPath (ProguardMappingFileOutput)}");
+					lines.Add ($"-printmapping \"{Path.GetFullPath (ProguardMappingFileOutput)}\"");
 				}
 				File.WriteAllLines (temp, lines);
 				tempFiles.Add (temp);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -56,8 +56,8 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidDexTool, "d8");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidLinkTool, "r8");
-			// Projects must provide a $(AndroidProguardMappingFile) value to opt in
-			proj.SetProperty (proj.ReleaseProperties, "AndroidProguardMappingFile", @"$(OutputPath)\mapping.txt");
+			// Projects must set $(AndroidCreateProguardMappingFile) to true to opt in
+			proj.SetProperty (proj.ReleaseProperties, "AndroidCreateProguardMappingFile", true);
 
 			using (var b = CreateApkBuilder ()) {
 				string mappingFile = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "mapping.txt");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -264,6 +264,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>
+	<AndroidCreateProguardMappingFile Condition="'$(AndroidCreateProguardMappingFile)' == '' And '$(AndroidLinkTool)' == 'r8'">True</AndroidCreateProguardMappingFile>
 
 	<!-- Figure out which is the main packaging format we want-->
 	<AndroidPackageFormat Condition=" $(AndroidPackageFormats.Contains('aab')) And '$(AndroidPackageFormat)' == '' ">aab</AndroidPackageFormat>
@@ -1807,6 +1808,7 @@ because xbuild doesn't support framework reference assemblies.
 		_CreateApplicationSharedLibraries;
 		_GetMonoPlatformJarPath;
 		_GetLibraryImports;
+		_SetProguardMappingFileProperty;
 		_CalculateProguardConfigurationFiles;
 	</_CompileToDalvikDependsOnTargets>
 	<_CompileToDalvikInputs>
@@ -1825,6 +1827,12 @@ because xbuild doesn't support framework reference assemblies.
 		_CompileToDalvik;
 	</_CompileDexDependsOn>
 </PropertyGroup>
+
+<Target Name="_SetProguardMappingFileProperty">
+	<PropertyGroup>
+		<AndroidProguardMappingFile Condition=" '$(AndroidLinkTool)' == 'r8' And '$(AndroidCreateProguardMappingFile)' == 'True' ">$(OutputPath)mapping.txt</AndroidProguardMappingFile>
+	</PropertyGroup>
+</Target>
 
 <Target Name="_CalculateProguardConfigurationFiles">
   <!-- Support the $(ProguardConfigFiles) property to keep backwards compatibility -->
@@ -1967,6 +1975,12 @@ because xbuild doesn't support framework reference assemblies.
       $(ApkFileIntermediate)
     </_BuildApkEmbedOutputs>
   </PropertyGroup>
+  <ItemGroup>
+    <AndroidAppBundleMetaDataFile
+        Condition=" Exists('$(AndroidProguardMappingFile)') "
+        Include="com.android.tools.build.obfuscation/proguard.map:$(AndroidProguardMappingFile)"
+    />
+  </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -2064,6 +2078,7 @@ because xbuild doesn't support framework reference assemblies.
       Output="$(_AppBundleIntermediate)"
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
       CustomBuildConfigFile="$(AndroidBundleConfigurationFile)"
+      MetaDataFiles="@(AndroidAppBundleMetaDataFile)"
   />
 </Target>
 

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
@@ -5,259 +5,259 @@
       "Size": 3768
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7191
+      "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68688
+      "Size": 68861
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 560342
+      "Size": 561736
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68430
+      "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936261
+      "Size": 936263
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
     },
     "assemblies/Plugin.Connectivity.Abstractions.dll": {
-      "Size": 3760
+      "Size": 3770
     },
     "assemblies/Plugin.Connectivity.dll": {
       "Size": 10201
     },
     "assemblies/System.Core.dll": {
-      "Size": 192206
+      "Size": 192216
     },
     "assemblies/System.Data.dll": {
-      "Size": 316107
+      "Size": 316113
     },
     "assemblies/System.dll": {
-      "Size": 443196
+      "Size": 443207
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 16345
+      "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113285
+      "Size": 113293
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 23251
+      "Size": 23262
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193447
+      "Size": 193453
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26590
+      "Size": 26599
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592565
+      "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34368
+      "Size": 34374
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7686
+      "Size": 7694
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124577
+      "Size": 124587
     },
     "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6649
+      "Size": 6661
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7355
+      "Size": 7363
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18262
+      "Size": 18269
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131922
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15433
+      "Size": 15442
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43119
+      "Size": 43128
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6705
+      "Size": 6710
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7053
+      "Size": 7063
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7185
+      "Size": 7191
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4865
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13574
+      "Size": 13581
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102425
+      "Size": 102429
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6260
+      "Size": 6271
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11260
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19420
+      "Size": 19428
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 471882
+      "Size": 471887
     },
     "assemblies/Xamarin.Forms.Performance.Integration.dll": {
-      "Size": 21996
+      "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114909
+      "Size": 114913
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367732
+      "Size": 367737
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56584
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55027
+      "Size": 55034
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43499
+      "Size": 43506
     },
     "classes.dex": {
-      "Size": 2499728
+      "Size": 2652924
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
-      "Size": 38632
+      "Size": 38680
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 870816
+      "Size": 871548
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 6742720
+      "Size": 6745752
     },
     "lib/armeabi-v7a/libaot-Mono.Security.dll.so": {
-      "Size": 443012
+      "Size": 443060
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 8676492
+      "Size": 8676524
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3394680
+      "Size": 3394728
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 21976
+      "Size": 22040
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 71320
+      "Size": 71372
     },
     "lib/armeabi-v7a/libaot-System.Core.dll.so": {
-      "Size": 2285028
+      "Size": 2285072
     },
     "lib/armeabi-v7a/libaot-System.Data.dll.so": {
-      "Size": 3262352
+      "Size": 3262396
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 3963520
+      "Size": 3963560
     },
     "lib/armeabi-v7a/libaot-System.Drawing.Common.dll.so": {
-      "Size": 69900
+      "Size": 69956
     },
     "lib/armeabi-v7a/libaot-System.Net.Http.dll.so": {
-      "Size": 1195504
+      "Size": 1195552
     },
     "lib/armeabi-v7a/libaot-System.Numerics.dll.so": {
-      "Size": 161460
+      "Size": 161508
     },
     "lib/armeabi-v7a/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 2204312
+      "Size": 2204372
     },
     "lib/armeabi-v7a/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 187292
+      "Size": 187356
     },
     "lib/armeabi-v7a/libaot-System.Xml.dll.so": {
-      "Size": 5967856
+      "Size": 5967900
     },
     "lib/armeabi-v7a/libaot-System.Xml.Linq.dll.so": {
-      "Size": 328092
+      "Size": 328140
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 48328
+      "Size": 48384
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 1643344
+      "Size": 1643404
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 42900
+      "Size": 42972
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 49460
+      "Size": 49516
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 220092
+      "Size": 220160
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 1716868
+      "Size": 1716920
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 156536
+      "Size": 156600
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 501772
+      "Size": 501832
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 41076
+      "Size": 41148
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 42644
+      "Size": 42708
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 42720
+      "Size": 42792
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 21308
+      "Size": 21376
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 116268
+      "Size": 116324
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 1462116
+      "Size": 1462180
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 34724
+      "Size": 34784
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 97840
+      "Size": 97908
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 205132
+      "Size": 205192
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 5411932
+      "Size": 5411984
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 239200
+      "Size": 239268
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 270612
+      "Size": 270688
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 3830648
+      "Size": 3830708
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 136580
+      "Size": 136636
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 547032
+      "Size": 547080
     },
     "lib/armeabi-v7a/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 609712
+      "Size": 609776
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -266,142 +266,142 @@
       "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 229116
+      "Size": 235164
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456332
+      "Size": 4456576
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 136376
+      "Size": 133596
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
-      "Size": 46012
+      "Size": 46232
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 823996
+      "Size": 824880
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 6318972
+      "Size": 6322112
     },
     "lib/x86/libaot-Mono.Security.dll.so": {
-      "Size": 413872
+      "Size": 414092
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 8035916
+      "Size": 8036132
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3159240
+      "Size": 3159460
     },
     "lib/x86/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 25620
+      "Size": 25860
     },
     "lib/x86/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 74392
+      "Size": 74616
     },
     "lib/x86/libaot-System.Core.dll.so": {
-      "Size": 2140152
+      "Size": 2140368
     },
     "lib/x86/libaot-System.Data.dll.so": {
-      "Size": 2960556
+      "Size": 2960776
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 3648424
+      "Size": 3648636
     },
     "lib/x86/libaot-System.Drawing.Common.dll.so": {
-      "Size": 73160
+      "Size": 73388
     },
     "lib/x86/libaot-System.Net.Http.dll.so": {
-      "Size": 1115380
+      "Size": 1115604
     },
     "lib/x86/libaot-System.Numerics.dll.so": {
-      "Size": 155088
+      "Size": 155312
     },
     "lib/x86/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 2052624
+      "Size": 2052860
     },
     "lib/x86/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 181152
+      "Size": 181388
     },
     "lib/x86/libaot-System.Xml.dll.so": {
-      "Size": 5452648
+      "Size": 5452864
     },
     "lib/x86/libaot-System.Xml.Linq.dll.so": {
-      "Size": 304104
+      "Size": 304328
     },
     "lib/x86/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 55568
+      "Size": 55800
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 1563132
+      "Size": 1563364
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 46212
+      "Size": 46452
     },
     "lib/x86/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 52584
+      "Size": 52816
     },
     "lib/x86/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 213260
+      "Size": 213500
     },
     "lib/x86/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 1640216
+      "Size": 1640444
     },
     "lib/x86/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 154400
+      "Size": 154632
     },
     "lib/x86/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 478256
+      "Size": 478488
     },
     "lib/x86/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 44384
+      "Size": 44632
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 45916
+      "Size": 46156
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 45944
+      "Size": 46192
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 24936
+      "Size": 25180
     },
     "lib/x86/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 114440
+      "Size": 114672
     },
     "lib/x86/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 1390308
+      "Size": 1390544
     },
     "lib/x86/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 38152
+      "Size": 38388
     },
     "lib/x86/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 96532
+      "Size": 96772
     },
     "lib/x86/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 198232
+      "Size": 198464
     },
     "lib/x86/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 4970836
+      "Size": 4971060
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 233824
+      "Size": 234068
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 192264
+      "Size": 192512
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 3528996
+      "Size": 3529232
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 103008
+      "Size": 103236
     },
     "lib/x86/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 500796
+      "Size": 501020
     },
     "lib/x86/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 589672
+      "Size": 589908
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -410,16 +410,16 @@
       "Size": 803352
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 297800
+      "Size": 306828
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212220
+      "Size": 4212336
     },
     "lib/x86/libxa-internal-api.so": {
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 134612
+      "Size": 136588
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 36295876
+  "PackageSize": 36435140
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
@@ -5,7 +5,7 @@
       "Size": 3768
     },
     "classes.dex": {
-      "Size": 2802888
+      "Size": 2974620
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -14,19 +14,19 @@
       "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
-      "Size": 4276344
+      "Size": 4276376
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 229116
+      "Size": 235164
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456332
+      "Size": 4456576
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 110724
+      "Size": 108520
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -35,19 +35,19 @@
       "Size": 803352
     },
     "lib/x86/libmonodroid_bundle_app.so": {
-      "Size": 4279696
+      "Size": 4284080
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 297800
+      "Size": 306828
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212220
+      "Size": 4212336
     },
     "lib/x86/libxa-internal-api.so": {
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 109168
+      "Size": 107576
     },
     "META-INF/android.arch.core_runtime.version": {
       "Size": 6
@@ -2993,5 +2993,5 @@
       "Size": 493672
     }
   },
-  "PackageSize": 16238582
+  "PackageSize": 16394230
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
@@ -5,139 +5,139 @@
       "Size": 3768
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7191
+      "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68888
+      "Size": 68861
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 561679
+      "Size": 561736
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68430
+      "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936261
+      "Size": 936263
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
     },
     "assemblies/Plugin.Connectivity.Abstractions.dll": {
-      "Size": 3760
+      "Size": 3770
     },
     "assemblies/Plugin.Connectivity.dll": {
       "Size": 10201
     },
     "assemblies/System.Core.dll": {
-      "Size": 192206
+      "Size": 192216
     },
     "assemblies/System.Data.dll": {
-      "Size": 316107
+      "Size": 316113
     },
     "assemblies/System.dll": {
-      "Size": 443196
+      "Size": 443207
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 16345
+      "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113285
+      "Size": 113293
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 23251
+      "Size": 23262
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193447
+      "Size": 193453
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26590
+      "Size": 26599
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592565
+      "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34368
+      "Size": 34374
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7686
+      "Size": 7694
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124577
+      "Size": 124587
     },
     "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6649
+      "Size": 6661
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7355
+      "Size": 7363
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18262
+      "Size": 18269
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131922
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15433
+      "Size": 15442
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43119
+      "Size": 43128
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6705
+      "Size": 6710
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7053
+      "Size": 7063
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7185
+      "Size": 7191
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4865
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13574
+      "Size": 13581
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102425
+      "Size": 102429
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6260
+      "Size": 6271
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11260
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19420
+      "Size": 19428
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 471882
+      "Size": 471887
     },
     "assemblies/Xamarin.Forms.Performance.Integration.dll": {
-      "Size": 21996
+      "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114910
+      "Size": 114913
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367732
+      "Size": 367737
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56584
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55027
+      "Size": 55034
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43499
+      "Size": 43506
     },
     "classes.dex": {
-      "Size": 2499792
+      "Size": 2652924
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
       "Size": 22716
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 288728
+      "Size": 289464
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
       "Size": 987268
@@ -224,22 +224,22 @@
       "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 233204
+      "Size": 235164
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456332
+      "Size": 4456576
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 136444
+      "Size": 133596
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
       "Size": 26524
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 265600
+      "Size": 266312
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
       "Size": 818880
@@ -326,16 +326,16 @@
       "Size": 803352
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 304284
+      "Size": 306828
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212220
+      "Size": 4212336
     },
     "lib/x86/libxa-internal-api.so": {
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 134800
+      "Size": 136588
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2159,5 +2159,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 17353168
+  "PackageSize": 17480144
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
@@ -2,136 +2,136 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 3748
+      "Size": 3768
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7191
+      "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68688
+      "Size": 68861
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 555037
+      "Size": 561736
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68430
+      "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936261
+      "Size": 936263
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
     },
     "assemblies/Plugin.Connectivity.Abstractions.dll": {
-      "Size": 3760
+      "Size": 3770
     },
     "assemblies/Plugin.Connectivity.dll": {
       "Size": 10201
     },
     "assemblies/System.Core.dll": {
-      "Size": 192206
+      "Size": 192216
     },
     "assemblies/System.Data.dll": {
-      "Size": 316107
+      "Size": 316113
     },
     "assemblies/System.dll": {
-      "Size": 443196
+      "Size": 443207
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 16345
+      "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113285
+      "Size": 113293
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 23251
+      "Size": 23262
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193447
+      "Size": 193453
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26590
+      "Size": 26599
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592565
+      "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34368
+      "Size": 34374
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7686
+      "Size": 7694
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124577
+      "Size": 124587
     },
     "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6649
+      "Size": 6661
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7355
+      "Size": 7363
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18262
+      "Size": 18269
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131922
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15433
+      "Size": 15442
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43119
+      "Size": 43128
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6705
+      "Size": 6710
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7053
+      "Size": 7063
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7185
+      "Size": 7191
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4865
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13574
+      "Size": 13581
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102425
+      "Size": 102429
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6260
+      "Size": 6271
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11260
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19420
+      "Size": 19428
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 471882
+      "Size": 471887
     },
     "assemblies/Xamarin.Forms.Performance.Integration.dll": {
-      "Size": 21996
+      "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114909
+      "Size": 114913
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367732
+      "Size": 367737
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56584
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55027
+      "Size": 55034
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43499
+      "Size": 43506
     },
     "classes.dex": {
-      "Size": 2473052
+      "Size": 2652924
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -140,16 +140,16 @@
       "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 229052
+      "Size": 235164
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456332
+      "Size": 4456576
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 136376
+      "Size": 133596
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -158,16 +158,16 @@
       "Size": 803352
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 297720
+      "Size": 306828
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212220
+      "Size": 4212336
     },
     "lib/x86/libxa-internal-api.so": {
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 134612
+      "Size": 136588
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1991,5 +1991,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 12854624
+  "PackageSize": 12997984
 }

--- a/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
@@ -5,13 +5,13 @@
       "Size": 2896
     },
     "assemblies/assemblies.blob": {
-      "Size": 2026794
+      "Size": 2027538
     },
     "assemblies/assemblies.manifest": {
       "Size": 1574
     },
     "classes.dex": {
-      "Size": 2940564
+      "Size": 2940568
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -20,16 +20,16 @@
       "Size": 736396
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 232320
+      "Size": 234328
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456332
+      "Size": 4456576
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 46832
+      "Size": 46844
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -38,16 +38,16 @@
       "Size": 803352
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 303316
+      "Size": 305648
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212220
+      "Size": 4212336
     },
     "lib/x86/libxa-internal-api.so": {
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 45500
+      "Size": 45632
     },
     "META-INF/android.arch.core_runtime.version": {
       "Size": 6
@@ -1610,5 +1610,5 @@
       "Size": 320016
     }
   },
-  "PackageSize": 9500681
+  "PackageSize": 9504777
 }


### PR DESCRIPTION
Fixes: #5378

Context: 2dab2bc

When uploading an `.apk` or `.aab` file which contains native
libraries such as AOT'd .NET assemblies to the Google Play store,
the Google Play Console reports the following warning:

> This App Bundle contains native code, and you've not uploaded
> debug symbols.  We recommend that you upload a symbol file to make
> your crashes and ANRs easier to analyse and debug.

Commit 2dab2bc addresses a similar warning regarding obfuscated
Java/Kotlin code.

Improve support for this scenario by adding a new
`$(AndroidCreateProguardMappingFile)` MSBuild property which controls
the creation of the ProGuard mapping file.

When True (the default when r8 is used), a ProGuard mapping file will
be created and added to `.apk`/`.aab` build outputs.  This increases
the size of resulting applications by ~1% for our unit tests, and
will remove the above warning for Google Play Store submissions.

To make `$(AndroidCreateProguardMappingFile)`=True *work*, add
support for a new `@(AndroidAppBundleMetaDataFile)` item group.
`%(AndroidAppBundleMetaDataFile.Include)` values are those used by
the [`bundletool build-bundle --metadata-file`][0] option:

> `--metadata-file=target-bundle-path:local-file-path`
>
>   * `target-bundle-path` specifies a path relative to the root of
>      the app bundle where you would like the metadata file to be
>      packaged, and
>   * `local-file-path` specifies the path to the local metadata file
>     itself.

When `$(AndroidCreateProguardMappingFile)`=True, we automatically add:

	<AndroidAppBundleMetaDataFile Include="com.android.tools.build.obfuscation/proguard.map:$(AndroidProguardMappingFile" />

which causes the ProGuard mapping file to be included into the bundle.
This only applies to `.aab` package formats.

For `.apk` files the ProGuard mapping file will not be included in the
`.apk`,  as it doesn't not support it. However the file will be copied
to the  `$(OutputPath)` along with the `.apk`. It can be manually uploaded
to the Google Play Store from there.

[0]: https://developer.android.com/studio/build/building-cmdline#bundletool-build