### PR TITLE
[ci] Improve test failure content uploads

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -42,7 +42,7 @@ steps:
     mkdir -p "$DEST" &&
     cp "${{ parameters.artifactSource }}" "$DEST"
   displayName: copy apk/aab
-  condition: true #ne(variables['agent.jobstatus'], 'Succeeded')
+  condition: ne(variables['Agent.JobStatus'], 'Succeeded')
   continueOnError: true
 
 - task: PublishTestResults@2

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -42,7 +42,7 @@ steps:
     mkdir -p "$DEST" &&
     cp "${{ parameters.artifactSource }}" "$DEST"
   displayName: copy apk/aab
-  condition: eq(variables['agent.jobstatus'], 'SucceededWithIssues')
+  condition: true #ne(variables['agent.jobstatus'], 'Succeeded')
   continueOnError: true
 
 - task: PublishTestResults@2

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -35,9 +35,10 @@ steps:
         -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}
+      continueOnError: true
 
 - script: >
-    DEST="$(Build.ArtifactStagingDirectory)/${{ parameters.artifactFolder }}/" &&
+    DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/" &&
     mkdir -p "$DEST" &&
     cp "${{ parameters.artifactSource }}" "$DEST"
   displayName: copy apk/aab

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -11,7 +11,7 @@ steps:
     arguments: --s=CopyExtraResultFilesForCI --verbosity v
     xaSourcePath: ${{ parameters.xaSourcePath }}
     displayName: Copy extra result files
-    condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
+    condition: ne(variables['Agent.JobStatus'], 'Succeeded')
 
 - ${{ if eq(parameters.includeBuildResults, false) }}:
   - template: publish-artifact.yaml
@@ -19,7 +19,7 @@ steps:
       displayName: upload test results
       artifactName: ${{ parameters.artifactName }}
       targetPath: $(Build.StagingDirectory)/Test${{ parameters.configuration }}
-      condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
+      condition: ne(variables['Agent.JobStatus'], 'Succeeded')
 
 # Copy Build$(Configuration) folder into test result root and upload single artifact
 - ${{ if eq(parameters.includeBuildResults, true) }}:
@@ -27,11 +27,11 @@ steps:
     inputs:
       sourceFolder: $(Build.StagingDirectory)/Build${{ parameters.configuration }}
       targetFolder: $(Build.StagingDirectory)/Test${{ parameters.configuration }}/Build${{ parameters.configuration }}
-    condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
+    condition: ne(variables['Agent.JobStatus'], 'Succeeded')
 
   - template: publish-artifact.yaml
     parameters:
       displayName: upload build and test results
       artifactName: ${{ parameters.artifactName }}
       targetPath: $(Build.StagingDirectory)/Test${{ parameters.configuration }}
-      condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
+      condition: ne(variables['Agent.JobStatus'], 'Succeeded')

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -11,7 +11,7 @@ steps:
     arguments: --s=CopyExtraResultFilesForCI --verbosity v
     xaSourcePath: ${{ parameters.xaSourcePath }}
     displayName: Copy extra result files
-    condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+    condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
 
 - ${{ if eq(parameters.includeBuildResults, false) }}:
   - template: publish-artifact.yaml
@@ -19,7 +19,7 @@ steps:
       displayName: upload test results
       artifactName: ${{ parameters.artifactName }}
       targetPath: $(Build.StagingDirectory)/Test${{ parameters.configuration }}
-      condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+      condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
 
 # Copy Build$(Configuration) folder into test result root and upload single artifact
 - ${{ if eq(parameters.includeBuildResults, true) }}:
@@ -27,11 +27,11 @@ steps:
     inputs:
       sourceFolder: $(Build.StagingDirectory)/Build${{ parameters.configuration }}
       targetFolder: $(Build.StagingDirectory)/Test${{ parameters.configuration }}/Build${{ parameters.configuration }}
-    condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+    condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')
 
   - template: publish-artifact.yaml
     parameters:
       displayName: upload build and test results
       artifactName: ${{ parameters.artifactName }}
       targetPath: $(Build.StagingDirectory)/Test${{ parameters.configuration }}
-      condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+      condition: true #ne(variables['Agent.JobStatus'], 'Succeeded')

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -26,7 +26,7 @@
     <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">5</AvdLaunchTimeoutMinutes>
     <AvdLaunchTimeoutSeconds>$([MSBuild]::Multiply($(AvdLaunchTimeoutMinutes), 60))</AvdLaunchTimeoutSeconds>
     <AvdLaunchTimeoutMS>$([MSBuild]::Multiply($(AvdLaunchTimeoutSeconds), 1000))</AvdLaunchTimeoutMS>
-    <_LogcatFilename>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)-full.log</_LogcatFilename>
+    <_LogcatFilenameBase>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
   </PropertyGroup>
 
   <ItemGroup>
@@ -69,7 +69,7 @@
         AvdManagerHome="$(AvdManagerHome)"
         Arguments="$(TestEmulatorArguments)"
         ImageName="$(TestAvdName)"
-        LogcatFile="$(_LogcatFilename)"
+        LogcatFile="$(_LogcatFilenameBase)-full.txt"
         Port="$(_AdbEmulatorPort)"
         ToolExe="$(EmulatorToolExe)"
         ToolPath="$(EmulatorToolPath)">
@@ -247,7 +247,6 @@
     <PropertyGroup>
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
-      <_LogcatFilenameBase>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
       <PlotDataLabelSuffix Condition=" '$(PlotDataLabelSuffix)' == '' ">$(TestsFlavor)</PlotDataLabelSuffix>
     </PropertyGroup>
     <RunInstrumentationTests

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Prepare
 		string [] testConfigFiles = {
 			"*.apkdesc",
 			"*.aabdesc",
-			"logcat*",
+			"logcat-*.txt",
 			"*log",
 			"TestOutput-*.txt",
 			"Timing_*",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -669,6 +669,9 @@ namespace Xamarin.Android.Build.Tests
 				foreach (var file in Directory.GetFiles (Path.Combine (output), "*.log", SearchOption.AllDirectories)) {
 					TestContext.AddTestAttachment (file, Path.GetFileName (output));
 				}
+				foreach (var bl in Directory.GetFiles (Path.Combine (output), "*.binlog", SearchOption.AllDirectories)) {
+					TestContext.AddTestAttachment (bl, Path.GetFileName (output));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes .apk/.aab file uploads when an apk test configuration fails.

The filters for log file uploading have also been improved to avoid a
situaton where we attempt to upload a file with the same name twice:

    Copying file '/Users/runner/work/1/s/xamarin-android/bin/TestRelease/logcat-Release-full.log' to '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' (overwrite destination: False)
    Copying file '/Users/runner/work/1/s/xamarin-android/bin/TestRelease/logcat-ReleaseAab-Mono.Android.NET_Tests.txt' to '/Users/runner/work/1/a/TestRelease/logcat-ReleaseAab-Mono.Android.NET_Tests.txt' (overwrite destination: False)
    ...
    Copying file '/Users/runner/work/1/s/xamarin-android/bin/TestRelease/logcat-Release-full.log' to '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' (overwrite destination: False)

    Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.
     ---> System.IO.IOException: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.

The `logcat-Release-full.log` file matched both `logcat*` and `*log`
upload file filters. Attempts to copy it twice would fail, which caused
us to miss certain files in the test result output that was eventually
uploaded.

MSBuild .binlog files will now be uploaded as test attachments for
failing tests.
