### PR TITLE
Add `dotnet-local` scripts to make using in tree dotnet easier.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,9 @@
         {
             "label": "Build Xamarin.Android Build Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Build /p:Configuration=${input:configuration}",
+            "windows": { "command": "dotnet-local.cmd build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration}", },
+            "linux": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration}",},
+            "osx": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration}",},
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -30,7 +32,9 @@
         {
             "label": "Clean Xamarin.Android Build Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj /restore /t:Clean /p:Configuration=${input:configuration}",
+            "windows": { "command": "dotnet-local.cmd build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration} -t:Clean", },
+            "linux": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration} -t:Clean",},
+            "osx": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj -c ${input:configuration} -t:Clean",},
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -42,7 +46,9 @@
         {
             "label": "Build Xamarin.Android Build Test Tasks",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build /p:Configuration=${input:configuration}",
+            "windows": { "command": "dotnet-local.cmd build src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}", },
+            "linux": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}",},
+            "osx": { "command": "./dotnet-local.sh build src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}",},
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -54,7 +60,9 @@
         {
             "label": "Build Xamarin.Android Build Device Tests",
             "type": "shell",
-            "command": "msbuild tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj /restore /t:Build /p:Configuration=${input:configuration}",
+            "windows": { "command": "dotnet-local.cmd build tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj -c ${input:configuration}", },
+            "linux": { "command": "./dotnet-local.sh build tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj -c ${input:configuration}",},
+            "osx": { "command": "./dotnet-local.sh build tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj -c ${input:configuration}",},
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -66,7 +74,9 @@
         {
             "label": "Build Xamarin.Android Build Commercial Tests",
             "type": "shell",
-            "command": "msbuild external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build /p:Configuration=${input:configuration}",
+            "windows": { "command": "dotnet-local.cmd build external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}", },
+            "linux": { "command": "./dotnet-local.sh build external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}",},
+            "osx": { "command": "./dotnet-local.sh build external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj -c ${input:configuration}",},
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -126,7 +136,9 @@
         {
           "label": "prepare-sample-under-dotnet",
           "type": "shell",
-          "command": "dotnet build --no-restore tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj -c ${input:configuration} -t:GenerateNuGetConfig -p:AndroidNETTestConfigOutputDir=${workspaceRoot}/samples",
+          "windows": { "command": "dotnet-local.cmd build --no-restore tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj -c ${input:configuration} -t:GenerateNuGetConfig -p:AndroidNETTestConfigOutputDir=${workspaceRoot}/samples", },
+          "linux": { "command": "./dotnet-local.sh build --no-restore tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj -c ${input:configuration} -t:GenerateNuGetConfig -p:AndroidNETTestConfigOutputDir=${workspaceRoot}/samples",},
+          "osx": { "command": "./dotnet-local.sh build --no-restore tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj -c ${input:configuration} -t:GenerateNuGetConfig -p:AndroidNETTestConfigOutputDir=${workspaceRoot}/samples",},
           "group": {
               "kind": "build",
               "isDefault": true
@@ -138,7 +150,9 @@
         {
           "label": "build-sample-under-dotnet",
           "type": "shell",
-          "command": "bin/${input:configuration}/dotnet/dotnet build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",
+          "windows": { "command": "dotnet-local.cmd build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}", },
+          "linux": { "command": "./dotnet-local.sh build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",},
+          "osx": { "command": "./dotnet-local.sh build ${input:project} -p:Configuration=${input:configuration} -t:${input:target}",},
           "group": {
               "kind": "build",
               "isDefault": true
@@ -150,7 +164,9 @@
         {
           "label": "run-sample-under-dotnet",
           "type": "shell",
-          "command": "bin/${input:configuration}/dotnet/dotnet build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}",
+          "windows": { "command": "dotnet-local.cmd build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}", },
+          "linux": { "command": "./dotnet-local.sh build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}",},
+          "osx": { "command": "./dotnet-local.sh build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach}",},
           "group": {
               "kind": "build",
               "isDefault": true

--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -106,10 +106,10 @@ Create a new project with `dotnet new android`:
 
 Build the project with:
 
-    $ bin/$(Configuration)/dotnet/dotnet build foo.csproj
+    $ ./dotnet-local.sh build foo.csproj
 
-Using the `dotnet` provisioned in `bin/$(Configuration)/dotnet` will use the
-locally built binaries.
+Using the `dotnet-local` script will execute the `dotnet` provisioned in
+`bin/$(Configuration)/dotnet` and will use the locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
 
@@ -155,7 +155,7 @@ make variable:
 
 In order to get a list of the tests you can use the `list-nunit-tests` make target
 
-    make list-nunit-tests 
+    make list-nunit-tests
 
 or via the `ListNUnitTests` target
 
@@ -262,23 +262,23 @@ For example:
 
 There are a few ways to do it:
 
-  * Use [`Configuration.Override.props`][override-props], and override 
+  * Use [`Configuration.Override.props`][override-props], and override
     `$(AndroidApiLevel)` and `$(AndroidFrameworkVersion)`.
 
   * Build all the platforms with:
-  
+
         make framework-assemblies
 
   * Build several platforms other than the default
-  
+
         make framework-assemblies API_LEVELS="LEVEL1 LEVEL2"
-  
+
     where *LEVEL1* and *LEVEL2* are [API levels from the `$(API_LEVELS)` variable][api-levels].
-  
+
   * Build just the platform you want, other than the default one with
-  
+
         make API_LEVEL=LEVEL
-  
+
     where *LEVEL* is one of the [API levels from the `$(API_LEVELS)` variable][api-levels].
 
 [override-props]: ../../README.md#build-configuration
@@ -367,7 +367,7 @@ top-level `make` and [`xabuild`](../../../tools/xabuild) invocations to use them
 For example, to rebuild Mono for armeabi-v7a:
 
 	$ make -C src/mono-runtimes/obj/Debug/armeabi-v7a
-	
+
 	# This updates bin/$(Configuration)/lib/xamarin.android/xbuild/Xamarin/Android/lib/armeabi-v7a/libmonosgen-2.0.so
 	$ msbuild /t:_InstallRuntimes src/mono-runtimes/mono-runtimes.csproj
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -31,7 +31,7 @@ MSBuild version 15 or later is required.
         msbuild Xamarin.Android.sln
 
  7. In order to use the in-tree Xamarin.Android, build xabuild:
- 
+
          msbuild tools/xabuild/xabuild.csproj /restore
 
  8. (For Microsoft team members only - Optional) In a [Developer Command
@@ -120,14 +120,14 @@ Create a new project with `dotnet new android`:
 
 Build the project in `cmd` with:
 
-    > bin\$(Configuration)\dotnet\dotnet build foo.csproj
+    > dotnet-local.cmd build foo.csproj
 
 Or in powershell:
 
-    > bin\$(Configuration)\dotnet\dotnet build foo.csproj
+    > dotnet-local.cmd build foo.csproj
 
-Using the `dotnet` provisioned in `bin/$(Configuration)`
-will use the locally built binaries.
+Using the `dotnet-local` script will execute the `dotnet` provisioned in
+`bin\$(Configuration)\dotnet` and will use the locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
 

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+IF EXIST "bin\Release\dotnet\dotnet.exe" (
+    call "bin\Release\dotnet\dotnet.exe" %*
+) ELSE (
+    call "bin\Debug\dotnet\dotnet.exe" %*
+)

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -2,6 +2,8 @@
 
 IF EXIST "bin\Release\dotnet\dotnet.exe" (
     call "bin\Release\dotnet\dotnet.exe" %*
-) ELSE (
+) ELSE IF EXIST "bin\Debug\dotnet\dotnet.exe" (
     call "bin\Debug\dotnet\dotnet.exe" %*
+) ELSE (
+    echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."
 )

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -d "bin/Release/dotnet" ]; then
+    ./bin/Release/dotnet/dotnet $@
+else
+    ./bin/Debug/dotnet/dotnet $@
+fi

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-if [ -d "bin/Release/dotnet" ]; then
-    ./bin/Release/dotnet/dotnet $@
+if [[ -x "bin/Release/dotnet/dotnet" ]]; then
+    exec ./bin/Release/dotnet/dotnet "$@"
+elif [[ -x "bin/Debug/dotnet/dotnet" ]]; then
+    exec ./bin/Debug/dotnet/dotnet "$@"
 else
-    ./bin/Debug/dotnet/dotnet $@
+    echo "You need to run 'make prepare' first."
 fi


### PR DESCRIPTION
Lets add a couple of `dotnet-local` scripts which will allow us to
use the in-tree dotnet install easier. Also update the VSCode tasks
to make use of this new script.