### PR TITLE
[README] Add d17.1 aka.ms link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Link   |
 |-----------------|--------|
-| **Commercial Xamarin.Android 12.1 (d17-0)** for Windows+Visual Studio 2022                 | [Download][commercial-d17-0-Windows-x86_64] |
-| **Commercial Xamarin.Android 12.1 (d17-0)** for macOS                                      | [Download][commercial-d17-0-macOS-x86_64]   |
-| **OSS Xamarin.Android 12.1.99 (main)** for Ubuntu\*                                        | [![OSS Linux/Ubuntu x86_64][oss-ubuntu-x86_64-icon]][oss-ubuntu-x86_64-status] |
+| **Commercial Xamarin.Android 12.2 (d17-1)** for Windows+Visual Studio 2022                 | [Download][commercial-d17-1-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.2 (d17-1)** for macOS                                      | No Stable VSMac 2022 17.1 Release   |
+| **OSS Xamarin.Android (main)** for Ubuntu\*                                                | [![OSS Linux/Ubuntu x86_64][oss-ubuntu-x86_64-icon]][oss-ubuntu-x86_64-status] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
 
@@ -34,6 +34,8 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Link   |
 |-----------------|--------|
+| **Commercial Xamarin.Android 12.1 (d17-0)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-0-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.1 (d17-0)** for macOS                                       | No Stable VSMac 2022 17.0 Release   |
 | **Commercial Xamarin.Android 12.0 (d16-11)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-11-Windows-x86_64] |
 | **Commercial Xamarin.Android 12.0 (d16-11)** for macOS                                      | [Download][commercial-d16-11-macOS-x86_64]   |
 | **Commercial Xamarin.Android 11.3 (d16-10)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-10-Windows-x86_64] |
@@ -84,7 +86,7 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d16-11-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-11-windows
 [commercial-d16-11-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-11-macos
 [commercial-d17-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-0-windows
-[commercial-d17-0-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d17-0-macos
+[commercial-d17-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-1-windows
 
 # Contributing
 


### PR DESCRIPTION
Add Windows d17.1 aka.ms link.

Remove Mac d17.0 aka.ms link, as there is no stable VSMac 17.0 or 17.1.  The previous link was to a pre-release build that contains the incorrect `0.1.2.0` `Java.Interop.dll`.