### PR TITLE
[Mono.Android] use Unsafe.As<T>() over Delegate.CreateDelegate()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Android.Runtime
 {
@@ -18,7 +19,7 @@ namespace Android.Runtime
 		{
 			switch (delegateType.Name) {
 				case nameof (_JniMarshal_PP_V): {
-					_JniMarshal_PP_V callback = (_JniMarshal_PP_V) Delegate.CreateDelegate (typeof (_JniMarshal_PP_V), dlg.Target, dlg.Method);
+					_JniMarshal_PP_V callback = Unsafe.As<_JniMarshal_PP_V> (dlg);
 					_JniMarshal_PP_V result = (jnienv, klazz) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -31,7 +32,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPI_V): {
-					_JniMarshal_PPI_V callback = (_JniMarshal_PPI_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPI_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPI_V callback = Unsafe.As<_JniMarshal_PPI_V> (dlg);
 					_JniMarshal_PPI_V result = (jnienv, klazz, p0) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -44,7 +45,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPL_L): {
-					_JniMarshal_PPL_L callback = (_JniMarshal_PPL_L) Delegate.CreateDelegate (typeof (_JniMarshal_PPL_L), dlg.Target, dlg.Method);
+					_JniMarshal_PPL_L callback = Unsafe.As<_JniMarshal_PPL_L> (dlg);
 					_JniMarshal_PPL_L result = (jnienv, klazz, p0) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -57,7 +58,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPL_V): {
-					_JniMarshal_PPL_V callback = (_JniMarshal_PPL_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPL_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPL_V callback = Unsafe.As<_JniMarshal_PPL_V> (dlg);
 					_JniMarshal_PPL_V result = (jnienv, klazz, p0) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -70,7 +71,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPL_Z): {
-					_JniMarshal_PPL_Z callback = (_JniMarshal_PPL_Z) Delegate.CreateDelegate (typeof (_JniMarshal_PPL_Z), dlg.Target, dlg.Method);
+					_JniMarshal_PPL_Z callback = Unsafe.As<_JniMarshal_PPL_Z> (dlg);
 					_JniMarshal_PPL_Z result = (jnienv, klazz, p0) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -83,7 +84,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPII_V): {
-					_JniMarshal_PPII_V callback = (_JniMarshal_PPII_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPII_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPII_V callback = Unsafe.As<_JniMarshal_PPII_V> (dlg);
 					_JniMarshal_PPII_V result = (jnienv, klazz, p0, p1) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -96,7 +97,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLI_V): {
-					_JniMarshal_PPLI_V callback = (_JniMarshal_PPLI_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPLI_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPLI_V callback = Unsafe.As<_JniMarshal_PPLI_V> (dlg);
 					_JniMarshal_PPLI_V result = (jnienv, klazz, p0, p1) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -109,7 +110,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLL_V): {
-					_JniMarshal_PPLL_V callback = (_JniMarshal_PPLL_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPLL_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPLL_V callback = Unsafe.As<_JniMarshal_PPLL_V> (dlg);
 					_JniMarshal_PPLL_V result = (jnienv, klazz, p0, p1) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -122,7 +123,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLL_Z): {
-					_JniMarshal_PPLL_Z callback = (_JniMarshal_PPLL_Z) Delegate.CreateDelegate (typeof (_JniMarshal_PPLL_Z), dlg.Target, dlg.Method);
+					_JniMarshal_PPLL_Z callback = Unsafe.As<_JniMarshal_PPLL_Z> (dlg);
 					_JniMarshal_PPLL_Z result = (jnienv, klazz, p0, p1) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -135,7 +136,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPIIL_V): {
-					_JniMarshal_PPIIL_V callback = (_JniMarshal_PPIIL_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPIIL_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPIIL_V callback = Unsafe.As<_JniMarshal_PPIIL_V> (dlg);
 					_JniMarshal_PPIIL_V result = (jnienv, klazz, p0, p1, p2) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -148,7 +149,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPILL_V): {
-					_JniMarshal_PPILL_V callback = (_JniMarshal_PPILL_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPILL_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPILL_V callback = Unsafe.As<_JniMarshal_PPILL_V> (dlg);
 					_JniMarshal_PPILL_V result = (jnienv, klazz, p0, p1, p2) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -161,7 +162,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLIL_Z): {
-					_JniMarshal_PPLIL_Z callback = (_JniMarshal_PPLIL_Z) Delegate.CreateDelegate (typeof (_JniMarshal_PPLIL_Z), dlg.Target, dlg.Method);
+					_JniMarshal_PPLIL_Z callback = Unsafe.As<_JniMarshal_PPLIL_Z> (dlg);
 					_JniMarshal_PPLIL_Z result = (jnienv, klazz, p0, p1, p2) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -174,7 +175,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLLL_L): {
-					_JniMarshal_PPLLL_L callback = (_JniMarshal_PPLLL_L) Delegate.CreateDelegate (typeof (_JniMarshal_PPLLL_L), dlg.Target, dlg.Method);
+					_JniMarshal_PPLLL_L callback = Unsafe.As<_JniMarshal_PPLLL_L> (dlg);
 					_JniMarshal_PPLLL_L result = (jnienv, klazz, p0, p1, p2) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -187,7 +188,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLLL_Z): {
-					_JniMarshal_PPLLL_Z callback = (_JniMarshal_PPLLL_Z) Delegate.CreateDelegate (typeof (_JniMarshal_PPLLL_Z), dlg.Target, dlg.Method);
+					_JniMarshal_PPLLL_Z callback = Unsafe.As<_JniMarshal_PPLLL_Z> (dlg);
 					_JniMarshal_PPLLL_Z result = (jnienv, klazz, p0, p1, p2) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -200,7 +201,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPIIII_V): {
-					_JniMarshal_PPIIII_V callback = (_JniMarshal_PPIIII_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPIIII_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPIIII_V callback = Unsafe.As<_JniMarshal_PPIIII_V> (dlg);
 					_JniMarshal_PPIIII_V result = (jnienv, klazz, p0, p1, p2, p3) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -213,7 +214,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLLLL_V): {
-					_JniMarshal_PPLLLL_V callback = (_JniMarshal_PPLLLL_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPLLLL_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPLLLL_V callback = Unsafe.As<_JniMarshal_PPLLLL_V> (dlg);
 					_JniMarshal_PPLLLL_V result = (jnienv, klazz, p0, p1, p2, p3) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -226,7 +227,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLIIII_V): {
-					_JniMarshal_PPLIIII_V callback = (_JniMarshal_PPLIIII_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPLIIII_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPLIIII_V callback = Unsafe.As<_JniMarshal_PPLIIII_V> (dlg);
 					_JniMarshal_PPLIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -239,7 +240,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPZIIII_V): {
-					_JniMarshal_PPZIIII_V callback = (_JniMarshal_PPZIIII_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPZIIII_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPZIIII_V callback = Unsafe.As<_JniMarshal_PPZIIII_V> (dlg);
 					_JniMarshal_PPZIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {
@@ -252,7 +253,7 @@ namespace Android.Runtime
 					return result;
 				}
 				case nameof (_JniMarshal_PPLIIIIIIII_V): {
-					_JniMarshal_PPLIIIIIIII_V callback = (_JniMarshal_PPLIIIIIIII_V) Delegate.CreateDelegate (typeof (_JniMarshal_PPLIIIIIIII_V), dlg.Target, dlg.Method);
+					_JniMarshal_PPLIIIIIIII_V callback = Unsafe.As<_JniMarshal_PPLIIIIIIII_V> (dlg);
 					_JniMarshal_PPLIIIIIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8) => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -27,6 +27,7 @@ var delegateTypes = new [] {
 #>
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Android.Runtime
 {
@@ -48,7 +49,7 @@ namespace Android.Runtime
 foreach (var info in delegateTypes) {
 #>
 				case nameof (<#= info.Type #>): {
-					<#= info.Type #> callback = (<#= info.Type #>) Delegate.CreateDelegate (typeof (<#= info.Type #>), dlg.Target, dlg.Method);
+					<#= info.Type #> callback = Unsafe.As<<#= info.Type #>> (dlg);
 					<#= info.Type #> result = <#= info.Signature #> => {
 						JNIEnv.WaitForBridgeProcessing ();
 						try {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -90,6 +90,7 @@ namespace Xamarin.Android.Build.Tests
 					"rc.bin",
 					"System.Private.CoreLib.dll",
 					"System.Runtime.dll",
+					"System.Runtime.CompilerServices.Unsafe.dll",
 					"System.Linq.dll",
 					"UnnamedProject.dll",
 				} :

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,10 +5,10 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 54996
+      "Size": 54984
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87650
+      "Size": 87771
     },
     "assemblies/rc.bin": {
       "Size": 1045
@@ -19,17 +19,20 @@
     "assemblies/System.Private.CoreLib.dll": {
       "Size": 521019
     },
+    "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
+      "Size": 1184
+    },
     "assemblies/System.Runtime.dll": {
       "Size": 2410
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3550
+      "Size": 3544
     },
     "classes.dex": {
       "Size": 345328
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382680
+      "Size": 382760
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3176048
@@ -44,19 +47,19 @@
       "Size": 150024
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 12376
+      "Size": 12424
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 2469
+      "Size": 2594
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2342
+      "Size": 2467
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4762
+      "Size": 4791
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200
@@ -80,5 +83,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2701204
+  "PackageSize": 2705399
 }


### PR DESCRIPTION
In porting System.Reflection.Emit code in 32cff438, I was considering
our use of `Delegate.CreateDelegate()`. This appears to take up
~2.83ms, when using `dotnet trace` to profile. Can we just cast
instead?

"generator" from xamarin/java.interop generates `internal` delegates
for each Java binding assembly:

    _JniMarshal_PP_V

A direct cast wouldn't work, if for example,
`Xamarin.AndroidX.AppCompat.dll` had its own `_JniMarshal_PP_V`, we
can't cast to the one in `Mono.Android.dll`.

To solve this problem we can use `Unsafe.As<T>()` instead:

https://docs.microsoft.com/dotnet/api/system.runtime.compilerservices.unsafe.as?view=net-6.0

Testing a `dotnet new maui` app on a Pixel 5, a `Release` build
without AOT:

    Before:
    02-04 16:03:18.603  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s64ms
    02-04 16:03:20.789  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s37ms
    02-04 16:03:23.038  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s65ms
    02-04 16:03:25.233  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s58ms
    02-04 16:03:27.434  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s36ms
    02-04 16:03:29.622  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s43ms
    02-04 16:03:31.807  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s48ms
    02-04 16:03:33.998  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s57ms
    02-04 16:03:36.146  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s35ms
    02-04 16:03:38.357  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s44ms
    Average(ms): 1048.7
    Std Err(ms): 3.64554522671164
    Std Dev(ms): 11.5282262295637
    After:
    02-04 22:23:22.592  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s26ms
    02-04 22:23:24.839  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s25ms
    02-04 22:23:27.079  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s58ms
    02-04 22:23:29.302  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s57ms
    02-04 22:23:31.539  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s76ms
    02-04 22:23:33.732  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s48ms
    02-04 22:23:35.956  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s55ms
    02-04 22:23:38.136  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s34ms
    02-04 22:23:40.360  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s37ms
    02-04 22:23:42.619  1867  2226 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +1s50ms
    Average(ms): 1046.6
    Std Err(ms): 5.08636521605666
    Std Dev(ms): 16.0844990941935

It did seem to save ~2.1ms in this case?