### PR TITLE
Run the `pack-dotnet` make target in single-threaded mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ all-tests::
 	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
 
 pack-dotnet::
-	$(call DOTNET_BINLOG,pack-dotnet) $(MSBUILD_FLAGS) $(SOLUTION) -t:PackDotNet
+	$(call DOTNET_BINLOG,pack-dotnet) $(MSBUILD_FLAGS) -m:1 $(SOLUTION) -t:PackDotNet
 
 install::
 	@if [ ! -d "bin/$(CONFIGURATION)" ]; then \


### PR DESCRIPTION
Running `make pack-dotnet` on Unix may fail with a combination of
the following errors:

    src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj(4,47): error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found.
    /usr/share/dotnet/sdk/6.0.101/Microsoft.Common.CurrentVersion.targets(4635,5): error MSB3030: Could not copy the file "obj/Debug/javadoc-to-mdoc.dll" because it was not found.

The errors tend to persist across several builds from scratch and
then suddenly the build starts working again.  After some head
scratching followed by a lot of testing it appears that disabling
parallel builds makes `pack-dotnet` work reliably.