### PR TITLE
$(AndroidPackVersionSuffix)=rc.1; net6 is 31.0.300.rc.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>31.0.300</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
We just branched:
* https://github.com/xamarin/xamarin-android/tree/release/6.0.3xx
* https://github.com/xamarin/xamarin-android/tree/release/6.0.3xx-rc1

xamarin-android/main will be 32.0.100-preview.4
xamarin-android/release/6.0.3xx will be 31.0.300-rc.2
xamarin-android/release/6.0.3xx-rc1 will be 31.0.300-rc.1