### PR TITLE
Disable gathering of JIT statistics on .NET6+

### DIFF
--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -203,16 +203,15 @@ namespace xamarin::android::internal
 			monodroid_gdb_wait = yes_no;
 		}
 
-		FILE *get_counters () const
-		{
-			return counters;
-		}
-
 #if defined (NET6)
 		void propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrowable javaException);
 #else // def NET6
 		void propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException);
-#endif // ndef NET6
+
+		FILE *get_counters () const
+		{
+			return counters;
+		}
 
 		// The reason we don't use the C++ overload feature here is that there appears to be an issue in clang++ that
 		// comes with the Android NDK. The issue is that for calls like:
@@ -231,6 +230,8 @@ namespace xamarin::android::internal
 		// function
 		void dump_counters (const char *format, ...);
 		void dump_counters_v (const char *format, va_list args);
+#endif // ndef NET6
+
 		char*	get_java_class_name_for_TypeManager (jclass klass);
 
 	private:
@@ -358,7 +359,10 @@ namespace xamarin::android::internal
 		timing_period       jit_time;
 		FILE               *jit_log;
 		MonoProfilerHandle  profiler_handle;
+#if !defined (NET6)
 		FILE               *counters;
+#endif // ndef NET6
+
 		/*
 		 * If set, monodroid will spin in a loop until the debugger breaks the wait by
 		 * clearing monodroid_gdb_wait.

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2186,7 +2186,8 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	}
 
 	androidSystem.setup_process_args (runtimeApks);
-
+#if !defined (NET6)
+	// JIT stats based on perf counters are disabled in dotnet/mono
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)) && !(log_timing_categories & LOG_TIMING_BARE)) {
 		mono_counters_enable (static_cast<int>(XA_LOG_COUNTERS));
 
@@ -2197,7 +2198,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		utils.set_world_accessable (counters_path.get ());
 	}
 
-#if !defined (NET6)
 	void *dso_handle = nullptr;
 #if defined (WINDOWS) || defined (APPLE_OS_X)
 	const char *my_location = get_my_location ();
@@ -2333,10 +2333,13 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		total_time.mark_end ();
 
 		Timing::info (total_time, "Runtime.init: end, total time");
+#if !defined (NET6)
 		dump_counters ("## Runtime.init: end");
+#endif // ndef NET6
 	}
 }
 
+#if !defined (NET6)
 void
 MonodroidRuntime::dump_counters (const char *format, ...)
 {
@@ -2361,6 +2364,7 @@ MonodroidRuntime::dump_counters_v (const char *format, va_list args)
 
 	mono_counters_dump (MonodroidRuntime::XA_LOG_COUNTERS, counters);
 }
+#endif // ndef NET6
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad (JavaVM *vm, void *reserved)
@@ -2467,8 +2471,9 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 		total_time.mark_end ();
 
 		Timing::info (total_time, "Runtime.register: end time");
-
+#if !defined (NET6)
 		dump_counters ("## Runtime.register: type=%s\n", type.get ());
+#endif
 	}
 }
 

--- a/src/monodroid/jni/pinvoke-override-api.cc
+++ b/src/monodroid/jni/pinvoke-override-api.cc
@@ -207,7 +207,9 @@ _monodroid_timezone_get_default_id ()
 static void
 _monodroid_counters_dump (const char *format, va_list args)
 {
+#if !defined (NET6)
 	monodroidRuntime.dump_counters_v (format, args);
+#endif // ndef NET6
 }
 
 static managed_timing_sequence*

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -303,6 +303,12 @@ namespace Xamarin.Android.Build.Tests
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 
+			string wantedFile;
+			if (Builder.UseDotNet) {
+				wantedFile = "methods.txt";
+			} else {
+				wantedFile = "counters.txt";
+			}
 			using (var builder = CreateApkBuilder ()) {
 				Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
 				RunAdbCommand ("shell setprop debug.mono.log timing");
@@ -312,7 +318,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.True (didLaunch, "Activity should have started.");
 				var directorylist = GetContentFromAllOverrideDirectories (proj.PackageName);
 				builder.Uninstall (proj);
-				StringAssert.Contains ("counters.txt", directorylist, $"counters.txt did not exist in the .__override__ directory.\nFound:{directorylist}");
+				StringAssert.Contains (wantedFile, directorylist, $"{wantedFile} did not exist in the .__override__ directory.\nFound:{directorylist}");
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6818

`dotnet/mono` disables gathering of performance counter statistics for
the JIT and, in effect, a largely empty file is generated by the
`mono_counters_dump` runtime function.

Disable support for dumping the counters in .NET6+ builds of the
runtime.