### PR TITLE
Bump LibZipSharp to 2.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>2.0.2</LibZipSharpVersion>
+    <LibZipSharpVersion>2.0.3</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -181,8 +181,10 @@ namespace Xamarin.Android.Tasks
 					AddFileToArchiveIfNewer (apk, dex.ItemSpec, DalvikPath + dexPath, compressionMethod: dexCompressionMethod);
 				}
 
-				if (EmbedAssemblies && !BundleAssemblies)
+				if (EmbedAssemblies && !BundleAssemblies) {
 					AddAssemblies (apk, debug, compress, compressedAssembliesInfo, assemblyStoreApkName);
+					apk.Flush ();
+				}
 
 				AddRuntimeLibraries (apk, supportedAbis);
 				apk.Flush();


### PR DESCRIPTION
We are seeing the following error on some builds

`error XABBA7000: Xamarin.Tools.Zip.ZipException: Zip archive inconsistent: entry 0: invalid WinZip AES extra field `

Verison 2.0.2 of LibZipSharp was supposed to fix this, but it had a [bug](https://github.com/xamarin/LibZipSharp/pull/104). 
Which would cause corruption in the zip file itself. 

This bug was fixed in 2.0.3 of LibZipSharp. So lets bump to that. 