### PR TITLE
[Xamarin.Android.Build.Tasks] Enable 'AndroidLinkResources' for .NET 6 Release Applications

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkDesignerBase.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkDesignerBase.cs
@@ -1,0 +1,151 @@
+using Mono.Cecil;
+using Mono.Linker;
+using Mono.Linker.Steps;
+using System;
+using System.Linq;
+using Xamarin.Android.Tasks;
+using System.Collections.Generic;
+using Mono.Cecil.Cil;
+using System.Text.RegularExpressions;
+#if ILLINK
+using Microsoft.Android.Sdk.ILLink;
+#endif
+
+
+namespace MonoDroid.Tuner  {
+	public abstract class LinkDesignerBase : BaseStep {
+		public virtual void LogMessage (string message)
+		{
+			Context.LogMessage (message);
+		}
+
+		public virtual AssemblyDefinition Resolve (AssemblyNameReference name)
+		{
+			return Context.Resolve (name);
+		}
+
+		protected bool FindResourceDesigner (AssemblyDefinition assembly, bool mainApplication, out TypeDefinition designer, out CustomAttribute designerAttribute)
+		{
+			string designerFullName = null;
+			designer = null;
+			designerAttribute = null;
+			foreach (CustomAttribute attribute in assembly.CustomAttributes)
+			{
+				if (attribute.AttributeType.FullName == "Android.Runtime.ResourceDesignerAttribute")
+				{
+					designerAttribute = attribute;
+					if (attribute.HasProperties)
+					{
+						foreach (var p in attribute.Properties)
+						{
+							if (p.Name == "IsApplication" && (bool)p.Argument.Value == (mainApplication ? mainApplication : (bool)p.Argument.Value))
+							{
+								designerFullName = attribute.ConstructorArguments[0].Value.ToString ();
+								break;
+							}
+						}
+					}
+					break;
+
+				}
+			}
+			if (string.IsNullOrEmpty(designerFullName))
+				return false;
+
+			foreach (ModuleDefinition module in assembly.Modules)
+			{
+				foreach (TypeDefinition type in module.Types)
+				{
+					if (type.FullName == designerFullName)
+					{
+						designer = type;
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		protected void ClearDesignerClass (TypeDefinition designer)
+		{
+			LogMessage ($"    TryRemoving {designer.FullName}");
+			designer.NestedTypes.Clear ();
+			designer.Methods.Clear ();
+			designer.Fields.Clear ();
+			designer.Properties.Clear ();
+			designer.CustomAttributes.Clear ();
+			designer.Interfaces.Clear ();
+			designer.Events.Clear ();
+		}
+		protected Dictionary<string, int> BuildResourceDesignerFieldLookup (TypeDefinition type)
+		{
+			var output = new Dictionary<string, int> ();
+			foreach (TypeDefinition definition in type.NestedTypes)
+			{
+				foreach (FieldDefinition field in definition.Fields)
+				{
+					string key = $"{definition.Name}::{field.Name}";
+					if (!output.ContainsKey (key))
+						output.Add(key, int.Parse (field.Constant?.ToString () ?? "0"));
+				}
+			}
+			return output;
+		}
+
+		protected void FixType (TypeDefinition type, TypeDefinition localDesigner)
+		{
+			foreach (MethodDefinition method in type.Methods)
+			{
+				if (!method.HasBody)
+					continue;
+				FixBody (method.Body, localDesigner);
+			}
+			foreach (PropertyDefinition property in type.Properties)
+			{
+				if (property.GetMethod != null && property.GetMethod.HasBody)
+				{
+					FixBody (property.GetMethod.Body, localDesigner);
+				}
+				if (property.SetMethod != null && property.SetMethod.HasBody)
+				{
+					FixBody (property.SetMethod.Body, localDesigner);
+				}
+			}
+			foreach (TypeDefinition nestedType in type.NestedTypes)
+			{
+				FixType (nestedType, localDesigner);
+			}
+		}
+
+		protected void FixupAssemblyTypes (AssemblyDefinition assembly, TypeDefinition designer)
+		{
+			foreach (ModuleDefinition module in assembly.Modules)
+			{
+				foreach (TypeDefinition type in module.Types)
+				{
+					if (type.FullName == designer.FullName)
+						continue;
+					FixType (type, designer);
+				}
+			}
+		}
+
+		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			LoadDesigner ();
+
+			var action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
+			if (action == AssemblyAction.Delete)
+				return;
+
+			if (ProcessAssemblyDesigner (assembly)) {
+				if (action == AssemblyAction.Skip || action == AssemblyAction.Copy)
+					Annotations.SetAction (assembly, AssemblyAction.Save);
+			}
+		}
+
+		internal abstract bool ProcessAssemblyDesigner (AssemblyDefinition assemblyDefinition);
+		protected abstract void LoadDesigner ();
+		protected abstract void FixBody (MethodBody body, TypeDefinition designer);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
@@ -7,19 +7,23 @@ using Xamarin.Android.Tasks;
 using System.Collections.Generic;
 using Mono.Cecil.Cil;
 using System.Text.RegularExpressions;
+#if ILLINK
+using Microsoft.Android.Sdk.ILLink;
+#endif
 
 namespace MonoDroid.Tuner
 {
-	public class RemoveResourceDesignerStep : BaseStep
+	public class RemoveResourceDesignerStep : LinkDesignerBase
 	{
 		TypeDefinition mainDesigner = null;
 		AssemblyDefinition mainAssembly = null;
 		CustomAttribute mainDesignerAttribute;
 		Dictionary<string, int> designerConstants;
 		Regex opCodeRegex = new Regex (@"([\w]+): ([\w]+) ([\w.]+) ([\w:./]+)");
-
-		protected override void Process ()
+		protected override void LoadDesigner ()
 		{
+			if (mainAssembly != null)
+				return;
 			// resolve the MainAssembly Resource designer TypeDefinition
 			AndroidLinkConfiguration config = AndroidLinkConfiguration.GetInstance (Context);
 			if (config == null)
@@ -31,95 +35,26 @@ namespace MonoDroid.Tuner
 				}
 			}
 			if (mainDesigner == null) {
-				Context.LogMessage ($"  Main Designer not found.");
+				LogMessage ($"  Main Designer not found.");
 				return;
 			}
-			Context.LogMessage ($"  Main Designer found {mainDesigner.FullName}.");
+			LogMessage ($"  Main Designer found {mainDesigner.FullName}.");
 			designerConstants = BuildResourceDesignerFieldLookup (mainDesigner);
 		}
 
 		protected override void EndProcess ()
 		{
 			if (mainDesigner != null) {
-				Context.LogMessage ($"  Setting Action on {mainAssembly.Name} to Save.");
+				LogMessage ($"  Setting Action on {mainAssembly.Name} to Save.");
 				Annotations.SetAction (mainAssembly, AssemblyAction.Save);
 			}
 		}
 
-		bool FindResourceDesigner (AssemblyDefinition assembly, bool mainApplication, out TypeDefinition designer, out CustomAttribute designerAttribute)
-		{
-			string designerFullName = null;
-			designer = null;
-			designerAttribute = null;
-			foreach (CustomAttribute attribute in assembly.CustomAttributes)
-			{
-				if (attribute.AttributeType.FullName == "Android.Runtime.ResourceDesignerAttribute")
-				{
-					designerAttribute = attribute;
-					if (attribute.HasProperties)
-					{
-						foreach (var p in attribute.Properties)
-						{
-							if (p.Name == "IsApplication" && (bool)p.Argument.Value == (mainApplication ? mainApplication : (bool)p.Argument.Value))
-							{
-								designerFullName = attribute.ConstructorArguments[0].Value.ToString ();
-								break;
-							}
-						}
-					}
-					break;
-
-				}
-			}
-			if (string.IsNullOrEmpty(designerFullName))
-				return false;
-
-			foreach (ModuleDefinition module in assembly.Modules)
-			{
-				foreach (TypeDefinition type in module.Types)
-				{
-					if (type.FullName == designerFullName)
-					{
-						designer = type;
-						return true;
-					}
-				}
-			}
-			return false;
-		}
-
-		Dictionary<string, int> BuildResourceDesignerFieldLookup (TypeDefinition type)
-		{
-			var output = new Dictionary<string, int> ();
-			foreach (TypeDefinition definition in type.NestedTypes)
-			{
-				foreach (FieldDefinition field in definition.Fields)
-				{
-					string key = $"{definition.Name}::{field.Name}";
-					if (!output.ContainsKey (key))
-						output.Add(key, int.Parse (field.Constant?.ToString () ?? "0"));
-				}
-			}
-			return output;
-		}
-
-		void ClearDesignerClass (TypeDefinition designer)
-		{
-			Context.LogMessage ($"    TryRemoving {designer.FullName}");
-			designer.NestedTypes.Clear ();
-			designer.Methods.Clear ();
-			designer.Fields.Clear ();
-			designer.Properties.Clear ();
-			designer.CustomAttributes.Clear ();
-			designer.Interfaces.Clear ();
-			designer.Events.Clear ();
-		}
-
-		void FixBody (MethodBody body, TypeDefinition localDesigner)
+		protected override void FixBody (MethodBody body, TypeDefinition designer)
 		{
 			Dictionary<Instruction, int> instructions = new Dictionary<Instruction, int>();
 			var processor = body.GetILProcessor ();
-			string designerFullName = $"{localDesigner.FullName}/";
+			string designerFullName = $"{designer.FullName}/";
 			foreach (var i in body.Instructions)
 			{
 				string line = i.ToString ();
@@ -134,77 +69,48 @@ namespace MonoDroid.Tuner
 				}
 			}
 			if (instructions.Count > 0)
-				Context.LogMessage ($"    Fixing up {body.Method.FullName}");
+				LogMessage ($"    Fixing up {body.Method.FullName}");
 			foreach (var i in instructions)
 			{
 				var newCode = Extensions.CreateLoadArraySizeOrOffsetInstruction (i.Value);
-				Context.LogMessage ($"      Replacing {i.Key}");
-				Context.LogMessage ($"      With {newCode}");
+				LogMessage ($"      Replacing {i.Key}");
+				LogMessage ($"      With {newCode}");
 				processor.Replace(i.Key, newCode);
 			}
 		}
 
-		void FixType (TypeDefinition type, TypeDefinition localDesigner)
-		{
-			foreach (MethodDefinition method in type.Methods)
-			{
-				if (!method.HasBody)
-					continue;
-				FixBody (method.Body, localDesigner);
-			}
-			foreach (PropertyDefinition property in type.Properties)
-			{
-				if (property.GetMethod != null && property.GetMethod.HasBody)
-				{
-					FixBody (property.GetMethod.Body, localDesigner);
-				}
-				if (property.SetMethod != null && property.SetMethod.HasBody)
-				{
-					FixBody (property.SetMethod.Body, localDesigner);
-				}
-			}
-			foreach (TypeDefinition nestedType in type.NestedTypes)
-			{
-				FixType (nestedType, localDesigner);
-			}
-		}
-
-		protected override void ProcessAssembly (AssemblyDefinition assembly)
+		internal override bool ProcessAssemblyDesigner (AssemblyDefinition assembly)
 		{
 			if (mainDesigner == null)
-				return;
+				return false;
 			var fileName = assembly.Name.Name + ".dll";
 			if (MonoAndroidHelper.IsFrameworkAssembly (fileName))
-				return;
+				return false;
 
-			Context.LogMessage ($"  Fixing up {assembly.Name.Name}");
+			LogMessage ($"  Fixing up {assembly.Name.Name}");
 			TypeDefinition localDesigner = null;
 			CustomAttribute designerAttribute;
 			if (assembly != mainAssembly) {
-				Context.LogMessage ($"   {assembly.Name.Name} is not the main assembly. ");
+				LogMessage ($"   {assembly.Name.Name} is not the main assembly. ");
 				if (!FindResourceDesigner (assembly, mainApplication: false, designer: out localDesigner, designerAttribute: out designerAttribute)) {
 					Context.LogMessage ($"   {assembly.Name.Name} does not have a designer file.");
-					return;
+					return false;
 				}
 			} else {
-				Context.LogMessage ($"   {assembly.Name.Name} is the main assembly. ");
+				LogMessage ($"   {assembly.Name.Name} is the main assembly. ");
 				localDesigner = mainDesigner;
 				designerAttribute = mainDesignerAttribute;
 			}
 
-			Context.LogMessage ($"   {assembly.Name.Name} has designer {localDesigner.FullName}.");
+			LogMessage ($"   {assembly.Name.Name} has designer {localDesigner.FullName}.");
 
-			foreach (var mod in assembly.Modules) {
-				foreach (var type in mod.Types) {
-					if (type == localDesigner)
-						continue;
-					FixType (type, localDesigner);
-				}
-			}
+			FixupAssemblyTypes (assembly, localDesigner);
+
 			ClearDesignerClass (localDesigner);
 			if (designerAttribute != null) {
 				assembly.CustomAttributes.Remove (designerAttribute);
 			}
+			return true;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -91,9 +91,9 @@
     <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
     <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
-    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>    
+    <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' and '$(PublishTrimmed)' == 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -231,7 +231,15 @@ namespace Xamarin.Android.Build.Tests
 					stream.Position = 0;
 					using (var assembly = AssemblyDefinition.ReadAssembly (stream)) {
 						var type = assembly.MainModule.GetType ($"{assemblyName}.Resource");
-						Assert.AreEqual (0, type.NestedTypes.Count, "All Nested Resource Types should be removed.");
+						var intType = typeof(int);
+						foreach (var nestedType in type.NestedTypes) {
+							int count = 0;
+							foreach (var field in nestedType.Fields) {
+								if (field.FieldType.FullName == intType.FullName)
+									count++;
+							}
+							Assert.AreEqual (0, count, "All Nested Resource Type int fields should be removed.");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The current implementation of the `RemoveResourceDesignerStep` does not
work under .NET 6. This is mostly down to the fact that we didn't
`override` the require methods to make it work in that environment.

This PR also reworks the `RemoveResourceDesignerStep` to split some
of the functionality out into a new base class. This new base class will
be used in the future by the Resource Assembly linker step. Since much of
the code is identical.

Apk size difference in a Basic Android Application. This is a single App Head project with no additional libraries or Nuget references.

```
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  -         596 assemblies/assemblies.blob
  -         760 lib/x86/libaot-DotNet6AndroidBasic.dll.so
  -         764 lib/armeabi-v7a/libaot-DotNet6AndroidBasic.dll.so
  -         864 lib/x86_64/libaot-DotNet6AndroidBasic.dll.so
  -       5,032 lib/arm64-v8a/libaot-DotNet6AndroidBasic.dll.so
Summary:
  -         596 Other entries -0.03% (of 2,347,758)
  +           0 Dalvik executables 0.00% (of 333,284)
  -       7,420 Shared libraries -0.03% (of 23,525,172)
  +           0 Package size difference 0.00% (of 11,745,501)
```

Basic Android Application which references AndroidX. This example includes an App Head project as well as a single Android Library project. Both contain 2-3 AndroidResource items and both reference AndroidX.  The `Resource.Designer.cs` file is 460kb in size. 

```
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  -      63,664 lib/x86/libaot-DotNet6AndroidTest.App.dll.so
  -      63,952 lib/x86_64/libaot-DotNet6AndroidTest.App.dll.so
  -      83,900 assemblies/assemblies.blob
  -      84,408 lib/arm64-v8a/libaot-DotNet6AndroidTest.App.dll.so
  -      92,340 lib/armeabi-v7a/libaot-DotNet6AndroidTest.App.dll.so
Summary:
  -      83,900 Other entries -2.83% (of 2,965,109)
  +           0 Dalvik executables 0.00% (of 959,460)
  -     304,364 Shared libraries -1.28% (of 23,781,188)
  -     163,840 Package size difference -1.30% (of 12,620,512)
```

Basic Maui Application size difference. This is just a standard `dotnet new maui` app built for the Android platform.

```
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  +          24 lib/arm64-v8a/libaot-Microsoft.Maui.Graphics.dll.so
  -          48 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.Xaml.dll.so
  -         396 lib/armeabi-v7a/libaot-Microsoft.Maui.dll.so
  -         448 lib/arm64-v8a/libaot-Microsoft.Maui.dll.so
  -         536 lib/x86/libaot-Microsoft.Maui.Controls.Compatibility.dll.so
  -         592 lib/x86_64/libaot-Microsoft.Maui.Controls.Compatibility.dll.so
  -         632 lib/armeabi-v7a/libaot-Microsoft.Maui.Controls.dll.so
  -         632 lib/x86/libaot-Microsoft.Maui.Controls.dll.so
  -         720 lib/x86_64/libaot-Microsoft.Maui.Controls.dll.so
  -       4,492 lib/x86/libaot-Microsoft.Maui.dll.so
  -       4,544 lib/x86_64/libaot-Microsoft.Maui.dll.so
  -       4,568 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.Compatibility.dll.so
  -       4,628 lib/armeabi-v7a/libaot-Microsoft.Maui.Controls.Compatibility.dll.so
  -       4,792 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.dll.so
  -      26,676 lib/x86/libaot-BasicMauiApp.dll.so
  -      27,000 lib/x86_64/libaot-BasicMauiApp.dll.so
  -      30,772 lib/armeabi-v7a/libaot-BasicMauiApp.dll.so
  -      31,096 lib/arm64-v8a/libaot-BasicMauiApp.dll.so
  -     124,129 assemblies/assemblies.blob
Summary:
  -     124,129 Other entries -1.18% (of 10,513,973)
  +           0 Dalvik executables 0.00% (of 6,459,432)
  -     142,548 Shared libraries -0.28% (of 51,768,960)
  -     167,936 Package size difference -0.57% (of 29,604,197)
```

For Android applications which make use of allot of resource, these changes can also impact startup times.
The follow are the start up improvements on the Android Application and Library projects both of which use AndroidX.

```
### All runs
| Before  | After   | Δ        | Notes                                |
| ------- | ------- | -------- | ------------------------------------ |
| 188.500 | 176.150 | -6.55% ✓ | defaults; 32-bit build               |
| 174.150 | 175.100 | +0.54% ✗ | defaults; profiled AOT; 32-bit build |
| 187.550 | 178.300 | -4.93% ✓ | defaults; full AOT; 32-bit build     |
| 173.250 | 174.050 | +0.46% ✗ | defaults; 64-bit build               |
| 186.400 | 176.450 | -5.34% ✓ | defaults; profiled AOT; 64-bit build |
| 181.350 | 174.400 | -3.83% ✓ | defaults; full AOT; 64-bit build     |
```