### PR TITLE
[ci] Use `internal-macos-11` for official macOS builds 

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -66,13 +66,17 @@ variables:
 - ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Real
-  - name: VSEngMacBuildPool
-    value: VSEng-Xamarin-RedmondMac-Android-Trusted
+  - name: MacBuildPoolName
+    value: Azure Pipelines
+  - name: MacBuildPoolImage
+    value: internal-macos-11
 - ${{ if or(and(ne(variables['Build.DefinitionName'],'Xamarin.Android'), ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Test
-  - name: VSEngMacBuildPool
+  - name: MacBuildPoolName
     value: VSEng-Xamarin-RedmondMac-Android-Untrusted
+  - name: MacBuildPoolImage
+    value: ''
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
@@ -84,9 +88,10 @@ stages:
   - job: mac_build_create_installers
     displayName: Build
     pool:
-      name: $(VSEngMacBuildPool)
-      demands:
-      - agent.osversionfamily -equals 10.15
+      name: $(MacBuildPoolName)
+      vmImage: $(MacBuildPoolImage)
+      ${{ if eq(variables['MacBuildPoolName'], 'VSEng-Xamarin-RedmondMac-Android-Untrusted') }}:
+        demands: agent.osversionfamily -equals 10.15
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -1476,9 +1481,8 @@ stages:
   - job: notarize_pkg_upload_storage
     displayName: Notarize and Upload
     pool:
-      name: $(VSEngMacBuildPool)
-      demands:
-      - agent.osversionfamily -equals 10.15
+      name: $(MacBuildPoolName)
+      vmImage: $(MacBuildPoolImage)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 1
     workspace:

--- a/build-tools/provisioning/xcode.csx
+++ b/build-tools/provisioning/xcode.csx
@@ -1,10 +1,10 @@
 if (IsMac) {
-	const string MinMacOSVersion = "10.14.4";
-	const string MinMacOSVersionForLatestXcode = "10.15.4";
+	const string MinMacOSVersion = "10.15.4";
+	const string MinMacOSVersionForLatestXcode = "11.3";
 	if (OSVersion < new Version (MinMacOSVersion))
-		throw new Exception ($"macOS {MinMacOSVersion} or newer is required for Xcode 11.");
+		throw new Exception ($"macOS {MinMacOSVersion} or newer is required for Xcode 12.");
 	if (OSVersion >= new Version (MinMacOSVersionForLatestXcode))
-		Xcode ("12.4").XcodeSelect ();
+		Xcode ("13.2").XcodeSelect ();
 	else
-		Xcode ("11.3.1").XcodeSelect ();
+		Xcode ("12.4").XcodeSelect ();
 }


### PR DESCRIPTION
Context: https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

Moves our offical macOS build to the `internal-macos-11` build pool as
part of ongoing security and compliance efforts.

The `VSEng-Xamarin-RedmondMac-Android-Untrusted` pool will continue to
be used for PR builds for performance reasons, and it will be updated to
macOS 11 over the next week or two.

We will also now provision and use Xcode 13.2 when running on macOS 11
machines.