### PR TITLE
Add missing restore instruction for building xabuild.csproj

### DIFF
--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -32,7 +32,8 @@ MSBuild version 15 or later is required.
 
  7. In order to use the in-tree Xamarin.Android, build xabuild:
  
-         msbuild tools/xabuild/xabuild.csproj
+         msbuild tools/xabuild/xabuild.csproj /t:Restore
+	 msbuild tools/xabuild/xabuild.csproj
 
  8. (For Microsoft team members only - Optional) In a [Developer Command
     Prompt][developer-prompt], build external proprietary git

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -32,8 +32,7 @@ MSBuild version 15 or later is required.
 
  7. In order to use the in-tree Xamarin.Android, build xabuild:
  
-         msbuild tools/xabuild/xabuild.csproj /t:Restore
-	 msbuild tools/xabuild/xabuild.csproj
+         msbuild tools/xabuild/xabuild.csproj /restore
 
  8. (For Microsoft team members only - Optional) In a [Developer Command
     Prompt][developer-prompt], build external proprietary git


### PR DESCRIPTION
It seems to be necessary to restore the packages before the first build of `xabuild.csproj` on Windows.