### PR TITLE
Default VerifyDependencyInjectionOpenGenericServiceTrimmability

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -98,6 +98,9 @@
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>		
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>    
+    <!-- Verify DI trimmability at development-time, but turn the validation off for Release builds. -->
+		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' and '$(Configuration)' == 'Release'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+		<VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 
     <!-- TODO: default to true when https://github.com/dotnet/linker/issues/2563 is fixed -->
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>


### PR DESCRIPTION
This feature switch ensures that DynamicallyAccessedMembers are applied correctly to open generic types used in Dependency Injection.

In the base SDK, this switch is enabled when PublishTrimmed=true. However, Android apps don't set PublishTrimmed=true in Debug builds. So devs are missing out on this validation.

Conversely, in published apps, we don't want to pay the cost of doing this validation. It was showing up in startup profiles. So turning the feature switch off in Release builds.