### PR TITLE
[NET6] Call JNIEnv.Initialize directly, via a function pointer

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -61,7 +61,9 @@ steps:
   inputs:
     command: restore
     projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
-    restoreArguments: --configfile ${{ parameters.xaSourcePath }}/NuGet.config -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
+    restoreArguments: -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
+    nugetConfigPath: ${{ parameters.xaSourcePath }}/NuGet.config
+    feedsToUse: config
 
 - task: DotNetCoreCLI@2
   displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -140,6 +140,9 @@ namespace Android.Runtime {
 			((AndroidTypeManager)androidRuntime!.TypeManager).RegisterNativeMembers (jniType, type, methods);
 		}
 
+#if NETCOREAPP
+		[UnmanagedCallersOnly]
+#endif
 		internal static unsafe void Initialize (JnienvInitializeArgs* args)
 		{
 			bool logTiming = (args->logCategories & (uint)LogCategories.Timing) != 0;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -324,9 +326,22 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
+			int android_runtime_jnienv_class_token = -1;
+			int jnienv_initialize_method_token = -1;
+			int jnienv_registerjninatives_method_token = -1;
 			foreach (var assembly in ResolvedAssemblies) {
 				updateNameWidth (assembly);
 				updateAssemblyCount (assembly);
+
+				if (android_runtime_jnienv_class_token != -1) {
+					continue;
+				}
+
+				if (!assembly.ItemSpec.EndsWith ("Mono.Android.dll", StringComparison.OrdinalIgnoreCase)) {
+					continue;
+				}
+
+				GetRequiredTokens (assembly.ItemSpec, out android_runtime_jnienv_class_token, out jnienv_initialize_method_token, out jnienv_registerjninatives_method_token);
 			}
 
 			if (!UseAssemblyStore) {
@@ -405,6 +420,9 @@ namespace Xamarin.Android.Tasks
 				MonoComponents = monoComponents,
 				NativeLibraries = uniqueNativeLibraries,
 				HaveAssemblyStore = UseAssemblyStore,
+				AndroidRuntimeJNIEnvToken = android_runtime_jnienv_class_token,
+				JNIEnvInitializeToken = jnienv_initialize_method_token,
+				JNIEnvRegisterJniNativesToken = jnienv_registerjninatives_method_token,
 			};
 			appConfigAsmGen.Init ();
 
@@ -440,6 +458,72 @@ namespace Xamarin.Android.Tasks
 			string ValidAssemblerString (string s)
 			{
 				return s.Replace ("\"", "\\\"");
+			}
+		}
+
+		void GetRequiredTokens (string assemblyFilePath, out int android_runtime_jnienv_class_token, out int jnienv_initialize_method_token, out int jnienv_registerjninatives_method_token)
+		{
+			using (var pe = new PEReader (File.OpenRead (assemblyFilePath))) {
+				GetRequiredTokens (pe.GetMetadataReader (), out android_runtime_jnienv_class_token, out jnienv_initialize_method_token, out jnienv_registerjninatives_method_token);
+			}
+
+			if (android_runtime_jnienv_class_token == -1 || jnienv_initialize_method_token == -1 || jnienv_registerjninatives_method_token == -1) {
+				throw new InvalidOperationException ($"Unable to find the required Android.Runtime.JNIEnv method tokens");
+			}
+		}
+
+		void GetRequiredTokens (MetadataReader reader, out int android_runtime_jnienv_class_token, out int jnienv_initialize_method_token, out int jnienv_registerjninatives_method_token)
+		{
+			android_runtime_jnienv_class_token = -1;
+			jnienv_initialize_method_token = -1;
+			jnienv_registerjninatives_method_token = -1;
+
+			TypeDefinition? typeDefinition = null;
+
+			foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions) {
+				TypeDefinition td = reader.GetTypeDefinition (typeHandle);
+				if (!TypeMatches (td)) {
+					continue;
+				}
+
+				typeDefinition = td;
+				android_runtime_jnienv_class_token = MetadataTokens.GetToken (reader, typeHandle);
+				break;
+			}
+
+			if (typeDefinition == null) {
+				return;
+			}
+
+			foreach (MethodDefinitionHandle methodHandle in typeDefinition.Value.GetMethods ()) {
+				MethodDefinition md = reader.GetMethodDefinition (methodHandle);
+				string name = reader.GetString (md.Name);
+
+				if (jnienv_initialize_method_token == -1 && String.Compare (name, "Initialize", StringComparison.Ordinal) == 0) {
+					jnienv_initialize_method_token = MetadataTokens.GetToken (reader, methodHandle);
+				} else if (jnienv_registerjninatives_method_token == -1 && String.Compare (name, "RegisterJniNatives", StringComparison.Ordinal) == 0) {
+					jnienv_registerjninatives_method_token = MetadataTokens.GetToken (reader, methodHandle);
+				}
+
+				if (jnienv_initialize_method_token != -1 && jnienv_registerjninatives_method_token != -1) {
+					break;
+				}
+			}
+
+
+			bool TypeMatches (TypeDefinition td)
+			{
+				string ns = reader.GetString (td.Namespace);
+				if (String.Compare (ns, "Android.Runtime", StringComparison.Ordinal) != 0) {
+					return false;
+				}
+
+				string name = reader.GetString (td.Name);
+				if (String.Compare (name, "JNIEnv", StringComparison.Ordinal) != 0) {
+					return false;
+				}
+
+				return true;
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -56,10 +56,13 @@ namespace Xamarin.Android.Build.Tests
 			public uint   bundled_assembly_name_width;
 			public uint   number_of_assembly_store_files;
 			public uint   number_of_dso_cache_entries;
+			public uint   android_runtime_jnienv_class_token;
+			public uint   jnienv_initialize_method_token;
+			public uint   jnienv_registerjninatives_method_token;
 			public uint   mono_components_mask;
 			public string android_package_name;
 		};
-		const uint ApplicationConfigFieldCount = 19;
+		const uint ApplicationConfigFieldCount = 22;
 
 		const string ApplicationConfigSymbolName = "application_config";
 		const string AppEnvironmentVariablesSymbolName = "app_environment_variables";
@@ -282,12 +285,27 @@ namespace Xamarin.Android.Build.Tests
 						ret.number_of_dso_cache_entries = ConvertFieldToUInt32 ("number_of_dso_cache_entries", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 17: // mono_components_mask: uint32_t / .word | .long
+					case 17: // android_runtime_jnienv_class_token: uint32_t / .word | .long
+						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
+						ret.number_of_dso_cache_entries = ConvertFieldToUInt32 ("android_runtime_jnienv_class_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
+						break;
+
+					case 18: // jnienv_initialize_method_token: uint32_t / .word | .long
+						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
+						ret.number_of_dso_cache_entries = ConvertFieldToUInt32 ("jnienv_initialize_method_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
+						break;
+
+					case 19: // jnienv_registerjninatives_method_token: uint32_t / .word | .long
+						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
+						ret.number_of_dso_cache_entries = ConvertFieldToUInt32 ("jnienv_registerjninatives_method_token", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
+						break;
+
+					case 20: // mono_components_mask: uint32_t / .word | .long
 						Assert.IsTrue (expectedUInt32Types.Contains (field [0]), $"Unexpected uint32_t field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						ret.mono_components_mask = ConvertFieldToUInt32 ("mono_components_mask", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 
-					case 18: // android_package_name: string / [pointer type]
+					case 21: // android_package_name: string / [pointer type]
 						Assert.IsTrue (expectedPointerTypes.Contains (field [0]), $"Unexpected pointer field type in '{envFile.Path}:{item.LineNumber}': {field [0]}");
 						pointers.Add (field [1].Trim ());
 						break;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfig.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Tasks
 	//   uint64_t |  ulong
 	//   int64_t  |  long
 	//   char*    |  string
-	//   
+	//
 	// Names should be the same as in the above struct, but it's not a requirement
 	// (they will be used only to generate comments in the native code)
 	sealed class ApplicationConfig
@@ -41,6 +41,9 @@ namespace Xamarin.Android.Tasks
 		public uint   bundled_assembly_name_width;
 		public uint   number_of_assembly_store_files;
 		public uint   number_of_dso_cache_entries;
+		public uint   android_runtime_jnienv_class_token;
+		public uint   jnienv_initialize_method_token;
+		public uint   jnienv_registerjninatives_method_token;
 		public uint   mono_components_mask;
 		public string android_package_name = String.Empty;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -166,6 +166,9 @@ namespace Xamarin.Android.Tasks
 		public int NumberOfAssembliesInApk { get; set; }
 		public int NumberOfAssemblyStoresInApks { get; set; }
 		public int BundledAssemblyNameWidth { get; set; } // including the trailing NUL
+		public int AndroidRuntimeJNIEnvToken { get; set; }
+		public int JNIEnvInitializeToken { get; set; }
+		public int JNIEnvRegisterJniNativesToken { get; set; }
 		public MonoComponent MonoComponents { get; set; }
 		public PackageNamingPolicy PackageNamingPolicy { get; set; }
 		public List<ITaskItem> NativeLibraries { get; set; }
@@ -204,6 +207,9 @@ namespace Xamarin.Android.Tasks
 				bundled_assembly_name_width = (uint)BundledAssemblyNameWidth,
 				number_of_assembly_store_files = (uint)NumberOfAssemblyStoresInApks,
 				number_of_dso_cache_entries = (uint)dsoCache.Count,
+				android_runtime_jnienv_class_token = (uint)AndroidRuntimeJNIEnvToken,
+				jnienv_initialize_method_token = (uint)JNIEnvInitializeToken,
+				jnienv_registerjninatives_method_token = (uint)JNIEnvRegisterJniNativesToken,
 				mono_components_mask = (uint)MonoComponents,
 				android_package_name = AndroidPackageName,
 			};

--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -58,6 +58,9 @@ const ApplicationConfig application_config = {
 	.bundled_assembly_name_width = 0,
 	.number_of_assembly_store_files = 2,
 	.number_of_dso_cache_entries = 2,
+	.android_runtime_jnienv_class_token = 1,
+	.jnienv_initialize_method_token = 2,
+	.jnienv_registerjninatives_method_token = 3,
 	.mono_components_mask = MonoComponent::None,
 	.android_package_name = android_package_name,
 };

--- a/src/monodroid/jni/cpp-util.hh
+++ b/src/monodroid/jni/cpp-util.hh
@@ -19,12 +19,8 @@
 #include "platform-compat.hh"
 
 static inline void
-do_abort_unless (bool condition, const char* fmt, ...)
+do_abort_unless (const char* fmt, ...)
 {
-	if (XA_LIKELY (condition)) {
-		return;
-	}
-
 	va_list ap;
 
 	va_start (ap, fmt);
@@ -39,7 +35,11 @@ do_abort_unless (bool condition, const char* fmt, ...)
 	std::abort ();
 }
 
-#define abort_unless(_condition_, _fmt_, ...) do_abort_unless (_condition_, "%s:%d (%s): " _fmt_, __FILE__, __LINE__, __FUNCTION__, ## __VA_ARGS__)
+#define abort_unless(_condition_, _fmt_, ...) \
+	if (XA_UNLIKELY (!(_condition_))) { \
+		do_abort_unless ("%s:%d (%s): " _fmt_, __FILE__, __LINE__, __FUNCTION__, ## __VA_ARGS__); \
+	}
+
 #define abort_if_invalid_pointer_argument(_ptr_) abort_unless ((_ptr_) != nullptr, "Parameter '%s' must be a valid pointer", #_ptr_)
 #define abort_if_negative_integer_argument(_arg_) abort_unless ((_arg_) > 0, "Parameter '%s' must be larger than 0", #_arg_)
 

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -126,6 +126,10 @@ namespace xamarin::android::internal
 			int             jniAddNativeMethodRegistrationAttributePresent;
 		};
 
+#if defined (NET6)
+		using jnienv_initialize_fn = void (*) (JnienvInitializeArgs*);
+#endif
+
 	private:
 		static constexpr char base_apk_name[] = "/base.apk";
 		static constexpr size_t SMALL_STRING_PARSE_BUFFER_LEN = 50;

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -33,6 +33,10 @@
 #include <mono/utils/mono-dl-fallback.h>
 #include <mono/utils/mono-logger.h>
 
+#if defined (NET6)
+#include <mono/metadata/mono-private-unstable.h>
+#endif
+
 #include "mono_android_Runtime.h"
 
 #if defined (DEBUG) && !defined (WINDOWS)
@@ -1089,19 +1093,11 @@ MonodroidRuntime::init_android_runtime (
 		);
 	}
 
-	// TODO: try looking up the method by its token
-	MonoClass *runtime;
-#if defined (NET6)
-	runtime = mono_class_from_name (image, SharedConstants::ANDROID_RUNTIME_NS_NAME, SharedConstants::JNIENV_CLASS_NAME);
-#else
-	runtime = utils.monodroid_get_class_from_image (domain, image, SharedConstants::ANDROID_RUNTIME_NS_NAME, SharedConstants::JNIENV_CLASS_NAME);
-#endif
-	MonoMethod *method = mono_class_get_method_from_name (runtime, "Initialize", 1);
+	MonoClass *runtime = mono_class_get (image, application_config.android_runtime_jnienv_class_token);
+	abort_unless (runtime != nullptr, "INTERNAL ERROR: unable to find the Android.Runtime.JNIEnv class!");
 
-	if (method == nullptr) {
-		log_fatal (LOG_DEFAULT, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.Initialize!");
-		exit (FATAL_EXIT_MISSING_INIT);
-	}
+	MonoMethod *method = mono_get_method (image, application_config.jnienv_initialize_method_token, runtime);
+	abort_unless (method != nullptr, "INTERNAL ERROR: Unable to find the Android.Runtime.JNIEnv.Initialize method!");
 
 	MonoAssembly *ji_assm;
 #if defined (NET6)
@@ -1126,12 +1122,10 @@ MonodroidRuntime::init_android_runtime (
 	 * so always make sure we have the freshest handle to the method.
 	 */
 	if (registerType == nullptr || is_running_on_desktop) {
-		registerType = mono_class_get_method_from_name (runtime, "RegisterJniNatives", 5);
+		registerType = mono_get_method (image, application_config.jnienv_registerjninatives_method_token, runtime);
 	}
-	if (registerType == nullptr) {
-		log_fatal (LOG_DEFAULT, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.RegisterJniNatives!");
-		exit (FATAL_EXIT_CANNOT_FIND_JNIENV);
-	}
+	abort_unless (registerType != nullptr, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.RegisterJniNatives!");
+
 	MonoClass *android_runtime_jnienv = runtime;
 	MonoClassField *bridge_processing_field = mono_class_get_field_from_name (runtime, const_cast<char*> ("BridgeProcessing"));
 	if (android_runtime_jnienv ==nullptr || bridge_processing_field == nullptr) {
@@ -1154,12 +1148,17 @@ MonodroidRuntime::init_android_runtime (
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		partial_time.mark_start ();
 
+#if defined (NET6)
+	MonoError error;
+	auto initialize = reinterpret_cast<jnienv_initialize_fn> (mono_method_get_unmanaged_callers_only_ftnptr (method, &error));
+	abort_unless (initialize != nullptr, "Failed to obtain unmanaged-callers-only pointer to the Android.Runtime.JNIEnv.Initialize method");
+	initialize (&init);
+
+#else // def NET6
 	void *args [] = {
 		&init,
 	};
-#if defined (NET6)
-	mono_runtime_invoke (method, nullptr, args, nullptr);
-#else // def NET6
+
 	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 #endif // ndef NET6
 

--- a/src/monodroid/jni/xamarin-app.hh
+++ b/src/monodroid/jni/xamarin-app.hh
@@ -216,6 +216,9 @@ struct ApplicationConfig
 	uint32_t bundled_assembly_name_width;
 	uint32_t number_of_assembly_store_files;
 	uint32_t number_of_dso_cache_entries;
+	uint32_t android_runtime_jnienv_class_token;
+	uint32_t jnienv_initialize_method_token;
+	uint32_t jnienv_registerjninatives_method_token;
 	MonoComponent mono_components_mask;
 	const char *android_package_name;
 };


### PR DESCRIPTION
With the .NET6 Mono runtime we are able to use the
`[UnmanagedCallersOnly]` attribute to mark certain methods as directly
callable from native code.  This is faster than going through
`mono_runtime_invoke`, as there is nearly no marshaling of parameters
performed.  Since `Android.Runtime.JNIEnv.Initialize` is called only by
our native runtime, we can use this approach here.

Additionally, remove some reflection use by looking up and saving
managed tokens of the `Android.Runtime.JNIEnv` class as well as its two
methods, `Initialize` and `RegisterJniNatives`.  This saves time by
allowing us to not look for the above methoods via their names at
startup.

Time savings aren't spectacular in the overall startup time, but the
"native to managed" phase (essentially a call to `JNIEnv.Initialize`)
paired with the reflection savings gives us a speedup of 0.1ms here on
Pixel 6 Pro (savings might be bigger on slower devices).