### PR TITLE
[Mono.Android-Tests] Stop using tls-test.internalx.com (#6678)

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -549,7 +549,6 @@ stages:
         testName: Mono.Android_TestsAppBundle
         project: tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
         testResultsFiles: TestResult-Mono.Android_TestsAppBundle-$(ApkTestConfiguration).xml
-        packageType: Aab
         artifactSource: bin/Test$(ApkTestConfiguration)/Mono.Android_TestsAppBundle-Signed.aab
         artifactFolder: Aab
 
@@ -775,7 +774,6 @@ stages:
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)Aab.xml
         extraBuildArgs: /p:TestsFlavor=Aab /p:AndroidPackageFormat=aab
-        packageType: Aab
         artifactSource: bin/Test$(XA.Build.Configuration)/net6.0-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: net6-Aab
         useDotNet: true

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -5,7 +5,6 @@ parameters:
   testResultsFiles: ""
   extraBuildArgs: ""
   testResultsFormat: NUnit
-  packageType: Apk
   artifactSource: ""
   artifactFolder: ""
   useDotNet: false
@@ -20,7 +19,7 @@ steps:
       configuration: ${{ parameters.configuration }}
       msbuildArguments: >-
         /restore
-        /t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
+        /t:RunTestApp
         /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         ${{ parameters.extraBuildArgs }}
     condition: ${{ parameters.condition }}
@@ -32,7 +31,7 @@ steps:
       displayName: run ${{ parameters.testName }}
       project: ${{ parameters.project }}
       arguments: >-
-        -t:AcquireAndroidTarget,SignAndroidPackage,DeployTest${{ parameters.packageType }}s,CheckAndRecordApkSizes,RunTestApks,UndeployTestApks,RenameApkTestCases,ReportComponentFailures
+        -t:RunTestApp
         -bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog
         -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -392,4 +392,22 @@
     />
   </Target>
 
+  <PropertyGroup>
+    <RunTestAppDependsOn>
+      AcquireAndroidTarget;
+      SignAndroidPackage;
+      DeployTestApks;
+      DeployTestAabs;
+      CheckAndRecordApkSizes;
+      RunTestApks;
+      UndeployTestApks;
+      RenameApkTestCases;
+      ReportComponentFailures;
+    </RunTestAppDependsOn>
+  </PropertyGroup>
+
+  <Target Name="RunTestApp"
+      DependsOnTargets="$(RunTestAppDependsOn)">
+  </Target>
+
 </Project>

--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -39,7 +39,7 @@ namespace System.NetTests {
 			Exception  exception  = null;
 
 			var thread = new Thread (() => {
-				string url = "https://tls-test-1.internalx.com";
+				string url = "https://dotnet.microsoft.com/";
 
 				var downloadTask = new WebClient ().DownloadDataTaskAsync (url);
 				var completeTask = downloadTask.ContinueWith (t => {


### PR DESCRIPTION
The TLS certificate on `tls-test*.internalx.com` has expired recently.
Since then, the unit test
`AndroidHandlerTestBase.Sanity_Tls_1_2_Url_WithMonoClientHandlerFails()`
has been failing:

	SHOULD NOT BE REACHED: BTLS is present, TLS 1.2 should work. Network error? System.AggregateException: One or more errors occurred. (The SSL connection could not be established, see inner exception.)
	  ---> System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
	  ---> System.Security.Authentication.AuthenticationException: Authentication failed, see inner exception.
	  ---> Mono.Btls.MonoBtlsException: Ssl error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
	  at /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/boringssl/ssl/handshake_client.c:1132
	  at Mono.Btls.MonoBtlsContext.ProcessHandshake ()
	  at Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake (Mono.Net.Security.AsyncOperationStatus status, System.Boolean renegotiate)
	  at (wrapper remoting-invoke-with-check) Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake(Mono.Net.Security.AsyncOperationStatus,bool)
	  at Mono.Net.Security.AsyncHandshakeRequest.Run (Mono.Net.Security.AsyncOperationStatus status)
	  at Mono.Net.Security.AsyncProtocolRequest.ProcessOperation (System.Threading.CancellationToken cancellationToken)
	--- End of inner exception stack trace ---
	  at Mono.Net.Security.MobileAuthenticatedStream.ProcessAuthentication (System.Boolean runSynchronously, Mono.Net.Security.MonoSslAuthenticationOptions options, System.Threading.CancellationToken cancellationToken)
	  at System.Net.Http.ConnectHelper.EstablishSslConnectionAsyncCore (System.IO.Stream stream, System.Net.Security.SslClientAuthenticationOptions sslOptions, System.Threading.CancellationToken cancellationToken)
	--- End of inner exception stack trace ---
	  at System.Net.Http.ConnectHelper.EstablishSslConnectionAsyncCore (System.IO.Stream stream, System.Net.Security.SslClientAuthenticationOptions sslOptions, System.Threading.CancellationToken cancellationToken)
	  at System.Net.Http.HttpConnectionPool.CreateConnectionAsync (System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
	  at System.Net.Http.HttpConnectionPool.WaitForCreatedConnectionAsync (System.Threading.Tasks.ValueTask1[TResult] creationTask)
	--- End of inner exception stack trace ---
	  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in <74d9125dbed14683af25cb9fe4197e48>:0
	  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken)
	  at System.Threading.Tasks.Task.Wait ()
	  at Xamarin.Android.NetTests.AndroidHandlerTestBase+<>c__DisplayClass5_1.<Sanity_Tls_1_2_Url_WithMonoClientHandlerFails>b__1 ()

Remove the `Sanity_Tls_1_2_Url_WithMonoClientHandlerFails()` and
`Tls_1_2_Url_Works()` unit tests, as we feel less need to verify BTLS
behavior (mono/2020-02 is rarely updated), and removing these tests
removes usage of `tls-test.internalx.com`.

Remove or update other unit tests to entirely remove all usage of
`tls-test*.internalx.com`, as maintaining these VMs is a headache.
This impacts:

  * `AndroidHandlerTestBase.Redirect_POST_With_Content_Works()`
  * `AndroidHandlerTestBase.Redirect_Without_Protocol_Works()`
  * `AndroidHandlerTestBase.Sanity_Tls_1_2_Url_WithMonoClientHandlerFails()`
  * `AndroidHandlerTestBase.Tls_1_2_Url_Works()`

Tests that attempted to run against a particular TLS version have
been removed; others have been updated to use `httpbingo.org`.

Finally, add a new `RunTestApp` target to
`build-tools/scripts/TestApks.targets`; this simplifies the YAML
invocation of some unit tests, and means that the
`yaml-templates/apk-instrumentation.yaml` template no longer needs
a `packageType:` parameter, as the `RunTestApp` target handles the
distinction.