### PR TITLE
[Mono.Android] avoid RegisterJniNatives() string allocation

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -306,7 +306,7 @@ namespace Android.Runtime {
 
 		static List<JniNativeMethodRegistration> sharedRegistrations = new List<JniNativeMethodRegistration> ();
 
-		static bool FastRegisterNativeMembers (JniType nativeClass, Type type, string? methods)
+		static bool FastRegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
 		{
 			if (!MagicRegistrationMap.Filled)
 				return false;
@@ -323,7 +323,7 @@ namespace Android.Runtime {
 				} else {
 					registrations = new List<JniNativeMethodRegistration> ();
 				}
-				JniNativeMethodRegistrationArguments arguments = new JniNativeMethodRegistrationArguments (registrations, methods);
+				JniNativeMethodRegistrationArguments arguments = new JniNativeMethodRegistrationArguments (registrations, methods.ToString ());
 				rv = MagicRegistrationMap.CallRegisterMethod (arguments, type.FullName!);
 
 				if (registrations.Count > 0)
@@ -376,22 +376,25 @@ namespace Android.Runtime {
 			}
 		}
 
-		public override void RegisterNativeMembers (JniType nativeClass, Type type, string? methods)
+		public override void RegisterNativeMembers (JniType nativeClass, Type type, string? methods) =>
+			RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
+
+		public void RegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
 		{
 			try {
 				if (FastRegisterNativeMembers (nativeClass, type, methods))
 					return;
 
-				if (string.IsNullOrEmpty (methods)) {
+				if (methods.IsEmpty) {
 					if (jniAddNativeMethodRegistrationAttributePresent)
-						base.RegisterNativeMembers (nativeClass, type, methods);
+						base.RegisterNativeMembers (nativeClass, type, methods.ToString ());
 					return;
 				}
 
 				int methodCount = CountMethods (methods);
 				if (methodCount < 1) {
 					if (jniAddNativeMethodRegistrationAttributePresent)
-						base.RegisterNativeMembers (nativeClass, type, methods);
+						base.RegisterNativeMembers (nativeClass, type, methods.ToString ());
 					return;
 				}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -136,7 +136,8 @@ namespace Android.Runtime {
 			JniType? jniType = null;
 			JniType.GetCachedJniType (ref jniType, className);
 
-			androidRuntime!.TypeManager.RegisterNativeMembers (jniType, type, methods_ptr == IntPtr.Zero ? null : new string ((char*) methods_ptr, 0, methods_len));
+			ReadOnlySpan<char> methods = new ReadOnlySpan<char> ((void*) methods_ptr, methods_len);
+			((AndroidTypeManager)androidRuntime!.TypeManager).RegisterNativeMembers (jniType, type, methods);
 		}
 
 		internal static unsafe void Initialize (JnienvInitializeArgs* args)


### PR DESCRIPTION
Based on the comments:

https://github.com/xamarin/xamarin-android/pull/6708#discussion_r801077205

Viewing `dotnet trace` output for the .NET Podcast app, we actually see:

    122.71ms (0.26%) Mono.Android!Android.Runtime.JNIEnv.RegisterJniNatives(intptr,int,intptr,intptr,int)
      5.13ms (0.01%) System.Private.CoreLib!System.String.Ctor(char*,int,int)

Once per type that enters RegisterJniNatives(), we were allocating a
potentially large `System.String` that contains every Java method that a
C# type overrides. If we use `ReadonlySpan<char>`, we can avoid this
allocation for each call.

After this change, instead I see:

    1.23ms System.Private.CoreLib!System.String.Ctor(char*,int,int)

This call happens earlier in the method, which it doesn't look like we
can use `ReadonlySpan<char>` for:

    string typeName = new string ((char*) typeName_ptr, 0, typeName_len);
    var type = Type.GetType (typeName);

I suspect this change saves 3-4ms of startup time in the .NET Podcast
app on a Pixel 5 device.