### PR TITLE
[tests] update BuildReleaseArm64SimpleDotNet.apkdesc

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,10 +5,10 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 55086
+      "Size": 54996
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 83182
+      "Size": 87650
     },
     "assemblies/rc.bin": {
       "Size": 1045
@@ -17,13 +17,13 @@
       "Size": 10157
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 520945
+      "Size": 521019
     },
     "assemblies/System.Runtime.dll": {
       "Size": 2410
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3551
+      "Size": 3550
     },
     "classes.dex": {
       "Size": 345328
@@ -44,7 +44,7 @@
       "Size": 150024
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12384
+      "Size": 12376
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2697108
+  "PackageSize": 2701204
 }


### PR DESCRIPTION
Some combination of merging:

* 32cff438
* f61cd81c

We missed an update to this file, as `Mono.Android.dll`'s size
increased beyond the threshold:

    stdErr: Error: apkdiff: File 'assemblies/Mono.Android.dll' has changed by 4,468 bytes (5.10 %). This exceeds the threshold of 5.00 %.
    Error: apkdiff: Size regression occured, 1 check(s) failed.