### PR TITLE
[ci] Sign vsix in separate job, add CodesignVerify task

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/arcade-8645
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: sdk-insertions
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1338,15 +1338,23 @@ stages:
       artifactName: nuget-signed
       artifactPatterns: |
         !*Darwin*
-      propsArtifactName: nuget-unsigned
+      propsArtifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
       runInParallel: false
       postConvertSteps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: $(NuGetArtifactName)
+          downloadPath: $(Build.StagingDirectory)\sign-verify
+          patterns: |
+            **/SignVerifyIgnore.txt
+
       - task: MicroBuildCodesignVerify@3
         displayName: verify signed msi content
         inputs:
           TargetFolders: $(Build.StagingDirectory)\bin\manifests
           ExcludeSNVerify: true
+          ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets
@@ -1470,8 +1478,7 @@ stages:
 
   - job: push_to_nuget_org
     displayName: Push to NuGet.org
-    pool:
-      vmImage: $(HostedWinImage)
+    pool: $(VSEngMicroBuildPool)
     dependsOn: wait_for_nuget_org_approval
     condition: eq(dependencies.wait_for_nuget_org_approval.result, 'Succeeded')
     steps:
@@ -1511,13 +1518,109 @@ stages:
   dependsOn: mac_build
   condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
   jobs:
-  # Check - "Xamarin.Android (Prepare Classic Release Sign and Upload)"
+  # Check - "Xamarin.Android (Prepare Classic Release Sign VSIX)"
+  - job: sign_vsix
+    displayName: Sign VSIX
+    pool: $(VSEngMicroBuildPool)
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(InstallerArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)\vsix-artifact
+        patterns: |
+          Xamarin.Android*.vsix
+
+    - powershell: |
+        $vsix = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\vsix-artifact\*" -Include *.vsix -File
+        if (![System.IO.File]::Exists($vsix)) {
+            throw [System.IO.FileNotFoundException] "Did not find .vsix file in $(System.DefaultWorkingDirectory)\vsix-artifact"
+        }
+        Write-Host "##vso[task.setvariable variable=XA.Unsigned.Vsix]$vsix"
+      displayName: set variables to unsigned installers
+
+    - powershell: |
+        $signList = "$(System.DefaultWorkingDirectory)\build-tools\create-packs\SignList.xml"
+        (Get-Content $signList).Replace("*", "%2A") | Set-Content -Path $signList
+      displayName: Escape SignList.xml
+
+    - template: yaml-templates\install-microbuild-tooling.yaml
+
+    - task: MSBuild@1
+      displayName: msbuild /t:Restore sign-content.proj
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:Restore /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\restore-sign-content.binlog
+
+    - task: MSBuild@1
+      displayName: unzip and sign .vsix content
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:_AddVsixContent;Build
+          /p:SignType=$(MicroBuildSignType)
+          /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)\MicroBuild\Plugins
+          /p:VsixPath=$(XA.Unsigned.Vsix)
+          /p:OutDir=$(Build.StagingDirectory)\
+          /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\sign-vsix-content.binlog
+
+    - task: MSBuild@1
+      displayName: rezip .vsix
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:_ZipVsixContent
+          /p:VsixPath=$(XA.Unsigned.Vsix)
+          /p:OutDir=$(Build.StagingDirectory)\
+          /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\zip-vsix-content.binlog
+
+    - task: MSBuild@1
+      displayName: sign .vsix
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >-
+          /t:_SignVsix;Build
+          /p:SignType=$(MicroBuildSignType)
+          /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)\MicroBuild\Plugins
+          /p:OutDir=$(System.DefaultWorkingDirectory)\vsix-artifact
+          /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\sign-vsix.binlog
+
+    - task: MicroBuildCodesignVerify@3
+      displayName: verify signed .vsix
+      inputs:
+        TargetFolders: $(System.DefaultWorkingDirectory)\vsix-artifact
+        ExcludeSNVerify: true
+        ApprovalListPathForCerts: $(System.DefaultWorkingDirectory)\build-tools\create-packs\SignVerifyIgnore.txt
+
+    - task: PublishPipelineArtifact@1
+      displayName: upload signed vsix
+      inputs:
+        artifactName: vsix-signed
+        targetPath: $(XA.Unsigned.Vsix)
+
+    - template: yaml-templates\remove-microbuild-tooling.yaml
+
+    - template: yaml-templates\upload-results.yaml
+      parameters:
+        artifactName: Clasic Signing Results - vsix
+        includeBuildResults: true
+
+  # Check - "Xamarin.Android (Prepare Classic Release Notarize and Upload)"
   - job: sign_upload_storage
-    displayName: Sign and Upload
+    dependsOn: sign_vsix
+    displayName: Notarize and Upload
     pool:
       name: $(MacBuildPoolName)
       vmImage: $(MacBuildPoolImage)
-    timeoutInMinutes: 210
+    timeoutInMinutes: 180
     workspace:
       clean: all
     variables:
@@ -1536,17 +1639,19 @@ stages:
         downloadPath: $(System.DefaultWorkingDirectory)/storage-artifacts
         patterns: |
           xamarin.android*.pkg
-          Xamarin.Android*.vsix
           updateinfo
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vsix-signed
+        downloadPath: $(System.DefaultWorkingDirectory)/storage-artifacts
 
     - powershell: |
         $pkg = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/storage-artifacts/*" -Include *.pkg -File
-        $vsix = Get-ChildItem -Path "$(System.DefaultWorkingDirectory)/storage-artifacts/*" -Include *.vsix -File
-        if (![System.IO.File]::Exists($pkg) -or ![System.IO.File]::Exists($vsix)) {
-            throw [System.IO.FileNotFoundException] "Did not find .pkg or .vsix file in $(System.DefaultWorkingDirectory)/storage-artifacts"
+        if (![System.IO.File]::Exists($pkg)) {
+            throw [System.IO.FileNotFoundException] "Did not find .pkg file in $(System.DefaultWorkingDirectory)/storage-artifacts"
         }
         Write-Host "##vso[task.setvariable variable=XA.Unsigned.Pkg]$pkg"
-        Write-Host "##vso[task.setvariable variable=XA.Unsigned.Vsix]$vsix"
       displayName: set variables to unsigned installers
 
     - template: yaml-templates/install-microbuild-tooling.yaml
@@ -1558,52 +1663,17 @@ stages:
         configuration: $(XA.Build.Configuration)
         msbuildArguments: /t:Restore /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
 
-    - powershell: |
-        $signList = "$(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/SignList.xml"
-        (Get-Content $signList).Replace("*", "%2A") | Set-Content -Path $signList
-      displayName: Escape SignList.xml
-
     - task: MSBuild@1
-      displayName: unzip and sign .vsix content
+      displayName: sign .pkg
       inputs:
         solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/installers/sign-content.proj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /t:_AddVsixContent;Build
-          /p:SignType=$(MicroBuildSignType)
-          /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
-          /p:VsixPath=$(XA.Unsigned.Vsix)
-          /p:OutDir=$(Build.StagingDirectory)/
-          /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/sign-vsix-content.binlog
-
-    - task: MicroBuildCodesignVerify@3
-      displayName: verify signed vsix content
-      inputs:
-        TargetFolders: $(Build.StagingDirectory)
-        ExcludeSNVerify: true
-
-    - task: MSBuild@1
-      displayName: rezip .vsix
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/installers/sign-content.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /t:_ZipVsixContent
-          /p:VsixPath=$(XA.Unsigned.Vsix)
-          /p:OutDir=$(Build.StagingDirectory)/
-          /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/zip-vsix-content.binlog
-
-    - task: MSBuild@1
-      displayName: sign classic installers
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/installers/sign-content.proj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /t:_AddClassicInstallers;Build
+          /t:_SignPkg;Build
           /p:SignType=$(MicroBuildSignType)
           /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
           /p:OutDir=$(System.DefaultWorkingDirectory)/storage-artifacts
-          /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/sign-installers.binlog
+          /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/sign-pkg.binlog
 
     - script: >
         cd $(System.DefaultWorkingDirectory)/release-scripts &&
@@ -1626,7 +1696,7 @@ stages:
     - template: yaml-templates/upload-results.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
-        artifactName: Legacy Signing Results - macOS
+        artifactName: Classic Signing Results - pkg
         includeBuildResults: true
 
 - stage: post_build

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1563,7 +1563,7 @@ stages:
         solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /t:_AddVsixContent;Build
+          /t:AddVsixContent;Build
           /p:SignType=$(MicroBuildSignType)
           /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)\MicroBuild\Plugins
           /p:VsixPath=$(XA.Unsigned.Vsix)
@@ -1576,7 +1576,7 @@ stages:
         solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /t:_ZipVsixContent
+          /t:ZipVsixContent
           /p:VsixPath=$(XA.Unsigned.Vsix)
           /p:OutDir=$(Build.StagingDirectory)\
           /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\zip-vsix-content.binlog
@@ -1587,7 +1587,7 @@ stages:
         solution: $(System.DefaultWorkingDirectory)\build-tools\installers\sign-content.proj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /t:_SignVsix;Build
+          /t:SignVsix;Build
           /p:SignType=$(MicroBuildSignType)
           /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)\MicroBuild\Plugins
           /p:OutDir=$(System.DefaultWorkingDirectory)\vsix-artifact
@@ -1669,7 +1669,7 @@ stages:
         solution: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/installers/sign-content.proj
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /t:_SignPkg;Build
+          /t:SignPkg;Build
           /p:SignType=$(MicroBuildSignType)
           /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
           /p:OutDir=$(System.DefaultWorkingDirectory)/storage-artifacts

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/arcade-8645
     endpoint: xamarin
   - repository: sdk-insertions
     type: github
@@ -1341,6 +1341,12 @@ stages:
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
       runInParallel: false
+      postConvertSteps:
+      - task: MicroBuildCodesignVerify@3
+        displayName: verify signed msi content
+        inputs:
+          TargetFolders: $(Build.StagingDirectory)\bin\manifests
+          ExcludeSNVerify: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets
@@ -1569,6 +1575,12 @@ stages:
           /p:VsixPath=$(XA.Unsigned.Vsix)
           /p:OutDir=$(Build.StagingDirectory)/
           /bl:$(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/sign-vsix-content.binlog
+
+    - task: MicroBuildCodesignVerify@3
+      displayName: verify signed vsix content
+      inputs:
+        TargetFolders: $(Build.StagingDirectory)
+        ExcludeSNVerify: true
 
     - task: MSBuild@1
       displayName: rezip .vsix

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -86,7 +86,7 @@ steps:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
     msbuildArguments: >-
-      /t:_AddMachOEntitlements;Build
+      /t:AddMachOEntitlements;Build
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -89,6 +89,7 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <_PackageFiles Include="$(MSBuildThisFileDirectory)\linux-README.md" PackagePath="\README.md" Condition=" '$(HostOS)' == 'Linux' " />
       <None Include="$(MSBuildThisFileDirectory)SignList.xml" CopyToOutputDirectory="PreserveNewest" />
+      <None Include="$(MSBuildThisFileDirectory)SignVerifyIgnore.txt" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 

--- a/build-tools/create-packs/SignVerifyIgnore.txt
+++ b/build-tools/create-packs/SignVerifyIgnore.txt
@@ -1,0 +1,2 @@
+**\*.xml,ignore unsigned xml
+**\cab*.cab.cab,ignore unsigned .cab

--- a/build-tools/installers/sign-content.proj
+++ b/build-tools/installers/sign-content.proj
@@ -30,7 +30,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     </PackageReference>
   </ItemGroup>
 
-  <Target Name="_AddMachOEntitlements" >
+  <Target Name="AddMachOEntitlements" >
     <Exec Command="codesign -vvvv -f -s - -o runtime --entitlements &quot;%(_MSBuildFilesUnixSignAndHarden.EntitlementsPath)&quot; &quot;%(_MSBuildFilesUnixSignAndHarden.Identity)&quot;" />
     <ItemGroup>
       <FilesToSign Include="@(_MSBuildFilesUnixSign)">
@@ -44,7 +44,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     </ItemGroup>
   </Target>
 
-  <Target Name="_AddVsixContent" >
+  <Target Name="AddVsixContent" >
     <RemoveDir Directories="$(UnzippedVsixDir)" />
     <MakeDir Directories="$(UnzippedVsixDir)" />
     <Unzip
@@ -74,7 +74,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ZipVsixContent" >
+  <Target Name="ZipVsixContent" >
     <Delete Files="$(VsixPath)" />
     <ZipDirectory
         SourceDirectory="$(UnzippedVsixDir)"
@@ -82,7 +82,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     />
   </Target>
 
-  <Target Name="_SignVsix" >
+  <Target Name="SignVsix" >
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\Xamarin.Android.Sdk-*.vsix">
         <Authenticode>VsixSHA2</Authenticode>
@@ -90,7 +90,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     </ItemGroup>
   </Target>
 
-  <Target Name="_SignPkg" >
+  <Target Name="SignPkg" >
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\xamarin.android-*.pkg">
         <Authenticode>MacDeveloper</Authenticode>

--- a/build-tools/installers/sign-content.proj
+++ b/build-tools/installers/sign-content.proj
@@ -82,14 +82,19 @@ ourself (using an empty signing identity) before passing these files to ESRP.
     />
   </Target>
 
-  <Target Name="_AddClassicInstallers" >
+  <Target Name="_SignVsix" >
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\Xamarin.Android.Sdk-*.vsix">
+        <Authenticode>VsixSHA2</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_SignPkg" >
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\xamarin.android-*.pkg">
         <Authenticode>MacDeveloper</Authenticode>
         <Zip>true</Zip>
-      </FilesToSign>
-      <FilesToSign Include="$(OutDir)\Xamarin.Android.Sdk-*.vsix">
-        <Authenticode>VsixSHA2</Authenticode>
       </FilesToSign>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
When looking at the [Xamarin.Android pipeline analytics][0] I noticed
that the Prepare Classic Release stage accounted for a very large
percentage of our overall failures.

![image](https://user-images.githubusercontent.com/2000163/163272391-00913ba6-ccd2-4d8e-b0a9-470502d474cb.png)

To help address this I've moved the vsix signing step into a new job
that runs on a Windows agent, where the signing tasks are hopefully more
resilient.  This seems to have sped up signing performance dramatically
as well, as a step that would take upwards of an hour or more on macOS
now seems to be completing in less than 10 minutes on the Windows
MicroBuild agent pool.

I've also added the `MicroBuildCodesignVerify` task in a couple of
places to validate the signing status of the vsix and msi files we ship.

[0]: https://devdiv.visualstudio.com/DevDiv/_pipeline/analytics/stageawareoutcome?definitionId=11410&contextType=build