### PR TITLE
[ci] Enable Android Designer tests on Windows

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -36,6 +36,11 @@ resources:
     ref: refs/heads/main
     endpoint: xamarin
 
+parameters:
+- name: provisionatorChannel
+  type: string
+  default: latest           # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
+
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
@@ -96,6 +101,8 @@ stages:
         condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - template: yaml-templates/commercial-build.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/remove-microbuild-tooling.yaml
       parameters:
@@ -335,6 +342,7 @@ stages:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
         configuration: $(ApkTestConfiguration)
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:
@@ -586,7 +594,7 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
-        configuration: $(XA.Build.Configuration)
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:
@@ -694,12 +702,14 @@ stages:
     parameters:
       job_name: mac_msbuild_tests_0
       nunit_categories: '|| cat == SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Xamarin.Android (Smoke Tests MSBuild - Win-0)
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
       job_name: win_msbuild_tests_0
       nunit_categories: '|| cat == SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Check - "Xamarin.Android (Smoke Tests MSBuild Emulator - macOS)"
   - job: mac_msbuilddevice_tests
@@ -712,6 +722,8 @@ stages:
       clean: all
     steps:
     - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:
@@ -770,6 +782,8 @@ stages:
     - template: yaml-templates/setup-ubuntu.yaml
 
     - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -803,6 +817,7 @@ stages:
       job_name: mac_msbuild_tests_1
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -811,6 +826,7 @@ stages:
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
       run_extra_tests: true
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -818,13 +834,15 @@ stages:
       job_name: mac_msbuild_tests_3
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
-      
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
       node_id: 4
       job_name: mac_msbuild_tests_4
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -832,6 +850,7 @@ stages:
       job_name: mac_msbuild_tests_5
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -839,6 +858,7 @@ stages:
       job_name: mac_msbuild_tests_6
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Xamarin.Android (Test MSBuild Legacy - Windows)
   - template: yaml-templates\run-msbuild-win-tests.yaml
@@ -848,6 +868,7 @@ stages:
       job_name: win_msbuild_tests_1
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -857,6 +878,7 @@ stages:
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
       run_extra_tests: true
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -865,6 +887,7 @@ stages:
       job_name: win_msbuild_tests_3
       job_suffix: Legacy
       nunit_categories: '&& cat != SmokeTests'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
 - stage: msbuild_dotnet
   displayName: One .NET Tests
@@ -879,6 +902,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -887,6 +911,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -895,6 +920,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -903,6 +929,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -911,6 +938,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-mac-tests.yaml
     parameters:
@@ -919,6 +947,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Xamarin.Android (Test MSBuild One .NET - Windows)
   - template: yaml-templates\run-msbuild-win-tests.yaml
@@ -929,6 +958,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -938,6 +968,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
@@ -947,6 +978,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
 - stage: msbuilddevice_tests
   displayName: MSBuild Emulator Tests
@@ -959,18 +991,21 @@ stages:
       node_id: 1
       job_name: mac_msbuilddevice_tests_1
       job_suffix: Legacy
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
       node_id: 2
       job_name: mac_msbuilddevice_tests_2
       job_suffix: Legacy
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
       node_id: 3
       job_name: mac_msbuilddevice_tests_3
       job_suffix: Legacy
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
@@ -980,6 +1015,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
@@ -988,6 +1024,7 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
@@ -996,14 +1033,16 @@ stages:
       job_suffix: One .NET
       nunit_categories: $(DotNetNUnitCategories)
       target_framework: 'net6.0'
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
 - stage: designer_tests
   displayName: Designer Tests
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'Designer')))
   jobs:
- # Check - "Xamarin.Android (Designer Tests macOS)"
+  # Check - "Xamarin.Android (Designer Tests macOS)"
   - job: designer_integration_mac
+    condition: false #TODO: Enable once test issues are fixed.
     displayName: macOS
     pool:
       vmImage: internal-macos-11
@@ -1027,7 +1066,7 @@ stages:
         if ("$(Build.Reason)" -eq "PullRequest") {
             $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
         }
-        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
+        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d1*")) {
             $branchName = "main"
         }
         Set-Location -Path $(System.DefaultWorkingDirectory)/UITools
@@ -1046,11 +1085,14 @@ stages:
         github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)/UITools/Designer/bot-provisioning/dependencies.csx
         provisioning_extra_args: -remove Xamarin.Android -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
         jdkTestFolder: $(JAVA_HOME_8_X64)
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: designer/android-designer-build-mac.yaml@yaml
       parameters:
@@ -1079,12 +1121,10 @@ stages:
         condition: ne(variables['Agent.JobStatus'], 'Succeeded')
 
   # Check - "Xamarin.Android (Designer Tests Windows)"
-  # TODO: Enable once Windows test issues are fixed.
   - job: designer_integration_win
-    condition: false
     displayName: Windows
     pool:
-      vmImage: windows-2019
+      vmImage: $(HostedWinImage)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1092,7 +1132,7 @@ stages:
     variables:
       EnableRegressionTest: true
       RegressionTestSuiteOutputDir: C:\Git\ADesRegTestSuite
-      VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+      VisualStudioInstallationPath: C:\Program Files\Microsoft Visual Studio\2022\Enterprise
     steps:
     - checkout: uitools
       clean: true
@@ -1107,7 +1147,7 @@ stages:
         if ("$(Build.Reason)" -eq "PullRequest") {
             $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
         }
-        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d16*")) {
+        if (("$branchName" -ne "main") -and ("$branchName" -notlike "d1*")) {
             $branchName = "main"
         }
         Set-Location -Path $(System.DefaultWorkingDirectory)\UITools
@@ -1126,15 +1166,20 @@ stages:
         github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)\UITools\Designer\bot-provisioning\dependencies.csx
         provisioning_extra_args: -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
+      env:
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates\setup-test-environment.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)\xamarin-android
         jdkTestFolder: $(JAVA_HOME_8_X64)
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: designer\android-designer-build-win.yaml@yaml
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)\UITools\Designer
+        uiToolsSourcePath: $(System.DefaultWorkingDirectory)\UITools
+        javaSdkDirectory: $(JAVA_HOME_8_X64)
 
     - template: designer\android-designer-tests.yaml@yaml
       parameters:
@@ -1172,6 +1217,8 @@ stages:
       clean: all
     steps:
     - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -1,6 +1,7 @@
 parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
   makeMSBuildArgs: ''
+  provisionatorChannel: latest
 
 steps:
 - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-11"
@@ -21,6 +22,8 @@ steps:
     github_token: $(GitHub.Token)
     provisioning_script: ${{ parameters.xaSourcePath }}/build-tools/provisioning/xcode.csx
     provisioning_extra_args: '-v -v -v -v'
+  env:
+    PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
 - script: make prepare-update-mono CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
   workingDirectory: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -1,5 +1,6 @@
 parameters:
   provisionExtraArgs: -vv -f
+  provisionatorChannel: latest
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -37,3 +38,5 @@ steps:
     provisioning_script: $(XA.Provisionator.Args)
     provisioning_extra_args: ${{ parameters.provisionExtraArgs }}
   condition: and(succeeded(), ne(variables['agent.os'], 'Linux'))
+  env:
+    PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -6,6 +6,7 @@ parameters:
   job_suffix: ''
   nunit_categories: ''
   target_framework: 'net472'
+  provisionatorChannel: latest
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -18,6 +19,8 @@ jobs:
       clean: all
     steps:
     - template: setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: run-xaprepare.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -7,6 +7,7 @@ parameters:
   nunit_categories: ''
   target_framework: 'net472'
   run_extra_tests: false
+  provisionatorChannel: latest
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -19,6 +20,8 @@ jobs:
       clean: all
     steps:
     - template: setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -8,6 +8,7 @@ parameters:
   nunit_categories: ''
   target_framework: 'net472'
   run_extra_tests: false
+  provisionatorChannel: latest
 
 jobs:
   - job: ${{ parameters.job_name }}
@@ -25,6 +26,8 @@ jobs:
     - template: clean.yaml
 
     - template: setup-test-environment.yaml
+      parameters:
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,6 +1,7 @@
 parameters:
   configuration: $(XA.Build.Configuration)
   provisionExtraArgs: -vv -f
+  provisionatorChannel: latest
   xaSourcePath: $(System.DefaultWorkingDirectory)
   updateVS: false
   jdkTestFolder: $(JAVA_HOME_11_X64)
@@ -20,6 +21,7 @@ steps:
 - template: run-installer.yaml
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
+    provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"


### PR DESCRIPTION
Context: https://github.com/xamarin/provisionator/pull/447
Context: https://github.com/xamarin/yaml-templates/pull/172
Context: https://github.com/xamarin/UITools/blob/a59d5dbc9ba48b7ffba40156dba3314d8fb12de3/Designer/build/automation/stages/validate-android-designer.yml#L14
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1469705

The Windows build and test job for the designer has been updated in
xamarin/UITools, and the tests have been re-enabled.  The macOS tests
have also been temporarily disabled.

Update our Designer test jobs to mirror their changes.

A new `provisionatorChannel` parameter has been added which will allow
builds to be manually queued against provisionator PRs for testing
purposes.