### PR TITLE
[Microsoft.Android.Sdk.IlLink] preserve methods in Android.Runtime classes

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/Mono.Android.xml
@@ -3,6 +3,8 @@
 	<assembly fullname="Mono.Android">
 		<type fullname="Android.Runtime.AnnotationAttribute" />
 		<type fullname="Android.Runtime.IJavaObject" />
+		<type fullname="Android.Runtime.InputStreamAdapter" preserve="methods" />
+		<type fullname="Android.Runtime.InputStreamInvoker" preserve="methods" />
 		<type fullname="Android.Runtime.JNIEnv">
 			<method name="Exit" />
 			<method name="Initialize" />
@@ -17,6 +19,8 @@
 		<type fullname="Android.Runtime.LogLevel" />
 		<type fullname="Android.Runtime.LogCategories" />
 		<type fullname="Android.Runtime.NamespaceMappingAttribute" />
+		<type fullname="Android.Runtime.OutputStreamAdapter" preserve="methods" />
+		<type fullname="Android.Runtime.OutputStreamInvoker" preserve="methods" />
 		<type fullname="Android.Runtime.PreserveAttribute" />
 		<type fullname="Android.Runtime.RaiseThrowableEventArgs" />
 		<type fullname="Android.Runtime.RegisterAttribute" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,31 +5,31 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 54720
+      "Size": 55086
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 78995
+      "Size": 83182
     },
     "assemblies/rc.bin": {
       "Size": 1045
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10152
+      "Size": 10157
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 508217
+      "Size": 520945
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2404
+      "Size": 2410
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3545
+      "Size": 3551
     },
     "classes.dex": {
       "Size": 345328
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382576
+      "Size": 382680
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3176048
@@ -44,7 +44,7 @@
       "Size": 150024
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12424
+      "Size": 12384
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2680724
+  "PackageSize": 2697108
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/2246
Fixes: https://github.com/dotnet/maui/issues/4262
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1447865

Revert "[One .NET] Do not preserve IO stream adapter/invoker (#5449)"

This reverts commit 051cad7.

`dotnet new maui-blazor` crashes in Release mode with:

    Android.Runtime.JavaProxyThrowable: Exception_WasThrown, Android.Runtime.JavaProxyThrowable
    --- End of managed Android.Runtime.JavaProxyThrowable stack trace ---
    android.runtime.JavaProxyThrowable: System.ArgumentException: Arg_DlgtTargMeth
    at System.Delegate.CreateDelegate(Type , Type , String , Boolean , Boolean )
    at System.Delegate.CreateDelegate(Type , Type , String )
    at Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType , Type , String )
    --- End of stack trace from previous location ---
    at Java.Interop.JniEnvironment.StaticMethods.CallStaticObjectMethod(JniObjectReference , JniMethodInfo , JniArgumentValue* )
    at Android.Runtime.JNIEnv.CallStaticObjectMethod(IntPtr , IntPtr , JValue* )
    at Android.Runtime.JNIEnv.CallStaticObjectMethod(IntPtr , IntPtr , JValue[] )
    at Android.Runtime.JNIEnv.FindClass(String )
    at Android.Runtime.JNIEnv.AllocObject(String )
    at Android.Runtime.JNIEnv.StartCreateInstance(String , String , JValue* )
    at Android.Runtime.JNIEnv.StartCreateInstance(String , String , JValue[] )
    at Android.Runtime.InputStreamAdapter..ctor(Stream )
    at Android.Runtime.InputStreamAdapter.ToLocalJniHandle(Stream )
    at Android.Webkit.WebResourceResponse..ctor(String , String , Int32 , String , IDictionary`2 , Stream )
    at Microsoft.AspNetCore.Components.WebView.Maui.WebKitWebViewClient.ShouldInterceptRequest(WebView view, IWebResourceRequest request)
    at Android.Webkit.WebViewClient.n_ShouldInterceptRequest_Landroid_webkit_WebView_Landroid_webkit_WebResourceRequest_(IntPtr , IntPtr , IntPtr , IntPtr )
    at crc64d693e2d9159537db.WebKitWebViewClient.n_shouldInterceptRequest(Native Method)
    at crc64d693e2d9159537db.WebKitWebViewClient.shouldInterceptRequest(WebKitWebViewClient.java:39)
    at Rr.a(chromium-TrichromeWebViewGoogle.apk-stable-410410686:16)
    at org.chromium.android_webview.AwContentsBackgroundThreadClient.shouldInterceptRequestFromNative(chromium-TrichromeWebViewGoogle.apk-stable-410410686:2)
    --- End of managed Android.Runtime.JavaProxyThrowable stack trace ---
    android.runtime.JavaProxyThrowable: System.ArgumentException: Arg_DlgtTargMeth
    at System.Delegate.CreateDelegate(Type , Type , String , Boolean , Boolean )
    at System.Delegate.CreateDelegate(Type , Type , String )
    at Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType , Type , String )
    --- End of stack trace from previous location ---
    at Java.Interop.JniEnvironment.StaticMethods.CallStaticObjectMethod(JniObjectReference , JniMethodInfo , JniArgumentValue* )
    at Android.Runtime.JNIEnv.CallStaticObjectMethod(IntPtr , IntPtr , JValue* )
    at Android.Runtime.JNIEnv.CallStaticObjectMethod(IntPtr , IntPtr , JValue[] )
    at Android.Runtime.JNIEnv.FindClass(String )
    at Android.Runtime.JNIEnv.AllocObject(String )
    at Android.Runtime.JNIEnv.StartCreateInstance(String , String , JValue* )
    at Android.Runtime.JNIEnv.StartCreateInstance(String , String , JValue[] )
    at Android.Runtime.InputStreamAdapter..ctor(Stream )
    at Android.Runtime.InputStreamAdapter.ToLocalJniHandle(Stream )
    at Android.Webkit.WebResourceResponse..ctor(String , String , Int32 , String , IDictionary`2 , Stream )
    at Microsoft.AspNetCore.Components.WebView.Maui.WebKitWebViewClient.ShouldInterceptRequest(WebView view, IWebResourceRequest request)
    at Android.Webkit.WebViewClient.n_ShouldInterceptRequest_Landroid_webkit_WebView_Landroid_webkit_WebResourceRequest_(IntPtr , IntPtr , IntPtr , IntPtr )
    at crc64d693e2d9159537db.WebKitWebViewClient.n_shouldInterceptRequest(Native Method)
    at crc64d693e2d9159537db.WebKitWebViewClient.shouldInterceptRequest(WebKitWebViewClient.java:39)
    at Rr.a(chromium-TrichromeWebViewGoogle.apk-stable-410410686:16)
    at org.chromium.android_webview.AwContentsBackgroundThreadClient.shouldInterceptRequestFromNative(chromium-TrichromeWebViewGoogle.apk-stable-410410686:2)

It turns out that `Java.IO.InputStream.GetReadHandler()` was linked away.

So we need to preserve:

    <linker>
        <assembly fullname="Mono.Android">
            <type fullname="Android.Runtime.InputStreamAdapter" preserve="methods" />
            <type fullname="Android.Runtime.InputStreamInvoker" preserve="methods" />

Long-term, we should consider reworking `mono.android.jar`, so that
the linker *knows* about any C# methods called from Java from this
library.

This regresses apk size a reasonable amount:

    --"PackageSize": 2680724
    ++"PackageSize": 2697108

Adding ~16kb.

I considered adding:

    <type fullname="Android.Runtime.XmlResourceParserReader" />
    <type fullname="Android.Runtime.XmlPullParserReader" />
    <type fullname="Android.Runtime.XmlReaderResourceParser" />
    <type fullname="Android.Runtime.XmlReaderPullParser" />

But this regressed app size by too much!

    1,141,062 Package size difference 42.57% (of 2,680,724)