### PR TITLE
Raise an error if the Resource starts with an Invalid Character.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -29,7 +29,7 @@ ms.date: 01/24/2020
 + [APT0001](apt0001.md): Unknown option \`{option}\`. Please check \`$(AndroidAapt2CompileExtraArgs)\` and \`$(AndroidAapt2LinkExtraArgs)\` to see if they include any \`aapt\` command line arguments that are no longer valid for \`aapt2\` and ensure that all other arguments are valid for `aapt2`.
 + APT0002: Invalid file name: It must contain only \[^a-zA-Z0-9_.-\]+.
 + APT0003: Invalid file name: It must contain only \[^a-zA-Z0-9_.\]+.
-+ APT0004: Invalid file name: It must start with \[^a-zA-Z_].
++ APT0004: Invalid file name: It must start with a letter or an underscore.
 
 ## JAVACxxxx: Java compiler
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -29,7 +29,7 @@ ms.date: 01/24/2020
 + [APT0001](apt0001.md): Unknown option \`{option}\`. Please check \`$(AndroidAapt2CompileExtraArgs)\` and \`$(AndroidAapt2LinkExtraArgs)\` to see if they include any \`aapt\` command line arguments that are no longer valid for \`aapt2\` and ensure that all other arguments are valid for `aapt2`.
 + APT0002: Invalid file name: It must contain only \[^a-zA-Z0-9_.-\]+.
 + APT0003: Invalid file name: It must contain only \[^a-zA-Z0-9_.\]+.
-+ APT0004: Invalid file name: It must start with a letter or an underscore.
++ APT0004: Invalid file name: It must start with either A-Z or a-z or an underscore.
 
 ## JAVACxxxx: Java compiler
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -29,6 +29,7 @@ ms.date: 01/24/2020
 + [APT0001](apt0001.md): Unknown option \`{option}\`. Please check \`$(AndroidAapt2CompileExtraArgs)\` and \`$(AndroidAapt2LinkExtraArgs)\` to see if they include any \`aapt\` command line arguments that are no longer valid for \`aapt2\` and ensure that all other arguments are valid for `aapt2`.
 + APT0002: Invalid file name: It must contain only \[^a-zA-Z0-9_.-\]+.
 + APT0003: Invalid file name: It must contain only \[^a-zA-Z0-9_.\]+.
++ APT0004: Invalid file name: It must start with \[^a-zA-Z_].
 
 ## JAVACxxxx: Java compiler
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -137,8 +137,7 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
     <comment>{0} - The regular expression that the file name must match</comment>
   </data>
   <data name="APT0004" xml:space="preserve">
-    <value>Invalid file name: It must start with {0}.</value>
-    <comment>{0} - The regular expression that the file name must match</comment>
+    <value>Invalid file name: It must start with a letter or an underscore.</value>
   </data>
   <data name="XA0000_API_for_TargetFrameworkVersion" xml:space="preserve">
     <value>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -137,7 +137,7 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
     <comment>{0} - The regular expression that the file name must match</comment>
   </data>
   <data name="APT0004" xml:space="preserve">
-    <value>Invalid file name: It must start with a letter or an underscore.</value>
+    <value>Invalid file name: It must start with A-z or a-z or an underscore.</value>
   </data>
   <data name="XA0000_API_for_TargetFrameworkVersion" xml:space="preserve">
     <value>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -136,6 +136,10 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
     <value>Invalid file name: It must contain only {0}.</value>
     <comment>{0} - The regular expression that the file name must match</comment>
   </data>
+  <data name="APT0004" xml:space="preserve">
+    <value>Invalid file name: It must start with {0}.</value>
+    <comment>{0} - The regular expression that the file name must match</comment>
+  </data>
   <data name="XA0000_API_for_TargetFrameworkVersion" xml:space="preserve">
     <value>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</value>
     <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,9 +28,9 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with {0}.</source>
-        <target state="new">Invalid file name: It must start with {0}.</target>
-        <note>{0} - The regular expression that the file name must match</note>
+        <source>Invalid file name: It must start with a letter or an underscore.</source>
+        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
 This error is likely caused by an issue with the AndroidManifest.xml file or an Android manifest generation attribute in a source code file.</target>
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
+      <trans-unit id="APT0004">
+        <source>Invalid file name: It must start with {0}.</source>
+        <target state="new">Invalid file name: It must start with {0}.</target>
+        <note>{0} - The regular expression that the file name must match</note>
+      </trans-unit>
       <trans-unit id="XA0031_NET">
         <source>Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</source>
         <target state="new">Java SDK {0} or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,8 +28,8 @@ This error is likely caused by an issue with the AndroidManifest.xml file or an 
         <note>{0} - The error message returned by the AAPT or AAPT2 tool</note>
       </trans-unit>
       <trans-unit id="APT0004">
-        <source>Invalid file name: It must start with a letter or an underscore.</source>
-        <target state="new">Invalid file name: It must start with a letter or an underscore.</target>
+        <source>Invalid file name: It must start with A-z or a-z or an underscore.</source>
+        <target state="new">Invalid file name: It must start with A-z or a-z or an underscore.</target>
         <note />
       </trans-unit>
       <trans-unit id="XA0031_NET">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -30,6 +30,10 @@ namespace Xamarin.Android.Tasks {
 					resourceFile = resource.ItemSpec;
 				var fileName = Path.GetFileName (resourceFile);
 				var directory = Path.GetFileName (Path.GetDirectoryName (resourceFile));
+				char firstChar = fileName [0];
+				if (!(Char.IsLetter (firstChar) || firstChar != '_')) {
+					Log.LogCodedError ("APT0004", resource.ItemSpec, 0, Properties.Resources.APT0004, fileNameCheck);
+				}
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {
 					var match = fileNameWithHyphenCheck.Match (fileName);
 					if (match.Success) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks {
 				var fileName = Path.GetFileName (resourceFile);
 				var directory = Path.GetFileName (Path.GetDirectoryName (resourceFile));
 				char firstChar = fileName [0];
-				if (!(Char.IsLetter (firstChar) || firstChar != '_')) {
+				if (!Char.IsLetter (firstChar) && firstChar != '_') {
 					Log.LogCodedError ("APT0004", resource.ItemSpec, 0, Properties.Resources.APT0004, fileNameCheck);
 				}
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -31,9 +31,8 @@ namespace Xamarin.Android.Tasks {
 				var fileName = Path.GetFileName (resourceFile);
 				var directory = Path.GetFileName (Path.GetDirectoryName (resourceFile));
 				char firstChar = fileName [0];
-				if (!(('a' <= firstChar && firstChar <= 'z') ||
-						('A' <= firstChar && firstChar <= 'Z') ||
-						firstChar == '_')) {
+				bool isValidFirstChar = ('a' <= firstChar && firstChar <= 'z') || ('A' <= firstChar && firstChar <= 'Z') || firstChar == '_';
+				if (!isValidFirstChar) {
 					Log.LogCodedError ("APT0004", resource.ItemSpec, 0, Properties.Resources.APT0004);
 				}
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -31,8 +31,10 @@ namespace Xamarin.Android.Tasks {
 				var fileName = Path.GetFileName (resourceFile);
 				var directory = Path.GetFileName (Path.GetDirectoryName (resourceFile));
 				char firstChar = fileName [0];
-				if (!Char.IsLetter (firstChar) && firstChar != '_') {
-					Log.LogCodedError ("APT0004", resource.ItemSpec, 0, Properties.Resources.APT0004, fileNameCheck);
+				if (!(('a' <= firstChar && firstChar <= 'z') ||
+						('A' <= firstChar && firstChar <= 'Z') ||
+						firstChar == '_')) {
+					Log.LogCodedError ("APT0004", resource.ItemSpec, 0, Properties.Resources.APT0004);
 				}
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {
 					var match = fileNameWithHyphenCheck.Match (fileName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckForInvalidResourceFileNamesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckForInvalidResourceFileNamesTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tasks;
+using TaskItem = Microsoft.Build.Utilities.TaskItem;
+
+namespace Xamarin.Android.Build.Tests
+{
+
+	[TestFixture]
+	[Category ("Node-2")]
+	public class CheckForInvalidResourceFileNamesTests : BaseTest {
+
+#pragma warning disable 414
+		static object [] InvalidResourceFileNamesChecks () => new object [] {
+			new object[] {
+				"myresource.xml",
+				true,
+				0,
+			},
+			new object[] {
+				"_myresource.xml",
+				true,
+				0,
+			},
+			new object[] {
+				"Myresource.xml",
+				true,
+				0,
+			},
+			new object[] {
+				"@myresource.xml",
+				false,
+				2,
+			},
+			new object[] {
+				"5myresource.xml",
+				false,
+				1,
+			},
+			new object[] {
+				".myresource.xml",
+				false,
+				1,
+			},
+			new object[] {
+				"-myresource.xml",
+				false,
+				2,
+			},
+		};
+#pragma warning restore 414
+		[Test]
+		[TestCaseSource(nameof(InvalidResourceFileNamesChecks))]
+		public void InvalidResourceFileNames (string file, bool shouldPass, int expectedErrorCount)
+		{
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = new CheckForInvalidResourceFileNames {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				Resources = new TaskItem [] {
+					new TaskItem (file),
+				},
+			};
+			Assert.AreEqual (shouldPass, task.Execute (), $"task.Execute() should have {(shouldPass ? "succeeded" : "failed")}.");
+			Assert.AreEqual (expectedErrorCount, errors.Count, "There should be one error.");
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1333264/

Android Resources MUST start with a Letter or an underscore. They cannot
start with any other character. We should raise a specific error for this
so it is obvious to the user what the issue is.