### PR TITLE
[tests] add linker test that makes HttpClient request

### DIFF
--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/HttpClientTest.cs
@@ -1,19 +1,24 @@
 using System;
+using System.Text;
 using System.Net.Http;
 
 public class HttpClientTest
 {
 	// [Test]
-	public static string NewHttpClient()
+	public static string Post ()
 	{
 		try
 		{
-			new HttpClient();
-			return $"[PASS] {nameof(NewHttpClient)}";
+			var client = new HttpClient ();
+			var data = new StringContent ("{\"foo\": \"bar\" }", Encoding.UTF8, "application/json");
+			var response = client.PostAsync ("https://httpbin.org/post", data).Result;
+			response.EnsureSuccessStatusCode ();
+			var json = response.Content.ReadAsStringAsync ().Result;
+			return $"[PASS] {nameof (HttpClientTest)}.{nameof (Post)}";
 		}
 		catch (Exception ex)
 		{
-			return $"[FAIL] {nameof(NewHttpClient)} FAILED: {ex}";
+			return $"[FAIL] {nameof (HttpClientTest)}.{nameof (Post)} FAILED: {ex}";
 		}
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/MainActivityReplacement.cs
@@ -112,8 +112,8 @@ namespace UnnamedProject
 				Android.Util.Log.Info(TAG, $"[LINKALLPASS] Unable to create instance of 'NonPreserved' as expected.\n{ex}");
 			}
 
-			// [Test] NewHttpClient
-			Android.Util.Log.Info(TAG, HttpClientTest.NewHttpClient ());
+			// [Test] Post
+			Android.Util.Log.Info(TAG, HttpClientTest.Post ());
 
 			var cldt = new CustomLinkerDescriptionTests();
 			Android.Util.Log.Info(TAG, cldt.TryAccessNonXmlPreservedMethodOfLinkerModeFullClass());


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/67402

This is a new regression test that should catch a problem like dotnet/runtime#67402 going forward.

This code runs in a class library that gets trimmed. `Mono.Android-Tests` has many tests including usage of `HttpWebRequest`, that I believe avoids the problem.