### PR TITLE
[Mono.Android] JNIEnv.GetObjectArray() can use Array.Empty<T>()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -1325,6 +1325,8 @@ namespace Android.Runtime {
 				return null;
 
 			int cnt = _GetArrayLength (array_ptr);
+			if (cnt == 0)
+				return Array.Empty<object> ();
 
 			var converter = GetConverter (NativeArrayElementToManaged, null, array_ptr);
 

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -122,7 +122,7 @@ namespace Java.Interop {
 		static Type[] GetParameterTypes (string? signature)
 		{
 			if (String.IsNullOrEmpty (signature))
-				return new Type[0];
+				return Array.Empty<Type> ();
 			string[] typenames = signature!.Split (':');
 			Type[] result = new Type [typenames.Length];
 			for (int i = 0; i < typenames.Length; i++)


### PR DESCRIPTION
Context: https://github.com/microsoft/dotnet-podcasts

In working on #6766 and reviewing `dotnet trace` output, I found time
being spent in `JNIEnv.GetObjectArray()`:

    17.09ms Mono.Android!Java.Interop.TypeManager.n_Activate(intptr,intptr,intptr,intptr,intptr,intptr)
    ...
     4.96ms Mono.Android!Android.Runtime.JNIEnv.GetObjectArray

In this case, it is taking an array of parameters and calling a
constructor. A lot of the time we are calling empty constructors!

Reviewing `JNIEnv.GetObjectArray()` we could add a check if the array
is of length 0 and return `Array.Empty<object>()`. I also found one
other place doing `new Type[0]` we can fix while we're at it.

After the change, I instead get:

    2.56ms Mono.Android!Android.Runtime.JNIEnv.GetObjectArray

I'm not able to see a noticeable difference in `dotnet new maui`,
likely as this is such as small improvement.