### PR TITLE
[Xamarin.Android.Build.Tasks] Use binutils for Aot and LLVM

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -697,10 +697,6 @@ stages:
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
-        # TODO: disable LLVM test, see:
-        # https://github.com/dotnet/runtime/issues/68914
-        # https://github.com/dotnet/runtime/issues/73304
-        condition: false
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-AotLlvm
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -61,7 +61,7 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
     </ItemGroup>
     <GetAotAssemblies
         AndroidAotMode="$(AndroidAotMode)"
-        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+        AndroidNdkDirectory="$(AndroidNdkDirectory)"
         AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
         AndroidApiLevel="$(_AndroidApiLevel)"
         MinimumSupportedApiLevel="$(AndroidMinimumSupportedApiLevel)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tasks
 
 		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: EnableLLVM, log: Log);
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: UseAndroidNdk, log: Log);
 			if (Log.HasLoggedErrors) {
 				return; // NdkTools.Create will log appropriate error
 			}
@@ -114,7 +114,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var abi in SupportedAbis) {
 				(string aotCompiler, string outdir, string mtriple, AndroidTargetArch arch) = GetAbiSettings (abi);
 
-				if (EnableLLVM && !ndk.ValidateNdkPlatform (LogMessage, LogCodedError, arch, enableLLVM:EnableLLVM)) {
+				if (UseAndroidNdk && !ndk.ValidateNdkPlatform (LogMessage, LogCodedError, arch, enableLLVM:EnableLLVM)) {
 					yield return Config.Invalid;
 					yield break;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotAssemblies.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Tasks
 
 		public override Task RunTaskAsync ()
 		{
-			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: EnableLLVM, log: Log);
+			NdkTools ndk = NdkTools.Create (AndroidNdkDirectory, logErrors: UseAndroidNdk, log: Log);
 			if (Log.HasLoggedErrors) {
 				return Task.CompletedTask; // NdkTools.Create will log appropriate error
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -62,9 +62,13 @@ namespace Xamarin.Android.Build.Tests {
 				IntermediateAssemblyDir = path
 			};
 
-			Assert.IsFalse (task2.Execute (), "Task should fail!");
-			BuildErrorEventArgs error2 = errors [1];
-			Assert.AreEqual (error1.Message, error2.Message, "Aot and MakeBundleNativeCodeExternal should produce the same error messages.");
+			if (androidNdkDirectory == "DoesNotExist") {
+				Assert.IsFalse (task2.Execute (), "Task should fail!");
+				BuildErrorEventArgs error2 = errors [1];
+				Assert.AreEqual (error1.Message, error2.Message, "Aot and MakeBundleNativeCodeExternal should produce the same error messages.");
+			} else {
+				Assert.IsTrue (task2.Execute (), "Aot task should succeed with null or empty NDK!");
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets
@@ -693,7 +693,7 @@ projects. .NET 5 projects will not import this file.
     <Aot
         Condition="'$(AotAssemblies)' == 'True'"
         AndroidAotMode="$(AndroidAotMode)"
-        AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+        AndroidNdkDirectory="$(AndroidNdkDirectory)"
         AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
         AndroidApiLevel="$(_AndroidApiLevel)"
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -77,7 +77,6 @@ projects.
         LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
         ReferenceAssemblyPaths="@(_AndroidApiInfoDirectories)">
       <Output TaskParameter="CommandLineToolsPath"      PropertyName="_AndroidToolsDirectory" />
-      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
       <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />
       <Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -661,6 +661,34 @@ using System.Runtime.Serialization.Json;
 		}
 
 		[Test]
+		public void RunWithLLVMEnabled ()
+		{
+			AssertHasDevices ();
+
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
+			proj.SetProperty ("EnableLLVM", true.ToString ());
+			if (!Builder.UseDotNet) {
+				proj.AotAssemblies = true;
+			}
+
+			builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+
+			if (Builder.UseDotNet)
+				Assert.True (builder.RunTarget (proj, "Run"), "Project should have run.");
+			else if (CommercialBuildAvailable)
+				Assert.True (builder.RunTarget (proj, "_Run"), "Project should have run.");
+			else
+				AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+
+			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log")));
+		}
+
+		[Test]
 		public void SingleProject_ApplicationId ()
 		{
 			AssertHasDevices ();

--- a/tests/Mono.Android-Tests/Mono.Android-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests.csproj
@@ -34,6 +34,7 @@
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidLatestStableFrameworkVersion)</TargetFrameworkVersion>
+    <AndroidNdkDirectory></AndroidNdkDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
+++ b/tests/Mono.Android-Tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
@@ -29,6 +29,7 @@
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AndroidNdkDirectory></AndroidNdkDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -20,13 +20,15 @@
     <PlotDataLabelSuffix>-$(TestsFlavor)NET6</PlotDataLabelSuffix>
     <WarningsAsErrors>IL2037</WarningsAsErrors>
     <AndroidUseNegotiateAuthentication>true</AndroidUseNegotiateAuthentication>
+    <AndroidNdkDirectory></AndroidNdkDirectory>
     <!--
       TODO: Fix excluded tests
-      For $(EnableLLVM), InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
+      For $(EnableLLVM)
+        InetAccess excluded: https://github.com/dotnet/runtime/issues/73304
+        NetworkInterfaces excluded: https://github.com/dotnet/runtime/issues/75155
     -->
     <ExcludeCategories>DotNetIgnore</ExcludeCategories>
-    <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):InetAccess</ExcludeCategories>
-    <ExcludeCategories Condition=" '$(UseInterpreter)' == 'true' ">$(ExcludeCategories):IgnoreInterpreter</ExcludeCategories>
+    <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):InetAccess:NetworkInterfaces</ExcludeCategories>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
+++ b/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
@@ -29,6 +29,7 @@
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AndroidNdkDirectory></AndroidNdkDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerNegotiateAuthenticationTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerNegotiateAuthenticationTests.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.NetTests {
 	// Important: We expect the Negotiate authentication feature to be enabled in all of these tests because we set $(AndroidUseNegotiateAuthentication)=true
 	// in the Mono.Android.NET-Tests.csproj file.
 	[TestFixture]
+	[Category ("InetAccess")]
 	public sealed class AndroidMessageHandlerNegotiateAuthenticationTests
 	{
 		// Negotiate authentication is available for Android since .NET 7

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -29,6 +29,7 @@
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AndroidNdkDirectory></AndroidNdkDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -135,8 +135,6 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
 			if (!string.IsNullOrEmpty (paths.AndroidSdkDirectory))
 				SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
-			if (!string.IsNullOrEmpty (paths.AndroidNdkDirectory))
-				SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
 
 			var projectImportSearchPaths = toolsets.SelectSingleNode ("projectImportSearchPaths");
 			var searchPaths = projectImportSearchPaths.SelectSingleNode ($"searchPaths[@os='{paths.SearchPathsOS}']") as XmlElement;


### PR DESCRIPTION
It appears that an Android NDK installation is no longer needed when
using Aot with LLVM.  Projects which enable Aot and LLVM will no longer
attempt to use the NDK unless it is explicitly requested by setting
`$(AndroidNdkDirectory)` to a valid NDK path in the project file.