### PR TITLE
[build] fix logic to compute .NET version band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <MicrosoftNETCoreAppRefPackageVersion>6.0.2-mauipre.1.22054.8</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Trim all characters after first `-` or `+` is encountered. -->
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace($(MicrosoftDotnetSdkInternalPackageVersion), `[-+].*$`, ""))</DotNetPreviewVersionBand>
+    <!-- Match the first three version numbers and append 00 -->
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Previously in 63a9aca4, we bumped from:

    6.0.100-rtm.21552.8 to 6.0.101-servicing.21562.12

And our existing logic that computes `$(DotNetPreviewVersionBand)`
came up with:

    <DotNetPreviewVersionBand>6.0.101</DotNetPreviewVersionBand>

While we need the version band to actually read 6.0.100!

At the time we just hardcoded 6.0.100, let's change the logic to
instead match:

    ^\d+\.\d+\.\d

Then appending '00' results in a correct version band.

I tested with this project:

    <Project>
      <PropertyGroup>
        <MicrosoftDotnetSdkInternalPackageVersion>6.0.201-preview.22055.18</MicrosoftDotnetSdkInternalPackageVersion>
        <DotNetPreviewVersionBand>$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
      </PropertyGroup>
      <Target Name="Build">
        <Message Text="DotNetPreviewVersionBand: $(DotNetPreviewVersionBand)" Importance="High" />
      </Target>
    </Project>

Which results in `DotNetPreviewVersionBand: 6.0.200`.