### PR TITLE
[main] Add maestro dependencies for dotnet/maui

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,138 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>059caa278b1e5a62d0d60c9d84bdd737b04e6da8</Sha>
     </Dependency>
+     <Dependency Name="Microsoft.Extensions.Primitives" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Hosting" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Options" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipelines" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="6.0.2-mauipre.1.22074.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>63715256cc94963d608ef3d683d2529332c5140c</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20181.7">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,39 @@
     <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.20181.7</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>6.0.2-mauipre.1.22075.3</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsPrimitivesPackageVersion>
+    <MicrosoftExtensionsHostingPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsHostingPackageVersion>
+    <MicrosoftExtensionsHostingAbstractionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsHostingAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingDebugPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingDebugPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersCompositePackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsFileProvidersCompositePackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
+    <MicrosoftExtensionsLoggingConfigurationPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingEventLogPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingEventLogPackageVersion>
+    <MicrosoftExtensionsLoggingEventSourcePackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsLoggingEventSourcePackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>6.0.2-mauipre.1.22074.5</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>6.0.2-mauipre.1.22074.5</SystemCodeDomPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.2-mauipre.1.22074.5</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.2-mauipre.1.22074.5</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>6.0.2-mauipre.1.22074.5</SystemDiagnosticsEventLogPackageVersion>
+    <SystemIOPipelinesPackageVersion>6.0.2-mauipre.1.22074.5</SystemIOPipelinesPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>6.0.2-mauipre.1.22074.5</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>6.0.2-mauipre.1.22074.5</SystemTextJsonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/4424

Maestro bumps in dotnet/maui are doing things like:

    -<Dependency Name="Microsoft.Extensions.Hosting" Version="6.0.2-mauipre.1.22069.5" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
    +<Dependency Name="Microsoft.Extensions.Hosting" Version="6.0.0" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">

We have a dependency chain such as:

* dotnet/maui -> depends on
* xamarin/xamarin-android -> depends on
* dotnet/runtime

The issue being that `Microsoft.Extensions.Hosting` is not defined in
xamarin-android's `Version.Details.xml`. For Maestro to "know" about
parent dependencies, sometimes you have to list additional
dependencies in repositories that don't use them. In order for
dependencies to use them appropriately.