### PR TITLE
Bump SQLite to v3.37.2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -421,7 +421,7 @@ namespace Foo {
 				IsRelease = true,
 				Jars = {
 					new AndroidItem.LibraryProjectZip ("Jars\\ActionBarSherlock-4.3.1.zip") {
-						WebContent = "https://github.com/xamarin/monodroid-samples/blob/master/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true"
+						WebContent = "https://github.com/xamarin/monodroid-samples/blob/main/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true"
 					}
 				},
 				AndroidClassParser = "class-parse",


### PR DESCRIPTION
Context: https://sqlite.org/releaselog/3_37_2.html
Context: https://sqlite.org/src/info/73c2b50211d3ae26
Context: https://sqlite.org/src/info/5232c9777fe4fb13

Changes:

  * Fix a bug introduced in version 3.35.0 (2021-03-12) that can cause database
    corruption if a SAVEPOINT is rolled back while in PRAGMA temp_store=MEMORY
    mode, and other changes are made, and then the outer transaction commits.
  * Fix a long-standing problem with ON DELETE CASCADE and ON UPDATE CASCADE
    in which a cache of the bytecode used to implement the cascading change
    was not being reset following a local DDL change.