### PR TITLE
[tests] fix logcat-Release-full.log name

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -26,7 +26,7 @@
     <AvdLaunchTimeoutMinutes Condition=" '$(AvdLaunchTimeoutMinutes)' == '' ">5</AvdLaunchTimeoutMinutes>
     <AvdLaunchTimeoutSeconds>$([MSBuild]::Multiply($(AvdLaunchTimeoutMinutes), 60))</AvdLaunchTimeoutSeconds>
     <AvdLaunchTimeoutMS>$([MSBuild]::Multiply($(AvdLaunchTimeoutSeconds), 1000))</AvdLaunchTimeoutMS>
-    <_LogcatFilename>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)-full.log</_LogcatFilename>
+    <_LogcatFilename>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)-full.log</_LogcatFilename>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5681472&view=logs&j=5ded96ba-e325-5baf-fde0-f1868aa3be52&t=b96eb06d-fc11-5c8d-c258-ab86ed07ddc3&l=384

In some cases, failed tests hit the error:

    Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI failed: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.
    ---> System.IO.IOException: The file '/Users/runner/work/1/a/TestRelease/logcat-Release-full.log' already exists.
    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
    at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
    at System.IO.File.Copy(String sourceFileName, String destFileName, Boolean overwrite)
    at Xamarin.Android.Prepare.Utilities.CopyFileInternal(String sourceFilePath, String destinationDirectory, String destinationFileName, Boolean overwriteDestinationFile) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Utilities.cs:line 433
    at Xamarin.Android.Prepare.Utilities.CopyFilesSimple(IEnumerable`1 sourceFiles, String destinationDirectory, Boolean overwriteDestinationFile) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Utilities.cs:line 385
    at Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI.CopyExtraTestFiles(String destinationRoot, Context context) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs:line 102
    at Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI.<>c__DisplayClass1_0.<Execute>b__0() in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs:line 23
    at System.Threading.Tasks.Task.InnerInvoke()
    at System.Threading.Tasks.Task.<>c.<.cctor>b__271_0(Object obj)
    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
    --- End of stack trace from previous location ---
    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
    --- End of stack trace from previous location ---
    at Xamarin.Android.Prepare.Step_CopyExtraResultFilesForCI.Execute(Context context) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs:line 22
    at Xamarin.Android.Prepare.Step.Run(Context context) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Step.cs:line 42
    at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 37
    --- End of inner exception stack trace ---
    at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 48
    at Xamarin.Android.Prepare.Context.Execute() in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Application/Context.cs:line 831
    at Xamarin.Android.Prepare.App.Run(String[] args) in /Users/runner/work/1/s/xamarin-android/build-tools/xaprepare/xaprepare/Main.cs:line 171

Reviewing the MSBuild logic, there is a case where it looks like
`logcat-Release-full.log` would be used.

Let's put `$(TestFlavor)` in the file name, like we do elsewhere:

https://github.com/xamarin/xamarin-android/blob/f61cd81cdf7ae7c857724b37ffcf89479fe94501/build-tools/scripts/TestApks.targets#L250