### PR TITLE
Bump to xamarin-android-tools@f0b3abdb, monodroid@5e2b25ea

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@2c3e786bb5c9292e0b1fb196cb70148171f5549e
+xamarin/monodroid:main@5e2b25ea1f299213f4b176f417dd26231c897eda
 mono/mono:2020-02@f34bd77e39212e3a3910775ff08489adfc1013e6


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/2c3e786bb5c9292e0b1fb196cb70148171f5549e...5e2b25ea1f299213f4b176f417dd26231c897eda

  * xamarin/monodroid@5e2b25ea1: Bump to xamarin/androidtools/main@01d05424 (#1241)

Changes: https://github.com/xamarin/xamarin-android-tools/compare/bbe85df4251fe6c2ccaa7fc3fd03b28e5649fff0...f0b3abdb7600bc47be8696bab2c170d849283f06

  * xamarin/xamarin-android-tools@f0b3abd: Revert "[Xamarin.Android.Tools.AndroidSdk] Update SDK component for API-32 (#156)"

We do not yet have all of our proverbial ducks in a row to bump these
Android SDK versions.  Revert until we're fully ready to bump.