### PR TITLE
[Xamarin.Android.Build.Tasks] default $(AndroidUseAssemblyStore) to false for debug builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1035,7 +1035,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			var proj = new XamarinAndroidApplicationProject {
 				EmbedAssembliesIntoApk = true,
 			};
-			proj.SetProperty ("AndroidUseAssemblyStore", "False");
 			using (var b = CreateApkBuilder ()) {
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
 					WebContentFileNameFromAzure = "PdbTestLibrary.dll"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -179,8 +179,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidFragmentType Condition=" '$(AndroidFragmentType)' == '' ">Android.App.Fragment</AndroidFragmentType>
 	<AndroidEnableAssemblyCompression Condition=" '$(AndroidEnableAssemblyCompression)' == '' ">True</AndroidEnableAssemblyCompression>
 	<AndroidIncludeWrapSh Condition=" '$(AndroidIncludeWrapSh)' == '' ">False</AndroidIncludeWrapSh>
-	<AndroidUseAssemblyStore Condition=" '$(EmbedAssembliesIntoApk)' == 'False' Or '$(BundleAssemblies)' == 'True'">False</AndroidUseAssemblyStore>
-	<AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">True</AndroidUseAssemblyStore>
 	<_AndroidCheckedBuild Condition=" '$(_AndroidCheckedBuild)' == '' "></_AndroidCheckedBuild>
 
 	<!-- Currently only C# is supported -->
@@ -328,6 +326,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		</PropertyGroup>
 	</Otherwise>
 </Choose>
+
+<PropertyGroup>
+  <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' and ('$(EmbedAssembliesIntoApk)' != 'true' or '$(AndroidIncludeDebugSymbols)' == 'true' or '$(BundleAssemblies)' == 'true') ">false</AndroidUseAssemblyStore>
+  <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
+</PropertyGroup>
 
 <!-- Do not resolve from the GAC under any circumstances in Mobile -->
 <PropertyGroup>

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -274,49 +274,63 @@ namespace ${ROOT_NAMESPACE} {
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* debugType */          "",
+			},
+			new object[] {
+				/* embedAssemblies */    true,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 null,
+				/* debugType */          "full",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* debugType */          "",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  true,
 				/* user */		 null,
+				/* debugType */          "",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* debugType */          "",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  true,
 				/* user */		 null,
+				/* debugType */          "",
 			},
 			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
+				/* debugType */          "",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
+				/* debugType */          "",
 			},
 		};
 #pragma warning restore 414
 
 		[Test, Category ("SmokeTests"), Category ("Debugger")]
 		[TestCaseSource (nameof(DebuggerTestCases))]
-		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username)
+		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username, string debugType)
 		{
 			AssertCommercialBuild ();
 			AssertHasDevices ();
@@ -356,6 +370,9 @@ namespace ${ROOT_NAMESPACE} {
 			app.AddReference (lib);
 			app.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
 			app.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
+			if (!string.IsNullOrEmpty (debugType)) {
+				app.SetProperty ("DebugType", debugType);
+			}
 			app.SetDefaultTargetDevice ();
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {


### PR DESCRIPTION
Context: https://github.com/xamarin/QualityAssurance/tree/master/Manual/CrossPlatformDebugging
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1430409
Fixes: https://github.com/xamarin/xamarin-android/issues/6480

A `CrossPlatformDebugging` sample project in the QA repo fails to
debug with:

    System.InvalidProgramException
    Message=Invalid IL code in Mono.SystemDependencyProvider:Initialize (): IL_002e: endfinally

The problem goes away if you do one of:

* Turn *on* Fast Deployment
* Add `<AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>`
* Change `$(DebugType)` to `portable`. (the project has `full`)

The problem appears to be:

1. `$(AndroidUseAssemblyStore)` defaults to `true` when you turn Fast
   Deployment *off*.

2. Assembly stores appear to have some issue when `DebugType=full` --
   that is where the crash occurs.

In this case let's address No. 1, as we don't *really* want the
assembly store to be used when debugging. I reordered default values
for MSBuild properties, so that `$(AndroidIncludeDebugSymbols)` is
taken into account.

I added parameters for a debugging test for `DebugType=full`, and I
updated another test that used to set `AndroidUseAssemblyStore=false`
that should not be needed.