### PR TITLE
[One .NET] use API 31 "ref" pack with 32 "runtime" pack

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -120,8 +120,6 @@
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android-aot" />
-      <!-- NOTE: temporary if $(AndroidDefaultTargetDotnetApiLevel) is not 32 -->
-      <_InstallArguments Include="android-32" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -122,10 +122,12 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <XamarinAndroidVersion>$(AndroidPackVersionLong)</XamarinAndroidVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '%24(TargetPlatformVersion)' == '31.0' ">
-    <_AndroidRuntimePackId>31</_AndroidRuntimePackId>
-    <_AndroidRuntimePackVersion>31.0.101-preview.11.117</_AndroidRuntimePackVersion>
+    <_AndroidTargetingPackId>31</_AndroidTargetingPackId>
+    <_AndroidTargetingPackVersion>31.0.101-preview.11.117</_AndroidTargetingPackVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <_AndroidTargetingPackId Condition=" '%24(_AndroidTargetingPackId)' == '' ">$(AndroidLatestStableApiLevel)</_AndroidTargetingPackId>
+    <_AndroidTargetingPackVersion Condition=" '%24(_AndroidTargetingPackVersion)' == '' ">**FromWorkload**</_AndroidTargetingPackVersion>
     <_AndroidRuntimePackId Condition=" '%24(_AndroidRuntimePackId)' == '' ">$(AndroidLatestStableApiLevel)</_AndroidRuntimePackId>
     <_AndroidRuntimePackVersion Condition=" '%24(_AndroidRuntimePackVersion)' == '' ">**FromWorkload**</_AndroidRuntimePackVersion>
   </PropertyGroup>
@@ -135,8 +137,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
         TargetFramework="$(_AndroidNETAppTargetFramework)"
         RuntimeFrameworkName="Microsoft.Android"
         LatestRuntimeFrameworkVersion="%24(_AndroidRuntimePackVersion)"
-        TargetingPackName="Microsoft.Android.Ref.%24(_AndroidRuntimePackId)"
-        TargetingPackVersion="%24(_AndroidRuntimePackVersion)"
+        TargetingPackName="Microsoft.Android.Ref.%24(_AndroidTargetingPackId)"
+        TargetingPackVersion="%24(_AndroidTargetingPackVersion)"
         RuntimePackNamePatterns="Microsoft.Android.Runtime.%24(_AndroidRuntimePackId).**RID**"
         RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
         Profile="Android"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,26 +6,15 @@
       "packs": [
         "Microsoft.Android.Sdk",
         "Microsoft.Android.Ref.31",
-        "Microsoft.Android.Runtime.31.android-arm",
-        "Microsoft.Android.Runtime.31.android-arm64",
-        "Microsoft.Android.Runtime.31.android-x86",
-        "Microsoft.Android.Runtime.31.android-x64",
-        "Microsoft.Android.Templates"
-      ],
-      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
-      "extends" : [ "microsoft-net-runtime-android" ]
-    },
-    "android-32": {
-      "description": "Support for Android API-32.",
-      "packs": [
         "Microsoft.Android.Ref.32",
         "Microsoft.Android.Runtime.32.android-arm",
         "Microsoft.Android.Runtime.32.android-arm64",
         "Microsoft.Android.Runtime.32.android-x86",
-        "Microsoft.Android.Runtime.32.android-x64"
+        "Microsoft.Android.Runtime.32.android-x64",
+        "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ],
-      "extends" : [ "android" ]
+      "extends" : [ "microsoft-net-runtime-android" ]
     },
     "android-aot": {
       "description": ".NET SDK Workload for building Android applications with AOT support.",
@@ -46,22 +35,6 @@
       }
     },
     "Microsoft.Android.Ref.31": {
-      "kind": "framework",
-      "version": "31.0.101-preview.11.117"
-    },
-    "Microsoft.Android.Runtime.31.android-arm": {
-      "kind": "framework",
-      "version": "31.0.101-preview.11.117"
-    },
-    "Microsoft.Android.Runtime.31.android-arm64": {
-      "kind": "framework",
-      "version": "31.0.101-preview.11.117"
-    },
-    "Microsoft.Android.Runtime.31.android-x86": {
-      "kind": "framework",
-      "version": "31.0.101-preview.11.117"
-    },
-    "Microsoft.Android.Runtime.31.android-x64": {
       "kind": "framework",
       "version": "31.0.101-preview.11.117"
     },


### PR DESCRIPTION
After 6eb11f15 went in, I realized an issue when using `net6.0-android31`:

1. You get API 31 by default. We bring in these packs from NuGet.org
   with the version 31.0.101-preview.11.117:

    Microsoft.Android.Ref.31
    Microsoft.Android.Runtime.31.[rid]

2. So now you can't get the latest changes for `libmonodroid.so`, for
   example? You'd have to opt-in via `net6.0-android32`.

Thinking about it more, we should only need to use the API 31 "ref" or
"targeting" pack. The "runtime" pack can just use the latest from the
workload.

To fix this:

1. Create new `$(_AndroidTargetingPackId)` and
   `$(_AndroidTargetingPackVersion)` properties to use independently
   of the runtime pack version.

2. Remove `Microsoft.Android.Runtime.31.[rid]` packs from the workload.

3. Remove the `android-32` workload, as it should no longer be needed.
   The API 31 "ref" pack is fairly small and can go in the `android`
   workload.

Now our `android` workload is:

    "Microsoft.Android.Sdk",
    "Microsoft.Android.Ref.31",
    "Microsoft.Android.Ref.32",
    "Microsoft.Android.Runtime.32.android-arm",
    "Microsoft.Android.Runtime.32.android-arm64",
    "Microsoft.Android.Runtime.32.android-x86",
    "Microsoft.Android.Runtime.32.android-x64",
    "Microsoft.Android.Templates"

After these changes, I get this assembly at build time:

    dotnet\packs\Microsoft.Android.Ref.31\31.0.101-preview.11.117\ref\net6.0\Mono.Android.dll

And this assembly at runtime:

    dotnet\packs\Microsoft.Android.Runtime.32.android-arm64\31.0.200-preview.13.21\runtimes\android-arm64\lib\net6.0\Mono.Android.dll