### PR TITLE
[ci] Remove extra .NET SDKs on Windows and Linux

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -151,6 +151,13 @@ stages:
       displayName: set JI_JAVA_HOME
 
     - template: yaml-templates\use-dot-net.yaml
+      parameters:
+        remove_dotnet: true
+
+    # xabuild still depends on .NET Core 3 or earlier
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
+        version: 3.1.417
 
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
     # The VS installer will attempt to resume any failed or partial installation before trying to downgrade Xamarin.Android.

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -28,6 +28,7 @@ jobs:
     - template: setup-test-environment.yaml
       parameters:
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
+        remove_dotnet: true
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -5,6 +5,7 @@ parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)
   updateVS: false
   jdkTestFolder: $(JAVA_HOME_11_X64)
+  remove_dotnet: false
 
 steps:
 - checkout: self
@@ -36,6 +37,8 @@ steps:
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - template: use-dot-net.yaml
+  parameters:
+    remove_dotnet: ${{ parameters.remove_dotnet }}
 
 - task: DotNetCoreCLI@2
   displayName: shut down existing build daemons

--- a/build-tools/automation/yaml-templates/setup-ubuntu.yaml
+++ b/build-tools/automation/yaml-templates/setup-ubuntu.yaml
@@ -17,6 +17,8 @@ steps:
   displayName: update packages
 
 - template: use-dot-net.yaml
+  parameters:
+    remove_dotnet: true
 
 - task: NuGetToolInstaller@1
   displayName: Use NuGet 5.x


### PR DESCRIPTION
Related: https://github.com/xamarin/xamarin-android/pull/6598

Our Windows and Linux pools are "stateful" and are only wiped fresh
every 7 or 3 days respectively.  This allows them to service jobs more
quickly when demand is high.  Now that we are starting to build and test
against .NET 7 previews we should enable .NET SDK clean up, as these
pools will be shared across .NET 6 and .NET 7 branches.