### PR TITLE
[One .NET] don't pass satellite assemblies to the AOT compiler

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -34,7 +34,7 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
 
   <Target Name="_AndroidAotInputs">
     <ItemGroup>
-      <_AndroidAotInputs Include="@(ResolvedFileToPublish)" Condition=" '%(Extension)' == '.dll' " />
+      <_AndroidAotInputs Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' and '%(ResolvedFileToPublish.AssetType)' != 'resources' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -523,10 +523,6 @@ namespace UnnamedProject
 				Language = language,
 				IsRelease = isRelease,
 			};
-			if (Builder.UseDotNet && isFSharp && isRelease) {
-				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
-				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
-			}
 			proj.SetProperty ("AndroidUseIntermediateDesignerFile", "True");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
@@ -553,10 +549,6 @@ namespace UnnamedProject
 				Language = language,
 				IsRelease = isRelease,
 			};
-			if (Builder.UseDotNet && isFSharp && isRelease) {
-				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
-				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
-			}
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var designerPath = GetResourceDesignerPath (b, proj);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -270,22 +270,34 @@ class MemTest {
 			}
 		}
 
+		static object [] BuildBasicApplicationFSharpSource = new object [] {
+			new object[] {
+				/*isRelease*/ false,
+				/*aot*/       false,
+			},
+			new object[] {
+				/*isRelease*/ true,
+				/*aot*/       false,
+			},
+			new object[] {
+				/*isRelease*/ true,
+				/*aot*/       true,
+			},
+		};
+
 		[Test]
+		[TestCaseSource (nameof (BuildBasicApplicationFSharpSource))]
 		[Category ("Minor"), Category ("FSharp")]
 		[NonParallelizable] // parallel NuGet restore causes failures
-		public void BuildBasicApplicationFSharp ([Values (true, false)] bool isRelease)
+		public void BuildBasicApplicationFSharp (bool isRelease, bool aot)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				Language = XamarinAndroidProjectLanguage.FSharp,
 				IsRelease = isRelease,
+				AotAssemblies = aot,
 			};
-			if (Builder.UseDotNet && isRelease) {
-				//TODO: temporary until this is fixed: https://github.com/mono/linker/issues/1448
-				proj.AndroidLinkModeRelease = AndroidLinkMode.None;
-			}
-			using (var b = CreateApkBuilder ()) {
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-			}
+			using var b = CreateApkBuilder ();
+			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/64269

An F# test was failing in AOT builds with:

    Microsoft.Android.Sdk.Aot.targets(74,5): Precompiling failed for C:\src\xamarin-android\bin\TestDebug\temp\BuildBasicApplicationFSharpTrue\obj\Release\android-arm\aot-in\FSharp.Core.resources.dll.
    AOT of image obj\Release\android-arm\aot-in\FSharp.Core.resources.dll failed.
    Mono Ahead of Time compiler - compiling assembly C:\src\xamarin-android\bin\TestDebug\temp\BuildBasicApplicationFSharpTrue\obj\Release\android-arm\aot-in\FSharp.Core.resources.dll
    AOTID 302CA46D-4000-DCAD-1A9F-642D849470DE
    Using profile data file 'C:\Program Files\dotnet\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.dotnet-release-aot-by-default.36\targets\dotnet.aotprofile'
    Added 0 methods from profile.
    Compiled: 0/0
    Executing the native assembler: "C:\Program Files\dotnet\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.dotnet-release-aot-by-default.36\tools\binutils\arm-linux-androideabi-as"   -mfpu=vfp3 -o obj\Release\android-arm\aot\armeabi-v7a\FSharp.Core.resources\temp.s.o obj\Release\android-arm\aot\armeabi-v7a\FSharp.Core.resources\temp.s
    Executing the native linker: "C:\Program Files\dotnet\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.dotnet-release-aot-by-default.36\tools\binutils\arm-linux-androideabi-ld" -Bsymbolic -shared -o obj\Release\android-arm\aot\FSharp.Core.resources.dll.so.tmp  obj\Release\android-arm\aot\armeabi-v7a\FSharp.Core.resources\temp.s.o
    Stripping the binary: "C:\Program Files\dotnet\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.dotnet-release-aot-by-default.36\tools\binutils\arm-linux-androideabi-strip" --strip-symbol=\$a --strip-symbol=\$d obj\Release\android-arm\aot\FSharp.Core.resources.dll.so.tmp [C:\src\xamarin-android\bin\TestDebug\temp\BuildBasicApplicationFSharpTrue\UnnamedProject.fsproj]

It turns out we shouldn't be passing satellite assemblies to the AOT
compiler, they appear to be included in `@(ResolvedFileToPublish)`:

    <ItemGroup>
      <_AndroidAotInputs Include="@(ResolvedFileToPublish)" Condition=" '%(Extension)' == '.dll' " />
    </ItemGroup>

Viewing these assemblies, I see the metadata
`%(ResolvedFileToPublish.AssetType)` is equal to `resources`. I think
we can simply check for this and ignore these files.

The F# test I parameterized to include an AOT build.

I also removed a `TODO` on F# tests, since this is fixed now:

https://github.com/mono/linker/issues/1448