### PR TITLE
[build] set $(ProduceReferenceAssemblyInOutDir)=True

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,8 @@
     <PrepTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\xa-prep-tasks.dll</PrepTasksAssembly>
     <!-- Copy PackageReference content to OutputDir for our build tasks, tests, and installer creation logic. This no longer happens by default in short-form projects. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Ensure reference assemblies copied to bin -->
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj
Context: https://github.com/dotnet/msbuild/issues/7355
Context: https://github.com/xamarin/java.interop/pull/949

Using the latest internal builds of Visual Studio, you hit the build
error when building xamarin-android:

    error MSB4018: The "CreateFrameworkListFile" task failed unexpectedly. [C:\src\xamarin-android\build-tools\create-packs\Microsoft.Android.Ref.proj] [C:\src\xamarin-android\build-tools\create-packs\Microsoft.Android.Sdk.proj]
    error MSB4018: System.IO.FileNotFoundException: Could not find file 'C:\src\xamarin-android\bin\Release\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\net6.0-android32\ref\Mono.Android.dll'.

This was a breaking change in MSBuild:

> ### Old behavior
> Since reference assemblies were added, the .NET SDK has written
> reference assemblies to the `ref` directory in the `OutDir`
> directory of the compilation.
>
> ### New behavior
> Now, reference assemblies are written to the `refint` directory of
> the `IntermediateOutputPath` directory by default, like many other
> intermediate artifacts.
>
> ### Reason for change
> Reference assemblies are generally not run-time assets, and so don't
> belong in the `OutDir` directory by default.

Since we *are* using the reference assembly as build output, I think
we *should* put the file in `bin`.

Let's set `$(ProduceReferenceAssemblyInOutDir)`=True to get the
old behavior.

I could not figure out how to use `$(TargetRefPath)` here, as
different projects are using the files than producing them... If the
same project was building `Mono.Android.dll` as packing it, we could
use that property and not have to know if the file is in `bin` or `obj`.