### PR TITLE
[ci] Push .NET artifacts to blob storage

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -39,7 +39,7 @@ resources:
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
-- template: templates/common/vs-release-vars@sdk-insertions
+- template: templates/common/vs-release-vars.yml@sdk-insertions
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -39,6 +39,7 @@ resources:
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
+- template: templates/common/vs-release-vars@sdk-insertions
   # Run all tests if:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
@@ -1307,8 +1308,8 @@ stages:
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
-        githubContext: nuget-artifacts
-        blobName: nuget-artifacts
+        githubContext: $(NupkgCommitStatusName)
+        blobName: $(NupkgCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\nuget-signed
         yamlResourceName: yaml
@@ -1316,16 +1317,16 @@ stages:
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
-        githubContext: vs-insertion
-        blobName: vs-insertion
+        githubContext: $(VSDropCommitStatusName)
+        blobName: $(VSDropCommitStatusName)
         packagePrefix: xamarin-android
-        artifactsPath: $(Build.StagingDirectory)/vs-insertion
+        artifactsPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
         yamlResourceName: yaml
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: vsdrop-signed
-            downloadPath: $(Build.StagingDirectory)/vs-insertion
+            downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
 
     - powershell: >-
         & dotnet build -v:n -c $(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,7 +19,7 @@ resources:
   - repository: sdk-insertions
     type: github
     name: xamarin/sdk-insertions
-    ref: refs/heads/main
+    ref: refs/heads/add-insertion-template
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -1311,6 +1311,7 @@ stages:
         blobName: nuget-artifacts
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\nuget-signed
+        yamlResourceName: yaml
 
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
@@ -1319,6 +1320,7 @@ stages:
         blobName: vs-insertion
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)/vs-insertion
+        yamlResourceName: yaml
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,6 +14,11 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
+    ref: refs/heads/dev/pjc/drop-vars-file
+    endpoint: xamarin
+  - repository: sdk-insertions
+    type: github
+    name: xamarin/sdk-insertions
     ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
@@ -1278,35 +1283,47 @@ stages:
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: nuget-signed
-        downloadPath: $(System.DefaultWorkingDirectory)\nuget-signed
+        downloadPath: $(Build.StagingDirectory)\nuget-signed
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: nuget-linux-signed
-        downloadPath: $(System.DefaultWorkingDirectory)\nuget-signed
+        downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vs-msi-nugets
+        downloadPath: $(Build.StagingDirectory)\nuget-signed
 
     - task: NuGetCommand@2
       displayName: push nupkgs
       inputs:
         command: push
-        packagesToPush: $(System.DefaultWorkingDirectory)\nuget-signed\*.nupkg
+        packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: $(DotNetFeedCredential)
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: vs-msi-nugets
-        downloadPath: $(System.DefaultWorkingDirectory)\vs-msi-nugets
+    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: nuget-artifacts
+        blobName: nuget-artifacts
+        packagePrefix: xamarin-android
+        artifactsPath: $(Build.StagingDirectory)\nuget-signed
 
-    - task: NuGetCommand@2
-      displayName: push msi nupkgs
-      inputs:
-        command: push
-        packagesToPush: $(System.DefaultWorkingDirectory)\vs-msi-nugets\*.nupkg
-        nuGetFeedType: external
-        publishFeedCredentials: $(DotNetFeedCredential)
-      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
+    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: vs-insertion
+        blobName: vs-insertion
+        packagePrefix: xamarin-android
+        artifactsPath: $(Build.StagingDirectory)/vs-insertion
+        downloadSteps:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: vsdrop-signed
+            downloadPath: $(Build.StagingDirectory)/vs-insertion
 
     - powershell: >-
         & dotnet build -v:n -c $(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1304,7 +1304,7 @@ stages:
         publishFeedCredentials: $(DotNetFeedCredential)
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
-    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+    - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
         githubContext: nuget-artifacts
@@ -1312,7 +1312,7 @@ stages:
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\nuget-signed
 
-    - template: templates/common/upload-vs-insertion-artifacts.yml@sdk-insertions
+    - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
         githubContext: vs-insertion

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,12 +14,12 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/drop-vars-file
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: sdk-insertions
     type: github
     name: xamarin/sdk-insertions
-    ref: refs/heads/add-insertion-template
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: monodroid
     type: github


### PR DESCRIPTION
Context: https://github.com/xamarin/sdk-insertions/blob/1ecc4ae21866d152a9e37465d422de97a8ac1019/templates/common/upload-vs-insertion-artifacts.yml

GitHub commit statuses will also be created for the .NET artifacts,
which will be used by a new VS insertion release pipeline.