### PR TITLE
[One .NET] fix GetAndroidDependencies target with --no-restore

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -899,6 +899,16 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
 		}
 
+		[Test]
+		public void GetAndroidDependencies()
+		{
+			var proj = new XASdkProject ();
+			var builder = CreateDotNetBuilder (proj);
+
+			// `dotnet build -t:GetAndroidDependencies --no-restore` should succeed
+			Assert.IsTrue (builder.Build (target: "GetAndroidDependencies", norestore: true), $"{proj.ProjectName} should succeed");
+		}
+
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)
 		{
 			if (string.IsNullOrEmpty (relativeProjectDir)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -92,9 +92,11 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Build (string target = null, string [] parameters = null)
+		public bool Build (string target = null, string [] parameters = null, bool norestore = false)
 		{
 			var arguments = GetDefaultCommandLineArgs ("build", target, parameters);
+			if (norestore)
+				arguments.Add ("--no-restore");
 			return Execute (arguments.ToArray ());
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -42,22 +42,30 @@ projects.
   </Target>
 
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
-    <_ResolveSdksDependsOnTargets>ResolveTargetingPackAssets</_ResolveSdksDependsOnTargets>
+    <_ResolveSdksDependsOnTargets>ProcessFrameworkReferences</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
     <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
 
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
-    <!-- When using .NET 5, provide a list of paths to the Android and NETCore targeting pack directories, e.g.
-          `packages\microsoft.android.ref\10.0.100-ci.master.22\ref\net5.0\` and
-          `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.6.20264.1\ref\net5.0\`
-         See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
-    -->
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
       <_AndroidApiInfo Include="$(MSBuildThisFileDirectory)..\data\*\AndroidApiInfo.xml" />
       <_AndroidApiInfoDirectories Include="@(_AndroidApiInfo->'%(RootDir)%(Directory)')" />
-      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />
+      <!--
+        When using .NET 6+, provide the directory containing Mono.Android.dll and System.dll.
+        Use %(TargetingPack.PackageDirectory) to get this information.
+        See: https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets#L49-L63
+      -->
+      <_MonoAndroidReferenceAssemblyPath
+          Condition=" '%(TargetingPack.Identity)' == 'Microsoft.NETCore.App' and '%(TargetingPack.PackageDirectory)' != '' "
+          Include="%(TargetingPack.PackageDirectory)\ref\*\System.dll"
+      />
+      <_MonoAndroidReferenceAssemblyPath
+          Condition=" '%(TargetingPack.Identity)' == 'Microsoft.Android' and '%(TargetingPack.PackageDirectory)' != '' "
+          Include="%(TargetingPack.PackageDirectory)\ref\*\Mono.Android.dll"
+      />
+      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(_MonoAndroidReferenceAssemblyPath->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(_MonoAndroidReferenceAssemblyPath.RootDir)%(_MonoAndroidReferenceAssemblyPath.Directory)' != '' " />
     </ItemGroup>
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' != 'true' ">
       <_AndroidApiInfoDirectories Include="$(_XATargetFrameworkDirectories)" />


### PR DESCRIPTION
I've noticed the following sometimes happens when a new .NET MAUI
project is created in VS 2022 on Windows:

    dotnet\sdk\6.0.200-preview.22055.18\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(267,5):
    error NETSDK1004: Assets file 'obj\project.assets.json' not found.
    Run a NuGet package restore to generate this file.

I seem to only get this for MAUI projects and only *sometimes*.
`dotnet new android` projects seem to always work fine.

When this error occurs, I think the dropdown fails to load the device
list. What you end up with is the play button that just says
`> Android Emulator`. After some amount of "fiddling", you can get the
IDE to load the device list.

What I think is happening is:

1. NuGet restore takes longer in MAUI projects than `dotnet new android`

2. Sometimes `GetAndroidDependencies` runs *before* NuGet restore, and
   that triggers the above error.

I could validate this hypothesis with:

    > dotnet new android
    > dotnet build -t:GetAndroidDependencies --no-restore

And I get the above error! I could also reproduce in a test.

This target works fine in a classic Xamarin.Android app:

    git clean -dxf .\samples\
    msbuild .\samples\HelloWorld\HelloWorld\HelloWorld.csproj -t:GetAndroidDependencies

(note that the absence of `-restore`, is the same as `--no-restore`)

After digging through `.binlog` files, I see
`$(_ResolveSdksDependsOnTargets)` depends on
`ResolveTargetingPackAssets`. This triggers the failure.

Reviewing another target:

https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets#L49-L63

`ProcessFrameworkReferences` runs a bit earlier, and does not appear
to fail with `--no-restore`. It also has a
`%(TargetingPack.PackageDirectory)` value we can use instead.

After this change, my earlier test passes. I think this might also
have a small improvement to the performance of the
`GetAndroidDependencies` target.

This change should improve the overall reliability of creating new
.NET MAUI projects in VS.