### PR TITLE
$(AndroidPackVersionSuffix)=preview.4; net7 is 33.0.100.preview.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,8 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>31.0.300</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
+    <AndroidPackVersion>32.0.100</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>32.0.100</AndroidPackVersion>
+    <AndroidPackVersion>33.0.100</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
We just branched:
* https://github.com/xamarin/xamarin-android/tree/release/6.0.3xx
* https://github.com/xamarin/xamarin-android/tree/release/6.0.3xx-rc1

xamarin-android/main will be 33.0.100-preview.4
xamarin-android/release/6.0.3xx will be 32.0.300-rc.2
xamarin-android/release/6.0.3xx-rc1 will be 32.0.300-rc.1