### PR TITLE
[tests] enable additional runtime tests for .NET 6

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/NetworkInterfaces.cs
+++ b/tests/Mono.Android-Tests/System.Net/NetworkInterfaces.cs
@@ -102,7 +102,6 @@ namespace System.NetTests
 		}
 
 		[Test, Category("NetworkInterfaces")]
-		[Category ("DotNetIgnore")] // https://github.com/dotnet/runtime/issues/35836
 		public void DotNetInterfacesShouldEqualJavaInterfaces ()
 		{
 			List <InterfaceInfo> dotnetInterfaces = GetInfos (MNetworkInterface.GetAllNetworkInterfaces ());

--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace System.NetTests {
 
-	[TestFixture, Category ("InetAccess"), Category ("DotNetIgnore")]
+	[TestFixture, Category ("InetAccess")]
 	public class SslTest
 	{
 		bool ShouldIgnoreException (WebException wex)


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/35836

These tests were disabled back when some HTTP and SSL-related features weren't working yet in .NET 6.

Let's enable these now, since they appear to pass for me locally.