### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Logging to report correct path

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Android.Tasks
 			ArchiveFileList files = new ArchiveFileList ();
 			bool refresh = true;
 			if (apkInputPath != null && File.Exists (apkInputPath) && !File.Exists (apkOutputPath)) {
-				Log.LogDebugMessage ($"Copying {apkInputPath} to {apkInputPath}");
+				Log.LogDebugMessage ($"Copying {apkInputPath} to {apkOutputPath}");
 				File.Copy (apkInputPath, apkOutputPath, overwrite: true);
 				refresh = false;
 			}


### PR DESCRIPTION
Our logging in `BuildApk` was not reporting the correct paths when
we copy the `packaged_resources` file. Lets fix that.