### PR TITLE
[ci] Update compiler version variables for OSS Linux build

### DIFF
--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -154,6 +154,9 @@ stages:
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
+    variables:
+      CXX: g++-10
+      CC: gcc-10
     steps:
     - checkout: self
       submodules: recursive


### PR DESCRIPTION
Fixes our OSS Linux build by ensuring that newer versions of the `g++`
and `gcc` compilers are used when needed.