### PR TITLE
[Mono.Android] JNIEnv.FindClass() can use StaticMethods.CallStaticObjectMethod()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -574,7 +574,7 @@ namespace Android.Runtime {
 			}
 
 			IntPtr global_ref = NewGlobalRef (local_ref.Handle);
-			DeleteLocalRef (local_ref.Handle);
+			JniObjectReference.Dispose (ref local_ref);
 			return global_ref;
 		}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -43,7 +43,7 @@ namespace Android.Runtime {
 		static IntPtr java_vm;
 		static IntPtr load_class_id;
 		static IntPtr gref_class;
-		static IntPtr mid_Class_forName;
+		static JniMethodInfo? mid_Class_forName;
 		static int version;
 		static int androidSdkVersion;
 
@@ -162,7 +162,7 @@ namespace Android.Runtime {
 			java_class_loader = args->grefLoader;
 			load_class_id     = args->Loader_loadClass;
 			gref_class        = args->grefClass;
-			mid_Class_forName = args->Class_forName;
+			mid_Class_forName = new JniMethodInfo (args->Class_forName, isStatic: true);
 
 			if (args->localRefsAreIndirect == 1)
 				IdentityHash = v => _monodroid_get_identity_hash_code (Handle, v);
@@ -557,19 +557,24 @@ namespace Android.Runtime {
 			return NewString (nameBuffer, length);
 		}
 
-		public static IntPtr FindClass (string classname)
+		public unsafe static IntPtr FindClass (string classname)
 		{
-			IntPtr local_ref;
+			JniObjectReference local_ref;
 
 			IntPtr native_str = BinaryName (classname);
 			try {
-				local_ref = CallStaticObjectMethod (gref_class, mid_Class_forName, new JValue (native_str), new JValue (true), new JValue (java_class_loader));
+				JniArgumentValue* parameters = stackalloc JniArgumentValue [3] {
+					new JniArgumentValue (native_str),
+					new JniArgumentValue (true),
+					new JniArgumentValue (java_class_loader),
+				};
+				local_ref = JniEnvironment.StaticMethods.CallStaticObjectMethod (Java.Lang.Class.Members.JniPeerType.PeerReference, mid_Class_forName!, parameters);
 			} finally {
 				DeleteLocalRef (native_str);
 			}
 
-			IntPtr global_ref = NewGlobalRef (local_ref);
-			DeleteLocalRef (local_ref);
+			IntPtr global_ref = NewGlobalRef (local_ref.Handle);
+			DeleteLocalRef (local_ref.Handle);
 			return global_ref;
 		}
 

--- a/src/Mono.Android/Java.Lang/Class.cs
+++ b/src/Mono.Android/Java.Lang/Class.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using Android.Runtime;
+using Java.Interop;
 
 namespace Java.Lang {
 
@@ -13,6 +11,7 @@ namespace Java.Lang {
 		public static readonly IntPtr CharSequence;
 
 		internal static readonly IntPtr CharSequence_toString;
+		internal static JniPeerMembers Members => _members;
 
 		static Class ()
 		{


### PR DESCRIPTION
Code paths using `JNIEnv.CallStaticObjectMethod` are using the "old"
way of doing Java.Interop. One such case is found when profiling the
.NET Podcast app:

    15.09ms Mono.Android!Android.Runtime.JNIEnv.FindClass
     6.25ms Mono.Android!Android.Runtime.JNIEnv.CallStaticObjectMethod

This is called in one place by:

    6.16ms Mono.Android!Android.Content.Intent..ctor(Android.Content.Context,System.Type)

If we instead define on `Java.Lang.Class`:

    internal static JniPeerMembers Members => _members;

We could access `Java.Lang.Class.Members.StaticMethods`, however in
this case we get the method ID from:

    internal static unsafe void Initialize (JnienvInitializeArgs* args)
    {
        // ...
        mid_Class_forName = args->Class_forName;

If we use the `IntPtr` here to create:

    new JniMethodInfo (args->Class_forName, isStatic: true)

We can instead use:

    JniEnvironment.StaticMethods.CallStaticObjectMethod (Java.Lang.Class.Members.JniPeerType.PeerReference, mid_Class_forName, parameters)

With this change in place, I'm not really seeing a noticeable
performance difference, but it should help a small amount by
allocating less?