### PR TITLE
[build] Bump Android tools versions

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -139,8 +139,8 @@
     <XABuildTools30PackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildTools30PackagePrefixWindows)</XABuildTools30PackagePrefix>
     <XABuildTools30Version>30.0.3</XABuildTools30Version>
     <XABuildTools30Folder Condition="'$(XABuildTools30Folder)' == ''">30.0.3</XABuildTools30Folder>
-    <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">e8b2b4cbe47c728c1e54c5f524440b52d4e1a33c.</XAPlatformToolsPackagePrefix>
-    <XAPlatformToolsVersion>31.0.3</XAPlatformToolsVersion>
+    <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
+    <XAPlatformToolsVersion>32.0.0</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.8.1</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>


### PR DESCRIPTION
Context: https://dl-ssl.google.com/android/repository/repository2-3.xml
Context: https://github.com/xamarin/xamarin-android/pull/6469
Context: https://github.com/xamarin/xamarin-android/pull/6764

Bump `$(XAPlatformToolsVersion)`=32.0.0, which is the current
non-RC `platform-tools` Android SDK package version.

We are already on the latest `build-tools` package version, and on
the latest NDK r23.* version.  (There are NDK r24 and r25 versions,
but we don't support them yet; see also PR #6469, #6764.)