### PR TITLE
[build] Use Azure Pipelines vars for Android SDK/NDK paths

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@91b4ef9fcfad5906b0699865afb3e46c383a5710
+xamarin/monodroid:main@297767fcc65fc43487949d51dee753d454c647f1
 mono/mono:2020-02@148f536b0b463a111a021b960ee3aeaed0cf203b

--- a/Configuration.props
+++ b/Configuration.props
@@ -78,7 +78,9 @@
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Linux' ">\usr</AndroidMxeInstallPrefix>
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Darwin' ">$(HostHomebrewPrefix)</AndroidMxeInstallPrefix>
+    <AndroidSdkDirectory Condition=" '$(AndroidSdkDirectory)' == '' And Exists($(ANDROID_SDK_ROOT)) ">$(ANDROID_SDK_ROOT)</AndroidSdkDirectory>
     <AndroidSdkDirectory Condition=" '$(AndroidSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
+    <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' And Exists($(ANDROID_NDK_LATEST_HOME)) ">$(ANDROID_NDK_LATEST_HOME)</AndroidNdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -33,7 +33,7 @@
     <PropertyGroup>
       <_Target>-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Target>
       <_D>-d "$(IntermediateOutputPath)jcw/bin"</_D>
-      <_AndroidJar>"$(AndroidToolchainDirectory)\sdk\platforms\android-$(AndroidPlatformId)\android.jar"</_AndroidJar>
+      <_AndroidJar>"$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\android.jar"</_AndroidJar>
       <_MonoAndroidJar>$(OutputPath)mono.android.jar</_MonoAndroidJar>
       <_MonoAndroidRuntimeJar>$(OutputPath)..\..\..\xbuild\Xamarin\Android\java_runtime.jar</_MonoAndroidRuntimeJar>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -29,6 +29,8 @@ namespace Xamarin.ProjectTools
 			if (String.IsNullOrEmpty (sdkPath))
 				sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
 			if (String.IsNullOrEmpty (sdkPath))
+				sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_ROOT");
+			if (String.IsNullOrEmpty (sdkPath))
 				sdkPath = Path.GetFullPath (Path.Combine (ToolchainPath, "sdk"));
 
 			return sdkPath;
@@ -42,6 +44,8 @@ namespace Xamarin.ProjectTools
 				ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
 			if (String.IsNullOrEmpty (ndkPath))
 				ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
+			if (String.IsNullOrEmpty (ndkPath))
+				ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_LATEST_HOME");
 			if (String.IsNullOrEmpty (ndkPath))
 				ndkPath = Path.GetFullPath (Path.Combine (ToolchainPath, "ndk"));
 

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -51,7 +51,7 @@
   />
   <PropertyGroup>
     <_Target Condition="'$(JavacSourceVersion)' != ''">-source $(JavacSourceVersion) -target $(JavacTargetVersion)</_Target>
-    <_AndroidJar>"$(AndroidToolchainDirectory)\sdk\platforms\android-$(AndroidJavaRuntimeApiLevel)\android.jar"</_AndroidJar>
+    <_AndroidJar>"$(AndroidSdkDirectory)\platforms\android-$(AndroidJavaRuntimeApiLevel)\android.jar"</_AndroidJar>
   </PropertyGroup>
   <Exec
       Command="&quot;$(JavaCPath)&quot; $(_Target) -d %(_RuntimeOutput.IntermediateRuntimeOutputPath) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;%(_RuntimeOutput.OutputJar)&quot; @%(_RuntimeOutput.IntermediateRuntimeClassesTxt)"


### PR DESCRIPTION
Context: https://github.com/actions/virtual-environments/blob/5cdc2e5f50ec21dbac1d3b475ae0fe364f4a2d12/images/linux/Ubuntu2004-Readme.md#environment-variables-3
Context: https://github.com/actions/virtual-environments/blob/5cdc2e5f50ec21dbac1d3b475ae0fe364f4a2d12/images/win/Windows2022-Readme.md#environment-variables-2
Context: https://github.com/actions/virtual-environments/blob/5cdc2e5f50ec21dbac1d3b475ae0fe364f4a2d12/images/macos/macos-11-Readme.md#environment-variables-2

Build and test against Android SDK and NDK paths set by Azure Pipelines
hosted images if those paths exist.