### PR TITLE
Revert "[One .NET] default $(TargetPlatformVersion) to API-32"

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -37,8 +37,8 @@
     <AndroidLatestUnstableApiLevel Condition="'$(AndroidLatestUnstableApiLevel)' == ''">33</AndroidLatestUnstableApiLevel>
     <AndroidLatestUnstablePlatformId Condition="'$(AndroidLatestUnstablePlatformId)' == ''">Tiramisu</AndroidLatestUnstablePlatformId>
     <AndroidLatestUnstableFrameworkVersion Condition="'$(AndroidLatestUnstableFrameworkVersion)'==''">v12.1.99</AndroidLatestUnstableFrameworkVersion>
-    <!-- The default API level used for $(TargetPlatformVersion) in .NET 6, can be increased again in .NET 7 -->
-    <AndroidDefaultTargetDotnetApiLevel Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' == '' ">32</AndroidDefaultTargetDotnetApiLevel>
+    <!-- The default API level used for $(TargetPlatformVersion) -->
+    <AndroidDefaultTargetDotnetApiLevel Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' == '' ">31</AndroidDefaultTargetDotnetApiLevel>
     <!-- The API level and TargetFrameworkVersion for the default Mono.Android.dll build -->
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">$(AndroidLatestStableApiLevel)</AndroidApiLevel>
     <AndroidPlatformId Condition=" '$(AndroidPlatformId)' == '' ">$(AndroidLatestStablePlatformId)</AndroidPlatformId>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -5,6 +5,7 @@
       "description": ".NET SDK Workload for building Android applications.",
       "packs": [
         "Microsoft.Android.Sdk",
+        "Microsoft.Android.Ref.31",
         "Microsoft.Android.Ref.32",
         "Microsoft.Android.Runtime.32.android-arm",
         "Microsoft.Android.Runtime.32.android-arm64",
@@ -39,6 +40,10 @@
         "win-x64": "Microsoft.Android.Sdk.Windows",
         "linux-x64": "Microsoft.Android.Sdk.Linux"
       }
+    },
+    "Microsoft.Android.Ref.31": {
+      "kind": "framework",
+      "version": "31.0.101-preview.11.117"
     },
     "Microsoft.Android.Ref.32": {
       "kind": "framework",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -217,7 +217,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void DotNetPack ([Values ("net6.0-android", "net6.0-android32")] string targetFramework)
+		public void DotNetPack ([Values ("net6.0-android", "net6.0-android31")] string targetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
@@ -249,8 +249,8 @@ namespace Xamarin.Android.Build.Tests
 			var nupkgPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "..", $"{proj.ProjectName}.1.0.0.nupkg");
 			FileAssert.Exists (nupkgPath);
 			using (var nupkg = ZipHelper.OpenZip (nupkgPath)) {
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android32.0/{proj.ProjectName}.dll");
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android32.0/{proj.ProjectName}.aar");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android31.0/{proj.ProjectName}.dll");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android31.0/{proj.ProjectName}.aar");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -219,7 +219,7 @@
     </ReplaceFileContents>
   </Target>
   <Target Name="_GenerateSupportedPlatforms"
-      Inputs="$(BootstrapTasksAssembly);$(MSBuildThisFile);..\..\Configuration.props;..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems"
+      Inputs="$(BootstrapTasksAssembly);$(MSBuildThisFile);..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems"
       Outputs="Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.SupportedPlatforms.targets">
     <GenerateSupportedPlatforms
         AndroidApiInfo="@(AndroidApiInfo)"


### PR DESCRIPTION
This reverts commit 7cc3cbb5e8cf8c6dd8b0d671ce91a1d2a19969a7.

We need to time this better so the IDEs can install API 32 by default
at the same time.

Conflicts:
    Configuration.props