### PR TITLE
[Xamarin.Android.Build.Tasks] fix $(EnableLLVM) + $(AndroidEnableProfiledAot)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -154,12 +154,6 @@ namespace Xamarin.Android.Tasks
 					if (!string.IsNullOrEmpty (MsymPath)) {
 						aotOptions.Add ($"msym-dir={MsymPath}");
 					}
-					if (!string.IsNullOrEmpty (LdName)) {
-						aotOptions.Add ($"ld-name={LdName}");
-					}
-					if (!string.IsNullOrEmpty (LdFlags)) {
-						aotOptions.Add ($"ld-flags={LdFlags}");
-					}
 					if (Profiles != null && Profiles.Length > 0) {
 						if (Path.GetFileNameWithoutExtension (assembly.ItemSpec) == TargetName) {
 							LogDebugMessage ($"Not using profile(s) for main assembly: {assembly.ItemSpec}");
@@ -170,6 +164,13 @@ namespace Xamarin.Android.Tasks
 								aotOptions.Add ($"profile={fp}");
 							}
 						}
+					}
+					// NOTE: ld-name and ld-flags MUST be last, otherwise Mono fails to parse it on Windows
+					if (!string.IsNullOrEmpty (LdName)) {
+						aotOptions.Add ($"ld-name={LdName}");
+					}
+					if (!string.IsNullOrEmpty (LdFlags)) {
+						aotOptions.Add ($"ld-flags={LdFlags}");
 					}
 
 					// we need to quote the entire --aot arguments here to make sure it is parsed

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -58,12 +58,13 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test, Category ("SmokeTests"), Category ("ProfiledAOT")]
-		public void BuildBasicApplicationReleaseProfiledAot ()
+		public void BuildBasicApplicationReleaseProfiledAot ([Values (true, false)] bool enableLLVM)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				AndroidEnableProfiledAot = true,
 			};
+			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidExtraAotOptions", "--verbose");
 			using var b = CreateApkBuilder ();
 			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6777

Building a Xamarin.Android application with:

    -p:Configuration=Release -p:AndroidEnableProfiledAot=true -p:EnableLLVM=true

Fails with:

    [aot-compiler stdout] Executing the native linker: "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold" -Bsymbolic -shared -o obj\Release\110\aot\arm64-v8a\libaot-FastExpressionCompiler.dll.so.tmp "obj\Release\110\aot\arm64-v8a\FastExpressionCompiler.dll\temp-llvm.o" obj\Release\110\aot\arm64-v8a\FastExpressionCompiler.dll\temp.s.o "-LC:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\aarch64-linux-android\4.9.x" "-LC:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\aarch64-linux-android\4.9.x\libgcc.a" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27\libc.so" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27\libm.so",profile-only,profile=C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\startup-xf.aotprofile
    [aot-compiler stderr] C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold: error: cannot open C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27\libm.so,profile-only,profile=C:\Program: Invalid argument
    [aot-compiler stderr] C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold: error: cannot open Files\Microsoft: No such file or directory
    [aot-compiler stderr] C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold: error: cannot open Visual: No such file or directory
    [aot-compiler stderr] C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold: error: cannot open Studio\2022\Community\MSBuild\Xamarin\Android\startup-xf.aotprofile: No such file or directory
    [aot-compiler stderr] AOT of image C:\agent\_work\27\s\src\android\obj\Release\110\android\assets\shrunk\FastExpressionCompiler.dll failed.
    [aot-compiler stdout] Mono Ahead of Time compiler - compiling assembly C:\agent\_work\27\s\src\android\obj\Release\110\android\assets\shrunk\FormsViewGroup.dll
    [aot-compiler stdout] AOTID F3A25575-7572-B484-FF58-F2DD03AE6C72
    [aot-compiler stdout] Executing opt: "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\opt" -f -O2 -disable-tail-calls -place-safepoints -spp-all-backedges -o "obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.opt.bc" "obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.bc"
    [aot-compiler stdout] Executing llc: "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\llc"  -enable-implicit-null-checks -disable-fault-maps -march=aarch64 -asm-verbose=false -mtriple=aarch64-linux-android -disable-gnu-eh-frame -enable-mono-eh-frame -mono-eh-frame-symbol=mono_aot_FormsViewGroup_eh_frame -disable-tail-calls -relocation-model=pic -o "obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp-llvm.s" "obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.opt.bc"
    [aot-compiler stdout] Compiled: 46/46
    [aot-compiler stdout] Executing the native assembler: "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-as"   -o obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.s.o obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.s
    [aot-compiler stdout] Executing the native assembler: "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-as"   -o obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp-llvm.o obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp-llvm.s
    [aot-compiler stdout] Executing the native linker: "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android-ld.gold" -Bsymbolic -shared -o obj\Release\110\aot\arm64-v8a\libaot-FormsViewGroup.dll.so.tmp "obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp-llvm.o" obj\Release\110\aot\arm64-v8a\FormsViewGroup.dll\temp.s.o "-LC:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\aarch64-linux-android\4.9.x" "-LC:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\lib\gcc\aarch64-linux-android\4.9.x\libgcc.a" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27\libc.so" "C:\ProgramData\Microsoft\AndroidNDK\android-ndk-r22b\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\lib\aarch64-linux-android\27\libm.so",profile-only,profile=C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\startup-xf.aotprofile
    [error]C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\Xamarin.Android.Legacy.targets(692,5): Error XA3001: Could not AOT the assembly: FastExpressionCompiler.dll

I could reproduce the problem by parameterizing a test.

In ae6da92a, I removed the comment:

    // MUST be before `ld-flags`, otherwise Mono fails to parse it on Windows

And I inadvertently set `ld-name` and `ld-flags` *before* AOT
profiles. Historically, `ld-name` and `ld-flags` were always set last.

This does not appear to be an issue in .NET 6, as the
`<MonoAOTCompiler/>` task now handles this for us.

After these changes, the new parameterized test passes.