### PR TITLE
$(AndroidPackVersionSuffix)=preview.14; net6 is 31.0.200.preview.14

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>31.0.200</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.13</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.14</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: http://aka.ms/maui-schedule

We branched xamarin-android/release/6.0.2xx-preview13, to reflect the
next release of .NET MAUI Preview 13.

xamarin-android/main becomes Preview 14.