### PR TITLE
[Mono.Android] add more "built-in" delegates for MAUI+Shell

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -169,6 +169,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static void Wrap_JniMarshal_PPLF_V (this _JniMarshal_PPLF_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, float p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
 		internal static IntPtr Wrap_JniMarshal_PPLI_L (this _JniMarshal_PPLI_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -192,6 +203,50 @@ namespace Android.Runtime
 		}
 
 		internal static void Wrap_JniMarshal_PPIIL_V (this _JniMarshal_PPIIL_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static int Wrap_JniMarshal_PPLII_I (this _JniMarshal_PPLII_I callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPLII_Z (this _JniMarshal_PPLII_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPLII_V (this _JniMarshal_PPLII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
+		internal static void Wrap_JniMarshal_PPIII_V (this _JniMarshal_PPIII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
 			try {
@@ -343,12 +398,22 @@ namespace Android.Runtime
 					return new _JniMarshal_PPLZ_V (Unsafe.As<_JniMarshal_PPLZ_V> (dlg).Wrap_JniMarshal_PPLZ_V);
 				case nameof (_JniMarshal_PPLL_V):
 					return new _JniMarshal_PPLL_V (Unsafe.As<_JniMarshal_PPLL_V> (dlg).Wrap_JniMarshal_PPLL_V);
+				case nameof (_JniMarshal_PPLF_V):
+					return new _JniMarshal_PPLF_V (Unsafe.As<_JniMarshal_PPLF_V> (dlg).Wrap_JniMarshal_PPLF_V);
 				case nameof (_JniMarshal_PPLI_L):
 					return new _JniMarshal_PPLI_L (Unsafe.As<_JniMarshal_PPLI_L> (dlg).Wrap_JniMarshal_PPLI_L);
 				case nameof (_JniMarshal_PPLL_Z):
 					return new _JniMarshal_PPLL_Z (Unsafe.As<_JniMarshal_PPLL_Z> (dlg).Wrap_JniMarshal_PPLL_Z);
 				case nameof (_JniMarshal_PPIIL_V):
 					return new _JniMarshal_PPIIL_V (Unsafe.As<_JniMarshal_PPIIL_V> (dlg).Wrap_JniMarshal_PPIIL_V);
+				case nameof (_JniMarshal_PPLII_I):
+					return new _JniMarshal_PPLII_I (Unsafe.As<_JniMarshal_PPLII_I> (dlg).Wrap_JniMarshal_PPLII_I);
+				case nameof (_JniMarshal_PPLII_Z):
+					return new _JniMarshal_PPLII_Z (Unsafe.As<_JniMarshal_PPLII_Z> (dlg).Wrap_JniMarshal_PPLII_Z);
+				case nameof (_JniMarshal_PPLII_V):
+					return new _JniMarshal_PPLII_V (Unsafe.As<_JniMarshal_PPLII_V> (dlg).Wrap_JniMarshal_PPLII_V);
+				case nameof (_JniMarshal_PPIII_V):
+					return new _JniMarshal_PPIII_V (Unsafe.As<_JniMarshal_PPIII_V> (dlg).Wrap_JniMarshal_PPIII_V);
 				case nameof (_JniMarshal_PPLLJ_Z):
 					return new _JniMarshal_PPLLJ_Z (Unsafe.As<_JniMarshal_PPLLJ_Z> (dlg).Wrap_JniMarshal_PPLLJ_Z);
 				case nameof (_JniMarshal_PPILL_V):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -89,6 +89,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1",
 	},
 	new {
+		Type = "_JniMarshal_PPLF_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, float p1",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
 		Type = "_JniMarshal_PPLI_L",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1",
 		Return = "IntPtr",
@@ -103,6 +109,30 @@ var delegateTypes = new [] {
 	new {
 		Type = "_JniMarshal_PPIIL_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, IntPtr p2",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLII_I",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2",
+		Return = "int",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLII_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPLII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
+		Type = "_JniMarshal_PPIII_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2",
 		Return = "void",
 		Invoke = "jnienv, klazz, p0, p1, p2",
 	},


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/ceaff6b3a6598c66b7b2c6a9f9fd3404fa17edf5

Since the "Shell" navigation pattern was added to the default `dotnet
new maui` template, we started hitting the System.Reflection.Emit code
path again:

    03-09 14:20:35.358 6711 6711 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLF_V': Void n_OnDrawerSlide_Landroid_view_View_F(IntPtr, IntPtr, IntPtr, Single)

So then I checked the .NET Podcast app:

    03-09 14:28:35.675  7278  7278 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLF_V': Void n_OnDrawerSlide_Landroid_view_View_F(IntPtr, IntPtr, IntPtr, Single)
    03-09 14:28:35.811  7278  7278 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_I': Int32 n_OnStartCommand_Landroid_content_Intent_II(IntPtr, IntPtr, IntPtr, Int32, Int32)
    03-09 14:28:35.813  7278  7278 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_Z': Boolean n_OnError_Landroid_media_MediaPlayer_II(IntPtr, IntPtr, IntPtr, Int32, Int32)
    03-09 14:28:36.314  7278  7278 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPIII_V': Void n_OnItemRangeMoved_III(IntPtr, IntPtr, Int32, Int32, Int32)
    03-09 14:28:36.328  7278  7278 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLII_V': Void n_OnScrolled_Landroidx_recyclerview_widget_RecyclerView_II(IntPtr, IntPtr, IntPtr, Int32, Int32)

Adding 5 more cases seems should avoid System.Reflection.Emit on
startup for both of these apps.

`dotnet trace` output for .NET Podcast app with these changes on a
Pixel 5:

    Before:
    9.35ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
    After:
    3.81ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)

This seems to save ~5ms of startup for this app.