### PR TITLE
$(AndroidPackVersionSuffix)=rc.1; net6 is 31.0.300.rc.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,8 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>31.0.200</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.14</AndroidPackVersionSuffix>
+    <AndroidPackVersion>31.0.300</AndroidPackVersion>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,8 +11,8 @@
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
+    <DotNetAndroidManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetAndroidManifestVersionBand>
     <!-- NOTE: temporarily hardcode these to 6.0.200 -->
-    <DotNetAndroidManifestVersionBand>6.0.200</DotNetAndroidManifestVersionBand>
     <DotNetMonoManifestVersionBand>6.0.200</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>6.0.200</DotNetEmscriptenManifestVersionBand>
   </PropertyGroup>


### PR DESCRIPTION
Context: http://aka.ms/maui-schedule
Context: https://github.com/xamarin/xamarin-android/blob/7e8cc34989bfcb5bd58cb857013ba67273c00c79/Documentation/guides/HowToBranch.md
Context: https://github.com/xamarin/xamarin-android/tree/release/6.0.2xx-preview14

We branched xamarin-android/release/6.0.2xx-preview14, to reflect the
next release of .NET MAUI Preview 14. It will remain on the .NET
6.0.200 version band.

xamarin-android/main becomes RC 1. main will also be targeting the
.NET 6.0.300 version band, so we should become 31.0.300.