### PR TITLE
[build] Remove aapt2 from bundletool during build

### DIFF
--- a/build-tools/installers/sign-pkg-content.proj
+++ b/build-tools/installers/sign-pkg-content.proj
@@ -28,23 +28,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     </PackageReference>
   </ItemGroup>
 
-  <!-- Strip aapt2 from bundletool.jar, as we pass it our own path to aapt2.
-    This simplifies macOS signing/hardening and reduces our installation footprint slightly. -->
-  <Target Name="_RemoveAapt2FromBundletool" >
-    <PropertyGroup>
-      <_BundleToolJar>$([System.IO.Path]::GetFullPath('$(MSBuildSrcDir)\bundletool.jar'))</_BundleToolJar>
-      <_BundleToolExtractLocation>$(MSBuildSrcDir)\sign-bundletool</_BundleToolExtractLocation>
-    </PropertyGroup>
-    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
-    <MakeDir Directories="$(_BundleToolExtractLocation)" />
-    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -xvf &quot;$(_BundleToolJar)&quot;" />
-    <Delete Files="$(_BundleToolJar);$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
-    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -cvmf META-INF/MANIFEST.MF &quot;$(_BundleToolJar)&quot; ." />
-    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
-  </Target>
-
   <Target Name="_AddMachOEntitlements"
-      DependsOnTargets="_RemoveAapt2FromBundletool"
       BeforeTargets="SignFiles"
       AfterTargets="AfterBuild" >
     <Exec Command="codesign -vvvv -f -s - -o runtime --entitlements &quot;%(_MSBuildFilesUnixSignAndHarden.EntitlementsPath)&quot; &quot;%(_MSBuildFilesUnixSignAndHarden.Identity)&quot;" />

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -3,22 +3,41 @@
   <PropertyGroup>
     <_Destination>$(XAInstallPrefix)xbuild\Xamarin\Android\</_Destination>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <_BundleToolDownloadLocation>$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar</_BundleToolDownloadLocation>
+    <_BundleToolExtractLocation>$(AndroidToolchainCacheDirectory)\bundletool-unzip</_BundleToolExtractLocation>
+    <_JarPath Condition=" '$(JavaSdkDirectory)' != '' ">$(JavaSdkDirectory)/bin/jar</_JarPath>
+    <_JarPath Condition=" '$(_JarPath)' == '' ">jar</_JarPath>
   </PropertyGroup>
 
-  <Target Name="_DownloadBundleTool" BeforeTargets="Build">
+  <Target Name="_DownloadBundleTool">
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
-        DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
+        DestinationFiles="$(_BundleToolDownloadLocation)"
     />
+  </Target>
+
+  <Target Name="_StripAndCopyBundleTool"
+      BeforeTargets="Build"
+      DependsOnTargets="_DownloadBundleTool"
+      Inputs="$(_BundleToolDownloadLocation)"
+      Outputs="$(_Destination)bundletool.jar" >
+    <!-- Strip aapt2 from bundletool.jar, as we pass it our own path to aapt2.
+      This simplifies macOS signing/hardening and reduces our installation footprint slightly. -->
+    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
+    <MakeDir Directories="$(_BundleToolExtractLocation)" />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -xf &quot;$(_BundleToolDownloadLocation)&quot;" />
+    <Delete Files="$(_BundleToolDownloadLocation);$(_BundleToolExtractLocation)\linux\aapt2;$(_BundleToolExtractLocation)\macos\aapt2;$(_BundleToolExtractLocation)\windows\aapt2.exe" />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="$(_JarPath) -cmf META-INF/MANIFEST.MF &quot;$(_BundleToolDownloadLocation)&quot; ." />
+    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
     <Copy
-        SourceFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
+        SourceFiles="$(_BundleToolDownloadLocation)"
         DestinationFiles="$(_Destination)bundletool.jar"
         SkipUnchangedFiles="True"
     />
   </Target>
 
   <Target Name="_CleanBundleTool" BeforeTargets="Clean">
-    <Delete Files="$(_Destination)bundletool.jar" />
+    <Delete Files="$(_BundleToolDownloadLocation);$(_Destination)bundletool.jar" />
   </Target>
 
 </Project>


### PR DESCRIPTION
We've been removing the aapt2 executables included in bundletool.jar
during our CI builds on macOS only.  This is being done to simplify the
work needed for installer signing and notarization.  We should move this
logic to the project that builds bundletool.jar to establish consistent
behavior across build environments.