### PR TITLE
[build] -t:InstallMaui can infer the version band

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -34,20 +34,21 @@
     />
   </Target>
   <Target Name="InstallMaui">
+    <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' " />
     <PropertyGroup>
       <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
+      <MauiVersionBand>$([System.Text.RegularExpressions.Regex]::Match($(MauiVersion), `^\d+\.\d+\.\d`))00</MauiVersionBand>
     </PropertyGroup>
-    <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' " />
     <MakeDir Directories="$(_TempDirectory)" />
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; restore maui.proj -p:MauiVersion=$(MauiVersion)"
+        Command="&quot;$(DotNetPreviewTool)&quot; restore maui.proj -p:MauiVersion=$(MauiVersion) -p:MauiVersionBand=$(MauiVersionBand)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
         EnvironmentVariables="NUGET_PACKAGES=$(_TempDirectory);DOTNET_MULTILEVEL_LOOKUP=0"
     />
 
     <!-- Copy WorkloadManifest.* files-->
     <ItemGroup>
-      <_WLManifest Include="$(_TempDirectory)\microsoft.net.sdk.maui.manifest-$(DotNetPreviewVersionBand)\$(MauiVersion)\data\WorkloadManifest.*" />
+      <_WLManifest Include="$(_TempDirectory)\microsoft.net.sdk.maui.manifest-$(MauiVersionBand)\$(MauiVersion)\data\WorkloadManifest.*" />
     </ItemGroup>
     <Copy SourceFiles="@(_WLManifest)" DestinationFolder="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.maui" />
 

--- a/build-tools/scripts/maui.proj
+++ b/build-tools/scripts/maui.proj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-$(DotNetPreviewVersionBand)" Version="[$(MauiVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-$(MauiVersionBand)" Version="[$(MauiVersion)]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Using xamarin-android/main, the command to install .NET MAUI fails
with:

    > msbuild Xamarin.Android.sln -t:InstallMaui -p:MauiVersion=6.0.200-preview.14.5055
    ...
    error NU1101: Unable to find package Microsoft.NET.Sdk.Maui.Manifest-6.0.300. No packages exist with this id in source(s):...

The problem being is there is not a Microsoft.NET.Sdk.Maui.Manifest
6.0.300 pack yet.

We should instead infer 6.0.200 from `-p:MauiVersion`:

    <MauiVersionBand>$([System.Text.RegularExpressions.Regex]::Match($(MauiVersion), `^\d+\.\d+\.\d`))00</MauiVersionBand>

We use a similar regex to infer the .NET SDK version band.

This should work more appropriately going forward.