### PR TITLE
[One .NET] fix incremental AOT builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -97,7 +97,7 @@ _ResolveAssemblies MSBuild target.
     <PropertyGroup>
       <_InnerIntermediateOutputPath>$(IntermediateOutputPath)%(_RIDs.Identity)\</_InnerIntermediateOutputPath>
       <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(_InnerIntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
-      <_AndroidLinkFlag>$(_InnerIntermediateOutputPath)link.flag</_AndroidLinkFlag>
+      <_AndroidLinkFlag Condition=" '$(RuntimeIdentifier)' == '' " >$(_InnerIntermediateOutputPath)link.flag</_AndroidLinkFlag>
     </PropertyGroup>
     <ItemGroup>
       <_ResolvedAssemblyFiles Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.dll' " />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -814,13 +814,14 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 		}
 
 		[Test]
-		public void DotNetIncremental ()
+		public void DotNetIncremental ([Values (true, false)] bool isRelease, [Values ("", "android-arm64")] string runtimeIdentifier)
 		{
 			// Setup dependencies App A -> Lib B
 			var path = Path.Combine ("temp", TestName);
 
 			var libB = new XASdkProject (outputType: "Library") {
-				ProjectName = "LibraryB"
+				ProjectName = "LibraryB",
+				IsRelease = isRelease,
 			};
 			libB.Sources.Clear ();
 			libB.Sources.Add (new BuildItem.Source ("Foo.cs") {
@@ -832,6 +833,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 
 			var appA = new XASdkProject {
 				ProjectName = "AppA",
+				IsRelease = isRelease,
 				Sources = {
 					new BuildItem.Source ("Bar.cs") {
 						TextContent = () => "public class Bar : Foo { }",
@@ -840,12 +842,20 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			};
 			appA.AddReference (libB);
 			var appBuilder = CreateDotNetBuilder (appA, Path.Combine (path, appA.ProjectName));
-			Assert.IsTrue (appBuilder.Build (), $"{appA.ProjectName} should succeed");
+			Assert.IsTrue (appBuilder.Build (runtimeIdentifier: runtimeIdentifier), $"{appA.ProjectName} should succeed");
 			appBuilder.AssertTargetIsNotSkipped ("CoreCompile");
+			if (isRelease) {
+				appBuilder.AssertTargetIsNotSkipped ("_RemoveRegisterAttribute");
+				appBuilder.AssertTargetIsNotSkipped ("_AndroidAot");
+			}
 
 			// Build again, no changes
-			Assert.IsTrue (appBuilder.Build (), $"{appA.ProjectName} should succeed");
+			Assert.IsTrue (appBuilder.Build (runtimeIdentifier: runtimeIdentifier), $"{appA.ProjectName} should succeed");
 			appBuilder.AssertTargetIsSkipped ("CoreCompile");
+			if (isRelease) {
+				appBuilder.AssertTargetIsSkipped ("_RemoveRegisterAttribute");
+				appBuilder.AssertTargetIsSkipped ("_AndroidAot");
+			}
 		}
 
 		[Test]
@@ -854,7 +864,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			var proj = new XASdkProject ();
 			var builder = CreateDotNetBuilder (proj);
 			var parameters = new [] { "BuildingInsideVisualStudio=true" };
-			Assert.IsTrue (builder.Build ("SignAndroidPackage", parameters), $"{proj.ProjectName} should succeed");
+			Assert.IsTrue (builder.Build ("SignAndroidPackage", parameters: parameters), $"{proj.ProjectName} should succeed");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -92,21 +92,21 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Build (string target = null, string [] parameters = null)
+		public bool Build (string target = null, string runtimeIdentifier = null, string [] parameters = null)
 		{
-			var arguments = GetDefaultCommandLineArgs ("build", target, parameters);
+			var arguments = GetDefaultCommandLineArgs ("build", target, runtimeIdentifier, parameters);
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Pack (string target = null, string [] parameters = null)
+		public bool Pack (string target = null, string runtimeIdentifier = null, string [] parameters = null)
 		{
-			var arguments = GetDefaultCommandLineArgs ("pack", target, parameters);
+			var arguments = GetDefaultCommandLineArgs ("pack", target, runtimeIdentifier, parameters);
 			return Execute (arguments.ToArray ());
 		}
 
-		public bool Publish (string target = null, string [] parameters = null)
+		public bool Publish (string target = null, string runtimeIdentifier = null, string [] parameters = null)
 		{
-			var arguments = GetDefaultCommandLineArgs ("publish", target, parameters);
+			var arguments = GetDefaultCommandLineArgs ("publish", target, runtimeIdentifier, parameters);
 			return Execute (arguments.ToArray ());
 		}
 
@@ -133,7 +133,7 @@ namespace Xamarin.ProjectTools
 
 		public bool IsTargetSkipped (string target) => BuildOutput.IsTargetSkipped (LastBuildOutput, target);
 
-		List<string> GetDefaultCommandLineArgs (string verb, string target = null, string [] parameters = null)
+		List<string> GetDefaultCommandLineArgs (string verb, string target = null, string runtimeIdentifier = null, string [] parameters = null)
 		{
 			string testDir = Path.GetDirectoryName (projectOrSolution);
 			if (string.IsNullOrEmpty (ProcessLogFile))
@@ -166,6 +166,11 @@ namespace Xamarin.ProjectTools
 				foreach (var parameter in parameters) {
 					arguments.Add ($"/p:{parameter}");
 				}
+			}
+			if (!string.IsNullOrEmpty (runtimeIdentifier)) {
+				// NOTE: that this one has to be -r, /r does not appear to work
+				arguments.Add ("-r");
+				arguments.Add (runtimeIdentifier);
 			}
 			return arguments;
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -131,7 +131,7 @@ namespace Xamarin.Android.Build.Tests
 			options.EvaluationOptions.UseExternalTypeResolver = true;
 			ClearAdbLogcat ();
 			dotnet.BuildLogFile = Path.Combine (Root, dotnet.ProjectDirectory, "run.log");
-			Assert.True (dotnet.Build ("Run", new string [] {
+			Assert.True (dotnet.Build ("Run", parameters: new [] {
 				$"AndroidSdbTargetPort={port}",
 				$"AndroidSdbHostPort={port}",
 				"AndroidAttachDebugger=True",


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6732

A problem occurs when you do:

    > dotnet new android
    > dotnet build -c Release -r android-arm64
    > dotnet build -c Release -r android-arm64

After the second build with no changes, MSBuild targets run that
shouldn't -- and you end up with an `.apk` that is missing all the
AOT'd assemblies!

What is happening is the `Inputs` to the `_RemoveRegisterAttribute`
have the wrong path of a file:

    Input file "obj\Release\net6.0-android\android-arm64\android-arm64\link.flag" does not exist.

Removing `-r android-arm64` from the above commands solve the problem!

The issue here being:

1. We have an "outer" build where normally `$(RuntimeIdentifiers)`
   (plural) triggers an "inner" build for each RID.

2. Each inner build runs ILLink & AOT compilation.

3. The outer build collects the resulting files and does other work.

At step 3, we were using the wrong path for `$(_AndroidLinkFlag)` --
but only when `$(RuntimeIdentifier)` (singular) is used.

I fixed this problem, and updated various tests to catch this in the
future.

I would ideally love for this inner/outer build situation to be
handled by the dotnet/sdk, but this is what we have for now.