### PR TITLE
[Mono.Android] add a few more _JniMarshal_ built-in delegates

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -26,6 +26,28 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static int Wrap_JniMarshal_PP_I (this _JniMarshal_PP_I callback, IntPtr jnienv, IntPtr klazz)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PP_Z (this _JniMarshal_PP_Z callback, IntPtr jnienv, IntPtr klazz)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static void Wrap_JniMarshal_PPI_V (this _JniMarshal_PPI_V callback, IntPtr jnienv, IntPtr klazz, int p0)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -34,6 +56,39 @@ namespace Android.Runtime
 			} catch (Exception e) when (_unhandled_exception (e)) {
 				AndroidEnvironment.UnhandledException (e);
 				
+			}
+		}
+
+		internal static IntPtr Wrap_JniMarshal_PPI_L (this _JniMarshal_PPI_L callback, IntPtr jnienv, IntPtr klazz, int p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static int Wrap_JniMarshal_PPI_I (this _JniMarshal_PPI_I callback, IntPtr jnienv, IntPtr klazz, int p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static long Wrap_JniMarshal_PPI_J (this _JniMarshal_PPI_J callback, IntPtr jnienv, IntPtr klazz, int p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
 			}
 		}
 
@@ -103,6 +158,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static IntPtr Wrap_JniMarshal_PPLI_L (this _JniMarshal_PPLI_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static bool Wrap_JniMarshal_PPLL_Z (this _JniMarshal_PPLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -122,6 +188,17 @@ namespace Android.Runtime
 			} catch (Exception e) when (_unhandled_exception (e)) {
 				AndroidEnvironment.UnhandledException (e);
 				
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPLLJ_Z (this _JniMarshal_PPLLJ_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, long p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
 			}
 		}
 
@@ -229,8 +306,18 @@ namespace Android.Runtime
 			switch (delegateType.Name) {
 				case nameof (_JniMarshal_PP_V):
 					return new _JniMarshal_PP_V (Unsafe.As<_JniMarshal_PP_V> (dlg).Wrap_JniMarshal_PP_V);
+				case nameof (_JniMarshal_PP_I):
+					return new _JniMarshal_PP_I (Unsafe.As<_JniMarshal_PP_I> (dlg).Wrap_JniMarshal_PP_I);
+				case nameof (_JniMarshal_PP_Z):
+					return new _JniMarshal_PP_Z (Unsafe.As<_JniMarshal_PP_Z> (dlg).Wrap_JniMarshal_PP_Z);
 				case nameof (_JniMarshal_PPI_V):
 					return new _JniMarshal_PPI_V (Unsafe.As<_JniMarshal_PPI_V> (dlg).Wrap_JniMarshal_PPI_V);
+				case nameof (_JniMarshal_PPI_L):
+					return new _JniMarshal_PPI_L (Unsafe.As<_JniMarshal_PPI_L> (dlg).Wrap_JniMarshal_PPI_L);
+				case nameof (_JniMarshal_PPI_I):
+					return new _JniMarshal_PPI_I (Unsafe.As<_JniMarshal_PPI_I> (dlg).Wrap_JniMarshal_PPI_I);
+				case nameof (_JniMarshal_PPI_J):
+					return new _JniMarshal_PPI_J (Unsafe.As<_JniMarshal_PPI_J> (dlg).Wrap_JniMarshal_PPI_J);
 				case nameof (_JniMarshal_PPL_L):
 					return new _JniMarshal_PPL_L (Unsafe.As<_JniMarshal_PPL_L> (dlg).Wrap_JniMarshal_PPL_L);
 				case nameof (_JniMarshal_PPL_V):
@@ -243,10 +330,14 @@ namespace Android.Runtime
 					return new _JniMarshal_PPLI_V (Unsafe.As<_JniMarshal_PPLI_V> (dlg).Wrap_JniMarshal_PPLI_V);
 				case nameof (_JniMarshal_PPLL_V):
 					return new _JniMarshal_PPLL_V (Unsafe.As<_JniMarshal_PPLL_V> (dlg).Wrap_JniMarshal_PPLL_V);
+				case nameof (_JniMarshal_PPLI_L):
+					return new _JniMarshal_PPLI_L (Unsafe.As<_JniMarshal_PPLI_L> (dlg).Wrap_JniMarshal_PPLI_L);
 				case nameof (_JniMarshal_PPLL_Z):
 					return new _JniMarshal_PPLL_Z (Unsafe.As<_JniMarshal_PPLL_Z> (dlg).Wrap_JniMarshal_PPLL_Z);
 				case nameof (_JniMarshal_PPIIL_V):
 					return new _JniMarshal_PPIIL_V (Unsafe.As<_JniMarshal_PPIIL_V> (dlg).Wrap_JniMarshal_PPIIL_V);
+				case nameof (_JniMarshal_PPLLJ_Z):
+					return new _JniMarshal_PPLLJ_Z (Unsafe.As<_JniMarshal_PPLLJ_Z> (dlg).Wrap_JniMarshal_PPLLJ_Z);
 				case nameof (_JniMarshal_PPILL_V):
 					return new _JniMarshal_PPILL_V (Unsafe.As<_JniMarshal_PPILL_V> (dlg).Wrap_JniMarshal_PPILL_V);
 				case nameof (_JniMarshal_PPLIL_Z):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -11,9 +11,39 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz",
 	},
 	new {
+		Type = "_JniMarshal_PP_I",
+		Signature = "IntPtr jnienv, IntPtr klazz",
+		Return = "int",
+		Invoke = "jnienv, klazz",
+	},
+	new {
+		Type = "_JniMarshal_PP_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz",
+		Return = "bool",
+		Invoke = "jnienv, klazz",
+	},
+	new {
 		Type = "_JniMarshal_PPI_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, int p0",
 		Return = "void",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPI_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPI_I",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0",
+		Return = "int",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPI_J",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0",
+		Return = "long",
 		Invoke = "jnienv, klazz, p0",
 	},
 	new {
@@ -53,6 +83,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1",
 	},
 	new {
+		Type = "_JniMarshal_PPLI_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
 		Type = "_JniMarshal_PPLL_Z",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
 		Return = "bool",
@@ -62,6 +98,12 @@ var delegateTypes = new [] {
 		Type = "_JniMarshal_PPIIL_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2",
 		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLLJ_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, long p2",
+		Return = "bool",
 		Invoke = "jnienv, klazz, p0, p1, p2",
 	},
 	new {


### PR DESCRIPTION
Context: https://github.com/microsoft/dotnet-podcasts

Running the MAUI podcast sample, shows several `_JniMarshal_`
delegates we could list:

    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PP_I': Int32 n_GetItemCount(IntPtr, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PP_I': Int32 n_GetOpacity(IntPtr, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PP_Z': Boolean n_CanScrollVertically(IntPtr, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPI_L': IntPtr n_CreateFragment_I(IntPtr, IntPtr, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPI_I': Int32 n_GetItemViewType_I(IntPtr, IntPtr, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPI_I': Int32 n_GetSpanSize_I(IntPtr, IntPtr, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPI_J': Int64 n_GetItemId_I(IntPtr, IntPtr, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLI_L': IntPtr n_OnCreateViewHolder_Landroid_view_ViewGroup_I(IntPtr, IntPtr, IntPtr, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLLJ_Z': Boolean n_DrawChild_Landroid_graphics_Canvas_Landroid_view_View_J(IntPtr, IntPtr, IntPtr, IntPtr, Int64)

These look to be the types of APIs that would be common in Android
applications. Listing 7 more of these in `JNINativeWrapper.g.tt` would
cover the above APIs.

A couple more appeared, but these don't seem like they would be as
common:

    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLF_V': Void n_OnDrawerSlide_Landroid_view_View_F(IntPtr, IntPtr, IntPtr, Single)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_I': Int32 n_OnStartCommand_Landroid_content_Intent_II(IntPtr, IntPtr, IntPtr, Int32, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_Z': Boolean n_OnError_Landroid_media_MediaPlayer_II(IntPtr, IntPtr, IntPtr, Int32, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPIII_V': Void n_OnItemRangeMoved_III(IntPtr, IntPtr, Int32, Int32, Int32)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_V': Void n_OnScrolled_Landroidx_recyclerview_widget_RecyclerView_II(IntPtr, IntPtr, IntPtr, Int32, Int32)

## Results ##

Testing a Release (non-AOT) build of the podcast app on a Pixel 5
device using our `dotnet trace` infrastructure:

https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/tracing.md

    Before:
    26.88ms (0.56%) mono.android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
     1.20ms (0.02%) mono.android!Android.Runtime.JNINativeWrapper.CreateBuiltInDelegate(System.Delegate,System.Type)

    After:
    17.19ms (0.34%) mono.android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
     1.15ms (0.02%) mono.android!Android.Runtime.JNINativeWrapper.CreateBuiltInDelegate(System.Delegate,System.Type)

I don't think that `CreateBuiltInDelegate` got any faster, but I would
consider it roughly "the same". I think this saves ~9ms in this method.