### PR TITLE
[MSBuildDeviceIntegration] Add nightly localization unit tests.

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
 			var showWindow = ShowWindow ? "" : " -no-window";
-			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-boot-anim -no-audio -no-snapshot -cache-size 512 -timezone \"Etc/UTC\" {showWindow}{port} -avd {ImageName}";
+			var arguments = $"{Arguments ?? string.Empty} -verbose -detect-image-hang -logcat-output \"{LogcatFile}\" -no-boot-anim -no-audio -no-snapshot -cache-size 512 -change-locale en-US -timezone \"Etc/UTC\" {showWindow}{port} -avd {ImageName}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -171,7 +171,7 @@ stages:
     parameters:
       node_id: 4
 
-  # Localisation test jobs
+  # Localization test jobs
   - template: yaml-templates/run-localization-tests.yaml
     parameters:
       node_id: 1

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -212,4 +212,12 @@ stages:
     parameters:
       node_id: 10
 
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 11
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 12
+
   - template: yaml-templates/run-systemapp-tests.yaml

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -188,4 +188,28 @@ stages:
     parameters:
       node_id: 4
 
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 5
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 6
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 7
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 8
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 9
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 10
+
   - template: yaml-templates/run-systemapp-tests.yaml

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -171,4 +171,21 @@ stages:
     parameters:
       node_id: 4
 
+  # Localisation test jobs
+- template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 1
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 2
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 3
+
+  - template: yaml-templates/run-localization-tests.yaml
+    parameters:
+      node_id: 4
+
   - template: yaml-templates/run-systemapp-tests.yaml

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -172,7 +172,7 @@ stages:
       node_id: 4
 
   # Localisation test jobs
-- template: yaml-templates/run-localization-tests.yaml
+  - template: yaml-templates/run-localization-tests.yaml
     parameters:
       node_id: 1
 

--- a/build-tools/automation/yaml-templates/run-localization-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-localization-tests.yaml
@@ -35,8 +35,9 @@ jobs:
     - template: run-nunit-tests.yaml
       parameters:
         testRunTitle: LocalizationTests On Device - macOS
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll
-        nunitConsoleExtraArgs: --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckLocalizationIsCorrectNode${{ parameters.node_id }}"
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+        useDotNet: true
+        dotNetTestExtraArgs:  --filter "Name~CheckLocalizationIsCorrectNode${{ parameters.node_id }}"
         testResultsFile: TestResult-LocalizationTests-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1

--- a/build-tools/automation/yaml-templates/run-localization-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-localization-tests.yaml
@@ -1,4 +1,4 @@
- Runs Localization tests against an emulator running on macOS
+# Runs Localization tests against an emulator running on macOS
 
 parameters:
   node_id: 0

--- a/build-tools/automation/yaml-templates/run-localization-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-localization-tests.yaml
@@ -1,0 +1,56 @@
+ Runs Localization tests against an emulator running on macOS
+
+parameters:
+  node_id: 0
+
+jobs:
+  - job: mac_localization_tests_${{ parameters.node_id }}
+    displayName: Localization Emulator Tests ${{ parameters.node_id }}
+    pool:
+      vmImage: $(HostedMacImage)
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: setup-test-environment.yaml
+
+    - template: run-xaprepare.yaml
+      parameters:
+        arguments: --s=EmulatorTestDependencies
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - template: run-nunit-tests.yaml
+      parameters:
+        testRunTitle: LocalizationTests On Device - macOS
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net472/MSBuildDeviceIntegration.dll
+        nunitConsoleExtraArgs: --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckLocalizationIsCorrectNode${{ parameters.node_id }}"
+        testResultsFile: TestResult-LocalizationTests-Node${{ parameters.node_id }}-$(XA.Build.Configuration).xml
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - template: upload-results.yaml
+      parameters:
+        artifactName: Test Results - TimeZoneInfo With Emulator - macOS - ${{ parameters.node_id }}
+
+    - template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-localization-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-localization-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     displayName: Localization Emulator Tests ${{ parameters.node_id }}
     pool:
       vmImage: $(HostedMacImage)
-    timeoutInMinutes: 120
+    timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -65,8 +65,8 @@ jobs:
         useDotNet: ${{ eq(parameters.target_framework, parameters.dotnet_targetframework) }}
         testRunTitle: MSBuildDeviceIntegration On Device - macOS-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
-        nunitConsoleExtraArgs: --where "cat == Node-${{ parameters.node_id }} && cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
-        dotNetTestExtraArgs: --filter "TestCategory = Node-${{ parameters.node_id }} & TestCategory != TimeZoneInfo ${{ parameters.nunit_categories }}"
+        nunitConsoleExtraArgs: --where "cat == Node-${{ parameters.node_id }} && cat != SystemApplication && cat != TimeZoneInfo && cat != Localization && cat != SmokeTests ${{ parameters.nunit_categories }}"
+        dotNetTestExtraArgs: --filter "TestCategory = Node-${{ parameters.node_id }} & TestCategory != TimeZoneInfo & TestCategory != Localization ${{ parameters.nunit_categories }}"
         testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-$(XA.Build.Configuration).xml
 
     # Tests with no "Node" category. This should be empty, but just in case! Only run these tests on node 1
@@ -76,8 +76,8 @@ jobs:
           useDotNet: ${{ eq(parameters.target_framework, parameters.dotnet_targetframework) }}
           testRunTitle: MSBuildDeviceIntegration On Device - macOS-NoNode - ${{ parameters.job_suffix }}
           testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/${{ parameters.target_framework }}/MSBuildDeviceIntegration.dll
-          nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3  && cat != Node-4 && cat != SystemApplication && cat != TimeZoneInfo && cat != SmokeTests ${{ parameters.nunit_categories }}"
-          dotNetTestExtraArgs: --filter "TestCategory != Node-1 & TestCategory != Node-2 & TestCategory != Node-3 & TestCategory != Node-4 & TestCategory != TimeZoneInfo ${{ parameters.nunit_categories }}"
+          nunitConsoleExtraArgs: --where "cat != Node-1 && cat != Node-2 && cat != Node-3 && cat != Node-4 && cat != SystemApplication && cat != TimeZoneInfo && cat != Localization && cat != SmokeTests ${{ parameters.nunit_categories }}"
+          dotNetTestExtraArgs: --filter "TestCategory != Node-1 & TestCategory != Node-2 & TestCategory != Node-3 & TestCategory != Node-4 & TestCategory != TimeZoneInfo & TestCategory != Localization ${{ parameters.nunit_categories }}"
           testResultsFile: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}-NoNode-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Android.Build.Tests
 			if (!HasDevices) {
 				// something went wrong with the emulator.
 				// lets restart it.
+				TestContext.Out.WriteLine ($"{nameof(CheckDevice)} is restarting the emulator.");
 				RestartDevice (Path.Combine (Root, "Emulator.csproj"));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="${ROOT_NAMESPACE}.MainPage">
     <StackLayout>
-        <Label Text="Welcome to Xamarin.Forms!" 
+        <Label x:Name="myLabel"
+           Text="Welcome to Xamarin.Forms!"
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand" />
         <Button Text="Click Me" Clicked="Button_Clicked" x:Name="myXFButton" AutomationId="myXFButton" />

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Android.Build.Tests
 			Console.WriteLine ($""TimeZoneInfoNative={Java.Util.TimeZone.Default.ID}"");
 			Console.WriteLine ($""TimeZoneInfo={TimeZoneInfo.Local.DisplayName}"");
 			Console.WriteLine ($""CurrentCulture={System.Globalization.CultureInfo.CurrentCulture.Name}"");
+			myLabel.Text = Strings.SomeString;
 ");
 			source = source.Replace ("Console.WriteLine (\"Button was Clicked!\");", @"Console.WriteLine (""Button was Clicked!"");
 			Console.WriteLine ($""TimeZoneInfoClick={TimeZoneInfo.Local.DisplayName}"");
@@ -405,6 +406,7 @@ namespace Xamarin.Android.Build.Tests
 			string currentLocale = RunAdbCommand ("shell getprop persist.sys.locale")?.Trim ();
 			string deviceLocale = string.Empty;
 			string logFile = Path.Combine (Root, builder.ProjectDirectory, $"startup-logcat-{locale.Replace ("/", "-")}.log");
+			string monitorLogFile = Path.Combine (Root, builder.ProjectDirectory, $"monitor-logcat-{locale.Replace ("/", "-")}.log");
 			try {
 				for (int attempt = 0; attempt < 5; attempt++) {
 					RunAdbCommand ($"shell su root setprop persist.sys.locale {locale}");
@@ -413,7 +415,7 @@ namespace Xamarin.Android.Build.Tests
 						if (l.Contains ("ActivityManager: Finished processing BOOT_COMPLETED for"))
 							return true;
 						return false;
-					}, logFile, timeout:30);
+					}, monitorLogFile, timeout:30);
 					WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 					deviceLocale = RunAdbCommand ("shell getprop persist.sys.locale")?.Trim ();
 					if (deviceLocale == locale) {
@@ -448,10 +450,11 @@ namespace Xamarin.Android.Build.Tests
 						if (l.Contains ("ActivityManager: Finished processing BOOT_COMPLETED for"))
 							return true;
 						return false;
-					}, logFile, timeout:30);
+					}, monitorLogFile, timeout:30);
 				}
 				if (File.Exists (logFile)) {
 					TestContext.AddTestAttachment (logFile);
+					TestContext.AddTestAttachment (monitorLogFile);
 				}
 			}
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Android.Build.Tests
 			var source = mainPage.TextContent ().Replace ("InitializeComponent ();", @"InitializeComponent ();
 			Console.WriteLine ($""TimeZoneInfoNative={Java.Util.TimeZone.Default.ID}"");
 			Console.WriteLine ($""TimeZoneInfo={TimeZoneInfo.Local.DisplayName}"");
+			Console.WriteLine ($""LocaleNative={Java.Util.Locale.Default.Language}-{Java.Util.Locale.Default.Country}"");
 			Console.WriteLine ($""CurrentCulture={System.Globalization.CultureInfo.CurrentCulture.Name}"");
 			Console.WriteLine ($""Strings.SomeString={Strings.SomeString}"");
 			myLabel.Text = Strings.SomeString;

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -223,8 +223,10 @@ namespace Xamarin.Android.Build.Tests
 			};
 
 			foreach (var tz in NodaTime.DateTimeZoneProviders.Tzdb.Ids) {
-				if (ignore.Contains (tz))
+				if (ignore.Contains (tz)) {
+					TestContext.WriteLine ($"Ignoring {tz} TimeZone Test");
 					continue;
+				}
 				tests.Add (new object [] {
 					tz,
 				});
@@ -308,8 +310,14 @@ namespace Xamarin.Android.Build.Tests
 				"zh-Hans",
 			};
 			foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures)) {
-				if (ignore.Contains (ci.Name))
+				if (ci.Name.Length > 5 && ci.Name[2] != '-') {
+					TestContext.WriteLine ($"Skipping {ci.Name} Localization Test");
 					continue;
+				}
+				if (ignore.Contains (ci.Name)) {
+					TestContext.WriteLine ($"Ignoring {ci.Name} Localization Test");
+					continue;
+				}
 				tests.Add (new object [] {
 					ci.Name,
 				});
@@ -358,7 +366,7 @@ namespace Xamarin.Android.Build.Tests
 							return true;
 						return false;
 					}, logFile, timeout:30);
-					WaitFor ((int)TimeSpan.FromSeconds (10).TotalMilliseconds);
+					WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 					deviceLocale = RunAdbCommand ("shell getprop persist.sys.locale")?.Trim ();
 					if (deviceLocale == locale) {
 						break;

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -307,7 +307,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		private const int LOCALIZATION_NODE_COUNT = 10;
+		private const int LOCALIZATION_NODE_COUNT = 12;
 
 		static object [] GetLocalizationTestCases (int node)
 		{

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -320,25 +320,25 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 0 })]
-		[Category ("Localisation")]
+		[Category ("Localization")]
 		[Retry (2)]
 		public void CheckLocalizationIsCorrectNode1 (string locale) => CheckLocalizationIsCorrect (locale);
 
 		[Test]
 		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 1 })]
-		[Category ("Localisation")]
+		[Category ("Localization")]
 		[Retry (2)]
 		public void CheckLocalizationIsCorrectNode2 (string locale) => CheckLocalizationIsCorrect (locale);
 
 		[Test]
 		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 2 })]
-		[Category ("Localisation")]
+		[Category ("Localization")]
 		[Retry (2)]
 		public void CheckLocalizationIsCorrectNode3 (string locale) => CheckLocalizationIsCorrect (locale);
 
 		[Test]
 		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 3 })]
-		[Category ("Localisation")]
+		[Category ("Localization")]
 		[Retry (2)]
 		public void CheckLocalizationIsCorrectNode4 (string locale) => CheckLocalizationIsCorrect (locale);
 

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -309,18 +309,8 @@ namespace Xamarin.Android.Build.Tests
 		static object [] GetLocalizationTestCases (int node)
 		{
 			List<object> tests = new List<object> ();
-			//var rnd = new Random (45623452);
 			var ignore = new string [] {
 				"zh-Hans",
-				// "ca-ES",
-				// "id-ID",
-				// "ts-ZA",
-				// "fi-FI",
-				// "nl-NL",
-				// "he-IL",
-				// "fr-FR",
-				// "el-GR",
-				// "de-DE",
 			};
 			foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures)) {
 				if (ci.Name.Length > 5) {
@@ -331,10 +321,6 @@ namespace Xamarin.Android.Build.Tests
 					TestContext.WriteLine ($"Ignoring {ci.Name} Localization Test");
 					continue;
 				}
-				// if (rnd.NextDouble () < 0.7) {
-				// 	TestContext.WriteLine ($"Randomly Skipping {ci.Name} Localization Test");
-				// 	continue;
-				// }
 				tests.Add (new object [] {
 					ci.Name,
 				});
@@ -422,7 +408,7 @@ namespace Xamarin.Android.Build.Tests
 						if (l.Contains ("ActivityManager: Finished processing BOOT_COMPLETED for"))
 							return true;
 						return false;
-					}, monitorLogFile, timeout:30)) {
+					}, monitorLogFile, timeout:60)) {
 						TestContext.Out.WriteLine ($"{nameof(CheckLocalizationIsCorrect)}: wating for boot to complete failed or timed out.");
 					}
 					WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
@@ -460,11 +446,13 @@ namespace Xamarin.Android.Build.Tests
 						if (l.Contains ("ActivityManager: Finished processing BOOT_COMPLETED for"))
 							return true;
 						return false;
-					}, monitorLogFile, timeout:30);
+					}, monitorLogFile, timeout:60);
 					WaitFor ((int)TimeSpan.FromSeconds (2).TotalMilliseconds);
 				}
 				if (File.Exists (logFile)) {
 					TestContext.AddTestAttachment (logFile);
+				}
+				if (File.Exists (monitorLogFile)) {
 					TestContext.AddTestAttachment (monitorLogFile);
 				}
 			}

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Android.Build.Tests
 			Console.WriteLine ($""TimeZoneInfoNative={Java.Util.TimeZone.Default.ID}"");
 			Console.WriteLine ($""TimeZoneInfo={TimeZoneInfo.Local.DisplayName}"");
 			Console.WriteLine ($""CurrentCulture={System.Globalization.CultureInfo.CurrentCulture.Name}"");
+			Console.WriteLine ($""Strings.SomeString={Strings.SomeString}"");
 			myLabel.Text = Strings.SomeString;
 ");
 			source = source.Replace ("Console.WriteLine (\"Button was Clicked!\");", @"Console.WriteLine (""Button was Clicked!"");
@@ -311,7 +312,6 @@ namespace Xamarin.Android.Build.Tests
 		{
 			List<object> tests = new List<object> ();
 			var ignore = new string [] {
-				"zh-Hans",
 			};
 			foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures)) {
 				if (ci.Name.Length > 5) {
@@ -432,7 +432,7 @@ namespace Xamarin.Android.Build.Tests
 				string logCatFile = Path.Combine (Root, builder.ProjectDirectory, $"locale-logcat-{locale.Replace ("/", "-")}.log");
 				ClickButton (proj.PackageName, "myXFButton", "CLICK ME");
 				Assert.IsTrue (MonitorAdbLogcat ((l) => {
-					if (l.Contains ("StringsClick=")) {
+					if (l.Contains ("StringsClick=") || l.Contains ("Strings.SomeString=")) {
 						line = l;
 						return l.Contains ($"{locale}");
 					}

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -313,6 +313,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			List<object> tests = new List<object> ();
 			var ignore = new string [] {
+				"he-IL", // maps to wi-IL on Android.
+				"id-ID", // maps to in-ID on Android
 			};
 			foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures)) {
 				if (ci.Name.Length > 5) {

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -306,12 +306,17 @@ namespace Xamarin.Android.Build.Tests
 		static object [] GetLocalizationTestCases (int node)
 		{
 			List<object> tests = new List<object> ();
-			var rnd = new Random ();
+			var rnd = new Random (45623452);
 			var ignore = new string [] {
 				"zh-Hans",
+				"ca-ES",
+				"id-ID",
+				"ts-ZA",
+				"fi-FI",
+				"nl-NL",
 			};
 			foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.SpecificCultures)) {
-				if (ci.Name.Length > 5 && ci.Name[2] != '-') {
+				if (ci.Name.Length > 5) {
 					TestContext.WriteLine ($"Skipping {ci.Name} Localization Test");
 					continue;
 				}
@@ -320,7 +325,7 @@ namespace Xamarin.Android.Build.Tests
 					continue;
 				}
 				if (rnd.NextDouble () < 0.7) {
-					TestContext.WriteLine ($"Randimly Skipping {ci.Name} Localization Test");
+					TestContext.WriteLine ($"Randomly Skipping {ci.Name} Localization Test");
 					continue;
 				}
 				tests.Add (new object [] {

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -306,6 +306,7 @@ namespace Xamarin.Android.Build.Tests
 		static object [] GetLocalizationTestCases (int node)
 		{
 			List<object> tests = new List<object> ();
+			var rnd = new Random ();
 			var ignore = new string [] {
 				"zh-Hans",
 			};
@@ -316,6 +317,10 @@ namespace Xamarin.Android.Build.Tests
 				}
 				if (ignore.Contains (ci.Name)) {
 					TestContext.WriteLine ($"Ignoring {ci.Name} Localization Test");
+					continue;
+				}
+				if (rnd.NextDouble () < 0.7) {
+					TestContext.WriteLine ($"Randimly Skipping {ci.Name} Localization Test");
 					continue;
 				}
 				tests.Add (new object [] {

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -434,7 +434,10 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (MonitorAdbLogcat ((l) => {
 					if (l.Contains ("StringsClick=") || l.Contains ("Strings.SomeString=")) {
 						line = l;
-						return l.Contains ($"{locale}");
+						bool result = l.Contains ($"{locale}");
+						if (l.Contains ("Strings.SomeString=") && !result)
+							return false;
+						return result;
 					}
 					return false;
 				}, logCatFile, timeout:30), $"Locale should have been {locale}. We found : {line}");

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -212,7 +212,7 @@ namespace Xamarin.Android.Build.Tests
 			}, Path.Combine (Root, builder.ProjectDirectory, "button-logcat.log")), "Button Should have been Clicked.");
 		}
 
-		private const int NODE_COUNT = 4;
+		private const int TIMEZONE_NODE_COUNT = 4;
 
 		static object [] GetTimeZoneTestCases (int node)
 		{
@@ -231,7 +231,7 @@ namespace Xamarin.Android.Build.Tests
 					tz,
 				});
 			}
-			return tests.Where (p => tests.IndexOf (p) % NODE_COUNT == node).ToArray ();
+			return tests.Where (p => tests.IndexOf (p) % TIMEZONE_NODE_COUNT == node).ToArray ();
 		}
 
 		[Test]
@@ -303,6 +303,8 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		private const int LOCALIZATION_NODE_COUNT = 10;
+
 		static object [] GetLocalizationTestCases (int node)
 		{
 			List<object> tests = new List<object> ();
@@ -324,16 +326,16 @@ namespace Xamarin.Android.Build.Tests
 					TestContext.WriteLine ($"Ignoring {ci.Name} Localization Test");
 					continue;
 				}
-				if (rnd.NextDouble () < 0.7) {
-					TestContext.WriteLine ($"Randomly Skipping {ci.Name} Localization Test");
-					continue;
-				}
+				// if (rnd.NextDouble () < 0.7) {
+				// 	TestContext.WriteLine ($"Randomly Skipping {ci.Name} Localization Test");
+				// 	continue;
+				// }
 				tests.Add (new object [] {
 					ci.Name,
 				});
 			}
 
-			return tests.Where (p => tests.IndexOf (p) % NODE_COUNT == node).ToArray ();
+			return tests.Where (p => tests.IndexOf (p) % LOCALIZATION_NODE_COUNT == node).ToArray ();
 		}
 
 		[Test]
@@ -359,6 +361,42 @@ namespace Xamarin.Android.Build.Tests
 		[Category ("Localization")]
 		[Retry (2)]
 		public void CheckLocalizationIsCorrectNode4 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 4 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode5 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 5 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode6 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 6 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode7 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 7 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode8 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 8 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode9 (string locale) => CheckLocalizationIsCorrect (locale);
+
+		[Test]
+		[TestCaseSource (nameof (GetLocalizationTestCases), new object [] { 9 })]
+		[Category ("Localization")]
+		[Retry (2)]
+		public void CheckLocalizationIsCorrectNode10 (string locale) => CheckLocalizationIsCorrect (locale);
 
 		public void CheckLocalizationIsCorrect (string locale)
 		{

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -143,7 +143,6 @@ namespace Xamarin.Android.NetTests {
 
 
 		[Test]
-		[Retry (2)]
 		public void CancelRequestViaProxy ()
 		{
 			using (var handler = CreateHandler ()) {

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -112,7 +112,7 @@ namespace Xamarin.Android.NetTests {
 			}
 		}
 
-		const int WaitTimeout = 5000;
+		const int WaitTimeout = 10000;
 
 		string port, TestHost, LocalServer;
 
@@ -143,6 +143,7 @@ namespace Xamarin.Android.NetTests {
 
 
 		[Test]
+		[Retry (2)]
 		public void CancelRequestViaProxy ()
 		{
 			using (var handler = CreateHandler ()) {


### PR DESCRIPTION
Lets add some unit tests for localization. These need to run on an
emulator like our timezone tests. We should do this on a nightly
test run as they take a long time to run.