### PR TITLE
[github] configure dependabot for two directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "/"
+    directory: "/src/r8/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/src/manifestmerger/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/network/updates/253221292

Dependabot failed with:

    Dependabot couldn't find a build.gradle(.kts)?.
    Dependabot requires a build.gradle(.kts)? to evaluate your Java
    dependencies. It had expected to find one at the path:
    /build.gradle(.kts)?.
    If this isn't a Java project, you may wish to disable updates for
    it in the .github/dependabot.yml config file in this repo.

I believe the only options here are `package-ecosystem`, `directory`,
and `schedule`. So I think we can configure two directories for r8 and
manifestmerger.

Unfortunately, it seems like we have to test this in the default
branch. When I tried another branch I see the message:

    Cannot configure Dependabot.
    To configure Dependabot, you must use this repository’s default branch.