### PR TITLE
[Mono.Android] remove OldAndroidSSLSocketFactory usage in .NET 6

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -367,7 +367,7 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleBasic.cs" />
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
-    <Compile Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
+    <Compile Condition=" '$(TargetFramework)' == 'monoandroid10' " Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1007,12 +1007,14 @@ namespace Xamarin.Android.Net
 				return;
 			}
 
+#if MONOANDROID1_0
 			// Context: https://github.com/xamarin/xamarin-android/issues/1615
 			int apiLevel = (int)Build.VERSION.SdkInt;
 			if (apiLevel >= 16 && apiLevel <= 20) {
 				httpsConnection.SSLSocketFactory = new OldAndroidSSLSocketFactory ();
 				return;
 			}
+#endif
 
 			var keyStore = KeyStore.GetInstance (KeyStore.DefaultType);
 			keyStore?.Load (null, null);


### PR DESCRIPTION
We noticed that .NET 6 MAUI apps include `OldAndroidSSLSocketFactory` even after being linked.

Since API 21 is the minimum, we can exclude this class from `Mono.Android.dll` in .NET 6.