### PR TITLE
[ci] Use Windows 2022 agent pools

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/sign-use-nuget
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/sign-use-nuget
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1362,7 +1362,8 @@ stages:
 
   - job: push_to_nuget_org
     displayName: Push to NuGet.org
-    pool: $(VSEngMicroBuildPool)
+    pool:
+      vmImage: $(HostedWinImage)
     dependsOn: wait_for_nuget_org_approval
     condition: eq(dependencies.wait_for_nuget_org_approval.result, 'Succeeded')
     steps:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1081,7 +1081,8 @@ stages:
   - job: designer_integration_win
     condition: false
     displayName: Windows
-    pool: $(HostedWinVS2019)
+    pool:
+      vmImage: windows-2019
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1230,6 +1231,7 @@ stages:
   - template: sign-artifacts/jobs/v2.yml@yaml
     parameters:
       name: sign_net_mac_win
+      poolName: $(VSEngMicroBuildPool)
       artifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
       signedArtifactName: nuget-signed
@@ -1240,6 +1242,7 @@ stages:
     parameters:
       name: sign_net_linux
       displayName: Sign Linux Archive
+      poolName: $(VSEngMicroBuildPool)
       artifactName: $(LinuxNuGetArtifactName)
       signType: $(MicroBuildSignType)
       signedArtifactName: nuget-linux-signed
@@ -1265,7 +1268,7 @@ stages:
     - sign_net_linux
     condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
     timeoutInMinutes: 60
-    pool: $(VSEngMicroBuild2019)
+    pool: $(VSEngMicroBuildPool)
     workspace:
       clean: all
     variables:
@@ -1359,7 +1362,7 @@ stages:
 
   - job: push_to_nuget_org
     displayName: Push to NuGet.org
-    pool: $(VSEngMicroBuild2019)
+    pool: $(VSEngMicroBuildPool)
     dependsOn: wait_for_nuget_org_approval
     condition: eq(dependencies.wait_for_nuget_org_approval.result, 'Succeeded')
     steps:
@@ -1493,7 +1496,7 @@ stages:
   - job: queue_vsix_signing
     displayName: Sign Vsix
     dependsOn: notarize_pkg_upload_storage
-    pool: $(VSEngMicroBuild2019)
+    pool: $(VSEngMicroBuildPool)
     timeoutInMinutes: 90
     cancelTimeoutInMinutes: 1
     workspace:
@@ -1521,7 +1524,8 @@ stages:
   # Check - "Xamarin.Android (Code Analysis Security and Compliance)"
   - job: run_static_analysis
     displayName: Security and Compliance
-    pool: $(HostedWinVS2019)
+    pool:
+      vmImage: $(HostedWinImage)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     steps:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -25,11 +25,11 @@ variables:
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
   value: macOS-11
-- name: HostedWinVS2019
-  value: Hosted Windows 2019 with VS2019
+- name: HostedWinImage
+  value: windows-2022
 - name: 1ESWindowsPool
   value: android-win-2022
-- name: VSEngMicroBuild2019
-  value: VSEngSS-MicroBuild2019-1ES
+- name: VSEngMicroBuildPool
+  value: VSEngSS-MicroBuild2022-1ES
 - name: TeamName
   value: XamarinAndroid


### PR DESCRIPTION
Updates our Microsoft hosted and VSEng scale set Windows pools to the
latest and greatest images.  The designer integration test job has been
disabled on Windows for some time, and it will continue to use the
`windows-2019` pool until it is re-enabled.