### PR TITLE
Update `dotnet-local` script to work from any directory.

### DIFF
--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,9 +1,9 @@
 @echo off
-
-IF EXIST "bin\Release\dotnet\dotnet.exe" (
-    call "bin\Release\dotnet\dotnet.exe" %*
-) ELSE IF EXIST "bin\Debug\dotnet\dotnet.exe" (
-    call "bin\Debug\dotnet\dotnet.exe" %*
+SET ROOT=%~dp0
+IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
+    call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
+) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
+    call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."
 )

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-if [[ -x "bin/Release/dotnet/dotnet" ]]; then
-    exec ./bin/Release/dotnet/dotnet "$@"
-elif [[ -x "bin/Debug/dotnet/dotnet" ]]; then
-    exec ./bin/Debug/dotnet/dotnet "$@"
+ROOT=$(dirname "${BASH_SOURCE}")
+if [[ -x "${ROOT}/bin/Release/dotnet/dotnet" ]]; then
+    exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
+elif [[ -x "${ROOT}/bin/Debug/dotnet/dotnet" ]]; then
+    exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
 else
     echo "You need to run 'make prepare' first."
 fi


### PR DESCRIPTION
The current `docnet-local` scripts relied on being run from the
same directory. This change uses the script location to run the
exists checks and to execute the `dotnet` binary. This way we can
run this from any directory.