### PR TITLE
[tests] update MSBuildDeviceIntegration.csv

### DIFF
--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -7,8 +7,8 @@ Build_No_Changes,2250
 Build_CSharp_Change,3350
 Build_AndroidResource_Change,3250
 Build_AndroidAsset_Change,10000
-Build_AndroidManifest_Change,3500
-Build_Designer_Change,2650
+Build_AndroidManifest_Change,3750
+Build_Designer_Change,3000
 Build_JLO_Change,10000
 Build_CSProj_Change,12500
 Build_XAML_Change,7400


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5619146&view=ms.vss-test-web.build-test-results-tab&runId=31222446&resultId=100025&paneView=debug
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5619146&view=ms.vss-test-web.build-test-results-tab&runId=31217648&resultId=100025&paneView=debug

Since ~Jan 4 (that is far as history goes back), we've noticed these
tests failing sometimes:

* `Build_Designer_Change`
* `Build_AndroidManifest_Change`

Reviewing the `.binlog` files, I don't see a regression in *our*
MSBuild tasks. So I suspect that maybe it is due to some change in the
.NET SDK, MSBuild, or CI machines?

On thing of suspect is how long project evaluation is taking: 447ms

Either way, I think we should just increase the times on these two
tests for now.