### PR TITLE
[Xamarin.Android.Build.Tasks] fix .aab deploying to different ABIs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2525,8 +2525,9 @@ because xbuild doesn't support framework reference assemblies.
   />
 </Target>
 
-<Target Name="_DeployAppBundle"
-    Condition=" '$(AndroidPackageFormat)' == 'aab' ">
+<Target Name="_BuildApkSet"
+    Inputs="$(_AndroidBuildPropertiesCache);$(_AdbPropertiesCache);$(_AppBundleIntermediate)"
+    Outputs="$(_ApkSetIntermediate)">
   <BuildApkSet
       ToolPath="$(JavaToolPath)"
       JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
@@ -2542,8 +2543,13 @@ because xbuild doesn't support framework reference assemblies.
       KeyPass="$(_ApkKeyPass)"
       StorePass="$(_ApkStorePass)"
       ExtraArgs="$(AndroidBundleToolExtraArgs)"
-      Condition="!Exists('$(_ApkSetIntermediate)')"
   />
+  <Touch Files="$(_ApkSetIntermediate)" />
+</Target>
+
+<Target Name="_DeployAppBundle"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' "
+    DependsOnTargets="_BuildApkSet">
   <PropertyGroup>
     <_UninstallCommand>&quot;$(AdbToolPath)adb&quot; $(AdbTarget) uninstall -k &quot;$(_AndroidPackage)&quot;</_UninstallCommand>
   </PropertyGroup>


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1447873

The following breaks in both Xamarin.Android & .NET 6:

1. Deploy a build with `AndroidPackageFormat=aab` to a device
2. Switch the dropdown in the IDE, deploy to an emulator

Fails with:

    HelloWorld.csproj  → Install
    Target _DeployAppBundle
        Task InstallApkSet
        Error [BT Missing APKs for [ABI] dimensions in the module 'base' for the provided device.

I could reproduce this in a test with a blank `$(AdbTarget)`, then set
`$(AdbTarget)` to the connected device. This should simulate what
happens in the IDE when you switch devices.

What happens is this `Condition`:

    Condition="!Exists('$(_ApkSetIntermediate)')"

Just skips if the file exists!

To solve the issue:

1. Move the `<BuildApkSet/>` task to a new `_BuildApkSet` target.

2. Add `Inputs` of `build.props`, `adb.props`, and
   `$(_AppBundleIntermediate)`.

3. Add `Outputs` for `$(_ApkSetIntermediate)`.

4. Add `<Touch Files="$(_ApkSetIntermediate)" />`, just in case!