### PR TITLE
[ci] Add job to run after Xamarin.Android pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -7,8 +7,8 @@ pr: none
 
 resources:
   pipelines:
-  - pipeline: macios
-    source: xamarin-macios
+  - pipeline: xamarin-android
+    source: Xamarin.Android
     trigger:
       stages:
       - post_build

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -2,11 +2,16 @@
 
 name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
-trigger:
-- none
+trigger: none
+pr: none
 
-pr:
-- none
+resources:
+  pipelines:
+  - pipeline: macios
+    source: xamarin-macios
+    trigger:
+      stages:
+      - post_build
 
 jobs:
 - job: release_trigger

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -24,22 +24,21 @@ jobs:
   - checkout: none
 
   - powershell: |
-      $json = @"
-      {
-          "triggeringbuild": {
-              "id": "$(Build.TriggeredBy.BuildId)",
-              "pipeline": "$(Build.TriggeredBy.DefinitionId)",
-              "project": "$(Build.TriggeredBy.ProjectID)"
+      $triggeringBuild = @{
+          "triggeringBuild" = @{
+              "id" = "$(Build.TriggeredBy.BuildId)"
+              "pipeline" = "$(Build.TriggeredBy.DefinitionId)"
+              "project" = "$(Build.TriggeredBy.ProjectID)"
           }
       }
-      "@
+      $json = $triggeringBuild | ConvertTo-Json
       New-Item -Path $(Build.StagingDirectory) -Name triggering-build.json -ItemType file -Value $json -Force
       $jsonContent = Get-Content "$(Build.StagingDirectory)\triggering-build.json" | ConvertFrom-Json
-      Write-Host Triggering Build Info: $jsonContent.triggeringbuild.project - $jsonContent.triggeringbuild.pipeline - $jsonContent.triggeringbuild.id
+      Write-Host Triggering Build Info: $jsonContent.triggeringBuild.project - $jsonContent.triggeringBuild.pipeline - $jsonContent.triggeringBuild.id
     displayName: write triggering-build.json
 
   - task: PublishPipelineArtifact@1
-    displayName: upload triggering-build.json
+    displayName: upload triggering-build-info
     inputs:
-      artifactName: triggering-build.json
+      artifactName: triggering-build-info
       targetPath: $(Build.StagingDirectory)\triggering-build.json

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -12,7 +12,7 @@ jobs:
 - job: release_trigger
   displayName: Upload Info from Triggering Build
   timeoutInMinutes: 30
-  pool: $(VSEngMicroBuildPool)
+  pool: VSEngSS-MicroBuild2022-1ES
   workspace:
     clean: all
   steps:

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -9,9 +9,9 @@ resources:
   pipelines:
   - pipeline: xamarin-android
     source: Xamarin.Android
-    trigger:
-      stages:
-      - post_build
+    trigger: true
+#      stages:
+#      - post_build
 
 jobs:
 - job: release_trigger

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -1,0 +1,40 @@
+# Xamarin.Android Release Definition Trigger
+
+name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+
+trigger:
+- none
+
+pr:
+- none
+
+jobs:
+- job: release_trigger
+  displayName: Upload Info from Triggering Build
+  timeoutInMinutes: 30
+  pool: $(VSEngMicroBuildPool)
+  workspace:
+    clean: all
+  steps:
+  - checkout: none
+
+  - powershell: |
+      $json = @"
+      {
+          "triggeringbuild": {
+              "id": "$(Build.TriggeredBy.BuildId)",
+              "pipeline": "$(Build.TriggeredBy.DefinitionId)",
+              "project": "$(Build.TriggeredBy.ProjectID)"
+          }
+      }
+      "@
+      New-Item -Path $(Build.StagingDirectory) -Name triggering-build.json -ItemType file -Value $json -Force
+      $jsonContent = Get-Content "$(Build.StagingDirectory)\triggering-build.json" | ConvertFrom-Json
+      Write-Host Triggering Build Info: $jsonContent.triggeringbuild.project - $jsonContent.triggeringbuild.pipeline - $jsonContent.triggeringbuild.id
+    displayName: write triggering-build.json
+
+  - task: PublishPipelineArtifact@1
+    displayName: upload triggering-build.json
+    inputs:
+      artifactName: triggering-build.json
+      targetPath: $(Build.StagingDirectory)\triggering-build.json

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -9,9 +9,9 @@ resources:
   pipelines:
   - pipeline: xamarin-android
     source: Xamarin.Android
-    trigger: true
-#      stages:
-#      - post_build
+    trigger:
+      stages:
+      - post_build
 
 jobs:
 - job: release_trigger

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1636,14 +1636,6 @@ stages:
       clean: all
     steps:
     - checkout: none
-    - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-      displayName: Trigger Release Dependency
-      inputs:
-        buildDefinition: 16022
-        useSameSourceVersion: false
-        waitForQueuedBuildsToFinish: true
-        authenticationMethod: OAuth Token
-        password: $(System.AccessToken)
 
 - stage: code_analysis
   dependsOn: []

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1612,30 +1612,18 @@ stages:
 
 - stage: post_build
   displayName: Post Build
-#  dependsOn:
-#  - dotnet_prepare_release
-#  - finalize_installers
-#  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
-  condition: eq(variables['MicroBuildSignType'], 'Real')
+  dependsOn:
+  - dotnet_prepare_release
+  - finalize_installers
+  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   jobs:
-#  - template: compliance/sbom/job.v1.yml@yaml
-#    parameters:
-#      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
-#      statusContexts: [ 'vsts-devdiv artifacts' ]
-#      packageName: xamarin-android
-#      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
-#      GitHub.Token: $(GitHub.Token)
-  # Run build https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16022 which can be used to queue release definitions
-  # https://github.com/huserben/TfsExtensions/tree/b8d3cdd39d0eb132e953abb9cb05eeae3b314fe6/BuildTasks/triggerbuildtask/triggerbuildtaskV4
-  - job: queue_release_trigger
-    displayName: Queue Release Dependency
-#    dependsOn: SBOM
-#    timeoutInMinutes: 30
-    pool: $(VSEngMicroBuildPool)
-    workspace:
-      clean: all
-    steps:
-    - checkout: none
+  - template: compliance/sbom/job.v1.yml@yaml
+    parameters:
+      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
+      statusContexts: [ 'vsts-devdiv artifacts' ]
+      packageName: xamarin-android
+      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
+      GitHub.Token: $(GitHub.Token)
 
 - stage: code_analysis
   dependsOn: []

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1625,7 +1625,7 @@ stages:
 #      packageName: xamarin-android
 #      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
 #      GitHub.Token: $(GitHub.Token)
-  # Run build https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11674 which can be used to queue release definitions
+  # Run build https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16022 which can be used to queue release definitions
   # https://github.com/huserben/TfsExtensions/tree/b8d3cdd39d0eb132e953abb9cb05eeae3b314fe6/BuildTasks/triggerbuildtask/triggerbuildtaskV4
   - job: queue_release_trigger
     displayName: Queue Release Dependency
@@ -1639,7 +1639,7 @@ stages:
     - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
       displayName: Trigger Release Dependency
       inputs:
-        buildDefinition: 11674
+        buildDefinition: 16022
         useSameSourceVersion: false
         waitForQueuedBuildsToFinish: true
         authenticationMethod: OAuth Token

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1617,7 +1617,7 @@ stages:
 #  - finalize_installers
 #  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   condition: eq(variables['MicroBuildSignType'], 'Real')
-#  jobs:
+  jobs:
 #  - template: compliance/sbom/job.v1.yml@yaml
 #    parameters:
 #      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1612,18 +1612,38 @@ stages:
 
 - stage: post_build
   displayName: Post Build
-  dependsOn:
-  - dotnet_prepare_release
-  - finalize_installers
-  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
-  jobs:
-  - template: compliance/sbom/job.v1.yml@yaml
-    parameters:
-      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
-      statusContexts: [ 'vsts-devdiv artifacts' ]
-      packageName: xamarin-android
-      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
-      GitHub.Token: $(GitHub.Token)
+#  dependsOn:
+#  - dotnet_prepare_release
+#  - finalize_installers
+#  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
+  condition: eq(variables['MicroBuildSignType'], 'Real')
+#  jobs:
+#  - template: compliance/sbom/job.v1.yml@yaml
+#    parameters:
+#      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
+#      statusContexts: [ 'vsts-devdiv artifacts' ]
+#      packageName: xamarin-android
+#      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
+#      GitHub.Token: $(GitHub.Token)
+  # Run build https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11674 which can be used to queue release definitions
+  # https://github.com/huserben/TfsExtensions/tree/b8d3cdd39d0eb132e953abb9cb05eeae3b314fe6/BuildTasks/triggerbuildtask/triggerbuildtaskV4
+  - job: queue_release_trigger
+    displayName: Queue Release Dependency
+#    dependsOn: SBOM
+#    timeoutInMinutes: 30
+    pool: $(VSEngMicroBuildPool)
+    workspace:
+      clean: all
+    steps:
+    - checkout: none
+    - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+      displayName: Trigger Release Dependency
+      inputs:
+        buildDefinition: 11674
+        useSameSourceVersion: false
+        waitForQueuedBuildsToFinish: true
+        authenticationMethod: OAuth Token
+        password: $(System.AccessToken)
 
 - stage: code_analysis
   dependsOn: []


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers

A new pipeline has been added to capture build information from the
Xamarin.Android pipeline, which can than be processed by old UI-style
release definitions.

The Xamarin.Android pipeline often has known or acceptable test failures
in the builds that we want to release, and old UI-style release
definitions will not run against partially failed builds.  This new
pipeline avoids that limitation as it will always be green.  The new
pipeline will also publish information about the Xamarin.Android build
that triggered it, which will allow an old UI-style release definition
to download artifacts from the Xamarin.Android build using the
[DownloadPipelineArtifact][1] task.

A [pipeline resource][0] controls the automatic triggering of this new
pipeline, and it will run once the `post_build` stage in the XA pipeline
completes successfully.

The classic VS insertions will look like this:

  1) A `Xamarin.Android` pipeline build finishes.
  2) A new build of `Xamarin.Android Release Trigger` will run automatically.
  3) This pipeline publishes a file containing `Xamarin.Android` build and pipeline ID information.
  4) The `Xamarin.Android - VS + VSM Release Insertion` release definition uses the
      build and pipeline ID to download the SBOM artifact in the corresponding `Xamarin.Android` build.

This new pipeline can also be used to "transfer" other build artifacts
from the `Xamarin.Android` pipeline to other release definitions in the
future if needed.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#define-a-pipelines-resource
[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact?view=azure-devops#arguments