### PR TITLE
[Mono.Android] improve performance of new Java arrays

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -1565,11 +1565,11 @@ namespace Android.Runtime {
 			elementType ??= value.GetType ().GetElementType ()!;
 
 			if (elementType.IsArray) {
-				IntPtr grefArrayClass = FindClass (elementType);
+				IntPtr grefArrayElementClass = FindClass (elementType);
 				try {
-					return NewArray (value, elementType, grefArrayClass);
+					return NewArray (value, elementType, grefArrayElementClass);
 				} finally {
-					DeleteGlobalRef (grefArrayClass);
+					DeleteGlobalRef (grefArrayElementClass);
 				}
 			}
 
@@ -1584,11 +1584,11 @@ namespace Android.Runtime {
 				return IntPtr.Zero;
 
 			if (typeof (T).IsArray) {
-				IntPtr grefArrayClass = FindClass (typeof (T));
+				IntPtr grefArrayElementClass = FindClass (typeof (T));
 				try {
-					return NewArray (array, typeof (T), grefArrayClass);
+					return NewArray (array, typeof (T), grefArrayElementClass);
 				} finally {
-					DeleteGlobalRef (grefArrayClass);
+					DeleteGlobalRef (grefArrayElementClass);
 				}
 			}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -1562,24 +1562,12 @@ namespace Android.Runtime {
 			if (value == null)
 				throw new ArgumentNullException ("value");
 
-			elementType = elementType ?? value.GetType ().GetElementType ()!;
+			elementType ??= value.GetType ().GetElementType ()!;
 
 			if (elementType.IsArray) {
-				IntPtr array = IntPtr.Zero;
 				IntPtr grefArrayClass = FindClass (elementType);
 				try {
-					array = NewObjectArray (value.Length, grefArrayClass, IntPtr.Zero);
-
-					for (int i = 0; i < value.Length; ++i) {
-						IntPtr subarray = NewArray ((Array) value.GetValue (i)!, elementType.GetElementType ());
-						SetObjectArrayElement (array, i, subarray);
-						DeleteLocalRef (subarray);
-					}
-
-					return array;
-				} catch {
-					DeleteLocalRef (array);
-					throw;
+					return NewArray (value, elementType, grefArrayClass);
 				} finally {
 					DeleteGlobalRef (grefArrayClass);
 				}
@@ -1596,12 +1584,39 @@ namespace Android.Runtime {
 				return IntPtr.Zero;
 
 			if (typeof (T).IsArray) {
-				return NewArray (array, typeof (T));
+				IntPtr grefArrayClass = FindClass (typeof (T));
+				try {
+					return NewArray (array, typeof (T), grefArrayClass);
+				} finally {
+					DeleteGlobalRef (grefArrayClass);
+				}
 			}
 
 			Func<Array, IntPtr> creator = GetConverter (CreateManagedToNativeArray, typeof (T), IntPtr.Zero);
 
 			return creator (array);
+		}
+
+		static IntPtr NewArray (Array value, Type elementType, IntPtr elementClass)
+		{
+			if (value == null)
+				throw new ArgumentNullException ("value");
+
+			IntPtr array = IntPtr.Zero;
+			try {
+				array = NewObjectArray (value.Length, elementClass, IntPtr.Zero);
+
+				for (int i = 0; i < value.Length; ++i) {
+					IntPtr subarray = NewArray ((Array) value.GetValue (i)!, elementType.GetElementType ());
+					SetObjectArrayElement (array, i, subarray);
+					DeleteLocalRef (subarray);
+				}
+
+				return array;
+			} catch {
+				DeleteLocalRef (array);
+				throw;
+			}
 		}
 
 		static Dictionary<Type, Action<IntPtr, int, object?>>? setNativeArrayElement;

--- a/tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
+++ b/tests/Mono.Android-Tests/Android.Runtime/JnienvArrayMarshaling.cs
@@ -294,6 +294,16 @@ namespace Android.RuntimeTests {
 			Assert.AreEqual ("[[I", t);
 		}
 
+		[Test]
+		public void NewArray_Int32ArrayArray_ArrayOverload ()
+		{
+			Array array = new int[][]{new[]{11, 12}, new []{21, 22}};
+			IntPtr x = JNIEnv.NewArray(array);
+			string t = JNIEnv.GetClassNameFromInstance (x);
+			JNIEnv.DeleteLocalRef (x);
+			Assert.AreEqual ("[[I", t);
+		}
+
 		// http://bugzilla.xamarin.com/show_bug.cgi?id=12479
 		[Test]
 		public void NewArray_Int32ArrayArray_ShouldNotLeak ()


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/blob/79f2fef9397bbfe2f6aa1527e40f933712a5d2ad/src/Core/src/Platform/Android/ColorStateListExtensions.cs#L50-L51

When running a `dotnet new maui` app, we noticed the log:

    W monodroid: typemap: failed to map managed type to Java type: System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e (Module ID: 8e4cd939-3275-41c4-968d-d5a4376b35f5; Type token: 33554653)
    W monodroid-assembly: typemap: called from
    W monodroid-assembly: at Android.Runtime.JNIEnv.TypemapManagedToJava(Type )
    W monodroid-assembly: at Android.Runtime.JNIEnv.GetJniName(Type )
    W monodroid-assembly: at Android.Runtime.JNIEnv.FindClass(Type )
    W monodroid-assembly: at Android.Runtime.JNIEnv.NewArray(Array , Type )
    W monodroid-assembly: at Android.Runtime.JNIEnv.NewArray[Int32[]](Int32[][] )
    W monodroid-assembly: at Android.Content.Res.ColorStateList..ctor(Int32[][] , Int32[] )
    W monodroid-assembly: at Microsoft.Maui.Platform.ColorStateListExtensions.CreateButton(Int32 enabled, Int32 disabled, Int32 off, Int32 pressed)

We see this ~17 times on startup. In this case, the Android binding is:

    public unsafe ColorStateList (int[][]? states, int[]? colors) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
    {
        //...
        IntPtr native_states = JNIEnv.NewArray (states);

Looking at the stack trace, it seems like this is happening for every
item in the array? We could probably call `FindClass (typeof (T))`
once, and use it for every item in the array. This would avoid many
typemap lookups.

Previously this showed up in `dotnet trace` output for a Pixel 5:

    6.05ms Mono.Android!Android.Runtime.JNIEnv.NewArray
    4.84ms Mono.Android!Android.Runtime.JNIEnv.NewArray(System.Array,System.Type)

After these changes:

    5.04ms Mono.Android!Android.Runtime.JNIEnv.NewArray
    3.83ms Mono.Android!Android.Runtime.JNIEnv.NewArray(System.Array,System.Type,intptr)

This change seems to save ~1ms on startup for `dotnet new maui` on a
Pixel 5 device.