### PR TITLE
[Mono.Android] add another "built-in" JNINativeWrapper

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -290,6 +290,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static void Wrap_JniMarshal_PPLLL_V (this _JniMarshal_PPLLL_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				
+			}
+		}
+
 		internal static IntPtr Wrap_JniMarshal_PPLLL_L (this _JniMarshal_PPLLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -420,6 +431,8 @@ namespace Android.Runtime
 					return new _JniMarshal_PPILL_V (Unsafe.As<_JniMarshal_PPILL_V> (dlg).Wrap_JniMarshal_PPILL_V);
 				case nameof (_JniMarshal_PPLIL_Z):
 					return new _JniMarshal_PPLIL_Z (Unsafe.As<_JniMarshal_PPLIL_Z> (dlg).Wrap_JniMarshal_PPLIL_Z);
+				case nameof (_JniMarshal_PPLLL_V):
+					return new _JniMarshal_PPLLL_V (Unsafe.As<_JniMarshal_PPLLL_V> (dlg).Wrap_JniMarshal_PPLLL_V);
 				case nameof (_JniMarshal_PPLLL_L):
 					return new _JniMarshal_PPLLL_L (Unsafe.As<_JniMarshal_PPLLL_L> (dlg).Wrap_JniMarshal_PPLLL_L);
 				case nameof (_JniMarshal_PPLLL_Z):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -155,6 +155,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1, p2",
 	},
 	new {
+		Type = "_JniMarshal_PPLLL_V",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2",
+		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
 		Type = "_JniMarshal_PPLLL_L",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2",
 		Return = "IntPtr",


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/680f1fbbdd9fa8e5e4e3f1614d798213d36eace9

`dotnet new maui` is logging:

    03-24 16:21:42.193 16360 16360 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLLL_V': Void
    n_OnComplete_Ljava_lang_Boolean_Landroid_graphics_drawable_Drawable_Ljava_lang_Runnable_(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr)

So we can add a case for `_JniMarshal_PPLLL_V`:

    Before:
    48.18ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
    After:
     3.13ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)

This was `dotnet trace` output running on a Pixel 5.