### PR TITLE
[ci] Fix variable names for release triggering build

### DIFF
--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -26,9 +26,9 @@ jobs:
   - powershell: |
       $triggeringBuild = @{
           "triggeringBuild" = @{
-              "id" = "$(Build.TriggeredBy.BuildId)"
-              "pipeline" = "$(Build.TriggeredBy.DefinitionId)"
-              "project" = "$(Build.TriggeredBy.ProjectID)"
+              "id" = "$(resources.pipeline.xamarin-android.runID)"
+              "pipeline" = "$(resources.pipeline.xamarin-android.pipelineID)"
+              "project" = "$(resources.pipeline.xamarin-android.projectName)"
           }
       }
       $json = $triggeringBuild | ConvertTo-Json

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -38,7 +38,7 @@ jobs:
       $json = $triggeringBuild | ConvertTo-Json
       New-Item -Path $(Build.StagingDirectory) -Name triggering-build.json -ItemType file -Value $json -Force
       $jsonContent = Get-Content "$(Build.StagingDirectory)\triggering-build.json" | ConvertFrom-Json
-      Write-Host Triggering Build Info: $jsonContent.triggeringBuild.project - $jsonContent.triggeringBuild.pipeline - $jsonContent.triggeringBuild.id
+      Write-Host Triggering Pipeline and Run IDs: $jsonContent.triggeringBuild.pipeline - $jsonContent.triggeringBuild.id
     displayName: write triggering-build.json
 
   - task: PublishPipelineArtifact@1

--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -23,12 +23,16 @@ jobs:
   steps:
   - checkout: none
 
+  - powershell: 'gci env: | format-table -autosize -wrap'
+    displayName: print environment variables
+
   - powershell: |
       $triggeringBuild = @{
           "triggeringBuild" = @{
               "id" = "$(resources.pipeline.xamarin-android.runID)"
               "pipeline" = "$(resources.pipeline.xamarin-android.pipelineID)"
-              "project" = "$(resources.pipeline.xamarin-android.projectName)"
+              "branch" = "$(resources.pipeline.xamarin-android.sourceBranch)"
+              "commit" = "$(resources.pipeline.xamarin-android.sourceCommit)"
           }
       }
       $json = $triggeringBuild | ConvertTo-Json

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1612,10 +1612,11 @@ stages:
 
 - stage: post_build
   displayName: Post Build
-  dependsOn:
-  - dotnet_prepare_release
-  - finalize_installers
-  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
+  #dependsOn:
+  #- dotnet_prepare_release
+  #- finalize_installers
+  #condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
+  condition: eq(variables['MicroBuildSignType'], 'Real')
   jobs:
   - template: compliance/sbom/job.v1.yml@yaml
     parameters:
@@ -1624,6 +1625,12 @@ stages:
       packageName: xamarin-android
       packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
       GitHub.Token: $(GitHub.Token)
+  - job: empty_job
+    displayName: Empty Post Build Job
+    pool:
+      vmImage: $(HostedWinImage)
+    steps:
+    - checkout: none
 
 - stage: code_analysis
   dependsOn: []

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1618,13 +1618,13 @@ stages:
   #condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   condition: eq(variables['MicroBuildSignType'], 'Real')
   jobs:
-  - template: compliance/sbom/job.v1.yml@yaml
-    parameters:
-      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
-      statusContexts: [ 'vsts-devdiv artifacts' ]
-      packageName: xamarin-android
-      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
-      GitHub.Token: $(GitHub.Token)
+#  - template: compliance/sbom/job.v1.yml@yaml
+#    parameters:
+#      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
+#      statusContexts: [ 'vsts-devdiv artifacts' ]
+#      packageName: xamarin-android
+#      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
+#      GitHub.Token: $(GitHub.Token)
   - job: empty_job
     displayName: Empty Post Build Job
     pool:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1612,25 +1612,18 @@ stages:
 
 - stage: post_build
   displayName: Post Build
-  #dependsOn:
-  #- dotnet_prepare_release
-  #- finalize_installers
-  #condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
-  condition: eq(variables['MicroBuildSignType'], 'Real')
+  dependsOn:
+  - dotnet_prepare_release
+  - finalize_installers
+  condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   jobs:
-#  - template: compliance/sbom/job.v1.yml@yaml
-#    parameters:
-#      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
-#      statusContexts: [ 'vsts-devdiv artifacts' ]
-#      packageName: xamarin-android
-#      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
-#      GitHub.Token: $(GitHub.Token)
-  - job: empty_job
-    displayName: Empty Post Build Job
-    pool:
-      vmImage: $(HostedWinImage)
-    steps:
-    - checkout: none
+  - template: compliance/sbom/job.v1.yml@yaml
+    parameters:
+      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
+      statusContexts: [ 'vsts-devdiv artifacts' ]
+      packageName: xamarin-android
+      packageFilter: '*.nupkg;*.msi;*.pkg;*.vsix'
+      GitHub.Token: $(GitHub.Token)
 
 - stage: code_analysis
   dependsOn: []


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-pipelines-pipeline?view=azure-pipelines#the-pipeline-resource-metadata-as-predefined-variables

Commit 7982895c added a new pipeline that can be used to trigger release
definitions, however the automatic trigger was not fully testable until
after it was merged.

Update the new pipeline to use the correct variable names that are set
when it is automatically triggered by the Xamarin.Android pipeline.
