### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for '<AndroidNamespaceReplacement>'.

### DIFF
--- a/Documentation/guides/messages/xa4233.md
+++ b/Documentation/guides/messages/xa4233.md
@@ -1,0 +1,35 @@
+---
+title: Xamarin.Android error XA4233
+description: XA4232 error code
+ms.date: 01/25/2022
+---
+# Xamarin.Android error XA4233
+
+## Example messages
+
+```
+error XA4233: The <AndroidNamespaceReplacement> for 'com.xamarin.androidx' does not specify a 'Replacement' attribute.
+```
+
+## Issue
+
+`<AndroidNamespaceReplacement>` items must include `Replacement` attribute
+
+## Solution
+
+To resolve this error, ensure that the specified `<AndroidNamespaceReplacement>` contains
+a 'Replacement' aatribute:
+
+```xml
+<ItemGroup>
+  <AndroidNamespaceReplacement Include="com.xamarin.androidx" Replacement="Xamarin.AndroidX" />
+</ItemGroup>
+```
+
+Note it is valid for the `Replacement` attribute value to be empty, however the attribute must still be provided:
+
+```xml
+<ItemGroup>
+  <AndroidNamespaceReplacement Include="com." Replacement="" />
+</ItemGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -81,6 +81,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         EnableBindingInterfaceConstants="$(AndroidBoundInterfacesContainConstants)"
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
+        NamespaceTransforms="@(AndroidNamespaceReplacement)"
     />
 
     <!-- Write a flag so we won't redo this target if nothing changed -->

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -864,4 +864,9 @@ In this message, the term "handheld app" means "app for handheld devices."
     </value>
     <comment>{0} - The path of the template file.</comment>
   </data>
+  <data name="XA4233" xml:space="preserve">
+    <value>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</value>
+    <comment>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -69,6 +69,12 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA4233">
+        <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
+        <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>
+        <note>The following are literal names and should not be translated: &lt;AndroidNamespaceReplacement&gt;
+{0} - The AndroidNamespaceReplacement MSBuild value.</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,10 +5,10 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 55086
+      "Size": 54996
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 83182
+      "Size": 87684
     },
     "assemblies/rc.bin": {
       "Size": 1045
@@ -17,7 +17,7 @@
       "Size": 10157
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 520945
+      "Size": 521019
     },
     "assemblies/System.Runtime.dll": {
       "Size": 2410
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2697108
+  "PackageSize": 2701204
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,10 +5,10 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 54996
+      "Size": 55086
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87684
+      "Size": 83182
     },
     "assemblies/rc.bin": {
       "Size": 1045
@@ -17,7 +17,7 @@
       "Size": 10157
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 521019
+      "Size": 520945
     },
     "assemblies/System.Runtime.dll": {
       "Size": 2410
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2701204
+  "PackageSize": 2697108
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,166 +8,166 @@
       "Size": 7251
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 61908
+      "Size": 61695
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 3843
+      "Size": 3834
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 441918
+      "Size": 437730
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3845
+      "Size": 3836
     },
     "assemblies/netstandard.dll": {
-      "Size": 5532
+      "Size": 5531
     },
     "assemblies/rc.bin": {
       "Size": 1045
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11590
+      "Size": 11584
     },
     "assemblies/System.Collections.dll": {
-      "Size": 19123
+      "Size": 19118
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 8485
+      "Size": 8475
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2007
+      "Size": 1999
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2611
+      "Size": 2604
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6015
+      "Size": 6010
     },
     "assemblies/System.Console.dll": {
-      "Size": 6595
+      "Size": 6590
     },
     "assemblies/System.Core.dll": {
-      "Size": 1969
+      "Size": 1964
     },
     "assemblies/System.Diagnostics.DiagnosticSource.dll": {
-      "Size": 3040
+      "Size": 3035
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6802
+      "Size": 6796
     },
     "assemblies/System.dll": {
-      "Size": 2318
+      "Size": 2313
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2002
+      "Size": 1996
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12245
+      "Size": 12241
     },
     "assemblies/System.Formats.Asn1.dll": {
       "Size": 26857
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 11464
+      "Size": 11458
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 18844
+      "Size": 18836
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10774
+      "Size": 10770
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19511
+      "Size": 19509
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 182121
+      "Size": 182118
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 221525
+      "Size": 221527
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 13162
+      "Size": 13159
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 8991
+      "Size": 8983
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 41097
+      "Size": 41094
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 48001
+      "Size": 48003
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3772
+      "Size": 3765
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 57902
+      "Size": 57897
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 54652
+      "Size": 54651
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12015
+      "Size": 12010
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 779672
+      "Size": 778992
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 193976
+      "Size": 193970
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 43918
+      "Size": 43915
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 251558
+      "Size": 251560
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 17105
+      "Size": 17097
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1341
+      "Size": 1340
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2598
+      "Size": 2595
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 2917
+      "Size": 2911
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 24196
+      "Size": 24188
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1940
+      "Size": 1934
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2675
+      "Size": 2668
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3982
+      "Size": 3975
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 42155
+      "Size": 42152
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 13843
+      "Size": 13846
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 8701
+      "Size": 8691
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 77131
+      "Size": 77130
     },
     "assemblies/System.Text.RegularExpressions.dll": {
       "Size": 76741
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 16872
+      "Size": 16868
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1826
+      "Size": 1820
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117240
+      "Size": 117239
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 6076
@@ -176,7 +176,7 @@
       "Size": 6099
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 112593
+      "Size": 112592
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
       "Size": 6816
@@ -185,7 +185,7 @@
       "Size": 16609
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 96724
+      "Size": 96725
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
       "Size": 14275
@@ -200,7 +200,7 @@
       "Size": 6595
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6675
+      "Size": 6674
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
       "Size": 3275
@@ -209,7 +209,7 @@
       "Size": 12676
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 84690
+      "Size": 84689
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
       "Size": 5082
@@ -233,13 +233,13 @@
       "Size": 60774
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 40136
+      "Size": 40135
     },
     "classes.dex": {
       "Size": 3483796
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382680
+      "Size": 382576
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3176048
@@ -254,7 +254,7 @@
       "Size": 150024
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 133976
+      "Size": 134016
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2009,5 +2009,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8582910
+  "PackageSize": 8578814
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,166 +8,166 @@
       "Size": 7251
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 61695
+      "Size": 61908
     },
     "assemblies/Microsoft.Win32.Primitives.dll": {
-      "Size": 3834
+      "Size": 3843
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 437730
+      "Size": 441918
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3836
+      "Size": 3845
     },
     "assemblies/netstandard.dll": {
-      "Size": 5531
+      "Size": 5532
     },
     "assemblies/rc.bin": {
       "Size": 1045
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11584
+      "Size": 11590
     },
     "assemblies/System.Collections.dll": {
-      "Size": 19118
+      "Size": 19123
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 8475
+      "Size": 8485
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 1999
+      "Size": 2007
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2604
+      "Size": 2611
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6010
+      "Size": 6015
     },
     "assemblies/System.Console.dll": {
-      "Size": 6590
+      "Size": 6595
     },
     "assemblies/System.Core.dll": {
-      "Size": 1964
+      "Size": 1969
     },
     "assemblies/System.Diagnostics.DiagnosticSource.dll": {
-      "Size": 3035
+      "Size": 3040
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6796
+      "Size": 6802
     },
     "assemblies/System.dll": {
-      "Size": 2313
+      "Size": 2318
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 1996
+      "Size": 2002
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12241
+      "Size": 12245
     },
     "assemblies/System.Formats.Asn1.dll": {
       "Size": 26857
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 11458
+      "Size": 11464
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 18836
+      "Size": 18844
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10770
+      "Size": 10774
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19509
+      "Size": 19511
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 182118
+      "Size": 182121
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 221527
+      "Size": 221525
     },
     "assemblies/System.Net.NameResolution.dll": {
-      "Size": 13159
+      "Size": 13162
     },
     "assemblies/System.Net.NetworkInformation.dll": {
-      "Size": 8983
+      "Size": 8991
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 41094
+      "Size": 41097
     },
     "assemblies/System.Net.Quic.dll": {
-      "Size": 48003
+      "Size": 48001
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3765
+      "Size": 3772
     },
     "assemblies/System.Net.Security.dll": {
-      "Size": 57897
+      "Size": 57902
     },
     "assemblies/System.Net.Sockets.dll": {
-      "Size": 54651
+      "Size": 54652
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 12010
+      "Size": 12015
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 778992
+      "Size": 779672
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 193970
+      "Size": 193976
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 43915
+      "Size": 43918
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 251560
+      "Size": 251558
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 17097
+      "Size": 17105
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1340
+      "Size": 1341
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2595
+      "Size": 2598
     },
     "assemblies/System.Runtime.InteropServices.RuntimeInformation.dll": {
-      "Size": 2911
+      "Size": 2917
     },
     "assemblies/System.Runtime.Numerics.dll": {
-      "Size": 24188
+      "Size": 24196
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1934
+      "Size": 1940
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2668
+      "Size": 2675
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3975
+      "Size": 3982
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 42152
+      "Size": 42155
     },
     "assemblies/System.Security.Cryptography.Encoding.dll": {
-      "Size": 13846
+      "Size": 13843
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 8691
+      "Size": 8701
     },
     "assemblies/System.Security.Cryptography.X509Certificates.dll": {
-      "Size": 77130
+      "Size": 77131
     },
     "assemblies/System.Text.RegularExpressions.dll": {
       "Size": 76741
     },
     "assemblies/System.Threading.Channels.dll": {
-      "Size": 16868
+      "Size": 16872
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1820
+      "Size": 1826
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117239
+      "Size": 117240
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 6076
@@ -176,7 +176,7 @@
       "Size": 6099
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 112592
+      "Size": 112593
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
       "Size": 6816
@@ -185,7 +185,7 @@
       "Size": 16609
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 96725
+      "Size": 96724
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
       "Size": 14275
@@ -200,7 +200,7 @@
       "Size": 6595
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6674
+      "Size": 6675
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
       "Size": 3275
@@ -209,7 +209,7 @@
       "Size": 12676
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 84689
+      "Size": 84690
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
       "Size": 5082
@@ -233,13 +233,13 @@
       "Size": 60774
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 40135
+      "Size": 40136
     },
     "classes.dex": {
       "Size": 3483796
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382576
+      "Size": 382680
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3176048
@@ -254,7 +254,7 @@
       "Size": 150024
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 134016
+      "Size": 133976
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2009,5 +2009,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8578814
+  "PackageSize": 8582910
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -39,6 +39,15 @@ namespace Xamarin.Android.JcwGenTests {
 		}
 
 		[Test]
+		public void NamespaceTransforms ()
+		{
+			// Really the only test here is that the type exists in the binding.
+			// If the transforms were not working it would be 'Com.Xamarin.Example.NamespaceTransform'.
+			var t = new Transformed.Namespace.NamespaceTransform ();
+			Assert.IsNotNull (t);
+		}
+
+		[Test]
 		public void TestBxc4288 ()
 		{
 			var t = new Com.Xamarin.Android.Bxc4288 ();

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
@@ -134,6 +134,9 @@
     <TestJarEntry Include="java\com\xamarin\android\StaticMethodsInterface.java">
       <OutputFile>Jars/xamarin-test.jar</OutputFile>
     </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\example\NamespaceTransform.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedJar Include="Jars\KotlinUnsignedTypes.jar" />
@@ -143,6 +146,10 @@
   </ItemGroup>
   <ItemGroup>
     <JavaSourceJar Include="$(OutputPath)xamarin-test-sources.jar" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include="xamarin.example" Replacement="Example" />
+    <AndroidNamespaceReplacement Include="com.example" Replacement="Transformed.Namespace" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="..\..\..\build-tools\scripts\Jar.targets" />

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/example/NamespaceTransform.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/example/NamespaceTransform.java
@@ -1,0 +1,4 @@
+package com.xamarin.example;
+
+public class NamespaceTransform {
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/727

Add an MSBuild equivalent to the `<ns-replace>` metadata feature added in https://github.com/xamarin/java.interop/issues/727.

This takes namespace transforms like:
```xml
<ItemGroup>
  <AndroidNamespaceReplacement Include='Androidx' Replacement='AndroidX' />
  <AndroidNamespaceReplacement Include='Com' Replacement='' />
  <AndroidNamespaceReplacement Include='Com.Google.' Replacement='Google' />
</ItemGroup>
```

And places them into a generated `msbuild-metadata.xml` file that is passed to `generator`:

```xml
<metadata>
  <ns-replace source='Androidx' replacement='AndroidX' />
  <ns-replace source='Com' replacement='' />
  <ns-replace source='Com.Google.' replacement='Google' />
</metadata>
```

Today, this only supports `<ns-replace>` metadata, but it could be expanded in the future if we feel that allowing other metadata is desirable.  (I am personally skeptical 😁.)