### PR TITLE
[docs] improve instructions for obtaining methods.txt

### DIFF
--- a/Documentation/guides/profiling.md
+++ b/Documentation/guides/profiling.md
@@ -163,7 +163,18 @@ selectively AOT'ing only the methods included in the profile.
 
 ## Profiling the JIT Compiler
 
-Before launching the app, run the `adb` command:
+If profiling a Release build, you'll need to edit your
+`AndroidManifest.xml` to make the application "debuggable":
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:debuggable="true" ...
+```
+
+Debug builds already set this value by default.
+
+Next, run the `adb` command:
 
     > adb shell setprop debug.mono.log timing,default
 
@@ -213,6 +224,8 @@ Mono:
     Methods JITted using mono JIT       : 921
     Methods JITted using LLVM           : 0
     Methods using the interpreter       : 0
+
+_NOTE: that `counters.txt` is not available in .NET 6 projects._
 
 `methods.txt` has the individual JIT times of each method:
 


### PR DESCRIPTION
When recording JIT times, we didn't have instructions to set
/manifest/application/@android:debuggable="true". This is a crucial
step for Release builds.

I also noted that `counters.txt` is not useful in .NET 6. It is
mostly empty text such as:

    ## Runtime.register: type=Microsoft.NetConf2021.Maui.MainApplication, Microsoft.NetConf2021.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
    ## Runtime.register: type=Microsoft.Maui.MauiApplication, Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
    ## Runtime.register: type=Microsoft.Maui.MauiApplication+ActivityLifecycleCallbacks, Microsoft.Maui

It might be worth removing support for this in .NET 6, but let's just
comment that it isn't useful for now.