### PR TITLE
[Xamarin.Android.Build.Tests] Ignore NoSymbolsArgShouldReduceAppSize

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -441,6 +441,7 @@ namespace "+ libName + @" {
 		}
 
 		[Test]
+		[Ignore ("Ignore while investigating/fixing.")]
 		[Category ("LLVM")]
 		public void NoSymbolsArgShouldReduceAppSize ([Values ("", "Hybrid")] string androidAotMode, [Values (false, true)] bool skipDebugSymbols)
 		{


### PR DESCRIPTION
Temporarily ignore this test to reduce noise on PR builds while it is
being fixed.  The test has seemingly been partially invalidated by
commit 5efda9d69, however it is still passing against Classic
Xamarin.Android on Windows.  More investigation is required as to why
we see different stripping results when using a combination of the `-s`,
`no-write-symbols`, and `nodebug` flags with different toolchains.