### PR TITLE
Remove unnecessary background Task in AndroidMessageHandler

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.Legacy.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.Legacy.cs
@@ -761,8 +761,9 @@ namespace Xamarin.Android.Net
 		/// <param name="conn">Pre-configured connection instance</param>
 		protected virtual Task SetupRequest (HttpRequestMessage request, HttpURLConnection conn)
 		{
-			Action a = AssertSelf;
-			return Task.Run (a);
+			AssertSelf ();
+			
+			return Task.CompletedTask;
 		}
 
 		/// <summary>

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -850,8 +850,9 @@ namespace Xamarin.Android.Net
 		/// <param name="conn">Pre-configured connection instance</param>
 		protected virtual Task SetupRequest (HttpRequestMessage request, HttpURLConnection conn)
 		{
-			Action a = AssertSelf;
-			return Task.Run (a);
+			AssertSelf ();
+			
+			return Task.CompletedTask;
 		}
 
 		internal Task SetupRequestInternal (HttpRequestMessage request, HttpURLConnection conn)


### PR DESCRIPTION
AndroidMessageHandler.SetupRequest returns a Task so overrides can be async. The base implementation checks the object hasn't been disposed. However, it is doing this check using Task.Run, which queues a work item to the ThreadPool. This is unnecessary and causes more threads to be spawned than what is needed.

The fix is to just check for disposed synchronously and return a completed Task.

Fix #6854