### PR TITLE
[ci] Print out Linux disk usage at create-nupkgs, copy sdk

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -293,10 +293,11 @@ stages:
       displayName: make create-nupkgs
 
     - script: >
+        df -h &&
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
-        cp $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.Linux*.nupkg
+        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.Linux*.nupkg
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
-        cp $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/SignList.xml
+        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/SignList.xml
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy linux sdk

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -8,6 +8,8 @@ endif
 create-installers: create-nupkgs create-pkg create-vsix
 
 create-nupkgs:
+	@echo Disk usage before create-nupkgs
+	-df -h
 	$(call DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
 
 create-pkg:


### PR DESCRIPTION
Context: 10ed0ec7806c65b75ea810215cb931e58e961497

Commit 10ed0ec7 mentioned:

> What we *don't* know is how much free space there was in the first
> place, or how much space we've consumed during the build.

Commit 10ed0ec7 updated `xaprepare` so that we'd have knowledge of
disk space usage near the *beginning* of the build, but we didn't
know about other points during the build.

Update the `make create-nupkgs` target and the **copy linux sdk**
YAML step to also print out `df -h` output.

Additionally, update the **copy linux sdk** step to use
[**ln**(1)][0] instead of [**cp**(1)][1], so that hard links are
created instead of copying the entire file.  This should reduce disk
space used by the **copy linux sdk** step.

[0]: https://www.man7.org/linux/man-pages/man1/ln.1.html
[1]: https://www.man7.org/linux/man-pages/man1/cp.1.html