### PR TITLE
[Xamarin.Android.Build.Tasks] remove Microsoft.AspNetCore.App.Runtime.linux workaround

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -14,15 +14,6 @@ _ResolveAssemblies MSBuild target.
   <UsingTask TaskName="Xamarin.Android.Tasks.ProcessNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.StripNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
-  <!-- HACK: workaround for: https://github.com/dotnet/sdk/issues/19891 -->
-  <Target Name="_RemoveLinuxFrameworkReferences"
-      AfterTargets="ProcessFrameworkReferences">
-    <ItemGroup>
-      <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
-      <PackageDownload Remove="Microsoft.AspNetCore.App.Runtime.%(_ProblematicRIDs.Identity)" />
-    </ItemGroup>
-  </Target>
-
   <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' == 'true' ">
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/19891

In 3f052b5f, I added a workaround to exclude
`Microsoft.AspNetCore.App.Runtime.linux` packages from Android builds.
This was a problem where the `android` RID "inherited" from the
`linux` RID, and so we ended up with unintended packages restored.

This was fixed in https://github.com/dotnet/installer/pull/12702, so
we should remove this workaround.