### PR TITLE
Speed up java-to-managed typemap lookups

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -119,6 +119,9 @@ namespace Android.Runtime {
 		[DllImport ("libc")]
 		static extern int gettid ();
 
+#if NETCOREAPP
+		[UnmanagedCallersOnly]
+#endif
 		static unsafe void RegisterJniNatives (IntPtr typeName_ptr, int typeName_len, IntPtr jniClass, IntPtr methods_ptr, int methods_len)
 		{
 			string typeName = new string ((char*) typeName_ptr, 0, typeName_len);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Build.Tests
 			"map_modules",
 			"map_module_count",
 			"java_type_count",
-			"java_name_width",
+			"map_java_hashes",
 			"map_java",
 			"mono_aot_mode_name",
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,10 +5,10 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 55111
+      "Size": 55106
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88334
+      "Size": 88461
     },
     "assemblies/rc.bin": {
       "Size": 1083
@@ -26,13 +26,13 @@
       "Size": 2374
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3551
+      "Size": 3546
     },
     "classes.dex": {
       "Size": 345328
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 380832
+      "Size": 382304
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3192432
@@ -47,7 +47,7 @@
       "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 8688
+      "Size": 9424
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -59,7 +59,7 @@
       "Size": 2467
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4762
+      "Size": 4791
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200
@@ -83,5 +83,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2701303
+  "PackageSize": 2705399
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -5,22 +5,22 @@
       "Size": 2604
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 67953
+      "Size": 67956
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 256591
+      "Size": 256630
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769016
+      "Size": 769015
     },
     "assemblies/System.Core.dll": {
-      "Size": 28198
+      "Size": 28199
     },
     "assemblies/System.dll": {
       "Size": 9180
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2880
+      "Size": 2881
     },
     "classes.dex": {
       "Size": 347796
@@ -32,7 +32,7 @@
       "Size": 750976
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 297544
+      "Size": 296192
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4030448
@@ -41,7 +41,7 @@
       "Size": 65512
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 18272
+      "Size": 19960
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,124 +8,124 @@
       "Size": 7247
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 62006
+      "Size": 62017
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 441706
+      "Size": 442008
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3798
+      "Size": 3803
     },
     "assemblies/netstandard.dll": {
-      "Size": 5499
+      "Size": 5503
     },
     "assemblies/rc.bin": {
       "Size": 1083
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11227
+      "Size": 11230
     },
     "assemblies/System.Collections.dll": {
-      "Size": 16736
+      "Size": 16741
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 8439
+      "Size": 8443
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 1961
+      "Size": 1965
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2566
+      "Size": 2569
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 5968
+      "Size": 5970
     },
     "assemblies/System.Console.dll": {
-      "Size": 6530
+      "Size": 6532
     },
     "assemblies/System.Core.dll": {
-      "Size": 1928
+      "Size": 1932
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6756
+      "Size": 6761
     },
     "assemblies/System.dll": {
-      "Size": 2275
+      "Size": 2279
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 1957
+      "Size": 1961
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12199
+      "Size": 12206
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 17218
+      "Size": 17221
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10566
+      "Size": 10569
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19474
+      "Size": 19480
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 182081
+      "Size": 182084
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 65831
+      "Size": 65842
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 22364
+      "Size": 22368
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3731
+      "Size": 3734
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 11970
+      "Size": 11974
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 757425
+      "Size": 757472
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 191072
+      "Size": 191079
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 43677
+      "Size": 43502
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 220171
+      "Size": 220183
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 17101
+      "Size": 17099
     },
     "assemblies/System.Runtime.CompilerServices.Unsafe.dll": {
-      "Size": 1214
+      "Size": 1216
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2557
+      "Size": 2561
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1889
+      "Size": 1893
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2634
+      "Size": 2637
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3940
+      "Size": 3943
     },
     "assemblies/System.Security.Cryptography.Algorithms.dll": {
-      "Size": 6809
+      "Size": 6815
     },
     "assemblies/System.Security.Cryptography.Primitives.dll": {
-      "Size": 2968
+      "Size": 2973
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 76698
+      "Size": 76702
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1779
+      "Size": 1782
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117239
+      "Size": 117237
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 6069
@@ -134,40 +134,40 @@
       "Size": 6095
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 112590
+      "Size": 112591
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 6809
+      "Size": 6810
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
       "Size": 16603
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 96723
+      "Size": 96722
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 14273
+      "Size": 14271
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 39924
+      "Size": 39926
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6132
+      "Size": 6133
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
       "Size": 6592
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6671
+      "Size": 6672
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3273
+      "Size": 3272
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 12671
+      "Size": 12670
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 84688
+      "Size": 84687
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
       "Size": 5077
@@ -176,13 +176,13 @@
       "Size": 10382
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 17986
+      "Size": 17985
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 528450
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384996
+      "Size": 384997
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56878
@@ -191,13 +191,13 @@
       "Size": 60774
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 40134
+      "Size": 40135
     },
     "classes.dex": {
       "Size": 3458288
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382776
+      "Size": 382304
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3192432
@@ -212,7 +212,7 @@
       "Size": 150032
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 133192
+      "Size": 98624
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1967,5 +1967,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 7930399
+  "PackageSize": 7942687
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -8,19 +8,19 @@
       "Size": 7215
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68919
+      "Size": 68921
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 567108
+      "Size": 567161
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68431
+      "Size": 68433
     },
     "assemblies/mscorlib.dll": {
       "Size": 915405
     },
     "assemblies/System.Core.dll": {
-      "Size": 164046
+      "Size": 164045
     },
     "assemblies/System.dll": {
       "Size": 388864
@@ -32,7 +32,7 @@
       "Size": 110642
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 15682
+      "Size": 15683
     },
     "assemblies/System.Runtime.Serialization.dll": {
       "Size": 186660
@@ -44,13 +44,13 @@
       "Size": 395657
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 116892
+      "Size": 116898
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 7701
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6650
+      "Size": 6651
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
       "Size": 125337
@@ -65,7 +65,7 @@
       "Size": 131939
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15429
+      "Size": 15430
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
       "Size": 43150
@@ -80,7 +80,7 @@
       "Size": 7195
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4874
+      "Size": 4875
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
       "Size": 13589
@@ -92,7 +92,7 @@
       "Size": 6283
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11271
+      "Size": 11270
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
       "Size": 19429
@@ -122,7 +122,7 @@
       "Size": 750976
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 297544
+      "Size": 296192
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4030448
@@ -131,7 +131,7 @@
       "Size": 65512
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 139912
+      "Size": 105016
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1883,5 +1883,5 @@
       "Size": 341040
     }
   },
-  "PackageSize": 9521310
+  "PackageSize": 9533598
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
@@ -7,31 +7,21 @@ namespace Xamarin.Android.Tasks
 	class NativeTypeMappingData
 	{
 		public TypeMapGenerator.ModuleReleaseData[] Modules { get; }
-		public IDictionary<string, string> AssemblyNames { get; }
-		public string[] JavaTypeNames                    { get; }
 		public TypeMapGenerator.TypeMapReleaseEntry[] JavaTypes { get; }
 
 		public uint MapModuleCount { get; }
 		public uint JavaTypeCount  { get; }
-		public uint JavaNameWidth  { get; }
 
-		public NativeTypeMappingData (Action<string> logger, TypeMapGenerator.ModuleReleaseData[] modules, int javaNameWidth)
+		public NativeTypeMappingData (Action<string> logger, TypeMapGenerator.ModuleReleaseData[] modules)
 		{
 			Modules = modules ?? throw new ArgumentNullException (nameof (modules));
 
 			MapModuleCount = (uint)modules.Length;
-			JavaNameWidth = (uint)javaNameWidth;
-
-			AssemblyNames = new Dictionary<string, string> (StringComparer.Ordinal);
 
 			var tempJavaTypes = new Dictionary<string, TypeMapGenerator.TypeMapReleaseEntry> (StringComparer.Ordinal);
-			int managedStringCounter = 0;
 			var moduleComparer = new TypeMapGenerator.ModuleUUIDArrayComparer ();
 
 			foreach (TypeMapGenerator.ModuleReleaseData data in modules) {
-				data.AssemblyNameLabel = $"map_aname.{managedStringCounter++}";
-				AssemblyNames.Add (data.AssemblyNameLabel, data.AssemblyName);
-
 				int moduleIndex = Array.BinarySearch (modules, data, moduleComparer);
 				if (moduleIndex < 0)
 					throw new InvalidOperationException ($"Unable to map module with MVID {data.Mvid} to array index");
@@ -44,16 +34,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			var javaNames = tempJavaTypes.Keys.ToArray ();
-			Array.Sort (javaNames, StringComparer.Ordinal);
-
-			var javaTypes = new TypeMapGenerator.TypeMapReleaseEntry[javaNames.Length];
-			for (int i = 0; i < javaNames.Length; i++) {
-				javaTypes[i] = tempJavaTypes[javaNames[i]];
-			}
-
-			JavaTypes = javaTypes;
-			JavaTypeNames = javaNames;
+			JavaTypes = tempJavaTypes.Values.ToArray ();
 			JavaTypeCount = (uint)JavaTypes.Length;
 		}
 	}

--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -24,15 +24,16 @@ const TypeMap type_map = {
 #else
 const uint32_t map_module_count = 0;
 const uint32_t java_type_count = 0;
-const uint32_t java_name_width = 0;
+const char* const java_type_names[] = {};
 
-const TypeMapModule map_modules[] = {};
+TypeMapModule map_modules[] = {};
 const TypeMapJava map_java[] = {};
+const xamarin::android::hash_t map_java_hashes[] = {};
 #endif
 
 CompressedAssemblies compressed_assemblies = {
-	/*.count = */ 0,
-	/*.descriptors = */ nullptr,
+	.count = 0,
+	.descriptors = nullptr,
 };
 
 //

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -548,8 +548,8 @@ EmbeddedAssemblies::install_preload_hooks_for_alc ()
 #endif // def NET6
 
 template<typename Key, typename Entry, int (*compare)(const Key*, const Entry*), bool use_precalculated_size>
-const Entry*
-EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nmemb, [[maybe_unused]] size_t precalculated_size)
+force_inline const Entry*
+EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nmemb, [[maybe_unused]] size_t precalculated_size) noexcept
 {
 	static_assert (compare != nullptr, "compare is a required template parameter");
 
@@ -599,9 +599,65 @@ EmbeddedAssemblies::binary_search (const Key *key, const Entry *base, size_t nme
 	return nullptr;
 }
 
+force_inline ssize_t
+EmbeddedAssemblies::binary_search (hash_t key, const hash_t *arr, size_t n) noexcept
+{
+	ssize_t left = -1;
+	ssize_t right = static_cast<ssize_t>(n);
+
+	while (right - left > 1) {
+		ssize_t middle = (left + right) >> 1;
+		if (arr[middle] < key) {
+			left = middle;
+		} else {
+			right = middle;
+		}
+	}
+
+	return arr[right] == key ? right : -1;
+}
+
+force_inline ptrdiff_t
+EmbeddedAssemblies::binary_search_branchless (hash_t x, const hash_t *arr, uint32_t len) noexcept
+{
+	const hash_t *base = arr;
+	while (len > 1) {
+		uint32_t half = len >> 1;
+		// __builtin_prefetch(&base[(len - half) / 2]);
+		// __builtin_prefetch(&base[half + (len - half) / 2]);
+		base = (base[half] < x ? &base[half] : base);
+		len -= half;
+	}
+
+	//return *(base + (*base < x));
+	ptrdiff_t ret = (base + (*base < x)) - arr;
+	return arr[ret] == x ? ret : -1;
+}
+
+#if defined (RELEASE) && defined (ANDROID)
+force_inline const TypeMapModuleEntry*
+EmbeddedAssemblies::binary_search (uint32_t key, const TypeMapModuleEntry *arr, uint32_t n) noexcept
+{
+	ssize_t left = -1;
+	ssize_t right = static_cast<ssize_t>(n);
+	ssize_t middle;
+
+	while (right - left > 1) {
+		middle = (left + right) >> 1;
+		if (arr[middle].type_token_id < key) {
+			left = middle;
+		} else {
+			right = middle;
+		}
+	}
+
+	return arr[right].type_token_id == key ? &arr[right] : nullptr;
+}
+#endif // def RELEASE && def ANDROID
+
 #if defined (DEBUG) || !defined (ANDROID)
-int
-EmbeddedAssemblies::compare_type_name (const char *type_name, const TypeMapEntry *entry)
+force_inline int
+EmbeddedAssemblies::compare_type_name (const char *type_name, const TypeMapEntry *entry) noexcept
 {
 	if (entry == nullptr)
 		return 1;
@@ -609,38 +665,39 @@ EmbeddedAssemblies::compare_type_name (const char *type_name, const TypeMapEntry
 	return strcmp (type_name, entry->from);
 }
 
-MonoReflectionType*
-EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
+force_inline MonoReflectionType*
+EmbeddedAssemblies::typemap_java_to_managed ([[maybe_unused]] hash_t hash, const MonoString *java_type) noexcept
 {
+	c_unique_ptr<char> java_type_name {mono_string_to_utf8 (const_cast<MonoString*>(java_type))};
 	const TypeMapEntry *entry = nullptr;
 
 	if (application_config.instant_run_enabled) {
 		TypeMap *module;
 		for (size_t i = 0; i < type_map_count; i++) {
 			module = &type_maps[i];
-			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, module->java_to_managed, module->entry_count);
+			entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name.get (), module->java_to_managed, module->entry_count);
 			if (entry != nullptr)
 				break;
 		}
 	} else {
-		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name, type_map.java_to_managed, type_map.entry_count);
+		entry = binary_search<const char, TypeMapEntry, compare_type_name, false> (java_type_name.get (), type_map.java_to_managed, type_map.entry_count);
 	}
 
 	if (XA_UNLIKELY (entry == nullptr)) {
-		log_info (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name);
+		log_info (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name.get ());
 		return nullptr;
 	}
 
 	const char *managed_type_name = entry->to;
 	if (managed_type_name == nullptr) {
-		log_debug (LOG_ASSEMBLY, "typemap: Java type '%s' maps either to an open generic type or an interface type.", java_type_name);
+		log_debug (LOG_ASSEMBLY, "typemap: Java type '%s' maps either to an open generic type or an interface type.", java_type_name.get ());
 		return nullptr;
 	}
-	log_debug (LOG_DEFAULT, "typemap: Java type '%s' corresponds to managed type '%s'", java_type_name, managed_type_name);
+ 	log_debug (LOG_DEFAULT, "typemap: Java type '%s' corresponds to managed type '%s'", java_type_name.get (), managed_type_name);
 
 	MonoType *type = mono_reflection_type_from_name (const_cast<char*>(managed_type_name), nullptr);
 	if (XA_UNLIKELY (type == nullptr)) {
-		log_info (LOG_ASSEMBLY, "typemap: managed type '%s' (mapped from Java type '%s') could not be loaded", managed_type_name, java_type_name);
+		log_info (LOG_ASSEMBLY, "typemap: managed type '%s' (mapped from Java type '%s') could not be loaded", managed_type_name, java_type_name.get ());
 		return nullptr;
 	}
 
@@ -653,46 +710,44 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
 	return ret;
 }
 #else
-MonoReflectionType*
-EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
+force_inline MonoReflectionType*
+EmbeddedAssemblies::typemap_java_to_managed (hash_t hash, const MonoString *java_type_name) noexcept
 {
-	TypeMapModule *module;
-	const TypeMapJava *java_entry = binary_search<const char, TypeMapJava, compare_java_name, true> (java_type_name, map_java, java_type_count, type_map_java_struct_size);
-	if (java_entry == nullptr) {
-		log_info (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s'", java_type_name);
+	// In microbrenchmarks, `binary_search_branchless` is faster than `binary_search` but in "real" application tests,
+	// the simple version appears to yield faster startup... Leaving both for now, for further investigation and
+	// potential optimizations
+	ssize_t idx = binary_search (hash, map_java_hashes, java_type_count);
+	//ptrdiff_t idx = binary_search_branchless (hash, map_java_hashes, java_type_count);
+
+	TypeMapJava const* java_entry = idx >= 0 ? &map_java[idx] : nullptr;
+	TypeMapModule *module = java_entry != nullptr && java_entry->module_index < map_module_count ? &map_modules[java_entry->module_index] : nullptr;
+	if (module == nullptr) {
+		if (java_entry == nullptr) {
+			log_info (LOG_ASSEMBLY, "typemap: unable to find mapping to a managed type from Java type '%s' (hash 0x%zx)", to_utf8 (java_type_name).get (), hash);
+		} else {
+			log_warn (LOG_ASSEMBLY, "typemap: mapping from Java type '%s' to managed type has invalid module index %u", to_utf8 (java_type_name).get (), java_entry->module_index);
+		}
 		return nullptr;
 	}
 
-	if (java_entry->module_index >= map_module_count) {
-		log_warn (LOG_ASSEMBLY, "typemap: mapping from Java type '%s' to managed type has invalid module index", java_type_name);
-		return nullptr;
-	}
-
-	module = const_cast<TypeMapModule*>(&map_modules[java_entry->module_index]);
-	const TypeMapModuleEntry *entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&java_entry->type_token_id, module->map, module->entry_count);
+	const TypeMapModuleEntry *entry = binary_search (java_entry->type_token_id, module->map, module->entry_count);
 	if (entry == nullptr) {
-		log_info (LOG_ASSEMBLY, "typemap: unable to find mapping from Java type '%s' to managed type with token ID %u in module [%s]", java_type_name, java_entry->type_token_id, MonoGuidString (module->module_uuid).get ());
+		log_info (LOG_ASSEMBLY, "typemap: unable to find mapping from Java type '%s' to managed type with token ID %u in module [%s]", to_utf8 (java_type_name).get (), java_entry->type_token_id, MonoGuidString (module->module_uuid).get ());
 		return nullptr;
 	}
-	uint32_t type_token_id = java_entry->type_token_id;
 
 	if (module->image == nullptr) {
 		module->image = mono_image_loaded (module->assembly_name);
 		if (module->image == nullptr) {
-			// TODO: load
-			log_error (LOG_ASSEMBLY, "typemap: assembly '%s' not loaded yet!", module->assembly_name);
-		}
-
-		if (module->image == nullptr) {
-			log_error (LOG_ASSEMBLY, "typemap: unable to load assembly '%s' when looking up managed type corresponding to Java type '%s'", module->assembly_name, java_type_name);
+			log_error (LOG_ASSEMBLY, "typemap: unable to load assembly '%s' when looking up managed type corresponding to Java type '%s'", module->assembly_name, to_utf8 (java_type_name).get ());
 			return nullptr;
 		}
 	}
 
-	log_debug (LOG_ASSEMBLY, "typemap: java type '%s' corresponds to managed token id %u (0x%x)", java_type_name, type_token_id, type_token_id);
-	MonoClass *klass = mono_class_get (module->image, static_cast<uint32_t>(type_token_id));
-	if (klass == nullptr) {
-		log_error (LOG_ASSEMBLY, "typemap: unable to find managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", type_token_id, module->assembly_name, java_type_name);
+	log_debug (LOG_ASSEMBLY, "typemap: java type '%s' corresponds to managed token id %u (0x%x)", to_utf8 (java_type_name).get (), java_entry->type_token_id, java_entry->type_token_id);
+	MonoClass *klass = mono_class_get (module->image, java_entry->type_token_id);
+	if (klass == nullptr) [[unlikely]] {
+		log_error (LOG_ASSEMBLY, "typemap: unable to find managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", java_entry->type_token_id, module->assembly_name, to_utf8 (java_type_name).get ());
 		return nullptr;
 	}
 
@@ -706,26 +761,16 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java_type_name)
 #endif
 	MonoReflectionType *ret = mono_type_get_object (domain, mono_class_get_type (klass));
 	if (ret == nullptr) {
-		log_warn (LOG_ASSEMBLY, "typemap: unable to instantiate managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", type_token_id, module->assembly_name, java_type_name);
+		log_warn (LOG_ASSEMBLY, "typemap: unable to instantiate managed type with token ID %u in assembly '%s', corresponding to Java type '%s'", java_entry->type_token_id, module->assembly_name, to_utf8 (java_type_name).get ());
 		return nullptr;
 	}
 
 	return ret;
 }
-
-int
-EmbeddedAssemblies::compare_java_name (const char *java_name, const TypeMapJava *entry)
-{
-	if (entry == nullptr || entry->java_name[0] == '\0') {
-		return -1;
-	}
-
-	return strcmp (java_name, reinterpret_cast<const char*>(entry->java_name));
-}
 #endif
 
 MonoReflectionType*
-EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
+EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type) noexcept
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
@@ -738,13 +783,17 @@ EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 		return nullptr;
 	}
 
-	c_unique_ptr<char> java_type_name {mono_string_to_utf8 (java_type)};
-	if (XA_UNLIKELY (!java_type_name || *java_type_name == '\0')) {
-		log_warn (LOG_ASSEMBLY, "typemap: empty Java type name passed to 'typemap_java_to_managed'");
+	// We need to generate hash for all the bytes, and since MonoString is Unicode, we double the length to get the
+	// number of bytes.
+	int name_len = mono_string_length (java_type) << 1;
+	if (XA_UNLIKELY (name_len <= 0)) {
+		log_warn (LOG_ASSEMBLY, "typemap: empty 'java_type' passed to 'typemap_java_to_managed'");
 		return nullptr;
 	}
 
-	MonoReflectionType *ret = typemap_java_to_managed (java_type_name.get ());
+	const mono_unichar2 *type_chars = mono_string_chars (java_type);
+	hash_t hash = xxhash::hash (reinterpret_cast<const char*>(type_chars), static_cast<size_t>(name_len));
+	MonoReflectionType *ret = typemap_java_to_managed (hash, java_type);
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
@@ -756,8 +805,8 @@ EmbeddedAssemblies::typemap_java_to_managed (MonoString *java_type)
 }
 
 #if defined (DEBUG) || !defined (ANDROID)
-inline const TypeMapEntry*
-EmbeddedAssemblies::typemap_managed_to_java (const char *managed_type_name)
+force_inline const TypeMapEntry*
+EmbeddedAssemblies::typemap_managed_to_java (const char *managed_type_name) noexcept
 {
 	const TypeMapEntry *entry = nullptr;
 
@@ -776,8 +825,8 @@ EmbeddedAssemblies::typemap_managed_to_java (const char *managed_type_name)
 	return entry;
 }
 
-inline const char*
-EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, [[maybe_unused]] const uint8_t *mvid)
+force_inline const char*
+EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, [[maybe_unused]] const uint8_t *mvid) noexcept
 {
 	c_unique_ptr<char> type_name {mono_type_get_name_full (type, MONO_TYPE_NAME_FORMAT_FULL_NAME)};
 	MonoImage *image = mono_class_get_image (klass);
@@ -800,59 +849,38 @@ EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, Mo
 	return entry->to;
 }
 #else
-inline int
-EmbeddedAssemblies::compare_type_token (const uint32_t *token, const TypeMapModuleEntry *entry)
-{
-	if (entry == nullptr) {
-		log_fatal (LOG_ASSEMBLY, "typemap: compare_type_token: entry is nullptr");
-		exit (FATAL_EXIT_MISSING_ASSEMBLY);
-	}
-
-	if (*token < entry->type_token_id)
-		return -1;
-	if (*token > entry->type_token_id)
-		return 1;
-	return 0;
-}
-
-inline int
-EmbeddedAssemblies::compare_mvid (const uint8_t *mvid, const TypeMapModule *module)
+force_inline int
+EmbeddedAssemblies::compare_mvid (const uint8_t *mvid, const TypeMapModule *module) noexcept
 {
 	return memcmp (mvid, module->module_uuid, sizeof(module->module_uuid));
 }
 
-inline const char*
-EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, const uint8_t *mvid)
+force_inline const char*
+EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, MonoClass *klass, const uint8_t *mvid) noexcept
 {
-	if (mvid == nullptr) {
-		log_warn (LOG_ASSEMBLY, "typemap: no mvid specified in call to typemap_managed_to_java");
-		return nullptr;
-	}
-
-	const TypeMapModule *map;
-	size_t map_entry_count;
-	map = map_modules;
-	map_entry_count = map_module_count;
-
-	const TypeMapModule *match = binary_search<uint8_t, TypeMapModule, compare_mvid> (mvid, map, map_entry_count);
+	const TypeMapModule *match = mvid != nullptr ? binary_search<uint8_t, TypeMapModule, compare_mvid> (mvid, map_modules, map_module_count) : nullptr;
 	if (match == nullptr) {
-		log_info (LOG_ASSEMBLY, "typemap: module matching MVID [%s] not found.", MonoGuidString (mvid).get ());
-		return nullptr;
-	}
-
-	if (match->map == nullptr) {
-		log_warn (LOG_ASSEMBLY, "typemap: module with MVID [%s] has no associated type map.", MonoGuidString (mvid).get ());
+		if (mvid == nullptr) {
+			log_warn (LOG_ASSEMBLY, "typemap: no mvid specified in call to typemap_managed_to_java");
+		} else {
+			log_info (LOG_ASSEMBLY, "typemap: module matching MVID [%s] not found.", MonoGuidString (mvid).get ());
+		}
 		return nullptr;
 	}
 
 	uint32_t token = mono_class_get_type_token (klass);
 	log_debug (LOG_ASSEMBLY, "typemap: MVID [%s] maps to assembly %s, looking for token %d (0x%x), table index %d", MonoGuidString (mvid).get (), match->assembly_name, token, token, token & 0x00FFFFFF);
 	// Each map entry is a pair of 32-bit integers: [TypeTokenID][JavaMapArrayIndex]
-	const TypeMapModuleEntry *entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&token, match->map, match->entry_count);
+	const TypeMapModuleEntry *entry = match->map != nullptr ? binary_search (token, match->map, match->entry_count) : nullptr;
 	if (entry == nullptr) {
+		if (match->map == nullptr) {
+			log_warn (LOG_ASSEMBLY, "typemap: module with mvid [%s] has no associated type map.", MonoGuidString (mvid).get ());
+			return nullptr;
+		}
+
 		if (match->duplicate_count > 0 && match->duplicate_map != nullptr) {
 			log_debug (LOG_ASSEMBLY, "typemap: searching module [%s] duplicate map for token %u (0x%x)", MonoGuidString (mvid).get (), token, token);
-			entry = binary_search <uint32_t, TypeMapModuleEntry, compare_type_token> (&token, match->duplicate_map, match->duplicate_count);
+			entry = binary_search (token, match->duplicate_map, match->duplicate_count);
 		}
 
 		if (entry == nullptr) {
@@ -861,15 +889,17 @@ EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, Mo
 		}
 	}
 
-	uint32_t java_entry_count;
-	java_entry_count = java_type_count;
-	if (entry->java_map_index >= java_entry_count) {
+	if (XA_UNLIKELY (entry->java_map_index >= java_type_count)) {
 		log_warn (LOG_ASSEMBLY, "typemap: type with token %d (0x%x) in module {%s} (%s) has invalid Java type index %u", token, token, MonoGuidString (mvid).get (), match->assembly_name, entry->java_map_index);
 		return nullptr;
 	}
 
-	const TypeMapJava *java_entry = reinterpret_cast<const TypeMapJava*> (reinterpret_cast<const uint8_t*>(map_java) + (type_map_java_struct_size * entry->java_map_index));
-	const char *ret = reinterpret_cast<const char*>(java_entry->java_name);
+	TypeMapJava const& java_entry = map_java[entry->java_map_index];
+	if (XA_UNLIKELY (java_entry.java_name_index >= java_type_count)) {
+		log_warn (LOG_ASSEMBLY, "typemap: type with token %d (0x%x) in module {%s} (%s) points to invalid Java type at index %u (invalid type name index %u)", token, token, MonoGuidString (mvid).get (), match->assembly_name, entry->java_map_index, java_entry.java_name_index);
+		return nullptr;
+	}
+	const char *ret = java_type_names[java_entry.java_name_index];
 
 	if (XA_UNLIKELY (ret == nullptr)) {
 		log_warn (LOG_ASSEMBLY, "typemap: empty Java type name returned for entry at index %u", entry->java_map_index);
@@ -890,7 +920,7 @@ EmbeddedAssemblies::typemap_managed_to_java ([[maybe_unused]] MonoType *type, Mo
 #endif
 
 const char*
-EmbeddedAssemblies::typemap_managed_to_java (MonoReflectionType *reflection_type, const uint8_t *mvid)
+EmbeddedAssemblies::typemap_managed_to_java (MonoReflectionType *reflection_type, const uint8_t *mvid) noexcept
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -128,6 +128,7 @@ namespace xamarin::android::internal
 
 #if defined (NET6)
 		using jnienv_initialize_fn = void (*) (JnienvInitializeArgs*);
+		using jnienv_register_jni_natives_fn = void (*)(const jchar *typeName_ptr, int32_t typeName_len, jclass jniClass, const jchar *methods_ptr, int32_t methods_len);
 #endif
 
 	private:
@@ -332,9 +333,11 @@ namespace xamarin::android::internal
 		static void jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo);
 		static void thread_start (MonoProfiler *prof, uintptr_t tid);
 		static void thread_end (MonoProfiler *prof, uintptr_t tid);
-		static MonoReflectionType* typemap_java_to_managed (MonoString *java_type_name);
+#if !defined (RELEASE) || !defined (ANDROID)
+		static MonoReflectionType* typemap_java_to_managed (MonoString *java_type_name) noexcept;
+		static const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid) noexcept;
+#endif // !def RELEASE || !def ANDROID
 
-		static const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid);
 #if defined (NET6)
 		static void monodroid_debugger_unhandled_exception (MonoException *ex);
 #endif
@@ -382,6 +385,9 @@ namespace xamarin::android::internal
 		static bool         startup_in_progress;
 
 #if defined (NET6)
+#if defined (ANDROID)
+		jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;
+#endif
 		MonoAssemblyLoadContextGCHandle default_alc = nullptr;
 
 		static std::mutex             pinvoke_map_write_lock;

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1043,8 +1043,22 @@ MonodroidRuntime::init_android_runtime (
 #endif // ndef NET6
 	JNIEnv *env, jclass runtimeClass, jobject loader)
 {
-	mono_add_internal_call ("Java.Interop.TypeManager::monodroid_typemap_java_to_managed", reinterpret_cast<const void*>(typemap_java_to_managed));
-	mono_add_internal_call ("Android.Runtime.JNIEnv::monodroid_typemap_managed_to_java", reinterpret_cast<const void*>(typemap_managed_to_java));
+	constexpr char icall_typemap_java_to_managed[] = "Java.Interop.TypeManager::monodroid_typemap_java_to_managed";
+	constexpr char icall_typemap_managed_to_java[] = "Android.Runtime.JNIEnv::monodroid_typemap_managed_to_java";
+
+#if defined (RELEASE) && defined (ANDROID)
+	// The reason for these using is that otherwise the compiler will complain about not being
+	// able to cast overloaded methods to const void* pointers.
+	using j2mFn = MonoReflectionType* (*)(MonoString *java_type);
+	using m2jFn = const char* (*)(MonoReflectionType *type, const uint8_t *mvid);
+
+	mono_add_internal_call (icall_typemap_java_to_managed, reinterpret_cast<const void*>(static_cast<j2mFn>(EmbeddedAssemblies::typemap_java_to_managed)));
+	mono_add_internal_call (icall_typemap_managed_to_java, reinterpret_cast<const void*>(static_cast<m2jFn>(EmbeddedAssemblies::typemap_managed_to_java)));
+#else
+	mono_add_internal_call (icall_typemap_java_to_managed, reinterpret_cast<const void*>(typemap_java_to_managed));
+	mono_add_internal_call (icall_typemap_managed_to_java, reinterpret_cast<const void*>(typemap_managed_to_java));
+#endif // def RELEASE && def ANDROID
+
 #if defined (NET6)
 	mono_add_internal_call ("Android.Runtime.JNIEnv::monodroid_debugger_unhandled_exception", reinterpret_cast<const void*> (monodroid_debugger_unhandled_exception));
 	mono_add_internal_call ("Android.Runtime.JNIEnv::monodroid_unhandled_exception", reinterpret_cast<const void*>(monodroid_unhandled_exception));
@@ -1138,6 +1152,10 @@ MonodroidRuntime::init_android_runtime (
 			registerType = mono_class_get_method_from_name (runtime, "RegisterJniNatives", 5);
 		} else {
 			registerType = mono_get_method (image, application_config.jnienv_registerjninatives_method_token, runtime);
+#if defined (NET6) && defined (ANDROID)
+			MonoError error;
+			jnienv_register_jni_natives = reinterpret_cast<jnienv_register_jni_natives_fn>(mono_method_get_unmanaged_callers_only_ftnptr (registerType, &error));
+#endif // def NET6 && def ANDROID
 		}
 	}
 	abort_unless (registerType != nullptr, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.RegisterJniNatives!");
@@ -1960,17 +1978,19 @@ MonodroidRuntime::monodroid_unhandled_exception (MonoObject *java_exception)
 }
 #endif // def NET6
 
+#if !defined (RELEASE) || !defined (ANDROID)
 MonoReflectionType*
-MonodroidRuntime::typemap_java_to_managed (MonoString *java_type_name)
+MonodroidRuntime::typemap_java_to_managed (MonoString *java_type_name) noexcept
 {
 	return embeddedAssemblies.typemap_java_to_managed (java_type_name);
 }
 
 const char*
-MonodroidRuntime::typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid)
+MonodroidRuntime::typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid) noexcept
 {
 	return embeddedAssemblies.typemap_managed_to_java (type, mvid);
 }
+#endif // !def RELEASE || !def ANDROID
 
 #if defined (WINDOWS)
 const char*
@@ -2429,7 +2449,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 	);
 }
 
-inline void
+force_inline void
 MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods)
 {
 	timing_period total_time;
@@ -2439,20 +2459,13 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
 
-	int managedType_len = env->GetStringLength (managedType);
+	jsize managedType_len = env->GetStringLength (managedType);
 	const jchar *managedType_ptr = env->GetStringChars (managedType, nullptr);
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
-		type.assign (mt_ptr, strlen (mt_ptr));
-		env->ReleaseStringUTFChars (managedType, mt_ptr);
-
-		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type.get ());
-	}
-
-	int methods_len = env->GetStringLength (methods);
+	jsize methods_len = env->GetStringLength (methods);
 	const jchar *methods_ptr = env->GetStringChars (methods, nullptr);
 
+#if !defined (NET6) || !defined (ANDROID)
 	void *args[] = {
 		&managedType_ptr,
 		&managedType_len,
@@ -2460,8 +2473,9 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 		&methods_ptr,
 		&methods_len,
 	};
-
 	MonoMethod *register_jni_natives = registerType;
+#endif // ndef NET6 || ndef ANDROID
+
 #if !defined (NET6)
 	MonoDomain *domain = utils.get_current_domain (/* attach_thread_if_needed */ false);
 	mono_jit_thread_attach (domain);
@@ -2475,7 +2489,11 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 
 	utils.monodroid_runtime_invoke (domain, register_jni_natives, nullptr, args, nullptr);
 #else // ndef NET6
+#if !defined (ANDROID)
 	mono_runtime_invoke (register_jni_natives, nullptr, args, nullptr);
+#else
+	jnienv_register_jni_natives (managedType_ptr, managedType_len, nativeClass, methods_ptr, methods_len);
+#endif // ndef ANDROID
 #endif // def NET6
 
 	env->ReleaseStringChars (methods, methods_ptr);
@@ -2483,6 +2501,12 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
+
+		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
+		type.assign (mt_ptr, strlen (mt_ptr));
+		env->ReleaseStringUTFChars (managedType, mt_ptr);
+
+		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type.get ());
 
 		Timing::info (total_time, "Runtime.register: end time");
 #if !defined (NET6)

--- a/src/monodroid/jni/platform-compat.hh
+++ b/src/monodroid/jni/platform-compat.hh
@@ -37,10 +37,15 @@ typedef struct dirent monodroid_dirent_t;
 #endif
 
 #define force_inline inline __attribute__((always_inline))
+#define never_inline __attribute__((noinline))
 #endif // _MSV_VER
 
 #ifndef force_inline
 #define force_inline inline
+#endif
+
+#ifndef never_inline
+#define never_inline
 #endif
 
 #ifndef inline

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -106,7 +106,7 @@ namespace xamarin::android
 		ssize_t          recv_uninterrupted (int fd, void *buf, size_t len);
 		jclass           get_class_from_runtime_field (JNIEnv *env, jclass runtime, const char *name, bool make_gref = false);
 
-		bool should_log (LogCategories category) const
+		static bool should_log (LogCategories category) noexcept
 		{
 			return (log_categories & category) != 0;
 		}

--- a/src/monodroid/jni/xamarin-app.hh
+++ b/src/monodroid/jni/xamarin-app.hh
@@ -7,6 +7,7 @@
 #include <mono/metadata/image.h>
 
 #include "monodroid.h"
+#include "xxhash.hh"
 
 static constexpr uint64_t FORMAT_TAG = 0x015E6972616D58;
 static constexpr uint32_t COMPRESSED_DATA_MAGIC = 0x5A4C4158; // 'XALZ', little-endian
@@ -75,7 +76,7 @@ struct TypeMapJava
 {
 	uint32_t module_index;
 	uint32_t type_token_id;
-	uint8_t  java_name[];
+	uint32_t java_name_index;
 };
 #endif
 
@@ -238,9 +239,10 @@ MONO_API MONO_API_EXPORT const TypeMap type_map; // MUST match src/Xamarin.Andro
 #else
 MONO_API MONO_API_EXPORT const uint32_t map_module_count;
 MONO_API MONO_API_EXPORT const uint32_t java_type_count;
-MONO_API MONO_API_EXPORT const uint32_t java_name_width;
-MONO_API MONO_API_EXPORT const TypeMapModule map_modules[];
+MONO_API MONO_API_EXPORT const char* const java_type_names[];
+MONO_API MONO_API_EXPORT TypeMapModule map_modules[];
 MONO_API MONO_API_EXPORT const TypeMapJava map_java[];
+MONO_API MONO_API_EXPORT const xamarin::android::hash_t map_java_hashes[];
 #endif
 
 MONO_API MONO_API_EXPORT CompressedAssemblies compressed_assemblies;


### PR DESCRIPTION
Up until now, Xamarin.Android used string comparison when finding a
Managed type corresponding to a given Java type.  Even though the
strings were pre-sorted at build time, multiple string comparisons
costed more time than necessary.  To improve comparison speed, this
commit implements lookups based on hash values (using the `xxHash`
algorithm) calculated for all the Java names at build time.  This allows
us to process each Java type once at run time - to generate its hash.
After that, the hash is used to binary search an array of hashes and the
result (if found) is an index into array with the appropriate
Java-to-Managed mapping.

This change also allows us to move Java type names from the mapping
structure (`TypeMapJava`) to a separate array.  We used to keep Java
type name in the structure to make matching slightly faster, but it
required unnecessarily complicated structure size calculation at
runtime, so that binary search can properly work on an array of
`TypeMapJava` structures whose size would differ from application to
application (and sometimes even between builds).  The change also saves
space, because when the Java type name was stored in the structure, all
the structures had to have the same size, and thus all type names
shorter than the longest one had to be padded with NUL characters.

A handful of other optimizations are implemented as well.  Namely:

  * the `JNIEnv.RegisterJniNatives` method is now called
    directly (thanks to the `[UnmanagedCallersOnly]` attribute) when
    running under .NET6
  * a conceptually simpler binary search function was implemented, which
    doesn't use C++ templates and also appears to generate faster code.
    There are two versions of the function, one "simple" using the
    standard branching binary search algorithm and the other
    "branchless". The latter is currently not used, needing a better
    timing infrastructure to make sure it's actually faster on Android
    devices (microbenchmarks suggest its faster, application
    measurements when the branchless version is used suggest it's slower
    than the simple one)
  * the `typemap_managed_to_java` and `typemap_java_to_managed` internal
    calls are now registered directly from the `EmbeddedAssemblies`
    class instead of from the `MonodroidRuntime` class
  * a number of native functions are now forcibly inlined
  * a number of native functions are now static instead of instance

Startup performance was measured a .NET6 MAUI application created with
the `dotnet new maui` template and the gains vary depending on where we
look. The `Displayed` time sees changes that are negligible, however the
most affected area of the startup sequence (the call to
`JNIEnv.Initialize`) which registers types and involves the biggest
number of lookups sees improvements of up to 12%.  The measurements have
a degree of uncertainty and instability to them because of our use of
Android `logcat` to report timings as they are taken (`logcat` calls
need to send messages to a system daemon which involves a lot of steps
and allows for a large variation in time spent processing each call) and
also because the `Displayed` time is not a very stable reporting
system (it depends on CPU and GPU load among other factors)

The changes will also positively affect application performance after
startup:

On Pixel 3 XL running Android 12:

| Before | After  | Δ        | Notes                                          |
| ------ | ------ | -------- | ---------------------------------------------- |
| 14.967 | 13.586 | -9.23% ✓ | preload enabled; 32-bit build                  |
| 15.312 | 14.343 | -6.33% ✓ | preload enabled; 32-bit build; no compression  |
| 13.577 | 12.792 | -5.78% ✓ | preload enabled; 64-bit build                  |
| 13.677 | 12.894 | -5.73% ✓ | preload disabled; 64-bit build; no compression |
| 13.601 | 12.838 | -5.61% ✓ | preload disabled; 64-bit build                 |
| 13.656 | 12.953 | -5.15% ✓ | preload enabled; 64-bit build; no compression  |
| 14.638 | 14.070 | -3.88% ✓ | preload disabled; 32-bit build                 |
| 15.053 | 14.526 | -3.50% ✓ | preload disabled; 32-bit build; no compression |

On Pixel 6 XL running Android 12:

| Before | After | Δ         | Notes                                          |
| ------ | ----- | --------- | ---------------------------------------------- |
| 8.972  | 7.826 | -12.78% ✓ | preload enabled; 32-bit build                  |
| 8.833  | 7.823 | -11.43% ✓ | preload enabled; 32-bit build; no compression  |
| 8.611  | 8.031 | -6.74% ✓  | preload disabled; 32-bit build; no compression |
| 6.533  | 6.104 | -6.57% ✓  | preload disabled; 64-bit build; no compression |
| 6.504  | 6.119 | -5.92% ✓  | preload enabled; 64-bit build; no compression  |
| 6.426  | 6.052 | -5.83% ✓  | preload disabled; 64-bit build                 |
| 6.493  | 6.125 | -5.67% ✓  | preload enabled; 64-bit build                  |
| 8.446  | 8.088 | -4.23% ✓  | preload disabled; 32-bit build                 |