### PR TITLE
[ci] Fix extra build args in nightly build

### DIFF
--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -51,7 +51,7 @@ endef
 
 # $(call DOTNET_BINLOG,name,build=$(DOTNET_VERB),dotnet=$(DOTNET_TOOL))
 define DOTNET_BINLOG
-	$(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -c $(CONFIGURATION) -v:n \
+	$(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -c $(CONFIGURATION) -v:n $(MSBUILD_ARGS) \
 		-bl:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 


### PR DESCRIPTION
Commit bb4e4a63 seemingly broke our nightly build, as the extra MSBuild
properties set in the `$MSBUILD_ARGS` make variable were no longer used
in `dotnet build` invocations.  Fix this by appending `$MSBUILD_ARGS` to
all `DOTNET_BINLOG` make function calls.