### PR TITLE
Revert "[One .NET] fix GetAndroidDependencies target with --no-restore"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -899,16 +899,6 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
 		}
 
-		[Test]
-		public void GetAndroidDependencies()
-		{
-			var proj = new XASdkProject ();
-			var builder = CreateDotNetBuilder (proj);
-
-			// `dotnet build -t:GetAndroidDependencies --no-restore` should succeed
-			Assert.IsTrue (builder.Build (target: "GetAndroidDependencies", norestore: true), $"{proj.ProjectName} should succeed");
-		}
-
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)
 		{
 			if (string.IsNullOrEmpty (relativeProjectDir)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -92,11 +92,9 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Build (string target = null, string [] parameters = null, bool norestore = false)
+		public bool Build (string target = null, string [] parameters = null)
 		{
 			var arguments = GetDefaultCommandLineArgs ("build", target, parameters);
-			if (norestore)
-				arguments.Add ("--no-restore");
 			return Execute (arguments.ToArray ());
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -42,30 +42,22 @@ projects.
   </Target>
 
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
-    <_ResolveSdksDependsOnTargets>ProcessFrameworkReferences</_ResolveSdksDependsOnTargets>
+    <_ResolveSdksDependsOnTargets>ResolveTargetingPackAssets</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
     <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
 
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
+    <!-- When using .NET 5, provide a list of paths to the Android and NETCore targeting pack directories, e.g.
+          `packages\microsoft.android.ref\10.0.100-ci.master.22\ref\net5.0\` and
+          `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.6.20264.1\ref\net5.0\`
+         See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
+    -->
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
       <_AndroidApiInfo Include="$(MSBuildThisFileDirectory)..\data\*\AndroidApiInfo.xml" />
       <_AndroidApiInfoDirectories Include="@(_AndroidApiInfo->'%(RootDir)%(Directory)')" />
-      <!--
-        When using .NET 6+, provide the directory containing Mono.Android.dll and System.dll.
-        Use %(TargetingPack.PackageDirectory) to get this information.
-        See: https://github.com/dotnet/sdk/blob/22c4860dcb2cf6b123dd641cc4a87a50380759d5/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets#L49-L63
-      -->
-      <_MonoAndroidReferenceAssemblyPath
-          Condition=" '%(TargetingPack.Identity)' == 'Microsoft.NETCore.App' and '%(TargetingPack.PackageDirectory)' != '' "
-          Include="%(TargetingPack.PackageDirectory)\ref\*\System.dll"
-      />
-      <_MonoAndroidReferenceAssemblyPath
-          Condition=" '%(TargetingPack.Identity)' == 'Microsoft.Android' and '%(TargetingPack.PackageDirectory)' != '' "
-          Include="%(TargetingPack.PackageDirectory)\ref\*\Mono.Android.dll"
-      />
-      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(_MonoAndroidReferenceAssemblyPath->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(_MonoAndroidReferenceAssemblyPath.RootDir)%(_MonoAndroidReferenceAssemblyPath.Directory)' != '' " />
+      <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />
     </ItemGroup>
     <ItemGroup Condition=" '$(UsingAndroidNETSdk)' != 'true' ">
       <_AndroidApiInfoDirectories Include="$(_XATargetFrameworkDirectories)" />


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/23562

This reverts commit a21d1a7d.

When installing from Visual Studio, builds can hit the error:

    error XA0002: Could not find mono.android.jar

Running `dotnet workload install maui` over top, solves the issue!

Since, `%(TargetingPack.PackageDirectory)` appears to be blank when
installed from Visual Studio, I think we just have to revert this
change.