### PR TITLE
[Xamarin.Android.Build.Tasks] XA2000 for bridge-implementation=old

### DIFF
--- a/Documentation/guides/messages/xa2000.md
+++ b/Documentation/guides/messages/xa2000.md
@@ -1,9 +1,11 @@
 ---
 title: Xamarin.Android warning XA2000
 description: XA2000 warning code
-ms.date: 1/13/2019
+ms.date: 3/30/2022
 ---
 # Xamarin.Android warning XA2000
+
+A feature used by your Android app will disappear in a future .NET release.
 
 ## Example messages
 
@@ -13,8 +15,17 @@ Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 6 will on
 
 _Note: this error maps to [`IL6200`](il6200.md]) in .NET 6 and higher._
 
+
+```
+Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.
+```
+
 ## Solution
 
+Migrate away from the feature being removed.
+
 Transition code away from `AppDomain.CreateDomain()` to a different API, such as [`AssemblyLoadContext`][unloadability].
+
+Transition code away from `MONO_GC_PARAMS=bridge-implementation=old`.
 
 [unloadability]: https://docs.microsoft.com/dotnet/standard/assembly/unloadability

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -471,6 +471,9 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</comment>
   </data>
+  <data name="XA2000_gcParams_bridgeImpl" xml:space="preserve">
+    <value>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</value>
+  </data>
   <data name="XA2001" xml:space="preserve">
     <value>Source file '{0}' could not be found.</value>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -74,6 +74,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
         <target state="new">The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</target>
         <note>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</note>
       </trans-unit>
+      <trans-unit id="XA2000_gcParams_bridgeImpl">
+        <source>Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</source>
+        <target state="new">Support for the 'MONO_GC_PARAMS=bridge-implementation=old' value will be removed in .NET 7.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4233">
         <source>The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</source>
         <target state="new">The &lt;AndroidNamespaceReplacement&gt; for '{0}' does not specify a 'Replacement' attribute.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -202,8 +202,12 @@ namespace Xamarin.Android.Tasks
 					var lineToWrite = line;
 					if (lineToWrite.StartsWith ("MONO_LOG_LEVEL=", StringComparison.Ordinal))
 						haveLogLevel = true;
-					if (lineToWrite.StartsWith ("MONO_GC_PARAMS=", StringComparison.Ordinal))
+					if (lineToWrite.StartsWith ("MONO_GC_PARAMS=", StringComparison.Ordinal)) {
 						haveMonoGCParams = true;
+						if (lineToWrite.IndexOf ("bridge-implementation=old", StringComparison.Ordinal) >= 0) {
+							Log.LogCodedWarning ("XA2000", Properties.Resources.XA2000_gcParams_bridgeImpl);
+						}
+					}
 					if (lineToWrite.StartsWith ("XAMARIN_BUILD_ID=", StringComparison.Ordinal))
 						havebuildId = true;
 					if (lineToWrite.StartsWith ("MONO_DEBUG=", StringComparison.Ordinal)) {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6875

The dotnet/runtime team would like to remove the
`MONO_GC_BRIDGE=bridge-implementation=old` backend in .NET 7.

Check for usage of `MONO_GC_BRIDGE=bridge-implementation=old`, and
emit an XA2000 warning if found.