### PR TITLE
DesignTime Builds should honour AndroidGenerateResourceDesigner.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -344,10 +344,14 @@ namespace Xamarin.Android.Build.Tests
 				.Replace ("Resource.Id.myButton", "0");
 
 			var dotnet = CreateDotNetBuilder (proj);
+			Assert.IsTrue (dotnet.Build(target: "CoreCompile", parameters: new string[] { "-p:BuildingInsideVisualStudio=true" }), "Designtime build should succeed.");
+			var intermediate = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);
+			var resource_designer_cs = Path.Combine (intermediate, "designtime",  "Resource.designer.cs");
+			FileAssert.DoesNotExist (resource_designer_cs);
+
 			Assert.IsTrue (dotnet.Build (), "build should succeed");
 
-			var intermediate = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);
-			var resource_designer_cs = Path.Combine (intermediate, "Resource.designer.cs");
+			resource_designer_cs = Path.Combine (intermediate, "Resource.designer.cs");
 			FileAssert.DoesNotExist (resource_designer_cs);
 
 			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.dll");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -344,7 +344,7 @@ namespace Xamarin.Android.Build.Tests
 				.Replace ("Resource.Id.myButton", "0");
 
 			var dotnet = CreateDotNetBuilder (proj);
-			Assert.IsTrue (dotnet.Build(target: "CoreCompile", parameters: new string[] { "-p:BuildingInsideVisualStudio=true" }), "Designtime build should succeed.");
+			Assert.IsTrue (dotnet.Build(target: "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true" }), "Designtime build should succeed.");
 			var intermediate = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);
 			var resource_designer_cs = Path.Combine (intermediate, "designtime",  "Resource.designer.cs");
 			FileAssert.DoesNotExist (resource_designer_cs);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.DesignTime.targets
@@ -37,11 +37,11 @@ This file is used by all project types, including binding projects.
       <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
     </PropertyGroup>
   </Target>
-  
+
   <Target Name="_SetupDesignTimeBuildForCompile" DependsOnTargets="_CreateStampDirectory">
     <PropertyGroup>
       <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
-      <ManagedDesignTimeBuild Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'true' And '$(DesignTimeBuild)' == 'true' And '$(BuildingInsideVisualStudio)' == 'true' ">true</ManagedDesignTimeBuild>
+      <ManagedDesignTimeBuild Condition=" '$(AndroidGenerateResourceDesigner)' == 'True' And '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'true' And '$(DesignTimeBuild)' == 'true' And '$(BuildingInsideVisualStudio)' == 'true' ">true</ManagedDesignTimeBuild>
       <ManagedDesignTimeBuild Condition=" '$(ManagedDesignTimeBuild)' == '' ">False</ManagedDesignTimeBuild>
       <_AndroidLibraryImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryImportsCache)') ">$(_AndroidLibraryImportsDesignTimeCache)</_AndroidLibraryImportsCache>
       <_AndroidLibraryProjectImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryProjectImportsCache)') ">$(_AndroidLibraryProjectImportsDesignTimeCache)</_AndroidLibraryProjectImportsCache>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -12,6 +12,7 @@ projects. .NET 5 projects will not import this file.
 
   <PropertyGroup>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">Java</AndroidBoundExceptionType>
+    <AndroidGenerateResourceDesigner>True</AndroidGenerateResourceDesigner>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidBuildApplicationPackage)' == 'True' And '$(AndroidApplication)' == 'True' ">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -12,7 +12,7 @@ projects. .NET 5 projects will not import this file.
 
   <PropertyGroup>
     <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">Java</AndroidBoundExceptionType>
-    <AndroidGenerateResourceDesigner>True</AndroidGenerateResourceDesigner>
+    <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">True</AndroidGenerateResourceDesigner>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AndroidBuildApplicationPackage)' == 'True' And '$(AndroidApplication)' == 'True' ">


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1440274

The design time build was not taking into account the `AndroidGenerateResourceDesigner` property value. 
As a result we would always get a `Resource.designer.cs` file generated in the designtime directory.

So lets turn off the designtime build if that property is set. 
Also note set a defaut for `AndroidGenerateResourceDesigner` in legacy so that it is always `true`. 
This is to get around some issues under legacy where `AndroidGenerateResourceDesigner` was not 
defined. This is because the designtime build tasks and targets are shared between both systems.