### PR TITLE
Fix LayoutBinding under AndroidX.

### DIFF
--- a/Documentation/guides/LayoutCodeBehind.md
+++ b/Documentation/guides/LayoutCodeBehind.md
@@ -138,7 +138,7 @@ namespace Binding {
 
     CommonSampleLibrary.LogFragment __fragmentWithExplicitManagedType;
     public CommonSampleLibrary.LogFragment fragmentWithExplicitManagedType => FindFragment (global::Xamarin.Android.Tests.CodeBehindFew.Resource.Id.fragmentWithExplicitManagedType, __fragmentWithExplicitManagedType, ref __fragmentWithExplicitManagedType);
-                
+
     global::Android.App.Fragment __fragmentWithInferredType;
     public global::Android.App.Fragment fragmentWithInferredType => FindFragment (global::Xamarin.Android.Tests.CodeBehindFew.Resource.Id.fragmentWithInferredType, __fragmentWithInferredType, ref __fragmentWithInferredType);
   }
@@ -201,7 +201,7 @@ class MainActivity : Activity {
      // or `null` if unknown
      return null;
   }
-  
+
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -263,7 +263,7 @@ namespace Example {
     Binding.Main __layout_binding;
 
     public override void SetContentView (global::Android.Views.View view);
-    void SetContentView (global::Android.Views.View view, 
+    void SetContentView (global::Android.Views.View view,
 	                     global::Xamarin.Android.Design.LayoutBinding.OnLayoutItemNotFoundHandler onLayoutItemNotFound);
 
     public override void SetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params);
@@ -314,7 +314,7 @@ Java.Lang.Object OnLayoutItemNotFound (int resourceId, Type expectedViewType)
   // or `null` if unknown
   return null;
 }
-  
+
 partial class MainActivity : Activity {
   protected override void OnCreate (Bundle savedInstanceState)
   {
@@ -489,7 +489,7 @@ a number of very simple adjustments to try to match the code, such as:
   * Look up a number of hard-coded types in internal tables. Currently the list includes the following types:
 
       * `WebView` -> `Android.Webkit.WebView`
-	
+
   * Strip number of hard-coded namespace *prefixes*. Currently the list includes the following prefixes:
 
     * `com.google.`
@@ -509,7 +509,7 @@ namespace declaration to the root element of the layout and the
 />
 ```
 
-Will use the `CommonSampleLibrary.LogFragment` type for the native type `commonsamplelibrary.LogFragment`. 
+Will use the `CommonSampleLibrary.LogFragment` type for the native type `commonsamplelibrary.LogFragment`.
 
 You can avoid adding the XML namespace declaration and the
 `xamarin:managedType` attribute by simply naming the type using its managed
@@ -534,12 +534,12 @@ The Android ecosystem currently supports two distinct implementations of the `Fr
 
 And in the near future, the AndroidX project will introduce the third type:
 
-    * Androidx.Fragment.App.Fragment
+    * AndroidX.Fragment.App.Fragment
 
 All three of those classes are **not** compatible with each other and so special care must be
 taken when generating binding code for `<fragment>` elements in the layout files. Xamarin.Android must
 choose one `Fragment` implementation as the default one to be used if the `<fragment>` element does not
-have any specific type (managed or otherwise) specified. Binding code generator uses the `AndroidFragmentType` 
+have any specific type (managed or otherwise) specified. Binding code generator uses the `AndroidFragmentType`
 MSBuild property for that purpose. The property can be overriden by the user to specify a type different
 than the default one. The property is set to `Android.App.Fragment` by default, unless overriden by the
 support libraries or the future AndroidX libraries.

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -78,12 +78,6 @@ multiple files, and they will be evaluated in no particular order (so don't
 specify the same environment variable or system property in multiple
 files).
 
-## AndroidFragmentType
-
-Specifies the default fully qualified type to be used for all `<fragment>` layout
-elements when generating the layout bindings code. The property defaults to the standard
-Android `Android.App.Fragment` type.
-
 ## AndroidJavaLibrary
 
 Files with a Build action of `AndroidJavaLibrary` are Java

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -538,6 +538,12 @@ deprecated API's to work.
 
 **Experimental**. This property was added in Xamarin.Android 6.1.
 
+## AndroidFragmentType
+
+Specifies the default fully qualified type to be used for all `<fragment>` layout
+elements when generating the layout bindings code. The property defaults to the standard
+Android `Android.App.Fragment` type.
+
 ## AndroidGenerateJniMarshalMethods
 
 A bool property which

--- a/src/Xamarin.Android.Build.Tasks/Resources/LayoutBinding.cs
+++ b/src/Xamarin.Android.Build.Tasks/Resources/LayoutBinding.cs
@@ -88,9 +88,14 @@ namespace Xamarin.Android.Design
 #endif // __HAVE_SUPPORT__
 
 #if __HAVE_ANDROIDX__
-		protected T FindFragment<T> (int resourceId, global::Androidx.Fragment.App.Fragment __ignoreMe, ref T cachedField) where T: global::Androidx.Fragment.App.Fragment
+		protected T FindFragment<T> (int resourceId, global::AndroidX.Fragment.App.Fragment __ignoreMe, ref T cachedField) where T: global::AndroidX.Fragment.App.Fragment
 		{
-			return __FindFragment<T> (resourceId, (activity) => activity.FragmentManager.FindFragmentById<T> (resourceId), ref cachedField);
+			return __FindFragment(resourceId, (activity) => {
+				if (activity is AndroidX.Fragment.App.FragmentActivity activity_) {
+					return global::Android.Runtime.Extensions.JavaCast<T>(activity_.SupportFragmentManager.FindFragmentById(resourceId));
+				}
+				throw new InvalidOperationException ($"When using AndroidX, your activity needs to derive from a subclass of {nameof(AndroidX.Fragment.App.FragmentActivity)}.");
+			}, ref cachedField);
 		}
 #endif // __HAVE_ANDROIDX__
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -209,8 +209,8 @@ namespace Xamarin.Android.Tasks
 			if (!GetRequiredMetadata (item, CalculateLayoutCodeBehind.WidgetCollectionKeyMetadata, out collectionKey))
 				return;
 
-			ICollection<LayoutWidget> widgets;
-			if (!CalculateLayoutCodeBehind.LayoutWidgets.TryGetValue (collectionKey, out widgets) || widgets.Count == 0) {
+			ICollection<LayoutWidget> widgets = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal<ICollection<LayoutWidget>> (collectionKey, RegisteredTaskObjectLifetime.Build);
+			if ((widgets?.Count ?? 0) == 0) {
 				string inputPaths = String.Join ("; ", resourceItems.Select (i => i.ItemSpec));
 				LogCodedWarning ("XA4222", Properties.Resources.XA4222, inputPaths);
 				return;

--- a/tests/CodeBehind/BuildTests/AnotherMainActivity.cs
+++ b/tests/CodeBehind/BuildTests/AnotherMainActivity.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Tests.CodeBehindBuildTests
 
 #if NOT_CONFLICTING_FRAGMENT
 			CommonSampleLibrary.LogFragment log2 = secondary_log_fragment;
+#elif __HAVE_ANDROIDX__
+			global::AndroidX.Fragment.App.Fragment log2 = secondary_log_fragment;
 #else
 			global::Android.App.Fragment log2 = secondary_log_fragment;
 #endif

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.NET.csproj
@@ -63,4 +63,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CommonSampleLibrary\CommonSampleLibrary.NET.csproj" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceAndroidX)' == 'True' ">
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.4.1.1" />
+  </ItemGroup>
 </Project>

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
@@ -111,5 +111,8 @@
       <Name>CommonSampleLibrary</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceAndroidX)' == 'True' ">
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.4.1.1" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/tests/CodeBehind/BuildTests/MainActivity.cs
+++ b/tests/CodeBehind/BuildTests/MainActivity.cs
@@ -24,6 +24,8 @@ namespace Xamarin.Android.Tests.CodeBehindBuildTests
 
 #if NOT_CONFLICTING_FRAGMENT
 			CommonSampleLibrary.LogFragment log2 = secondary_log_fragment;
+#elif __HAVE_ANDROIDX__
+			global::AndroidX.Fragment.App.Fragment log2 = secondary_log_fragment;
 #else
 			global::Android.App.Fragment log2 = secondary_log_fragment;
 #endif


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6893

Context: 92cd68c7beb3a26dab55957b2e061faf6cdc1d89
Context: https://github.com/xamarin/AndroidX/blob/628cf049e0ef61e140cb17600df16ed801449814/source/AndroidXTargets.cshtml#L36

When:

 1. The [`$(AndroidFragmentType)`][0] MSBuild property is set, *and*
 2. The [`$(AndroidGenerateLayoutBindings)`][1]=True, *and*
 3. There is a Layout XML file which has an `id`, *and*
 4. Define `__HAVE_ANDROIDX__` C# symbol.

then [`LayoutBinding.cs`][2] (92cd68c7) fails to compile.

Repro:

 1. `dotnet new android`
 2. Edit `Resources/layout/activity_main.xml` so that the
    `<TextView/>` has `android:id="@+id/text_view"`:

        <TextView
          android:id="@+id/text_view"
          android:layout_width="wrap_content"                                     
          android:layout_height="wrap_content"                                    
          android:layout_centerInParent="true"                                    
          android:text="@string/app_text"                                         
        />

 3. Build!

        dotnet build -p:AndroidFragmentType=AndroidX.Fragment.App.Fragment \
          -p:AndroidGenerateLayoutBindings=True \
          -p:DefineConstants=__HAVE_ANDROIDX__

Expected results: no errors.

Actual results:

	…/LayoutBinding.cs(91,56): error CS0400: The type or namespace name 'Androidx' could not be found in the global namespace
	…/LayoutBinding.cs(91,135): error CS0400: The type or namespace name 'Androidx' could not be found in the global namespace

Update `LayoutBinding.cs` so that it uses the correct `AndroidX`
namespace.  Additionally, `FragmentManager` has been deprecated;
update `LayoutBinding.cs` to use `SupportFragmentManager`, which is
available on the `AndroidX.Fragment.App.FragmentActivity` class.

Finally, remove the use of a `static` field to share object state between
tasks. We have been on `msbuild` rather than `xbuild` on *nix for a while
now, so this workaround is no longer needed.

TODO: Add [`LayoutCodeBehind.md` docs][3] to
[MicrosoftDocs/xamarin-docs][4].

[0]: https://docs.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-items#androidfragmenttype
[1]: https://docs.microsoft.com/en-us/xamarin/android/deploy-test/building-apps/build-properties#androidgeneratelayoutbindings
[2]: https://github.com/xamarin/xamarin-android/blob/16bbf6f0b0cd49f96f73197d28e8faf31aa9e499/src/Xamarin.Android.Build.Tasks/Resources/LayoutBinding.cs
[3]: https://github.com/xamarin/xamarin-android/blob/16bbf6f0b0cd49f96f73197d28e8faf31aa9e499/Documentation/guides/LayoutCodeBehind.md
[4]: https://github.com/MicrosoftDocs/xamarin-docs/tree/live/docs/android/deploy-test/building-apps