### PR TITLE
[One .NET] fix PublishTrimmed=true for Debug builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -107,6 +107,7 @@ _ResolveAssemblies MSBuild target.
         RuntimeIdentifiers="@(_RIDs)"
         InputAssemblies="@(_ResolvedAssemblyFiles->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles->Distinct())"
+        AndroidIncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
         PublishTrimmed="$(PublishTrimmed)">
       <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
       <Output TaskParameter="ResolvedSymbols"  ItemName="ResolvedSymbols" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string [] RuntimeIdentifiers { get; set; } = Array.Empty<string>();
 
+		public bool AndroidIncludeDebugSymbols { get; set; }
+
 		public bool PublishTrimmed { get; set; }
 
 		public ITaskItem [] InputAssemblies { get; set; } = Array.Empty<ITaskItem> ();
@@ -63,7 +65,8 @@ namespace Xamarin.Android.Tasks
 			ResolvedSymbols = symbols.Values.ToArray ();
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
-			if (PublishTrimmed) {
+			// This should match the Condition on the _RemoveRegisterAttribute target
+			if (PublishTrimmed && !AndroidIncludeDebugSymbols) {
 				var shrunkAssemblies = new List<ITaskItem> (OutputAssemblies.Length);
 				foreach (var assembly in OutputAssemblies) {
 					var dir = Path.GetDirectoryName (assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -885,6 +885,13 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 				/* publishTrimmed */ true,
 				/* aot */            true,
 			},
+			// Debug + PublishTrimmed
+			new object [] {
+				/* isRelease */      false,
+				/* useInterpreter */ false,
+				/* publishTrimmed */ true,
+				/* aot */            false,
+			},
 		};
 
 		[Test]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6628

The following will fail:

    > dotnet new android
    > dotnet build -p:PublishTrimmed=true

with:

    error XABLD7023: System.IO.DirectoryNotFoundException: Could not find a part of the path 'obj\Debug\net6.0-android\android-arm\linked\shrunk\UnnamedProject.dll'.
    at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
    at System.IO.File.OpenRead(String path)
    at Xamarin.Android.Tasks.MonoAndroidHelper.IsReferenceAssembly(String assembly)
    at Xamarin.Android.Tasks.BuildApk.<AddAssemblies>g__AddAssembliesFromCollection|146_0(ITaskItem[] assemblies, <>c__DisplayClass146_0& )
    at Xamarin.Android.Tasks.BuildApk.AddAssemblies(ZipArchiveEx apk, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo, String assemblyStoreApkName)
    at Xamarin.Android.Tasks.BuildApk.ExecuteWithAbi(String[] supportedAbis, String apkInputPath, String apkOutputPath, Boolean debug, Boolean compress, IDictionary`2 compressedAssembliesInfo, String assemblyStoreApkName)
    at Xamarin.Android.Tasks.BuildApk.RunTask()
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in C:\src\xamarin-android\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\AndroidTask.cs:line 17

The problem being that the logic in the `<ProcessAssemblies/>` MSBuild
task does not match exactly with the `_RemoveRegisterAttribute`
MSBuild target. Then we end up attempting to use the `shrunk` folder
that does not exist!

I added a parameterized test for this case, and fixed the logic so the
two places now match.