### PR TITLE
[build] Remove jna content from manifestmerger.jar

### DIFF
--- a/build-tools/installers/sign-pkg-content.proj
+++ b/build-tools/installers/sign-pkg-content.proj
@@ -43,24 +43,8 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
   </Target>
 
-  <!-- Remove the jna subdirectory in manifestmerger.jar as it should not be needed by our usage.
-    This simplifies signing/notarization and reduces our installation footprint slightly. -->
-  <Target Name="_RemoveJnaFromManifestMerger" >
-    <PropertyGroup>
-      <_ManifestMergerJar>$([System.IO.Path]::GetFullPath('$(MSBuildSrcDir)\manifestmerger.jar'))</_ManifestMergerJar>
-      <_ManifestMergerExtractLocation>$(MSBuildSrcDir)\mm-unzipped</_ManifestMergerExtractLocation>
-    </PropertyGroup>
-    <RemoveDir Directories="$(_ManifestMergerExtractLocation)" />
-    <MakeDir Directories="$(_ManifestMergerExtractLocation)" />
-    <Exec WorkingDirectory="$(_ManifestMergerExtractLocation)" Command="jar -xvf &quot;$(_ManifestMergerJar)&quot;" />
-    <Delete Files="$(_ManifestMergerJar)" />
-    <RemoveDir Directories="$(_ManifestMergerExtractLocation)\com\sun\jna" />
-    <Exec WorkingDirectory="$(_ManifestMergerExtractLocation)" Command="jar -cvmf META-INF/MANIFEST.MF &quot;$(_ManifestMergerJar)&quot; ." />
-    <RemoveDir Directories="$(_ManifestMergerExtractLocation)" />
-  </Target>
-
   <Target Name="_AddMachOEntitlements"
-      DependsOnTargets="_RemoveAapt2FromBundletool;_RemoveJnaFromManifestMerger"
+      DependsOnTargets="_RemoveAapt2FromBundletool"
       BeforeTargets="SignFiles"
       AfterTargets="AfterBuild" >
     <Exec Command="codesign -vvvv -f -s - -o runtime --entitlements &quot;%(_MSBuildFilesUnixSignAndHarden.EntitlementsPath)&quot; &quot;%(_MSBuildFilesUnixSignAndHarden.Identity)&quot;" />

--- a/build-tools/installers/sign-pkg-content.proj
+++ b/build-tools/installers/sign-pkg-content.proj
@@ -43,8 +43,24 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     <RemoveDir Directories="$(_BundleToolExtractLocation)" />
   </Target>
 
+  <!-- Remove the jna subdirectory in manifestmerger.jar as it should not be needed by our usage.
+    This simplifies signing/notarization and reduces our installation footprint slightly. -->
+  <Target Name="_RemoveJnaFromManifestMerger" >
+    <PropertyGroup>
+      <_ManifestMergerJar>$([System.IO.Path]::GetFullPath('$(MSBuildSrcDir)\manifestmerger.jar'))</_ManifestMergerJar>
+      <_ManifestMergerExtractLocation>$(MSBuildSrcDir)\mm-unzipped</_ManifestMergerExtractLocation>
+    </PropertyGroup>
+    <RemoveDir Directories="$(_ManifestMergerExtractLocation)" />
+    <MakeDir Directories="$(_ManifestMergerExtractLocation)" />
+    <Exec WorkingDirectory="$(_ManifestMergerExtractLocation)" Command="jar -xvf &quot;$(_ManifestMergerJar)&quot;" />
+    <Delete Files="$(_ManifestMergerJar)" />
+    <RemoveDir Directories="$(_ManifestMergerExtractLocation)\com\sun\jna" />
+    <Exec WorkingDirectory="$(_ManifestMergerExtractLocation)" Command="jar -cvmf META-INF/MANIFEST.MF &quot;$(_ManifestMergerJar)&quot; ." />
+    <RemoveDir Directories="$(_ManifestMergerExtractLocation)" />
+  </Target>
+
   <Target Name="_AddMachOEntitlements"
-      DependsOnTargets="_RemoveAapt2FromBundletool"
+      DependsOnTargets="_RemoveAapt2FromBundletool;_RemoveJnaFromManifestMerger"
       BeforeTargets="SignFiles"
       AfterTargets="AfterBuild" >
     <Exec Command="codesign -vvvv -f -s - -o runtime --entitlements &quot;%(_MSBuildFilesUnixSignAndHarden.EntitlementsPath)&quot; &quot;%(_MSBuildFilesUnixSignAndHarden.Identity)&quot;" />

--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -38,7 +38,8 @@ jar {
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     } {
-        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+        // Exclude native jnidispatch content to simplify installer signing and notarization
+        exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'com/sun/jna/**/*jnidispatch*'
     }
     archiveName 'manifestmerger.jar'
 }


### PR DESCRIPTION
Our .pkg notarization step has been failing since bumping manifestmerger
to 30.0.4.  After further investigation, this appears to be due to some
new macOS binaries:

    "issues": [
        {
          "severity": "error",
          "code": null,
          "path": "xamarin.android.pkg Contents/Payload/Library/Frameworks/Xamarin.Android.framework/Versions/12.2.99.37/lib/xamarin.android/xbuild/Xamarin/Android/manifestmerger.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
          "message": "The binary is not signed.",
          "docUrl": null,
          "architecture": "i386"
        }
    ]

Rather than trying to sign/harden these files ourselves, we should be
able to remove them from manifestmerger.jar to fix this.
