### PR TITLE
[Xamarin.Android.Build.Tasks] improve <ManifestMerger/> error messages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -66,8 +66,8 @@ namespace Xamarin.Android.Tasks
 			at com.android.dx.command.Main.main(Main.java:106)
 		*/
 		const string ExceptionRegExString = @"(?<exception>java.lang.+):(?<error>.+)";
-		protected static readonly Regex CodeErrorRegEx = new Regex (CodeErrorRegExString, RegexOptions.Compiled);
-		protected static readonly Regex ExceptionRegEx = new Regex (ExceptionRegExString, RegexOptions.Compiled);
+		static readonly Regex codeErrorRegEx = new Regex (CodeErrorRegExString, RegexOptions.Compiled);
+		static readonly Regex exceptionRegEx = new Regex (ExceptionRegExString, RegexOptions.Compiled);
 		bool foundError = false;
 		List<string> errorLines = new List<string> ();
 		StringBuilder errorText = new StringBuilder ();
@@ -85,6 +85,10 @@ namespace Xamarin.Android.Tasks
 		protected override string ToolName {
 			get { return OS.IsWindows ? "java.exe" : "java"; }
 		}
+
+		protected virtual Regex CodeErrorRegEx => codeErrorRegEx;
+
+		protected virtual Regex ExceptionRegEx => exceptionRegEx;
 
 		protected override bool HandleTaskExecutionErrors ()
 		{
@@ -136,10 +140,8 @@ namespace Xamarin.Android.Tasks
 					errorText.Clear ();
 				}
 				file = match.Groups ["file"].Value;
-				line = int.Parse (match.Groups ["line"].Value) + 1;
 				var error = match.Groups ["error"].Value;
-				column = 0;
-
+				GetLineNumber (match.Groups ["line"].Value, out line, out column);
 				errorText.AppendLine (error);
 				return true;
 			} else if (exceptionMatch.Success) {
@@ -166,6 +168,12 @@ namespace Xamarin.Android.Tasks
 				errorText.AppendLine (singleLine);
 			}
 			return true;
+		}
+
+		protected virtual void GetLineNumber (string match, out int line, out int column)
+		{
+			line = int.Parse (match) + 1;
+			column = 0;
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6634

Adding a `[Service]` with `[IntentFilter]` requires you to specify
`[Service(Exported=true)]` in API 30. Newer versions of
`manifestmerger.jar` enforce this at build time -- instead of
previously you would only hit the error during `adb install`.

Unfortunately, Xamarin.Android displays the error message poorly:

    D : \agent\1\s\src\Essentials\samples\Samples\obj\Debug\net6.0-android\AndroidManifest.xml error :  [D:\agent\1\s\src\Essentials\samples\Samples\Essentials.Sample.csproj]

The error text is literally `D`!

To fix this:

1. Make `JavaToolTask.CodeErrorRegEx` overridable.

2. Provide a `Regex` to match the error messages that
   `manifestmerger.jar` gives for `AndroidManifest.xml` files.

We now get appropriate error messages with line numbers:

    obj\Debug\AndroidManifest.xml(12,5): java.exe error AMM0000: android:exported needs to be explicitly specified for element <service#crc642ecd25190884e03d.TestService>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.