### PR TITLE
[Mono.Android-Tests] Stop using tls-test.internalx.com

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -383,7 +383,6 @@ stages:
         testName: Mono.Android_TestsAppBundle
         project: tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
         testResultsFiles: TestResult-Mono.Android_TestsAppBundle-$(ApkTestConfiguration).xml
-        packageType: Aab
         artifactSource: bin/Test$(ApkTestConfiguration)/Mono.Android_TestsAppBundle-Signed.aab
         artifactFolder: Aab
 
@@ -609,7 +608,6 @@ stages:
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Aab.xml
         extraBuildArgs: /p:TestsFlavor=Aab /p:AndroidPackageFormat=aab
-        packageType: Aab
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: net6-Aab
         useDotNet: true

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -5,7 +5,6 @@ parameters:
   testResultsFiles: ""
   extraBuildArgs: ""
   testResultsFormat: NUnit
-  packageType: Apk
   artifactSource: ""
   artifactFolder: ""
   useDotNet: false
@@ -20,7 +19,7 @@ steps:
       configuration: ${{ parameters.configuration }}
       msbuildArguments: >-
         /restore
-        /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
+        /t:RunTestApp
         /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         ${{ parameters.extraBuildArgs }}
     condition: ${{ parameters.condition }}
@@ -32,7 +31,7 @@ steps:
       displayName: run ${{ parameters.testName }}
       project: ${{ parameters.project }}
       arguments: >-
-        -t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
+        -t:RunTestApp
         -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -392,4 +392,22 @@
     />
   </Target>
 
+  <PropertyGroup>
+    <RunTestAppDependsOn>
+      AcquireAndroidTarget;
+      SignAndroidPackage;
+      DeployTestApks;
+      DeployTestAabs;
+      CheckAndRecordApkSizes;
+      RunTestApks;
+      UndeployTestApks;
+      RenameApkTestCases;
+      ReportComponentFailures;
+    </RunTestAppDependsOn>
+  </PropertyGroup>
+
+  <Target Name="RunTestApp"
+      DependsOnTargets="$(RunTestAppDependsOn)">
+  </Target>
+
 </Project>

--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -39,7 +39,7 @@ namespace System.NetTests {
 			Exception  exception  = null;
 
 			var thread = new Thread (() => {
-				string url = "https://tls-test-1.internalx.com";
+				string url = "https://dotnet.microsoft.com/";
 
 				var downloadTask = new WebClient ().DownloadDataTaskAsync (url);
 				var completeTask = downloadTask.ContinueWith (t => {

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -147,28 +147,6 @@ namespace Xamarin.Android.NetTests {
 
 	public abstract class AndroidHandlerTestBase : HttpClientHandlerTestBase
 	{
-		const string Tls_1_2_Url = "https://tls-test.internalx.com";
-
-		[Test]
-		public void Tls_1_2_Url_Works ()
-		{
-			if (((int) Build.VERSION.SdkInt) < 16) {
-				Assert.Ignore ("Host platform doesn't support TLS 1.2.");
-				return;
-			}
-			using (var c = new HttpClient (CreateHandler ())) {
-				var tr = ConnectIgnoreFailure (() => c.GetAsync (Tls_1_2_Url), out bool connectionFailed);
-				if (connectionFailed)
-					return;
-
-				RunIgnoringNetworkIssues (() => tr.Wait (), out connectionFailed);
-				if (connectionFailed)
-					return;
-
-				tr.Result.EnsureSuccessStatusCode ();
-			}
-		}
-
 		static IEnumerable<Exception> Exceptions (Exception e)
 		{
 			yield return e;
@@ -192,43 +170,6 @@ namespace Xamarin.Android.NetTests {
 			Assert.IsNotNull (handlerField);
 			object innerHandler = innerHandlerField.GetValue (handler);
 			return innerHandler.GetType ();
-		}
-
-		[Test, Category ("DotNetIgnore")]
-		public void Sanity_Tls_1_2_Url_WithMonoClientHandlerFails ()
-		{
-			var tlsProvider   = global::System.Environment.GetEnvironmentVariable ("XA_TLS_PROVIDER");
-			var supportTls1_2 = tlsProvider.Equals ("btls", StringComparison.OrdinalIgnoreCase);
-			using (var c = new HttpClient (new HttpClientHandler ())) {
-				try {
-					Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (c).Name, 
-						"Underlying HttpClientHandler is expected to use SocketsHttpHandler by default. " + 
-						"XA_HTTP_CLIENT_HANDLER_TYPE=" + global::System.Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE"));
-
-					var tr = ConnectIgnoreFailure (() => c.GetAsync (Tls_1_2_Url), out bool connectionFailed);
-					if (connectionFailed)
-						return;
-
-					RunIgnoringNetworkIssues (() => tr.Wait (), out connectionFailed);
-					if (connectionFailed)
-						return;
-
-					tr.Result.EnsureSuccessStatusCode ();
-					if (!supportTls1_2) {
-						Assert.Fail ("SHOULD NOT BE REACHED: Mono's HttpClientHandler doesn't support TLS 1.2.");
-					}
-				}
-				catch (AggregateException e) {
-					if (supportTls1_2) {
-						Assert.Fail ("SHOULD NOT BE REACHED: BTLS is present, TLS 1.2 should work. Network error? {0}", e.ToString ());
-					}
-					if (!supportTls1_2) {
-						Assert.IsTrue (IsSecureChannelFailure (e),
-							       "Nested exception and/or corresponding status code did not match expected results for TLS 1.2 incompatibility {0}",
-							       e);
-					}
-				}
-			}
 		}
 
 		[Test]
@@ -305,8 +246,8 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_Without_Protocol_Works()
 		{
-			var requestURI = new Uri ("http://tls-test.internalx.com/redirect.php");
-			var redirectedURI = new Uri ("http://tls-test.internalx.com/redirect-301.html");
+			var requestURI = new Uri ("https://httpbingo.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
+			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var tr = ConnectIgnoreFailure (() => c.GetAsync (requestURI), out bool connectionFailed);
 				if (connectionFailed)
@@ -324,8 +265,8 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_POST_With_Content_Works ()
 		{
-			var requestURI = new Uri ("http://tls-test.internalx.com/redirect.php");
-			var redirectedURI = new Uri ("http://tls-test.internalx.com/redirect-301.html");
+			var requestURI = new Uri ("https://httpbingo.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
+			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var request = new HttpRequestMessage (HttpMethod.Post, requestURI);
 				request.Content = new StringContent("{}", Encoding.UTF8, "application/json");


### PR DESCRIPTION
Drops the dependency we have on the `tls-test*.internalx.com` VMs.

Tests that attempted to run against a particular TLS version have been
removed, others have been updated to use httpbingo.org

A small `TestApks.targets` change has also been added to simplify local
test execution.