### PR TITLE
[Xamarin.Android.Build.Tasks] default $(UseInterpreter) for Debug mode

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -42,6 +42,7 @@
   <!--  User-facing configuration-specific defaults -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
+    <UseInterpreter Condition=" '$(UseInterpreter)' == '' and '$(AndroidUseInterpreter)' == '' ">true</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">true</EmbedAssembliesIntoApk>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6729
Fixes: https://github.com/xamarin/xamarin-android/issues/6841

The `dotnet new maui` template enables:

    <!-- Required for C# Hot Reload -->
    <UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>

This should really just belong in each platform SDK instead of the
template.

Additionally, I found the interpreter improves startup times. For
example Release builds on a Pixel 5 would get:

| Application        | JIT Time(ms) | Interpreter Time(ms) | Profiled AOT Time(ms) |
|------------------- | ------------:| --------------------:| ---------------------:|
| dotnet new android |        244.1 |                210.1 |                 165.5 |
| dotnet new maui    |        887.6 |                717.2 |                 469.9 |

Source: https://github.com/jonathanpeppers/maui-profiling

So there is an improvement to the development loop into doing this.