### PR TITLE
[ci] Swap Maestro and artifact status ordering

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1323,7 +1323,7 @@ stages:
         & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
         & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
       displayName: add build to default darc channel
-      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
+      condition: false
 
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1346,7 +1346,7 @@ stages:
         & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
         & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
       displayName: add build to default darc channel
-      condition: false
+      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
 
     - template: yaml-templates\upload-results.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1306,25 +1306,6 @@ stages:
         publishFeedCredentials: $(DotNetFeedCredential)
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
-    - powershell: >-
-        & dotnet build -v:n -c $(XA.Build.Configuration)
-        -t:PushManifestToBuildAssetRegistry
-        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-        -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
-        $(Build.StagingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
-        -bl:$(Build.StagingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
-      displayName: generate and publish BAR manifest
-      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
-
-    - powershell: |
-        $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
-        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-      displayName: add build to default darc channel
-      condition: false
-
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
@@ -1348,9 +1329,28 @@ stages:
             artifactName: vsdrop-signed
             downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
 
+    - powershell: >-
+        & dotnet build -v:n -c $(XA.Build.Configuration)
+        -t:PushManifestToBuildAssetRegistry
+        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+        -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
+        $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
+        -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
+      displayName: generate and publish BAR manifest
+      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
+
+    - powershell: |
+        $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+      displayName: add build to default darc channel
+      condition: false
+
     - template: yaml-templates\upload-results.yaml
       parameters:
-        xaSourcePath: $(Build.StagingDirectory)
+        xaSourcePath: $(System.DefaultWorkingDirectory)
         artifactName: Prepare Release - Push Internal
         includeBuildResults: true
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1306,6 +1306,25 @@ stages:
         publishFeedCredentials: $(DotNetFeedCredential)
       condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
+    - powershell: >-
+        & dotnet build -v:n -c $(XA.Build.Configuration)
+        -t:PushManifestToBuildAssetRegistry
+        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+        -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
+        $(Build.StagingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
+        -bl:$(Build.StagingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
+      displayName: generate and publish BAR manifest
+      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
+
+    - powershell: |
+        $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+      displayName: add build to default darc channel
+      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
+
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
         githubToken: $(GitHub.Token)
@@ -1321,32 +1340,19 @@ stages:
         githubContext: $(VSDropCommitStatusName)
         blobName: $(VSDropCommitStatusName)
         packagePrefix: xamarin-android
-        artifactsPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+        artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
         yamlResourceName: yaml
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:
             artifactName: vsdrop-signed
-            downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+            downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
 
-    - powershell: >-
-        & dotnet build -v:n -c $(XA.Build.Configuration)
-        -t:PushManifestToBuildAssetRegistry
-        -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-        -p:OutputPath=$(System.DefaultWorkingDirectory)\nuget-signed\
-        $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
-        -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
-      displayName: generate and publish BAR manifest
-      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
-
-    - powershell: |
-        $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
-        $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-        $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-        & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-        & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-      displayName: add build to default darc channel
-      condition: and(succeeded(), eq(variables['PushXAPackageInfoToMaestro'], 'true'))
+    - template: yaml-templates\upload-results.yaml
+      parameters:
+        xaSourcePath: $(Build.StagingDirectory)
+        artifactName: Prepare Release - Push Internal
+        includeBuildResults: true
 
 # .NET 6 VS Insertion Stage
 # Check - "Xamarin.Android (VS Insertion - Wait For Approval)"

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -180,7 +180,7 @@
         RepoCommit="$(BUILD_SOURCEVERSION)"
         PublishingVersion="3" />
 
-    <!--MSBuild
+    <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
@@ -189,7 +189,7 @@
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
-    /-->
+    />
   </Target>
 
 </Project>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -180,7 +180,7 @@
         RepoCommit="$(BUILD_SOURCEVERSION)"
         PublishingVersion="3" />
 
-    <MSBuild
+    <!--MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
@@ -189,7 +189,7 @@
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
-    />
+    /-->
   </Target>
 
 </Project>


### PR DESCRIPTION
We've seen some failures in recent attempts to push package info to the
Maestro Build Asset Registry.  Fix this by using the correct OutputPath
when running `<PushManifestToBuildAssetRegistry/>`.