### PR TITLE
[Mono.Android] avoid capturing variables in JNINativeWrapper

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -15,256 +15,256 @@ namespace Android.Runtime
 			return true;
 		}
 
+		internal static void Wrap_JniMarshal_PP_V (this _JniMarshal_PP_V callback, IntPtr jnienv, IntPtr klazz)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPI_V (this _JniMarshal_PPI_V callback, IntPtr jnienv, IntPtr klazz, int p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static IntPtr Wrap_JniMarshal_PPL_L (this _JniMarshal_PPL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPL_V (this _JniMarshal_PPL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPL_Z (this _JniMarshal_PPL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPII_V (this _JniMarshal_PPII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLI_V (this _JniMarshal_PPLI_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLL_V (this _JniMarshal_PPLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPLL_Z (this _JniMarshal_PPLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPIIL_V (this _JniMarshal_PPIIL_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPILL_V (this _JniMarshal_PPILL_V callback, IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPLIL_Z (this _JniMarshal_PPLIL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static IntPtr Wrap_JniMarshal_PPLLL_L (this _JniMarshal_PPLLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPLLL_Z (this _JniMarshal_PPLLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPIIII_V (this _JniMarshal_PPIIII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2, int p3)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2, p3);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLLLL_V (this _JniMarshal_PPLLLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr p3)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2, p3);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLIIII_V (this _JniMarshal_PPLIIII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2, p3, p4);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPZIIII_V (this _JniMarshal_PPZIIII_V callback, IntPtr jnienv, IntPtr klazz, bool p0, int p1, int p2, int p3, int p4)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2, p3, p4);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLIIIIIIII_V (this _JniMarshal_PPLIIIIIIII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
 		private static Delegate CreateBuiltInDelegate (Delegate dlg, Type delegateType)
 		{
 			switch (delegateType.Name) {
-				case nameof (_JniMarshal_PP_V): {
-					_JniMarshal_PP_V callback = Unsafe.As<_JniMarshal_PP_V> (dlg);
-					_JniMarshal_PP_V result = (jnienv, klazz) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPI_V): {
-					_JniMarshal_PPI_V callback = Unsafe.As<_JniMarshal_PPI_V> (dlg);
-					_JniMarshal_PPI_V result = (jnienv, klazz, p0) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPL_L): {
-					_JniMarshal_PPL_L callback = Unsafe.As<_JniMarshal_PPL_L> (dlg);
-					_JniMarshal_PPL_L result = (jnienv, klazz, p0) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPL_V): {
-					_JniMarshal_PPL_V callback = Unsafe.As<_JniMarshal_PPL_V> (dlg);
-					_JniMarshal_PPL_V result = (jnienv, klazz, p0) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPL_Z): {
-					_JniMarshal_PPL_Z callback = Unsafe.As<_JniMarshal_PPL_Z> (dlg);
-					_JniMarshal_PPL_Z result = (jnienv, klazz, p0) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPII_V): {
-					_JniMarshal_PPII_V callback = Unsafe.As<_JniMarshal_PPII_V> (dlg);
-					_JniMarshal_PPII_V result = (jnienv, klazz, p0, p1) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLI_V): {
-					_JniMarshal_PPLI_V callback = Unsafe.As<_JniMarshal_PPLI_V> (dlg);
-					_JniMarshal_PPLI_V result = (jnienv, klazz, p0, p1) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLL_V): {
-					_JniMarshal_PPLL_V callback = Unsafe.As<_JniMarshal_PPLL_V> (dlg);
-					_JniMarshal_PPLL_V result = (jnienv, klazz, p0, p1) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLL_Z): {
-					_JniMarshal_PPLL_Z callback = Unsafe.As<_JniMarshal_PPLL_Z> (dlg);
-					_JniMarshal_PPLL_Z result = (jnienv, klazz, p0, p1) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0, p1);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPIIL_V): {
-					_JniMarshal_PPIIL_V callback = Unsafe.As<_JniMarshal_PPIIL_V> (dlg);
-					_JniMarshal_PPIIL_V result = (jnienv, klazz, p0, p1, p2) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPILL_V): {
-					_JniMarshal_PPILL_V callback = Unsafe.As<_JniMarshal_PPILL_V> (dlg);
-					_JniMarshal_PPILL_V result = (jnienv, klazz, p0, p1, p2) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLIL_Z): {
-					_JniMarshal_PPLIL_Z callback = Unsafe.As<_JniMarshal_PPLIL_Z> (dlg);
-					_JniMarshal_PPLIL_Z result = (jnienv, klazz, p0, p1, p2) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0, p1, p2);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLLL_L): {
-					_JniMarshal_PPLLL_L callback = Unsafe.As<_JniMarshal_PPLLL_L> (dlg);
-					_JniMarshal_PPLLL_L result = (jnienv, klazz, p0, p1, p2) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0, p1, p2);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLLL_Z): {
-					_JniMarshal_PPLLL_Z callback = Unsafe.As<_JniMarshal_PPLLL_Z> (dlg);
-					_JniMarshal_PPLLL_Z result = (jnienv, klazz, p0, p1, p2) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							return callback (jnienv, klazz, p0, p1, p2);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							return default;
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPIIII_V): {
-					_JniMarshal_PPIIII_V callback = Unsafe.As<_JniMarshal_PPIIII_V> (dlg);
-					_JniMarshal_PPIIII_V result = (jnienv, klazz, p0, p1, p2, p3) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2, p3);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLLLL_V): {
-					_JniMarshal_PPLLLL_V callback = Unsafe.As<_JniMarshal_PPLLLL_V> (dlg);
-					_JniMarshal_PPLLLL_V result = (jnienv, klazz, p0, p1, p2, p3) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2, p3);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLIIII_V): {
-					_JniMarshal_PPLIIII_V callback = Unsafe.As<_JniMarshal_PPLIIII_V> (dlg);
-					_JniMarshal_PPLIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2, p3, p4);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPZIIII_V): {
-					_JniMarshal_PPZIIII_V callback = Unsafe.As<_JniMarshal_PPZIIII_V> (dlg);
-					_JniMarshal_PPZIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2, p3, p4);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
-				case nameof (_JniMarshal_PPLIIIIIIII_V): {
-					_JniMarshal_PPLIIIIIIII_V callback = Unsafe.As<_JniMarshal_PPLIIIIIIII_V> (dlg);
-					_JniMarshal_PPLIIIIIIII_V result = (jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8) => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							callback (jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8);
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							
-						}
-					};
-					return result;
-				}
+				case nameof (_JniMarshal_PP_V):
+					return new _JniMarshal_PP_V (Unsafe.As<_JniMarshal_PP_V> (dlg).Wrap_JniMarshal_PP_V);
+				case nameof (_JniMarshal_PPI_V):
+					return new _JniMarshal_PPI_V (Unsafe.As<_JniMarshal_PPI_V> (dlg).Wrap_JniMarshal_PPI_V);
+				case nameof (_JniMarshal_PPL_L):
+					return new _JniMarshal_PPL_L (Unsafe.As<_JniMarshal_PPL_L> (dlg).Wrap_JniMarshal_PPL_L);
+				case nameof (_JniMarshal_PPL_V):
+					return new _JniMarshal_PPL_V (Unsafe.As<_JniMarshal_PPL_V> (dlg).Wrap_JniMarshal_PPL_V);
+				case nameof (_JniMarshal_PPL_Z):
+					return new _JniMarshal_PPL_Z (Unsafe.As<_JniMarshal_PPL_Z> (dlg).Wrap_JniMarshal_PPL_Z);
+				case nameof (_JniMarshal_PPII_V):
+					return new _JniMarshal_PPII_V (Unsafe.As<_JniMarshal_PPII_V> (dlg).Wrap_JniMarshal_PPII_V);
+				case nameof (_JniMarshal_PPLI_V):
+					return new _JniMarshal_PPLI_V (Unsafe.As<_JniMarshal_PPLI_V> (dlg).Wrap_JniMarshal_PPLI_V);
+				case nameof (_JniMarshal_PPLL_V):
+					return new _JniMarshal_PPLL_V (Unsafe.As<_JniMarshal_PPLL_V> (dlg).Wrap_JniMarshal_PPLL_V);
+				case nameof (_JniMarshal_PPLL_Z):
+					return new _JniMarshal_PPLL_Z (Unsafe.As<_JniMarshal_PPLL_Z> (dlg).Wrap_JniMarshal_PPLL_Z);
+				case nameof (_JniMarshal_PPIIL_V):
+					return new _JniMarshal_PPIIL_V (Unsafe.As<_JniMarshal_PPIIL_V> (dlg).Wrap_JniMarshal_PPIIL_V);
+				case nameof (_JniMarshal_PPILL_V):
+					return new _JniMarshal_PPILL_V (Unsafe.As<_JniMarshal_PPILL_V> (dlg).Wrap_JniMarshal_PPILL_V);
+				case nameof (_JniMarshal_PPLIL_Z):
+					return new _JniMarshal_PPLIL_Z (Unsafe.As<_JniMarshal_PPLIL_Z> (dlg).Wrap_JniMarshal_PPLIL_Z);
+				case nameof (_JniMarshal_PPLLL_L):
+					return new _JniMarshal_PPLLL_L (Unsafe.As<_JniMarshal_PPLLL_L> (dlg).Wrap_JniMarshal_PPLLL_L);
+				case nameof (_JniMarshal_PPLLL_Z):
+					return new _JniMarshal_PPLLL_Z (Unsafe.As<_JniMarshal_PPLLL_Z> (dlg).Wrap_JniMarshal_PPLLL_Z);
+				case nameof (_JniMarshal_PPIIII_V):
+					return new _JniMarshal_PPIIII_V (Unsafe.As<_JniMarshal_PPIIII_V> (dlg).Wrap_JniMarshal_PPIIII_V);
+				case nameof (_JniMarshal_PPLLLL_V):
+					return new _JniMarshal_PPLLLL_V (Unsafe.As<_JniMarshal_PPLLLL_V> (dlg).Wrap_JniMarshal_PPLLLL_V);
+				case nameof (_JniMarshal_PPLIIII_V):
+					return new _JniMarshal_PPLIIII_V (Unsafe.As<_JniMarshal_PPLIIII_V> (dlg).Wrap_JniMarshal_PPLIIII_V);
+				case nameof (_JniMarshal_PPZIIII_V):
+					return new _JniMarshal_PPZIIII_V (Unsafe.As<_JniMarshal_PPZIIII_V> (dlg).Wrap_JniMarshal_PPZIIII_V);
+				case nameof (_JniMarshal_PPLIIIIIIII_V):
+					return new _JniMarshal_PPLIIIIIIII_V (Unsafe.As<_JniMarshal_PPLIIIIIIII_V> (dlg).Wrap_JniMarshal_PPLIIIIIIII_V);
 				default:
 					return null;
 			}

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -4,25 +4,120 @@
 <#@ output extension=".cs" #>
 <#
 var delegateTypes = new [] {
-	new { Type = "_JniMarshal_PP_V", Signature = "(jnienv, klazz)", Return = false },
-	new { Type = "_JniMarshal_PPI_V", Signature = "(jnienv, klazz, p0)", Return = false },
-	new { Type = "_JniMarshal_PPL_L", Signature = "(jnienv, klazz, p0)", Return = true },
-	new { Type = "_JniMarshal_PPL_V", Signature = "(jnienv, klazz, p0)", Return = false },
-	new { Type = "_JniMarshal_PPL_Z", Signature = "(jnienv, klazz, p0)", Return = true },
-	new { Type = "_JniMarshal_PPII_V", Signature = "(jnienv, klazz, p0, p1)", Return = false },
-	new { Type = "_JniMarshal_PPLI_V", Signature = "(jnienv, klazz, p0, p1)", Return = false },
-	new { Type = "_JniMarshal_PPLL_V", Signature = "(jnienv, klazz, p0, p1)", Return = false },
-	new { Type = "_JniMarshal_PPLL_Z", Signature = "(jnienv, klazz, p0, p1)", Return = true },
-	new { Type = "_JniMarshal_PPIIL_V", Signature = "(jnienv, klazz, p0, p1, p2)", Return = false },
-	new { Type = "_JniMarshal_PPILL_V", Signature = "(jnienv, klazz, p0, p1, p2)", Return = false },
-	new { Type = "_JniMarshal_PPLIL_Z", Signature = "(jnienv, klazz, p0, p1, p2)", Return = true },
-	new { Type = "_JniMarshal_PPLLL_L", Signature = "(jnienv, klazz, p0, p1, p2)", Return = true },
-	new { Type = "_JniMarshal_PPLLL_Z", Signature = "(jnienv, klazz, p0, p1, p2)", Return = true },
-	new { Type = "_JniMarshal_PPIIII_V", Signature = "(jnienv, klazz, p0, p1, p2, p3)", Return = false },
-	new { Type = "_JniMarshal_PPLLLL_V", Signature = "(jnienv, klazz, p0, p1, p2, p3)", Return = false },
-	new { Type = "_JniMarshal_PPLIIII_V", Signature = "(jnienv, klazz, p0, p1, p2, p3, p4)", Return = false },
-	new { Type = "_JniMarshal_PPZIIII_V", Signature = "(jnienv, klazz, p0, p1, p2, p3, p4)", Return = false },
-	new { Type = "_JniMarshal_PPLIIIIIIII_V", Signature = "(jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8)", Return = false },
+	new {
+		Type = "_JniMarshal_PP_V",
+		Signature = "IntPtr jnienv, IntPtr klazz",
+		Return = "void",
+		Invoke = "jnienv, klazz",
+	},
+	new {
+		Type = "_JniMarshal_PPI_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPL_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
+		Type = "_JniMarshal_PPLI_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
+		Type = "_JniMarshal_PPLL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
+		Type = "_JniMarshal_PPLL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
+		Type = "_JniMarshal_PPIIL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPILL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1, IntPtr p2",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLIL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, IntPtr p2",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLLL_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLLL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPIIII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2, int p3",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3",
+	},
+	new {
+		Type = "_JniMarshal_PPLLLL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr p3",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3",
+	},
+	new {
+		Type = "_JniMarshal_PPLIIII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3, p4",
+	},
+	new {
+		Type = "_JniMarshal_PPZIIII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, bool p0, int p1, int p2, int p3, int p4",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3, p4",
+	},
+	new {
+		Type = "_JniMarshal_PPLIIIIIIII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3, p4, p5, p6, p7, p8",
+	},
 };
 #>
 using System;
@@ -42,25 +137,31 @@ namespace Android.Runtime
 			return true;
 		}
 
+<#
+foreach (var info in delegateTypes) {
+#>
+		internal static <#= info.Return #> Wrap<#= info.Type #> (this <#= info.Type #> callback, <#= info.Signature #>)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				<#= info.Return != "void" ? "return " : "" #>callback (<#= info.Invoke #>);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				<#= info.Return != "void" ? "return default;" : "" #>
+			}
+		}
+
+<#
+}
+#>
 		private static Delegate CreateBuiltInDelegate (Delegate dlg, Type delegateType)
 		{
 			switch (delegateType.Name) {
 <#
 foreach (var info in delegateTypes) {
 #>
-				case nameof (<#= info.Type #>): {
-					<#= info.Type #> callback = Unsafe.As<<#= info.Type #>> (dlg);
-					<#= info.Type #> result = <#= info.Signature #> => {
-						JNIEnv.WaitForBridgeProcessing ();
-						try {
-							<#= info.Return ? "return " : "" #>callback <#= info.Signature #>;
-						} catch (Exception e) when (_unhandled_exception (e)) {
-							AndroidEnvironment.UnhandledException (e);
-							<#= info.Return ? "return default;" : "" #>
-						}
-					};
-					return result;
-				}
+				case nameof (<#= info.Type #>):
+					return new <#= info.Type #> (Unsafe.As<<#= info.Type #>> (dlg).Wrap<#= info.Type #>);
 <#
 }
 #>


### PR DESCRIPTION
One performance issue with the existing code:

    _JniMarshal_PP_V callback = Unsafe.As<_JniMarshal_PP_V> (dlg);
    _JniMarshal_PP_V result = (jnienv, klazz) => {
        JNIEnv.WaitForBridgeProcessing ();
        try {
            callback (jnienv, klazz);
        } catch (Exception e) when (_unhandled_exception (e)) {
            AndroidEnvironment.UnhandledException (e);
        }
    };
    return result;

In this example, `callback` is "captured", and an intermediate class
is generated to store this data such as
`Android.Runtime.JNINativeWrapper/<>c__DisplayClass5_15`.

A way to do this is:

    return new _JniMarshal_PP_V (Unsafe.As<_JniMarshal_PP_V> (dlg).Wrap_JniMarshal_PP_V);

Where `Wrap_JniMarshal_PP_V` is an extension method:

    internal static void Wrap_JniMarshal_PP_V (this _JniMarshal_PP_V callback, IntPtr jnienv, IntPtr klazz)
    {
        JNIEnv.WaitForBridgeProcessing ();
        try {
            callback (jnienv, klazz);
        } catch (Exception e) when (_unhandled_exception (e)) {
            AndroidEnvironment.UnhandledException (e);
        }
    }

This avoids the captured variable *and* uses "regular" methods.

## Results ##

Running a regular (non-AOT) Release build of `dotnet new maui` on a
Pixel 5:

    Before:
    02-07 14:47:25.935  1566  1566 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::493336
    02-07 14:47:27.158  1635  1635 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::234846
    02-07 14:47:28.347  1737  1737 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::245159
    02-07 14:47:29.562  1794  1794 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::511304
    02-07 14:47:30.732  1850  1850 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::256304
    02-07 14:47:31.913  1956  1956 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::323647
    02-07 14:47:33.143  2043  2043 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::58491
    02-07 14:47:34.355  2137  2137 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::172086
    02-07 14:47:35.559  2217  2217 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::335627
    02-07 14:47:36.789  2352  2352 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::679325
    Average(ms): 19.3310125
    Std Err(ms): 0.0579249384982648
    Std Dev(ms): 0.18317473897969
    After:
    02-07 14:42:24.153 30712 30712 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::694950
    02-07 14:42:25.353 30770 30770 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::700315
    02-07 14:42:26.535 30825 30825 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::764169
    02-07 14:42:27.733 30887 30887 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::940054
    02-07 14:42:28.984 30950 30950 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::255731
    02-07 14:42:30.161 31013 31013 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::712554
    02-07 14:42:31.367 31070 31070 I monodroid-timing: Runtime.register: end time; elapsed: 0s:19::198700
    02-07 14:42:32.555 31126 31126 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::775367
    02-07 14:42:33.810 31190 31190 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::937189
    02-07 14:42:34.997 31245 31245 I monodroid-timing: Runtime.register: end time; elapsed: 0s:18::897606
    Average(ms): 18.8876635
    Std Err(ms): 0.0639684356019523
    Std Dev(ms): 0.202285954859973

This was using:

    msbuild Xamarin.Android.sln -t:InstallMaui -p:MauiVersion=6.0.200-preview.14.2816

After this change goes in, I will update the built-in AOT profiles at
a later date.