### PR TITLE
Enable github dependabot for gradle files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Context: https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/
Context: https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates

To help us keep r8 and manifest-merger updated, we can configure
Github's dependabot to send us PRs weekly.

It appears we have to merge this file and "see if it works"?

I did this in another repo for NuGet packages here:

https://github.com/jonathanpeppers/boots/commit/b5f191d1fc1ccd7a024472245f6fb89ac77210e0

And the file seems to be what configures everything.