### PR TITLE
Strip AOT shared libraries when linking

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -58,7 +58,8 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         AotOutputDirectory="$(_AndroidAotBinDirectory)"
         RuntimeIdentifier="$(RuntimeIdentifier)"
         EnableLLVM="$(EnableLLVM)"
-        Profiles="@(AndroidAotProfile)">
+        Profiles="@(AndroidAotProfile)"
+        StripLibraries="$(_AndroidAotStripLibraries)">
       <Output PropertyName="_Triple"     TaskParameter="Triple" />
       <Output PropertyName="_ToolPrefix" TaskParameter="ToolPrefix" />
       <Output PropertyName="_MsymPath"   TaskParameter="MsymPath" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -204,26 +204,6 @@ _ResolveAssemblies MSBuild target.
         IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)">
       <Output TaskParameter="OutputLibraries" ItemName="FrameworkNativeLibrary" />
     </ProcessNativeLibraries>
-    <ItemGroup>
-      <_StrippedFrameworkNativeLibrary Include="@(FrameworkNativeLibrary->'$(IntermediateOutputPath)native\%(RuntimeIdentifier)\%(Filename)%(Extension)')" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_StripFrameworkNativeLibraries"
-      Condition=" '$(AndroidIncludeDebugSymbols)' != 'true' "
-      DependsOnTargets="_IncludeNativeSystemLibraries"
-      Inputs="@(FrameworkNativeLibrary)"
-      Outputs="@(_StrippedFrameworkNativeLibrary)">
-    <StripNativeLibraries
-        SourceFiles="@(FrameworkNativeLibrary)"
-        DestinationFiles="@(_StrippedFrameworkNativeLibrary)"
-        ToolPath="$(AndroidBinUtilsDirectory)"
-    />
-    <ItemGroup Condition=" '$(AndroidIncludeDebugSymbols)' != 'true' ">
-      <FrameworkNativeLibrary Remove="@(FrameworkNativeLibrary)"/>
-      <FrameworkNativeLibrary Include="@(_StrippedFrameworkNativeLibrary)"/>
-      <FileWrites Include="@(_StrippedFrameworkNativeLibrary)" />
-    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -74,7 +74,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CheckApkPerAbiFlag;
       _LintChecks;
       _IncludeNativeSystemLibraries;
-      _StripFrameworkNativeLibraries;
       _CheckGoogleSdkRequirements;
     </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -47,6 +47,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool EnableLLVM { get; set; }
 
+		public bool StripLibraries { get; set; }
+
 		public string AndroidSequencePointsMode { get; set; } = "";
 
 		public ITaskItem [] Profiles { get; set; } = Array.Empty<ITaskItem> ();
@@ -291,7 +293,17 @@ namespace Xamarin.Android.Tasks
 
 				ldFlags = $"\\\"{string.Join ("\\\";\\\"", libs)}\\\"";
 			}
-			return ldFlags;
+
+			if (!StripLibraries) {
+				return ldFlags;
+			}
+
+			const string StripFlag = "-s";
+			if (ldFlags.Length == 0) {
+				return StripFlag;
+			}
+
+			return $"{ldFlags} {StripFlag}";
 		}
 
 		static string GetNdkToolchainLibraryDir (NdkTools ndk, string binDir, string archDir = null)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -193,6 +193,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' ">None</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' And '$(AndroidAotMode)' != 'Interpreter' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
+    <_AndroidAotStripLibraries Condition=" '$(_AndroidAotStripLibraries)' == '' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</_AndroidAotStripLibraries>
 
 	<AndroidUseDebugRuntime
 			Condition="'$(AndroidUseDebugRuntime)' == '' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(Optimize)' == 'True' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -708,7 +708,8 @@ projects. .NET 5 projects will not import this file.
         AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
         YieldDuringToolExecution="$(YieldDuringToolExecution)"
         EnableLLVM="$(EnableLLVM)"
-        Profiles="@(_AotProfiles)">
+        Profiles="@(_AotProfiles)"
+        StripLibraries="$(_AndroidAotStripLibraries)">
       <Output TaskParameter="NativeLibrariesReferences" ItemName="_AdditionalNativeLibraryReferences" />
     </Aot>
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6840
Context: https://github.com/xamarin/xamarin-android/pull/6683

Pass the `-s` flag to the native linker in order to produce shared
AOT libraries without debug symbols.  Symbols are stripped unless
the `$(DebugSymbols)` property is set to `True`.