### PR TITLE
[Mono.Android] add "built-in" delegate for _JniMarshal_PPLZ_V

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -147,6 +147,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static void Wrap_JniMarshal_PPLZ_V (this _JniMarshal_PPLZ_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
 		internal static void Wrap_JniMarshal_PPLL_V (this _JniMarshal_PPLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -328,6 +339,8 @@ namespace Android.Runtime
 					return new _JniMarshal_PPII_V (Unsafe.As<_JniMarshal_PPII_V> (dlg).Wrap_JniMarshal_PPII_V);
 				case nameof (_JniMarshal_PPLI_V):
 					return new _JniMarshal_PPLI_V (Unsafe.As<_JniMarshal_PPLI_V> (dlg).Wrap_JniMarshal_PPLI_V);
+				case nameof (_JniMarshal_PPLZ_V):
+					return new _JniMarshal_PPLZ_V (Unsafe.As<_JniMarshal_PPLZ_V> (dlg).Wrap_JniMarshal_PPLZ_V);
 				case nameof (_JniMarshal_PPLL_V):
 					return new _JniMarshal_PPLL_V (Unsafe.As<_JniMarshal_PPLL_V> (dlg).Wrap_JniMarshal_PPLL_V);
 				case nameof (_JniMarshal_PPLI_L):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -77,6 +77,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1",
 	},
 	new {
+		Type = "_JniMarshal_PPLZ_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
 		Type = "_JniMarshal_PPLL_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
 		Return = "void",


### PR DESCRIPTION
Profiling `dotnet new maui` is hitting:

    39.66ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
    28.35ms System.Private.CorLib!System.Reflection.Emit.DynamicMethod..ctor(...)

Which is due to:

    03-08 08:53:30.436 23350 23350 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLZ_V': Void n_OnFocusChange_Landroid_view_View_Z(IntPtr, IntPtr, IntPtr, Boolean)

It appears new usage of `OnFocusChange()` is prompting us to include
`_JniMarshal_PPLZ_V` in our list of "built-in" delegates.

After this change, we don't hit the SRE code path anymore:

    2.80ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)