### PR TITLE
Move dotnet sandbox to build output directory

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -138,7 +138,7 @@
         {
           "label": "build-sample-under-dotnet",
           "type": "shell",
-          "command": "${env:HOME}/android-toolchain/dotnet/dotnet build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",
+          "command": "bin/${input:configuration}/dotnet/dotnet build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",
           "group": {
               "kind": "build",
               "isDefault": true
@@ -150,7 +150,7 @@
         {
           "label": "run-sample-under-dotnet",
           "type": "shell",
-          "command": "${env:HOME}/android-toolchain/dotnet/dotnet build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}",
+          "command": "bin/${input:configuration}/dotnet/dotnet build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}",
           "group": {
               "kind": "build",
               "isDefault": true

--- a/Configuration.props
+++ b/Configuration.props
@@ -81,8 +81,6 @@
     <AndroidSdkDirectory Condition=" '$(AndroidSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' And Exists($(ANDROID_NDK_LATEST_HOME)) ">$(ANDROID_NDK_LATEST_HOME)</AndroidNdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(AndroidToolchainDirectory)\dotnet\</DotNetPreviewPath>
-    <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <WixToolPath Condition=" '$(WixToolPath)' == '' ">$(AndroidToolchainDirectory)\wix\</WixToolPath>
     <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.18.1</AndroidCmakeVersion>
     <AndroidCmakeUrlPrefix Condition=" '$(HostOS)' == 'Windows' And '$(AndroidCmakeUrlPrefix)' == '' ">7c386a739f915f5bd60051f2572c24782388e807.</AndroidCmakeUrlPrefix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,8 @@
     <TestOutputDirectory>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputDirectory>
     <BootstrapTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\Xamarin.Android.Tools.BootstrapTasks.dll</BootstrapTasksAssembly>
     <PrepTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\xa-prep-tasks.dll</PrepTasksAssembly>
+    <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(BuildOutputDirectory)dotnet\</DotNetPreviewPath>
+    <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <!-- Copy PackageReference content to OutputDir for our build tasks, tests, and installer creation logic. This no longer happens by default in short-form projects. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Ensure reference assemblies copied to bin -->

--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -80,7 +80,7 @@ installer.
 # Creating a local .NET 6 Workload
 
 `make prepare` provisions a specific build of .NET 6 to
-`~/android-toolchain/dotnet`.
+`bin/$(Configuration)/dotnet`.
 
 Once `make all` or `make jenkins` have completed, you can build the .NET 6
 packages with:
@@ -89,7 +89,7 @@ packages with:
 
 Several `.nupkg` files will be output in `./bin/BuildDebug/nuget-unsigned`,
 but this is only part of the story. Your local
-`~/android-toolchain/dotnet/packs` directory will be populated with a
+`bin/$(Configuration)/dotnet/packs` directory will be populated with a
 local Android "workload" in `Microsoft.Android.Sdk.$(HostOS)` matching
 your operating system.
 
@@ -106,9 +106,9 @@ Create a new project with `dotnet new android`:
 
 Build the project with:
 
-    $ ~/android-toolchain/dotnet/dotnet build foo.csproj
+    $ bin/$(Configuration)/dotnet/dotnet build foo.csproj
 
-Using the `dotnet` provisioned in `~/android-toolchain` will use the
+Using the `dotnet` provisioned in `bin/$(Configuration)/dotnet` will use the
 locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -94,7 +94,7 @@ So for example:
 # Creating a local .NET 6 Workload
 
 `msbuild Xamarin.Android.sln /t:Prepare` provisions a specific build
-of .NET 6 to `%USERPROFILE%\android-toolchain\dotnet`.
+of .NET 6 to `bin\$(Configuration)\dotnet`.
 
 Once `msbuild Xamarin.Android.sln /t:Build` is complete, you can build
 the .NET 6 packages with:
@@ -103,7 +103,7 @@ the .NET 6 packages with:
 
 Several `.nupkg` files will be output in `.\bin\BuildDebug\nuget-unsigned`,
 but this is only part of the story. Your local
-`%USERPROFILE%\android-toolchain\dotnet\packs` directory will be
+`bin\$(Configuration)\dotnet\packs` directory will be
 populated with a local Android "workload" in
 `Microsoft.Android.Sdk.$(HostOS)` matching your operating system.
 
@@ -120,13 +120,13 @@ Create a new project with `dotnet new android`:
 
 Build the project in `cmd` with:
 
-    > %USERPROFILE%\android-toolchain\dotnet\dotnet build foo.csproj
+    > bin\$(Configuration)\dotnet\dotnet build foo.csproj
 
 Or in powershell:
 
-    > ~\android-toolchain\dotnet\dotnet build foo.csproj
+    > bin\$(Configuration)\dotnet\dotnet build foo.csproj
 
-Using the `dotnet` provisioned in `%USERPROFILE%\android-toolchain`
+Using the `dotnet` provisioned in `bin/$(Configuration)`
 will use the locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.

--- a/Documentation/workflow/DevelopmentTips.md
+++ b/Documentation/workflow/DevelopmentTips.md
@@ -458,7 +458,7 @@ copying `.nupkg` files to the `library-packs` directory of a given
 
 * `C:\Program Files\dotnet\library-packs`
 * `/usr/local/share/dotnet/library-packs`
-* `~/android-toolchain/dotnet/library-packs`
+* `bin/$(Configuration)/dotnet/library-packs`
 
 The `library-packs` directory is simply an implicit NuGet feed that is
 automatically picked up by the .NET SDK.
@@ -518,7 +518,7 @@ be preferred if it is not blank.
 `make pack-dotnet` or `msbuild Xamarin.Android.sln -t:PackDotNet`
 provisions a .NET SDK and locally built Android workload in:
 
-    ~/android-toolchain/dotnet/
+    bin/$(Configuration)/dotnet/
 
 If you *also* want .NET MAUI, you don't want to `dotnet workload
 install maui`, because it will blow away your local build of the

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateWixFile.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
 	/// <summary>
-	/// Generates a .wix file for the contents of ~/android-toolchain/dotnet/packs
+	/// Generates a .wix file for the contents of bin/$(Configuration)/dotnet/packs
 	/// The .wix file can be used to generate the .msi installer for Windows.
 	/// </summary>
 	public class GenerateWixFile : Task

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -1,5 +1,6 @@
 parameters:
-  configuration: ""
+  configuration: $(XA.Build.Configuration)
+  xaSourcePath: $(System.DefaultWorkingDirectory)
   testName: ""
   project: ""
   testResultsFiles: ""
@@ -20,7 +21,7 @@ steps:
       msbuildArguments: >-
         /restore
         /t:RunTestApp
-        /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
+        /bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         ${{ parameters.extraBuildArgs }}
     condition: ${{ parameters.condition }}
     continueOnError: true
@@ -28,11 +29,13 @@ steps:
 - ${{ if eq(parameters.useDotNet, true) }}:
   - template: run-dotnet-preview.yaml
     parameters:
+      configuration: ${{ parameters.configuration }}
+      xaSourcePath: ${{ parameters.xaSourcePath }}
       displayName: run ${{ parameters.testName }}
       project: ${{ parameters.project }}
       arguments: >-
         -t:RunTestApp
-        -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
+        -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}
       continueOnError: true

--- a/build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+++ b/build-tools/automation/yaml-templates/run-dotnet-preview.yaml
@@ -1,4 +1,6 @@
 parameters:
+  configuration: $(XA.Build.Configuration)
+  xaSourcePath: $(System.DefaultWorkingDirectory)
   command: build
   project: ''
   arguments: ''
@@ -10,9 +12,9 @@ parameters:
 steps:
 - powershell: |
     if ([Environment]::OSVersion.Platform -eq "Unix") {
-        $dotnetPath = "$env:HOME/android-toolchain/dotnet/dotnet"
+        $dotnetPath = "${{ parameters.xaSourcePath }}/bin/${{ parameters.configuration }}/dotnet/dotnet"
     } else {
-        $dotnetPath = "$env:USERPROFILE\android-toolchain\dotnet\dotnet.exe"
+        $dotnetPath = "${{ parameters.xaSourcePath }}\bin\${{ parameters.configuration }}\dotnet\dotnet.exe"
     }
     & $dotnetPath ${{ parameters.command }} ${{ parameters.project }} ${{ parameters.arguments }}
     if ([System.Convert]::ToBoolean("${{ parameters.useExitCodeForErrors }}") -and $LASTEXITCODE -ne 0) {

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -1,5 +1,6 @@
 parameters:
-  nunitConsole: $(System.DefaultWorkingDirectory)/build-tools/scripts/nunit3-console
+  configuration: $(XA.Build.Configuration)
+  xaSourcePath: $(System.DefaultWorkingDirectory)
   testRunTitle: Xamarin Android Tests
   testAssembly: ''
   testResultsFile: TestResult.xml
@@ -14,9 +15,9 @@ steps:
   - powershell: |
       Write-Host '##vso[task.setvariable variable=TestResultsFormat]NUnit'
       if ([Environment]::OSVersion.Platform -eq "Unix") {
-          & ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
+          & ${{ parameters.xaSourcePath }}/build-tools/scripts/nunit3-console ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
       } else {
-          & cmd /c '${{ parameters.nunitConsole }}.cmd' ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
+          & cmd /c '${{ parameters.xaSourcePath }}\build-tools\scripts\nunit3-console.cmd' ${{ parameters.testAssembly }} --result ${{ parameters.testResultsFile }} --workers=${{ parameters.workers }} ${{ parameters.nunitConsoleExtraArgs }}
       }
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Test suite had $LASTEXITCODE failure(s)."
@@ -31,6 +32,8 @@ steps:
   - powershell: Write-Host '##vso[task.setvariable variable=TestResultsFormat]VSTest'
   - template: run-dotnet-preview.yaml
     parameters:
+      configuration: ${{ parameters.configuration }}
+      xaSourcePath: ${{ parameters.xaSourcePath }}
       command: test
       project: ${{ parameters.testAssembly }}
       useExitCodeForErrors: true

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -25,13 +25,13 @@ steps:
 
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"
-    echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]$HOME/android-toolchain/dotnet/dotnet"
+    echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}/bin/${{ parameters.configuration }}/dotnet/dotnet"
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), ne(variables['agent.os'], 'Windows_NT'))
 
 - script: |
     echo ##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}
-    echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]%USERPROFILE%\android-toolchain\dotnet\dotnet.exe
+    echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}\bin\${{ parameters.configuration }}\dotnet\dotnet.exe
   displayName: set JI_JAVA_HOME
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 

--- a/build-tools/scripts/Paths.targets
+++ b/build-tools/scripts/Paths.targets
@@ -37,10 +37,4 @@
         Importance="High"
     />
   </Target>
-  <Target Name="GetDotNetPreviewPath">
-    <Message
-        Text="$(DotNetPreviewPath)"
-        Importance="High"
-    />
-  </Target>
 </Project>

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -10,6 +10,6 @@ msbuild /p:Configuration=Release /restore .\tools\xabuild\xabuild.csproj
 Write-Output "Building legacy BuildReleaseArm64 tests"
 msbuild /p:Configuration=Release Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"
 Write-Output "Building DotNet BuildReleaseArm64 tests"
-~\android-toolchain\dotnet\dotnet test -p:Configuration=Release --filter BuildTest.BuildReleaseArm64 .\bin\TestRelease\net6.0\Xamarin.Android.Build.Tests.dll
+bin\Release\dotnet\dotnet test -p:Configuration=Release --filter BuildTest.BuildReleaseArm64 .\bin\TestRelease\net6.0\Xamarin.Android.Build.Tests.dll
 Write-Output "Updating reference files"
 Copy-Item -Verbose bin\TestRelease\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Prepare
 			var dotnetTool = Path.Combine (dotnetPath, "dotnet");
 			var dotnetPreviewVersion = context.Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion);
 
-			// Always delete the ~/android-toolchain/dotnet/ directory
+			// Always delete the bin/$(Configuration)/dotnet/ directory
 			Utilities.DeleteDirectory (dotnetPath);
 
 			if (!await InstallDotNetAsync (context, dotnetPath, dotnetPreviewVersion)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -92,13 +92,9 @@ namespace Xamarin.ProjectTools
 			return JavaSdkVersionString;
 		}
 
-		// Cache the result, so we don't run MSBuild on every call
-		static string DotNetPreviewPath;
 		public static string GetDotNetPreviewPath ()
 		{
-			if (string.IsNullOrEmpty (DotNetPreviewPath))
-				DotNetPreviewPath = RunPathsTargets ("GetDotNetPreviewPath");
-			return DotNetPreviewPath;
+			return Path.Combine (XABuildPaths.PrefixDirectory, "dotnet");
 		}
 
 		static string RunPathsTargets (string target)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -103,8 +103,8 @@ namespace Xamarin.ProjectTools
 		/// If a local build tree can not be found, or if it is empty, this will return the system installation or .NET sandbox location instead:<br/>
 		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android <br/>
 		///	macOS:    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android<br/>
-		///	Windows (dotnet):  %USERPROFILE%\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\$(Latest)\tools<br/>
-		///	macOS (dotnet):    $HOME/android-toolchain/dotnet/packs/Microsoft.Android.Sdk.Darwin/$(Latest)/tools
+		///	Windows (dotnet):  bin\Debug\dotnet\packs\Microsoft.Android.Sdk.Windows\$(Latest)\tools<br/>
+		///	macOS (dotnet):    bin/Debug/dotnet/packs/Microsoft.Android.Sdk.Darwin/$(Latest)/tools
 		/// </summary>
 		public string AndroidMSBuildDirectory {
 			get {


### PR DESCRIPTION
Moves the "sandbox" installation of `dotnet` that we use for testing
purposes into the repo at bin/$(Configuration)/dotnet.  While this could
lead to increased disk usage across some local build environments it
provides a handful of benefits.

Every time `make prepare` or `-t:Prepare` runs we remove this directory
and start fresh.  Having it in a single "global" location is not too
desirable when working out of multiple checkout locations (fork vs
non-fork for example), or when using multiple build configurations at
the same time.

This sandbox can also now more easily be removed with a `git clean` if
desirable, we had no "automatic" way to remove the ~/android-toolchain
installation location previously.

This move will also make it easier to eventually structure our .NET
build output in a way that will allow it to be tested without having to
pack and unpack .nupkg files.