### PR TITLE
[One .NET] fix libmono-profiler-aot.so recording

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -43,7 +43,7 @@ variables:
 - name: RunAllTests
   value: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
 - name: DotNetNUnitCategories
-  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != ProfiledAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
+  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
 - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -66,6 +66,9 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
       <Output PropertyName="_LdFlags"    TaskParameter="LdFlags" />
       <Output ItemName="_MonoAOTAssemblies" TaskParameter="ResolvedAssemblies" />
     </GetAotAssemblies>
+    <ItemGroup Condition=" '$(AndroidExtraAotOptions)' != '' ">
+      <_MonoAOTAssemblies Update="@(_MonoAOTAssemblies)" ProcessArguments="$(AndroidExtraAotOptions)" />
+    </ItemGroup>
     <PropertyGroup>
       <_MonoAOTCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', '$(RuntimeIdentifier)'))</_MonoAOTCompilerPath>
       <_LLVMPath Condition=" '$(EnableLLVM)' == 'true' ">$([System.IO.Path]::GetDirectoryName ('$(_MonoAOTCompilerPath)'))</_LLVMPath>

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1686,6 +1686,7 @@ MonodroidRuntime::set_profile_options ()
 			.append (AOT_EXT);
 
 		value
+			.append (",")
 			.append (OUTPUT_ARG)
 			.append (output_path.get (), output_path.length ());
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -1,6 +1,7 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.IO;
+using System.Net;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
@@ -26,6 +27,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86");
+			AddDotNetProfilerNativeLibraries (proj);
 			var port = 9000 + new Random ().Next (1000);
 			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());
 			proj.AndroidManifest = string.Format (PermissionManifest, proj.PackageName);
@@ -35,9 +37,46 @@ namespace Xamarin.Android.Build.Tests
 				WaitForAppBuiltForOlderAndroidWarning (proj.PackageName, Path.Combine (Root, b.ProjectDirectory, "oldsdk-logcat.log"));
 				System.Threading.Thread.Sleep (5000);
 				b.BuildLogFile = "build2.log";
+
+				// Need execute permission
+				if (Builder.UseDotNet && !IsWindows) {
+					var aprofutil = Path.Combine (Root, b.ProjectDirectory, "aprofutil");
+					RunProcess ("chmod", $"u+x {aprofutil}");
+				}
+
 				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling", doNotCleanupOnUpdate: true), "Run of FinishAotProfiling should have succeeded.");
 				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
 				FileAssert.Exists (customProfile);
+			}
+		}
+
+		void AddDotNetProfilerNativeLibraries (XamarinAndroidApplicationProject proj)
+		{
+			// TODO: only needed in .NET 6+
+			// See https://github.com/dotnet/runtime/issues/56989
+			if (!Builder.UseDotNet)
+				return;
+
+			// Files are built from dotnet/runtime & stored at:
+			const string github = "https://github.com/jonathanpeppers/android-profiled-aot";
+
+			proj.Sources.Add (new BuildItem ("None", "aprofutil") {
+				WebContent = $"{github}/raw/main/binaries/aprofutil"
+			});
+			proj.Sources.Add (new BuildItem ("None", "aprofutil.exe") {
+				WebContent = $"{github}/raw/main/binaries/aprofutil.exe"
+			});
+			proj.Sources.Add (new BuildItem ("None", "Mono.Profiler.Log.dll") {
+				WebContent = $"{github}/raw/main/binaries/Mono.Profiler.Log.dll"
+			});
+			proj.SetProperty ("AProfUtilToolPath", "$(MSBuildThisFileDirectory)");
+
+			foreach (var rid in proj.GetProperty (KnownProperties.RuntimeIdentifiers).Split (';')) {
+				//NOTE: each rid has the same file name, so using WebClient directly
+				var bytes = new WebClient ().DownloadData ($"{github}/raw/main/binaries/{rid}/libmono-profiler-aot.so");
+				proj.Sources.Add (new AndroidItem.AndroidNativeLibrary ($"{rid}\\libmono-profiler-aot.so") {
+					BinaryContent = () => bytes,
+				});
 			}
 		}
 	}


### PR DESCRIPTION
I found when I went to update the AOT profile in .NET MAUI:

https://github.com/jonathanpeppers/android-profiled-aot
https://github.com/dotnet/maui/pull/4355

The profiler crashed with:

    01-27 11:10:16.119 28922 28922 W monodroid: Creating public update directory: `/data/user/0/com.androidaot.MauiApp1/files/.__override__`
    ...
    01-27 11:10:16.119 28922 28922 W monodroid: Initializing profiler with options: aot:port=9999output=/data/user/0/com.androidaot.MauiApp1/files/.__override__/profile.aotprofile
    01-27 11:10:16.119 28922 28922 W monodroid: Looking for profiler init symbol 'mono_profiler_init_aot'? 0x7325b6355c
    01-27 11:10:16.119 28922 28922 E mono-prof: Could not create AOT profiler output file 'output.aotprofile': Read-only file system

But the directory was writeable?

    adb shell run-as com.androidaot.MauiApp1 touch files/.__override__/foo

After some digging, it turned out appending `,` to this line fixed the
issue:

https://github.com/xamarin/xamarin-android/blob/b7a368a27667c69117f64be81050403f2d5c8560/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets#L45

What happened was we lost a `,` somewhere in this commit:

https://github.com/xamarin/xamarin-android/pull/6171/commits/f73a323ca4968054359a8e9856a932a58e2a2be4

To fix this:

1. Prepend a `,`

2. I found a way to actually enable tests for Profiled AOT in .NET 6
   by downloading binaries from my Github repo.

In enabling the `ProfiledAOT` category for .NET 6, I found that this
setting wasn't working:

    <AndroidExtraAotOptions>--verbose</AndroidExtraAotOptions>

I updated `%(_MonoAOTAssemblies.ProcessArguments)` to solve this.