### PR TITLE
Use new LLVM-based Xamarin.Android toolchain

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -132,7 +132,7 @@ the Android [binutils][binutils] such as `ld`, the native linker,
 and `as`, the native assembler. These tools are included in the
 Xamarin.Android installation.
 
-The default value is `$(MonoAndroidBinDirectory)\binutils\`.
+The default value is `$(MonoAndroidBinDirectory)\binutils\bin\`.
 
 Added in Xamarin.Android 10.0.
 

--- a/build-tools/create-packs/SignList.xml
+++ b/build-tools/create-packs/SignList.xml
@@ -14,18 +14,12 @@
     <ThirdParty Include="protobuf-net.dll" />
     <ThirdParty Include="SgmlReaderDll.dll" />
     <ThirdParty Include="aapt2.exe" />
-    <ThirdParty Include="aarch64-linux-android-as.exe" />
+    <ThirdParty Include="llvm-mc.exe" />
+    <ThirdParty Include="llvm-strip.exe" />
     <ThirdParty Include="aarch64-linux-android-ld.exe" />
-    <ThirdParty Include="aarch64-linux-android-strip.exe" />
-    <ThirdParty Include="arm-linux-androideabi-as.exe" />
     <ThirdParty Include="arm-linux-androideabi-ld.exe" />
-    <ThirdParty Include="arm-linux-androideabi-strip.exe" />
-    <ThirdParty Include="i686-linux-android-as.exe" />
     <ThirdParty Include="i686-linux-android-ld.exe" />
-    <ThirdParty Include="i686-linux-android-strip.exe" />
-    <ThirdParty Include="x86_64-linux-android-as.exe" />
     <ThirdParty Include="x86_64-linux-android-ld.exe" />
-    <ThirdParty Include="x86_64-linux-android-strip.exe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -322,22 +322,22 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\llvm-mc.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\llvm-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-as.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-ld.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-strip.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-as.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-ld.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-strip.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-as.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-ld.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-strip.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-as.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-ld.cmd" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\llvm-mc.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\llvm-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\aarch64-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\aarch64-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\aarch64-linux-android-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\arm-linux-androideabi-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\arm-linux-androideabi-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\arm-linux-androideabi-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\i686-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\i686-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\i686-linux-android-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\x86_64-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\x86_64-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\x86_64-linux-android-strip.cmd" />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
@@ -356,23 +356,8 @@
       <Permission>755</Permission>
     </_MSBuildFilesUnixSignAndHarden>
   </ItemDefinitionGroup>
+  <Import Project="unix-binutils.projitems" />
   <ItemGroup>
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\llvm-mc" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\llvm-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\arm-linux-androideabi-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\i686-linux-android-strip" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-as" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-ld" />
-    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" Permission="755" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" Permission="755" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" ExcludeFromAndroidNETSdk="true" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -322,18 +322,22 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-strip.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-as.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-ld.exe" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\as.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\ld.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\llvm-mc.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\llvm-strip.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\aarch64-linux-android-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\arm-linux-androideabi-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\i686-linux-android-strip.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-as.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-ld.cmd" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\x86_64-linux-android-strip.cmd" />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
@@ -353,6 +357,10 @@
     </_MSBuildFilesUnixSignAndHarden>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\llvm-mc" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\llvm-strip" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-as" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-ld" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\aarch64-linux-android-strip" />

--- a/build-tools/installers/unix-binutils.projitems
+++ b/build-tools/installers/unix-binutils.projitems
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Linux' ">so.13</_LlvmLibExtension>
+    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Darwin' ">dylib</_LlvmLibExtension>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\aarch64-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\aarch64-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\aarch64-linux-android-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\arm-linux-androideabi-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\arm-linux-androideabi-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\arm-linux-androideabi-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\i686-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\i686-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\i686-linux-android-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\llvm-mc" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\llvm-strip" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\x86_64-linux-android-as" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\x86_64-linux-android-ld" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\bin\x86_64-linux-android-strip" />
+
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldCOFF.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldCommon.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldCore.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldDriver.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldELF.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldMachO.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldMachO2.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldMinGW.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldReaderWriter.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldWasm.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\liblldYAML.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64AsmParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64CodeGen.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64Desc.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64Disassembler.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64Info.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAArch64Utils.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAggressiveInstCombine.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAnalysis.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMAsmParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMCodeGen.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMDesc.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMDisassembler.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMInfo.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMARMUtils.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAsmParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMAsmPrinter.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMBinaryFormat.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMBitReader.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMBitstreamReader.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMBitWriter.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMCFGuard.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMCodeGen.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMCore.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMCoroutines.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMDebugInfoCodeView.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMDebugInfoDWARF.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMDebugInfoMSF.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMDebugInfoPDB.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMDemangle.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMExtensions.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMFrontendOpenMP.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMGlobalISel.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMInstCombine.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMInstrumentation.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMipo.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMIRReader.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMLibDriver.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMLinker.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMLTO.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMMC.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMMCDisassembler.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMMCParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMMIRParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMObjCARCOpts.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMObject.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMOption.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMPasses.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMProfileData.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMRemarks.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMScalarOpts.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMSelectionDAG.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMSupport.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMTableGen.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMTableGenGlobalISel.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMTarget.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMTextAPI.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMTransformUtils.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMVectorize.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMWindowsManifest.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMX86AsmParser.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMX86CodeGen.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMX86Desc.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMX86Disassembler.$(_LlvmLibExtension)" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\binutils\lib\libLLVMX86Info.$(_LlvmLibExtension)" />
+  </ItemGroup>
+</Project>

--- a/build-tools/xaprepare/xaprepare/Application/NDKTool.cs
+++ b/build-tools/xaprepare/xaprepare/Application/NDKTool.cs
@@ -6,12 +6,14 @@ namespace Xamarin.Android.Prepare
 	{
 		public string Name               { get; }
 		public string DestinationName    { get; } = String.Empty;
+		public bool Prefixed             { get; }
 
-		public NDKTool (string name, string? destinationName = null)
+		public NDKTool (string name, string? destinationName = null, bool prefixed = false)
 		{
 			if (name.Trim ().Length == 0) {
 				throw new ArgumentException (nameof (name), "must not be empty");
 			}
+			Prefixed = prefixed;
 			Name = name;
 			if (String.IsNullOrWhiteSpace (destinationName)) {
 				return;

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "L_13.0.1-4.0.0";
+		const string BinutilsVersion                = "L_13.0.1-4.0.1";
 
 		const string MicrosoftOpenJDK11Version      = "11.0.10";
 		const string MicrosoftOpenJDK11Release      = "9.1";

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "2.35.2-XA.1";
+		const string BinutilsVersion                = "L_13.0.1-4.0.0";
 
 		const string MicrosoftOpenJDK11Version      = "11.0.10";
 		const string MicrosoftOpenJDK11Release      = "9.1";
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Prepare
 
 			public static Uri MonoArchive_BaseUri = new Uri ("https://xamjenkinsartifact.azureedge.net/mono-sdks/");
 
-			public static Uri BinutilsArchive = new Uri ($"https://github.com/xamarin/xamarin-android-binutils/releases/download/{BinutilsVersion}/xamarin-android-binutils-{BinutilsVersion}.7z");
+			public static Uri BinutilsArchive = new Uri ($"https://github.com/xamarin/xamarin-android-binutils/releases/download/{BinutilsVersion}/xamarin-android-toolchain-{BinutilsVersion}.7z");
 		}
 
 		public static partial class Defaults
@@ -219,9 +219,16 @@ namespace Xamarin.Android.Prepare
 			};
 
 			public static readonly List <NDKTool> NDKTools = new List<NDKTool> {
+				// Tools prefixed with architecture triple
+				new NDKTool (name: "as", prefixed: true),
+				new NDKTool (name: "ld", prefixed: true),
+				new NDKTool (name: "strip", prefixed: true),
+
+				// Unprefixed tools
 				new NDKTool (name: "as"),
 				new NDKTool (name: "ld"),
-				new NDKTool (name: "strip"),
+				new NDKTool (name: "llvm-mc"),
+				new NDKTool (name: "llvm-strip"),
 			};
 		}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.Unix.cs
@@ -2,6 +2,6 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Step_InstallGNUBinutils
 	{
-		const string? ExecutableExtension = null;
+		const string[]? ExecutableExtensions = null;
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.Windows.cs
@@ -3,6 +3,6 @@ namespace Xamarin.Android.Prepare
 	partial class Step_InstallGNUBinutils
 	{
 		const string HostName = "windows";
-		const string ExecutableExtension = ".exe";
+		static readonly string[]? ExecutableExtensions = WindowsExtensions;
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.cs
@@ -54,19 +54,36 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
+
+
 		bool CopyToDestination (Context context, string label, string sourceDir, string destinationDir, string osName = HostName, string[]? executableExtensions = null)
 		{
 			Log.StatusLine ();
 			Log.StatusLine ($"Installing for {label}:");
 
-			string sourcePath = Path.Combine (sourceDir, osName);
+			string osSourcePath = Path.Combine (sourceDir, osName);
+			string sourcePath = Path.Combine (osSourcePath, "bin");
 			foreach (var kvp in Configurables.Defaults.AndroidToolchainPrefixes) {
 				string prefix = kvp.Value;
 				CopyTools (prefix);
 			}
 			CopyTools (String.Empty);
+			CopyLibraries ();
 
 			return true;
+
+			void CopyLibraries ()
+			{
+				if (osName == "windows") {
+					return;
+				}
+
+				string libSourcePath = Path.Combine (osSourcePath, "lib");
+				string libDestPath = Path.Combine (destinationDir, "lib");
+				foreach (string file in Directory.EnumerateFiles (libSourcePath)) {
+					Utilities.CopyFileToDir (file, libDestPath);
+				}
+			}
 
 			void CopyTools (string prefix)
 			{
@@ -78,7 +95,7 @@ namespace Xamarin.Android.Prepare
 
 					string toolSourcePath = GetToolPath (sourcePath, prefix, tool, executableExtensions, throwOnMissing: true);
 					string toolName = Path.GetFileName (toolSourcePath);
-					string toolDestinationPath = Path.Combine (destinationDir, toolName);
+					string toolDestinationPath = Path.Combine (destinationDir, "bin", toolName);
 					string versionMarkerPath = GetVersionMarker (toolDestinationPath);
 
 					Log.StatusLine ($"  {context.Characters.Bullet} Installing ", toolName, tailColor: ConsoleColor.White);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Tasks
 			}
 			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 			MonoAndroidLibPath  = MonoAndroidHelper.GetOSLibPath () + Path.DirectorySeparatorChar;
-			AndroidBinUtilsPath = MonoAndroidBinPath + "binutils" + Path.DirectorySeparatorChar;
+			AndroidBinUtilsPath = MonoAndroidBinPath + "binutils" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar;
 
 			var minVersion      = Version.Parse (MinimumSupportedJavaVersion);
 			var maxVersion      = Version.Parse (LatestSupportedJavaVersion);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/StripNativeLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/StripNativeLibraries.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		protected override string ToolName => OS.IsWindows ? $"{triple}-strip.exe" : $"{triple}-strip";
+		protected override string ToolName => GetToolName ($"{triple}-strip");
 
 		protected override string GenerateFullPathToTool () => Path.Combine (ToolPath, ToolName);
 
@@ -79,6 +79,17 @@ namespace Xamarin.Android.Tasks
 				"x86_64" => "x86_64-linux-android",
 				_ => throw new InvalidOperationException ($"Unknown ABI: {abi}"),
 			};
+		}
+
+		// We need this because `GenerateFullPathToTool()` is ignored when `ToolPath` is set (https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.utilities.tooltask.generatefullpathtotool?view=msbuild-17-netcore)
+		// Some tools we use with llvm-based toolchain have .cmd wrappers instead of .exe, so we need to determine the actual name from filesystem.
+		string GetToolName (string toolName)
+		{
+			if (OS.IsWindows) {
+				return Path.GetFileName (MonoAndroidHelper.GetExecutablePath (ToolPath, toolName));
+			}
+
+			return toolName;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -143,8 +143,11 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		// DotNet fails, see https://github.com/xamarin/xamarin-android/issues/6685
+		// Enable the commented out signature (and AOT) once the above is fixed
 		[Test]
 		[Category ("SmokeTests")]
+//		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms, [Values (false, true)] bool aot)
 		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms)
 		{
 			var testName = "テスト";
@@ -155,9 +158,8 @@ namespace Xamarin.Android.Build.Tests
 				new XamarinAndroidApplicationProject ();
 			proj.ProjectName = testName;
 			proj.IsRelease = true;
-			// TODO: AOT fails https://github.com/xamarin/xamarin-android/issues/6685
-			// .NET 6 uses AOT by default for Release
-			proj.AotAssemblies = false;
+			proj.AotAssemblies = false; /* = true; once AOT is fixed */
+
 			if (forms) {
 				proj.PackageReferences.Clear ();
 				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -143,12 +143,11 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		// DotNet fails, see https://github.com/xamarin/xamarin-android/issues/6685
+		// DotNet fails, see https://github.com/dotnet/runtime/issues/65484
 		// Enable the commented out signature (and AOT) once the above is fixed
 		[Test]
 		[Category ("SmokeTests")]
-//		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms, [Values (false, true)] bool aot)
-		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms)
+		public void SmokeTestBuildWithSpecialCharacters ([Values (false, true)] bool forms, [Values (false /*, true*/)] bool aot)
 		{
 			var testName = "テスト";
 
@@ -158,7 +157,7 @@ namespace Xamarin.Android.Build.Tests
 				new XamarinAndroidApplicationProject ();
 			proj.ProjectName = testName;
 			proj.IsRelease = true;
-			proj.AotAssemblies = false; /* = true; once AOT is fixed */
+			proj.AotAssemblies = aot;
 
 			if (forms) {
 				proj.PackageReferences.Clear ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -305,6 +305,7 @@ namespace Xamarin.ProjectTools
 			}
 			args.Append ($" @\"{responseFile}\"");
 			using (var sw = new StreamWriter (responseFile, append: false, encoding: Encoding.UTF8)) {
+				sw.WriteLine ("/p:_DisableParallelAot=true");
 				sw.WriteLine ($" /p:BuildingInsideVisualStudio={BuildingInsideVisualStudio}");
 				if (BuildingInsideVisualStudio) {
 					sw.WriteLine (" /p:BuildingOutOfProcess=true");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -148,7 +148,8 @@ namespace Xamarin.ProjectTools
 				$"\"{projectOrSolution}\"",
 				"/noconsolelogger",
 				$"/flp1:LogFile=\"{BuildLogFile}\";Encoding=UTF-8;Verbosity={Verbosity}",
-				$"/bl:\"{Path.Combine (testDir, $"{binlog}.binlog")}\""
+				$"/bl:\"{Path.Combine (testDir, $"{binlog}.binlog")}\"",
+				"/p:_DisableParallelAot=true",
 			};
 			if (!string.IsNullOrEmpty (target)) {
 				arguments.Add ($"/t:{target}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,37 +5,37 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 55094
+      "Size": 54996
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87709
+      "Size": 88096
     },
     "assemblies/rc.bin": {
       "Size": 1083
     },
     "assemblies/System.Linq.dll": {
-      "Size": 10116
+      "Size": 10113
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 519296
+      "Size": 519420
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
       "Size": 1163
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2369
+      "Size": 2367
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3543
+      "Size": 3552
     },
     "classes.dex": {
       "Size": 345328
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382776
+      "Size": 382200
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3192432
+      "Size": 3171952
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 776216
@@ -47,7 +47,7 @@
       "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12440
+      "Size": 10104
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -59,7 +59,7 @@
       "Size": 2467
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4791
+      "Size": 4762
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyGenerator/NativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyGenerator/NativeAssemblyGenerator.cs
@@ -207,7 +207,7 @@ namespace Xamarin.Android.Tasks
 
 		public virtual void WriteFileTop ()
 		{
-			WriteDirective (".file", QuoteString (fileName));
+			WriteDirective (".file", QuoteString (fileName.Replace ("\\", "\\\\")));
 		}
 
 		public virtual void WriteFileEnd ()

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/WithClangNoBinutils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NdkTools/WithClangNoBinutils.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks
 		{
 			string toolName = GetToolName (kind);
 			string triple = GetArchTriple (arch);
-			string binutilsDir = Path.Combine (OSBinPath, "binutils");
+			string binutilsDir = Path.Combine (OSBinPath, "binutils", "bin");
 
 			return GetExecutablePath (Path.Combine (binutilsDir, $"{triple}-{toolName}"), mustExist: true);
 		}

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
@@ -8,16 +8,16 @@
       "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68861
+      "Size": 68737
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 561736
+      "Size": 565324
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936263
+      "Size": 936188
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
@@ -29,7 +29,7 @@
       "Size": 10201
     },
     "assemblies/System.Core.dll": {
-      "Size": 192216
+      "Size": 192217
     },
     "assemblies/System.Data.dll": {
       "Size": 316113
@@ -44,10 +44,10 @@
       "Size": 113293
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 23262
+      "Size": 23260
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193453
+      "Size": 193454
     },
     "assemblies/System.ServiceModel.Internals.dll": {
       "Size": 26599
@@ -56,7 +56,7 @@
       "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34374
+      "Size": 34373
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 7694
@@ -134,130 +134,130 @@
       "Size": 2652924
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
-      "Size": 38680
+      "Size": 45364
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 871548
+      "Size": 1231332
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 6745752
+      "Size": 8915144
     },
     "lib/armeabi-v7a/libaot-Mono.Security.dll.so": {
-      "Size": 443060
+      "Size": 627000
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 8676524
+      "Size": 11543188
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3394728
+      "Size": 4372444
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 22040
+      "Size": 24340
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 71372
+      "Size": 83940
     },
     "lib/armeabi-v7a/libaot-System.Core.dll.so": {
-      "Size": 2285072
+      "Size": 2961476
     },
     "lib/armeabi-v7a/libaot-System.Data.dll.so": {
-      "Size": 3262396
+      "Size": 4404348
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 3963560
+      "Size": 5337264
     },
     "lib/armeabi-v7a/libaot-System.Drawing.Common.dll.so": {
-      "Size": 69956
+      "Size": 84568
     },
     "lib/armeabi-v7a/libaot-System.Net.Http.dll.so": {
-      "Size": 1195552
+      "Size": 1508424
     },
     "lib/armeabi-v7a/libaot-System.Numerics.dll.so": {
-      "Size": 161508
+      "Size": 197448
     },
     "lib/armeabi-v7a/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 2204372
+      "Size": 2879608
     },
     "lib/armeabi-v7a/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 187356
+      "Size": 235400
     },
     "lib/armeabi-v7a/libaot-System.Xml.dll.so": {
-      "Size": 5967900
+      "Size": 7876800
     },
     "lib/armeabi-v7a/libaot-System.Xml.Linq.dll.so": {
-      "Size": 328140
+      "Size": 410784
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 48384
+      "Size": 59408
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 1643404
+      "Size": 2092912
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 42972
+      "Size": 50416
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 49516
+      "Size": 59388
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 220160
+      "Size": 272676
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 1716920
+      "Size": 2189164
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 156600
+      "Size": 192216
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 501832
+      "Size": 633088
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 41148
+      "Size": 48452
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 42708
+      "Size": 51904
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 42792
+      "Size": 52512
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 21376
+      "Size": 24612
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 116324
+      "Size": 145424
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 1462180
+      "Size": 1794660
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 34784
+      "Size": 41572
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 97908
+      "Size": 116716
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 205192
+      "Size": 250088
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 5411984
+      "Size": 6954228
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 239268
+      "Size": 309552
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 270688
+      "Size": 281164
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 3830708
+      "Size": 4833316
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 136636
+      "Size": 146100
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 547080
+      "Size": 680912
     },
     "lib/armeabi-v7a/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 609776
+      "Size": 749908
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -275,133 +275,133 @@
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 133596
+      "Size": 142832
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
-      "Size": 46232
+      "Size": 37964
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 824880
+      "Size": 849884
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 6322112
+      "Size": 6416724
     },
     "lib/x86/libaot-Mono.Security.dll.so": {
-      "Size": 414092
+      "Size": 429788
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 8036132
+      "Size": 8422168
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 3159460
+      "Size": 3289008
     },
     "lib/x86/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 25860
+      "Size": 17524
     },
     "lib/x86/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 74616
+      "Size": 67364
     },
     "lib/x86/libaot-System.Core.dll.so": {
-      "Size": 2140368
+      "Size": 2287256
     },
     "lib/x86/libaot-System.Data.dll.so": {
-      "Size": 2960776
+      "Size": 3106352
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 3648636
+      "Size": 3816660
     },
     "lib/x86/libaot-System.Drawing.Common.dll.so": {
-      "Size": 73388
+      "Size": 66640
     },
     "lib/x86/libaot-System.Net.Http.dll.so": {
-      "Size": 1115604
+      "Size": 1158812
     },
     "lib/x86/libaot-System.Numerics.dll.so": {
-      "Size": 155312
+      "Size": 155756
     },
     "lib/x86/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 2052860
+      "Size": 2180408
     },
     "lib/x86/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 181388
+      "Size": 188936
     },
     "lib/x86/libaot-System.Xml.dll.so": {
-      "Size": 5452864
+      "Size": 5685348
     },
     "lib/x86/libaot-System.Xml.Linq.dll.so": {
-      "Size": 304328
+      "Size": 310800
     },
     "lib/x86/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 55800
+      "Size": 47704
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 1563364
+      "Size": 1559952
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 46452
+      "Size": 38108
     },
     "lib/x86/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 52816
+      "Size": 44488
     },
     "lib/x86/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 213500
+      "Size": 209368
     },
     "lib/x86/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 1640444
+      "Size": 1638520
     },
     "lib/x86/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 154632
+      "Size": 146636
     },
     "lib/x86/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 478488
+      "Size": 475108
     },
     "lib/x86/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 44632
+      "Size": 36280
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 46156
+      "Size": 38132
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 46192
+      "Size": 42128
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 25180
+      "Size": 21056
     },
     "lib/x86/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 114672
+      "Size": 110992
     },
     "lib/x86/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 1390544
+      "Size": 1390192
     },
     "lib/x86/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 38388
+      "Size": 34452
     },
     "lib/x86/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 96772
+      "Size": 93024
     },
     "lib/x86/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 198464
+      "Size": 191132
     },
     "lib/x86/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 4971060
+      "Size": 5116508
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 234068
+      "Size": 227528
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 192512
+      "Size": 184160
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 3529232
+      "Size": 3643272
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 103236
+      "Size": 94904
     },
     "lib/x86/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 501020
+      "Size": 509984
     },
     "lib/x86/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 589908
+      "Size": 583296
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -419,7 +419,7 @@
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 136588
+      "Size": 141596
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 36435140
+  "PackageSize": 41891012
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
@@ -11,7 +11,7 @@
       "Size": 68737
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 565320
+      "Size": 565323
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68437
@@ -116,7 +116,7 @@
       "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114914
+      "Size": 114917
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
       "Size": 367737
@@ -131,94 +131,94 @@
       "Size": 43506
     },
     "classes.dex": {
-      "Size": 2652924
+      "Size": 2639828
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
-      "Size": 23224
+      "Size": 23692
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 296796
+      "Size": 457200
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 1079748
+      "Size": 1896308
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 2353648
+      "Size": 3527556
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 437332
+      "Size": 720148
     },
     "lib/armeabi-v7a/libaot-System.Core.dll.so": {
-      "Size": 788152
+      "Size": 1100260
     },
     "lib/armeabi-v7a/libaot-System.Data.dll.so": {
-      "Size": 176416
+      "Size": 426528
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 556868
+      "Size": 897968
     },
     "lib/armeabi-v7a/libaot-System.Net.Http.dll.so": {
-      "Size": 99884
+      "Size": 164652
     },
     "lib/armeabi-v7a/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 117192
+      "Size": 270996
     },
     "lib/armeabi-v7a/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 16776
+      "Size": 25760
     },
     "lib/armeabi-v7a/libaot-System.Xml.dll.so": {
-      "Size": 217492
+      "Size": 601068
     },
     "lib/armeabi-v7a/libaot-System.Xml.Linq.dll.so": {
-      "Size": 31912
+      "Size": 50204
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 13592
+      "Size": 12468
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 110812
+      "Size": 242324
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 24708
+      "Size": 35252
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 76928
+      "Size": 192156
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 33012
+      "Size": 42896
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 58532
+      "Size": 95296
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 111164
+      "Size": 214904
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 24188
+      "Size": 28476
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 31804
+      "Size": 45776
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 1985956
+      "Size": 2831940
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 13728
+      "Size": 18712
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 270688
+      "Size": 277200
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 1483524
+      "Size": 1971376
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 113568
+      "Size": 122172
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 93736
+      "Size": 131496
     },
     "lib/armeabi-v7a/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 59152
+      "Size": 98024
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
@@ -236,94 +236,94 @@
       "Size": 48844
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 143740
+      "Size": 141260
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
-      "Size": 27028
+      "Size": 19112
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 273584
+      "Size": 277860
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 902032
+      "Size": 911652
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 2079504
+      "Size": 2150468
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 385724
+      "Size": 383552
     },
     "lib/x86/libaot-System.Core.dll.so": {
-      "Size": 728760
+      "Size": 741508
     },
     "lib/x86/libaot-System.Data.dll.so": {
-      "Size": 130480
+      "Size": 125684
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 479884
+      "Size": 487232
     },
     "lib/x86/libaot-System.Net.Http.dll.so": {
-      "Size": 91188
+      "Size": 82796
     },
     "lib/x86/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 87968
+      "Size": 80400
     },
     "lib/x86/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 20708
+      "Size": 13616
     },
     "lib/x86/libaot-System.Xml.dll.so": {
-      "Size": 135404
+      "Size": 128724
     },
     "lib/x86/libaot-System.Xml.Linq.dll.so": {
-      "Size": 31644
+      "Size": 22856
     },
     "lib/x86/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 17532
+      "Size": 8492
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 89580
+      "Size": 79604
     },
     "lib/x86/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 28464
+      "Size": 20440
     },
     "lib/x86/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 56124
+      "Size": 45764
     },
     "lib/x86/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 36676
+      "Size": 26976
     },
     "lib/x86/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 49720
+      "Size": 45464
     },
     "lib/x86/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 93812
+      "Size": 85944
     },
     "lib/x86/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 27932
+      "Size": 19244
     },
     "lib/x86/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 35480
+      "Size": 26248
     },
     "lib/x86/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 1769736
+      "Size": 1820860
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 21764
+      "Size": 11384
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 192512
+      "Size": 182040
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 1318988
+      "Size": 1353492
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 80600
+      "Size": 71196
     },
     "lib/x86/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 85124
+      "Size": 79564
     },
     "lib/x86/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 54564
+      "Size": 47020
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
@@ -341,7 +341,7 @@
       "Size": 61112
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 145724
+      "Size": 140024
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2165,5 +2165,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 17713830
+  "PackageSize": 19475110
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6685
Context: fd5f31cc89648957243f31ba8fd7af7fccba11e4

So far, `Xamarin.Android` has been using a GNU Binutils toolchain to compile and link native assembler code we generate
during application build.  Unfortunately, Binutils have a problem with certain filename encodings on Windows and so we
decided to switch to an LLVM-based toolchain which handles such file names without issues.

However, since Mono/dotnet AOT expects a GNU build chain, it was necessary to implement a GNU Assembler (`gas`) wrapper
around the LLVM `llvm-mc` assembler, so that command lines used by the Mono AOT compiler keep working fine.

Since LLVM utilities are multi-target by default and, unlike GNU Binutils, they don't need separate builds of every utility,
we provide GNU Binutils architecture-prefixed wrapper scripts which invoke their LLVM counterparts with appropriate parameters.

The following LLVM utilities are included:

 - `llvm-mc` (assembler)
 - `lld` (linker)
 - `llvm-strip`
