### PR TITLE
Optionally force `res` directory creation for `.aar` libraries.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -10,6 +10,7 @@ projects.
 -->
 <Project>
 
+  <UsingTask TaskName="Xamarin.Android.Tasks.AppendCustomMetadataToItemGroup" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.CreateAar"          AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ExtractJarsFromAar" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
@@ -31,13 +32,21 @@ projects.
         * set %(Pack) to false for located .aar files, we should not repackage into NuGets
         * %(AndroidSkipResourceProcessing) is required for located .aar's; there could be custom views.
       -->
-      <AndroidAarLibrary
+      <_AndroidAarLibrary
           Include="@(_AarFromLibraries)"
           Exclude="@(AndroidAarLibrary)"
           Pack="false"
           AndroidSkipResourceProcessing="false"
       />
+      <AndroidAarLibrary Include="@(_AndroidAarLibrary)" Condition="'$(AndroidApplication)' != 'True'"/>
     </ItemGroup>
+    <AppendCustomMetadataToItemGroup
+      Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)"
+      Inputs="@(_AndroidAarLibrary)"
+      MetaDataItems="@(AndroidCustomMetaDataForAarLibrary)"
+    >
+      <Output TaskParameter="Output" ItemName="AndroidAarLibrary" />
+    </AppendCustomMetadataToItemGroup>
   </Target>
 
   <Target Name="_CreateAarCache"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -41,7 +41,7 @@ projects.
       <AndroidAarLibrary Include="@(_AndroidAarLibrary)" Condition="'$(AndroidApplication)' != 'True'"/>
     </ItemGroup>
     <AppendCustomMetadataToItemGroup
-      Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)"
+      Condition="'$(AndroidApplication)' != '' And $(AndroidApplication) And '@(_AndroidAarLibrary->Count())' != '0'"
       Inputs="@(_AndroidAarLibrary)"
       MetaDataItems="@(AndroidCustomMetaDataForAarLibrary)"
     >

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AndroidLibraries.targets
@@ -40,6 +40,10 @@ projects.
       />
       <AndroidAarLibrary Include="@(_AndroidAarLibrary)" Condition="'$(AndroidApplication)' != 'True'"/>
     </ItemGroup>
+    <!--
+      NOTE: We have to do this here rather than in _AddAndroidCustomMetaData because
+      we use the outputs of that target to search for .aar files.
+    -->
     <AppendCustomMetadataToItemGroup
       Condition="'$(AndroidApplication)' != '' And $(AndroidApplication) And '@(_AndroidAarLibrary->Count())' != '0'"
       Inputs="@(_AndroidAarLibrary)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "RLP";
 
 		internal const string AndroidSkipResourceExtraction = "AndroidSkipResourceExtraction";
+		internal const string AndroidForceCreateResourceDirectory = "AndroidForceCreateResourceDirectory";
 
 		[Required]
 		public string ImportsDirectory { get; set; }
@@ -344,6 +345,7 @@ namespace Xamarin.Android.Tasks
 				string importsDir = Path.Combine (outDirForDll, ImportsDirectory);
 				string resDir = Path.Combine (importsDir, "res");
 				string resDirArchive = Path.Combine (resDir, "..", "res.zip");
+
 				string assetsDir = Path.Combine (importsDir, "assets");
 
 				bool updated = false;
@@ -351,6 +353,12 @@ namespace Xamarin.Android.Tasks
 				string stamp = Path.Combine (outdir, aarIdentityName + ".stamp");
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				var aarFullPath = Path.GetFullPath (aarFile.ItemSpec);
+
+				var forceResourceDirectory = aarFile.GetMetadata (AndroidForceCreateResourceDirectory);
+				if (!string.IsNullOrEmpty (forceResourceDirectory) && String.Compare (forceResourceDirectory, "True", ignoreCase: true) == 0) {
+					Directory.CreateDirectory (resDir);
+				}
+
 				if (aarHash == stampHash) {
 					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
 					if (Directory.Exists (importsDir)) {


### PR DESCRIPTION
Normally an `R.java` class is generated for each library. This would
allow the `R.*` classes to be access from Java without needing to get
them from C# first. However our `R.java` generation code only did this
for libraries which contain a `res` folder. This made sense at the time
as it helped reduce apk size by not generating an `R.java` when it did
not seem to be needed.

In Maui we have a few places where we want to be able to access the
AndroidResource identifiers from within custom Java Code. However this
library does NOT have any resources of its own, so we don't generate a
`R.java` file for it. This means we have to look up the code in C# then
pass that value into the custom Java code. These values then become
part of the API. Its not ideal.

So lets add support for adding additional metadata to `AarLibrary`
ItemGroup Items like we do for `References`. This new metadata item will
be `AndroidCustomMetaDataForAarLibrary`. This will allow us to add
additional metadata for `.aar` files we discover as part of the build
process.

In this case we want to support a new `AndroidForceCreateResourceDirectory`
metadata property. This will cause the `ResolveLibraryProjectImports`
task to create an empty `res` directory as part of its `.aar` extraction
process. This empty directory will be ignored when calling `aapt2` but
will allow the generation of the required `R.java` file. This will allow
us to access things like `R.styleable` in Java code for the library and
have it resolve to the correct value at runtime.