### PR TITLE
[Xamarin.Android.Build.Tasks] add libaot-*.dll.so files to dso_cache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -354,8 +354,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			var uniqueNativeLibraries = new List<ITaskItem> ();
+			var seenNativeLibraryNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 			if (NativeLibraries != null) {
-				var seenNativeLibraryNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 				foreach (ITaskItem item in NativeLibraries) {
 					// We don't care about different ABIs here, just the file name
 					string name = Path.GetFileName (item.ItemSpec);
@@ -365,6 +365,19 @@ namespace Xamarin.Android.Tasks
 
 					seenNativeLibraryNames.Add (name);
 					uniqueNativeLibraries.Add (item);
+				}
+			}
+
+			// In "classic" Xamarin.Android, we need to add libaot-*.dll.so files
+			if (!UsingAndroidNETSdk && usesMonoAOT) {
+				foreach (var assembly in ResolvedAssemblies) {
+					string name = $"libaot-{Path.GetFileNameWithoutExtension (assembly.ItemSpec)}.dll.so";
+					if (seenNativeLibraryNames.Contains (name)) {
+						continue;
+					}
+
+					seenNativeLibraryNames.Add (name);
+					uniqueNativeLibraries.Add (new TaskItem (name));
 				}
 			}
 


### PR DESCRIPTION
In testing Profiled AOT, I found a problem in "classic"
Xamarin.Android that was working in .NET 6:

1. Build & run a Release build using AOT

2. Enable AOT-related logging via:

    adb shell setprop debug.mono.log=all,mono_log_level=debug,mono_log_mask=aot

Notice we are missing messages that AOT is being used! I was not able
to find messages like `libaot-` or `AOT: FOUND method`.

c227042b worked appropriately for .NET 6, because the build ordering is:

1. linker
2. AOT
3. `<GeneratePackageManagerJava/>`

The problem in "classic" Xamarin.Android, is the ordering is
different:

1. linker
2. `<GeneratePackageManagerJava/>`
3. AOT

And so the list of native libraries would not contain any
`libaot-*.dll.so` files.

The difference of ordering, is due to how .NET 6 runs an "inner" build
per `$(RuntimeIdentifier)`. It was much simpler to run the AOT
compiler inside the "inner" build to get things working.

To solve the problem, I think we should simply emit `libaot-*.dll.so`
file names in `<GeneratePackageManagerJava/>`. Trying to make c227042b
a .NET 6-only feature or reordering the build, seems like it would
complicate things.

I updated a test for this scenario.

After this change, I can see the AOT log messages, and things are
working again:

    02-02 13:22:59.665 24009 24009 D Mono    : Prepared to set up assembly 'HelloWorld' (HelloWorld.dll)
    02-02 13:22:59.665 24009 24009 V Mono    : Loading assembly HelloWorld (0x741faf83e0) into domain RootDomain (0x749fadedf0) and ALC 0x0
    02-02 13:22:59.665 24009 24009 D Mono    : Assembly HelloWorld[0x741faf83e0] added to domain RootDomain, ref_count=1
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: monodroid_dlopen: hash for name 'HelloWorld.dll.so' is 0xdacd7936300d6334
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: looking for hash 0xdacd7936300d6334
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: entry_hash == 0x8da9f07ad98f854a
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: entry_hash == 0xd32c30d21c7615fc
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: entry_hash == 0xe99c30c1484d7f4f
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: entry_hash == 0xe156906e01e8a274
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: dso_cache: entry_hash == 0xdacd7936300d6334
    02-02 13:22:59.665 24009 24009 D monodroid-assembly: monodroid_dlopen: hash match found, DSO name is 'libaot-HelloWorld.dll.so'
    02-02 13:22:59.665 24009 24009 I monodroid-assembly: Trying to load shared library '/data/app/~~-fEdInfI9lIjBKycz2PKJw==/com.xamarin.android.helloworld-Z3O_lA5hXtmCqwFkb8DAuw==/base.apk!/lib/arm64-v8a/libaot-HelloWorld.dll.so'
    02-02 13:22:59.666 24009 24009 W linker  : Warning: "/data/app/~~-fEdInfI9lIjBKycz2PKJw==/com.xamarin.android.helloworld-Z3O_lA5hXtmCqwFkb8DAuw==/base.apk!/lib/arm64-v8a/libaot-HelloWorld.dll.so" has no DT_SONAME (will use libaot-HelloWorld.dll.so instead) and will not work when the app moves to API level 23 or later (https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#missing-soname-enforced-for-api-level-23) (allowing for now because this app's target API level is still 21)
    02-02 13:22:59.666 24009 24009 V Mono    : AOT: module HelloWorld.dll.so wants to load image 0: HelloWorld
    ...
    02-02 13:22:59.823 24009 24009 D Mono    : AOT: FOUND method HelloWorld.MainActivity:OnCreate (Android.OS.Bundle) [0x7320dd3430 - 0x7320dd3630 0x7320dd3d21]