### PR TITLE
Bump LibZipSharp to 2.0.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>2.0.0</LibZipSharpVersion>
+    <LibZipSharpVersion>2.0.2</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>


### PR DESCRIPTION
Changes

- Use a different license tag for nuget generation 
- Fix corrupt data when Deleting entries from zip files.

https://github.com/xamarin/LibZipSharp/compare/2.0.0...2.0.2