### PR TITLE
[One .NET] Fix targeting API 33, build API 31 ref pack

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -56,6 +56,11 @@
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
   </Target>
 
+  <Target Name="_CreateDefaultRefPack"
+      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+  </Target>
+
   <Target Name="_CreatePreviewPacks"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -66,7 +71,7 @@
   </Target>
 
   <Target Name="CreateAllPacks"
-      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks">
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks;_CreateDefaultRefPack">
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -137,14 +142,19 @@
 
   <Target Name="DeleteExtractedWorkloadPacks" >
     <ItemGroup>
+      <_PackApiLevels Include="$(AndroidDefaultTargetDotnetApiLevel)" />
+      <_PackApiLevels Include="$(AndroidLatestStableApiLevel)" />
+      <_PackApiLevels Include="$(AndroidLatestUnstableApiLevel)" />
+    </ItemGroup>
+    <ItemGroup>
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)metadata" />
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.sdk.android" />
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)sdk-manifests\$(DotNetPreviewVersionBand)\microsoft.net.workload.android" />
-      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Ref" />
-      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-arm" />
-      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-arm64" />
-      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-x86" />
-      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.android-x64" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Ref.%(_PackApiLevels.Identity)" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.%(_PackApiLevels.Identity).android-arm" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.%(_PackApiLevels.Identity).android-arm64" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.%(_PackApiLevels.Identity).android-x86" />
+      <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Runtime.%(_PackApiLevels.Identity).android-x64" />
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Darwin" />
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Linux" />
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)packs\Microsoft.Android.Sdk.Windows" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -102,57 +102,11 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <BundledVersionsFileName>Microsoft.Android.Sdk.BundledVersions.targets</BundledVersionsFileName>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_AndroidNETAppRuntimePackRids Include="android-arm;android-arm64;android-x86;android-x64" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <BundledVersionsContent>
-<![CDATA[
-<!--
-***********************************************************************************************
-$(BundledVersionsFileName)
-WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
-          created a backup copy.  Incorrect changes to this file will make it
-          impossible to load or build your projects from the command-line or the IDE.
-***********************************************************************************************
--->
-<Project>
-  <PropertyGroup>
-    <AndroidNETSdkVersion>$(AndroidPackVersionLong)</AndroidNETSdkVersion>
-    <XamarinAndroidVersion>$(AndroidPackVersionLong)</XamarinAndroidVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '%24(TargetPlatformVersion)' == '31.0' ">
-    <_AndroidTargetingPackId>31</_AndroidTargetingPackId>
-    <_AndroidTargetingPackVersion>31.0.101-preview.11.117</_AndroidTargetingPackVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <_AndroidTargetingPackId Condition=" '%24(_AndroidTargetingPackId)' == '' ">$(AndroidLatestStableApiLevel)</_AndroidTargetingPackId>
-    <_AndroidTargetingPackVersion Condition=" '%24(_AndroidTargetingPackVersion)' == '' ">**FromWorkload**</_AndroidTargetingPackVersion>
-    <_AndroidRuntimePackId Condition=" '%24(_AndroidRuntimePackId)' == '' ">$(AndroidLatestStableApiLevel)</_AndroidRuntimePackId>
-    <_AndroidRuntimePackVersion Condition=" '%24(_AndroidRuntimePackVersion)' == '' ">**FromWorkload**</_AndroidRuntimePackVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <KnownFrameworkReference
-        Include="Microsoft.Android"
-        TargetFramework="$(_AndroidNETAppTargetFramework)"
-        RuntimeFrameworkName="Microsoft.Android"
-        LatestRuntimeFrameworkVersion="%24(_AndroidRuntimePackVersion)"
-        TargetingPackName="Microsoft.Android.Ref.%24(_AndroidTargetingPackId)"
-        TargetingPackVersion="%24(_AndroidTargetingPackVersion)"
-        RuntimePackNamePatterns="Microsoft.Android.Runtime.%24(_AndroidRuntimePackId).**RID**"
-        RuntimePackRuntimeIdentifiers="@(_AndroidNETAppRuntimePackRids, '%3B')"
-        Profile="Android"
-    />
-  </ItemGroup>
-</Project>
-]]>
-      </BundledVersionsContent>
-    </PropertyGroup>
-
-    <WriteLinesToFile File="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\$(BundledVersionsFileName)"
-                      Lines="$(BundledVersionsContent)"
-                      Overwrite="true" />
+    <ReplaceFileContents
+        SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"
+        DestinationFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\$(BundledVersionsFileName)"
+        Replacements="@ANDROID_PACK_VERSION_LONG@=$(AndroidPackVersionLong);@ANDROID_LATEST_STABLE_API_LEVEL@=$(AndroidLatestStableApiLevel)" >
+    </ReplaceFileContents>
   </Target>
 
 </Project>

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -5,6 +5,16 @@
   <Target Name="PackDotNet">
     <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild
+         Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
+         Properties="TargetFramework=net6.0;AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel);DisableApiCompatibilityCheck=true"
+    />
+    <MSBuild
+         Condition=" '$(AndroidLatestUnstableApiLevel)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
+         Properties="TargetFramework=net6.0;AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId);DisableApiCompatibilityCheck=true"
+    />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->
@@ -65,18 +75,5 @@
         EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
     />
     <RemoveDir Directories="$(_TempDirectory)" />
-  </Target>
-  <Target Name="BuildDotNetPreviewApiLevel">
-    <ItemGroup>
-      <_DotNetPreviewProperties Include="TargetFramework=net6.0" />
-      <_DotNetPreviewProperties Include="AndroidApiLevel=$(AndroidLatestUnstableApiLevel)" />
-      <_DotNetPreviewProperties Include="AndroidPlatformId=$(AndroidLatestUnstablePlatformId)" />
-      <_DotNetPreviewProperties Include="AndroidFrameworkVersion=$(AndroidLatestUnstableFrameworkVersion)" />
-      <_DotNetPreviewProperties Include="AndroidPreviousFrameworkVersion=$(AndroidLatestStableFrameworkVersion)" />
-    </ItemGroup>
-    <MSBuild
-        Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
-        Properties="@(_DotNetPreviewProperties)"
-    />
   </Target>
 </Project>

--- a/build-tools/scripts/XABuildConfig.cs.in
+++ b/build-tools/scripts/XABuildConfig.cs.in
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tools
 		public const string XamarinAndroidBranch = "@XAMARIN_ANDROID_BRANCH@";
 		public const int NDKMinimumApiAvailable = @NDK_MINIMUM_API_AVAILABLE@;
 		public const int AndroidLatestStableApiLevel = @ANDROID_LATEST_STABLE_API_LEVEL@;
+		public const int AndroidLatestUnstableApiLevel = @ANDROID_LATEST_UNSTABLE_API_LEVEL@;
 		public const int AndroidDefaultTargetDotnetApiLevel = @ANDROID_DEFAULT_TARGET_DOTNET_API_LEVEL@;
 		public static readonly Version NDKVersion = new Version (@NDK_VERSION_MAJOR@, @NDK_VERSION_MINOR@, @NDK_VERSION_MICRO@);
 

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -7,6 +7,7 @@ namespace Xamarin.Android.Prepare
 		public const string AndroidCmakeVersionPath             = "AndroidCmakeVersionPath";
 		public const string AndroidDefaultTargetDotnetApiLevel  = "AndroidDefaultTargetDotnetApiLevel";
 		public const string AndroidLatestStableApiLevel         = "AndroidLatestStableApiLevel";
+		public const string AndroidLatestUnstableApiLevel       = "AndroidLatestUnstableApiLevel";
 		public const string AndroidLatestStableFrameworkVersion = "AndroidLatestStableFrameworkVersion";
 		public const string AndroidMxeFullPath                  = "AndroidMxeFullPath";
 		public const string AndroidNdkDirectory                 = "AndroidNdkDirectory";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -11,6 +11,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.AndroidCmakeVersionPath,             StripQuotes (@"@AndroidCmakeVersionPath@"));
 			properties.Add (KnownProperties.AndroidDefaultTargetDotnetApiLevel,  StripQuotes ("@AndroidDefaultTargetDotnetApiLevel@"));
 			properties.Add (KnownProperties.AndroidLatestStableApiLevel,         StripQuotes ("@AndroidLatestStableApiLevel@"));
+			properties.Add (KnownProperties.AndroidLatestUnstableApiLevel,       StripQuotes ("@AndroidLatestUnstableApiLevel@"));
 			properties.Add (KnownProperties.AndroidLatestStableFrameworkVersion, StripQuotes ("@AndroidLatestStableFrameworkVersion@"));
 			properties.Add (KnownProperties.AndroidMxeFullPath,                  StripQuotes (@"@AndroidMxeFullPath@"));
 			properties.Add (KnownProperties.AndroidNdkDirectory,                 StripQuotes (@"@AndroidNdkDirectory@"));

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -168,6 +168,7 @@ namespace Xamarin.Android.Prepare
 				{ "@XA_SUPPORTED_ABIS@",         context.Properties.GetRequiredValue (KnownProperties.AndroidSupportedTargetJitAbis).Replace (':', ';') },
 				{ "@ANDROID_DEFAULT_TARGET_DOTNET_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidDefaultTargetDotnetApiLevel) },
 				{ "@ANDROID_LATEST_STABLE_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidLatestStableApiLevel) },
+				{ "@ANDROID_LATEST_UNSTABLE_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidLatestUnstableApiLevel) },
 				{ "@XAMARIN_ANDROID_VERSION@",   context.Properties.GetRequiredValue (KnownProperties.ProductVersion) },
 				{ "@XAMARIN_ANDROID_COMMIT_HASH@", context.BuildInfo.XACommitHash },
 				{ "@XAMARIN_ANDROID_BRANCH@", context.BuildInfo.XABranch },

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -45,6 +45,7 @@
       <Replacement Include="@AndroidCmakeVersionPath@=$(AndroidCmakeVersionPath)" />
       <Replacement Include="@AndroidDefaultTargetDotnetApiLevel@=$(AndroidDefaultTargetDotnetApiLevel)" />
       <Replacement Include="@AndroidLatestStableApiLevel@=$(AndroidLatestStableApiLevel)" />
+      <Replacement Include="@AndroidLatestUnstableApiLevel@=$(AndroidLatestUnstableApiLevel)" />
       <Replacement Include="@AndroidMxeFullPath@=$(AndroidMxeFullPath)" />
       <Replacement Include="@AndroidNdkDirectory@=$(AndroidNdkDirectory)" />
       <Replacement Include="@AndroidNdkVersion@=$(AndroidNdkVersion)" />

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -386,8 +386,8 @@
   <Target Name="GetTargetPath" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <!-- Only build the 'net6.0' version of 'Mono.Android.dll' for the latest stable Android version or higher. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidLatestStableApiLevel)' ">
+  <!-- Only build the 'net6.0' version of 'Mono.Android.dll' for the default API level that is supported or higher. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidDefaultTargetDotnetApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -1,0 +1,32 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.BundledVersions.targets
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+***********************************************************************************************
+-->
+<Project>
+  <PropertyGroup>
+    <AndroidNETSdkVersion>@ANDROID_PACK_VERSION_LONG@</AndroidNETSdkVersion>
+    <XamarinAndroidVersion>@ANDROID_PACK_VERSION_LONG@</XamarinAndroidVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_AndroidTargetingPackId>$(TargetPlatformVersion.TrimEnd('.0'))</_AndroidTargetingPackId>
+    <_AndroidRuntimePackId Condition=" '$(_AndroidTargetingPackId)' &lt; '@ANDROID_LATEST_STABLE_API_LEVEL@' ">@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidRuntimePackId>
+    <_AndroidRuntimePackId Condition=" '$(_AndroidRuntimePackId)' == '' ">$(_AndroidTargetingPackId)</_AndroidRuntimePackId>
+  </PropertyGroup>
+  <ItemGroup>
+    <KnownFrameworkReference
+        Include="Microsoft.Android"
+        TargetFramework="net6.0"
+        RuntimeFrameworkName="Microsoft.Android"
+        LatestRuntimeFrameworkVersion="**FromWorkload**"
+        TargetingPackName="Microsoft.Android.Ref.$(_AndroidTargetingPackId)"
+        TargetingPackVersion="**FromWorkload**"
+        RuntimePackNamePatterns="Microsoft.Android.Runtime.$(_AndroidRuntimePackId).**RID**"
+        RuntimePackRuntimeIdentifiers="android-arm;android-arm64;android-x86;android-x64"
+        Profile="Android"
+    />
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -43,7 +43,7 @@
     },
     "Microsoft.Android.Ref.31": {
       "kind": "framework",
-      "version": "31.0.101-preview.11.117"
+      "version": "@WORKLOAD_VERSION@"
     },
     "Microsoft.Android.Ref.32": {
       "kind": "framework",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -216,8 +216,20 @@ namespace Xamarin.Android.Build.Tests
 			dotnet.AssertHasNoWarnings ();
 		}
 
+		static readonly object[] DotNetPackTargetFrameworks = new object[] {
+			new object[] {
+				"net6.0-android",
+				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
+			},
+			new object[] {
+				$"net6.0-android{XABuildConfig.AndroidDefaultTargetDotnetApiLevel}",
+				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
+			},
+		};
+
 		[Test]
-		public void DotNetPack ([Values ("net6.0-android", "net6.0-android31")] string targetFramework)
+		[TestCaseSource (nameof (DotNetPackTargetFrameworks))]
+		public void DotNetPack (string targetFramework, int apiLevel)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
@@ -228,6 +240,9 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 			};
+			if (IsPreviewFrameworkVersion (targetFramework)) {
+				proj.SetProperty ("EnablePreviewFeatures", "true");
+			}
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidResource ("Resources\\raw\\bar.txt") {
 				BinaryContent = () => Array.Empty<byte> (),
 			});
@@ -249,8 +264,8 @@ namespace Xamarin.Android.Build.Tests
 			var nupkgPath = Path.Combine (FullProjectDirectory, proj.OutputPath, "..", $"{proj.ProjectName}.1.0.0.nupkg");
 			FileAssert.Exists (nupkgPath);
 			using (var nupkg = ZipHelper.OpenZip (nupkgPath)) {
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android31.0/{proj.ProjectName}.dll");
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android31.0/{proj.ProjectName}.aar");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android{apiLevel}.0/{proj.ProjectName}.dll");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/net6.0-android{apiLevel}.0/{proj.ProjectName}.aar");
 			}
 		}
 
@@ -677,17 +692,67 @@ namespace Xamarin.Android.Build.Tests
 			dotnet.AssertHasNoWarnings ();
 		}
 
-		[Test]
-		public void DotNetPublish ([Values (false, true)] bool isRelease)
+		static readonly object[] DotNetTargetFrameworks = new object[] {
+			new object[] {
+				"net6.0-android",
+				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
+			},
+			new object[] {
+				$"net6.0-android{XABuildConfig.AndroidDefaultTargetDotnetApiLevel}",
+				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
+			},
+			new object[] {
+				XABuildConfig.AndroidLatestStableApiLevel == XABuildConfig.AndroidDefaultTargetDotnetApiLevel ? null : $"net6.0-android{XABuildConfig.AndroidLatestStableApiLevel}.0",
+				XABuildConfig.AndroidLatestStableApiLevel,
+			},
+			new object[] {
+				XABuildConfig.AndroidLatestUnstableApiLevel == XABuildConfig.AndroidLatestStableApiLevel ? null : $"net6.0-android{XABuildConfig.AndroidLatestUnstableApiLevel}.0",
+				XABuildConfig.AndroidLatestUnstableApiLevel,
+			},
+		};
+
+		static bool IsPreviewFrameworkVersion (string targetFramework)
 		{
+			return (targetFramework.Contains ($"{XABuildConfig.AndroidLatestUnstableApiLevel}")
+				&& XABuildConfig.AndroidLatestUnstableApiLevel != XABuildConfig.AndroidLatestStableApiLevel);
+		}
+
+		[Test]
+		public void DotNetPublish ([Values (false, true)] bool isRelease, [ValueSource(nameof(DotNetTargetFrameworks))] object[] data)
+		{
+			var targetFramework = (string)data[0];
+			var apiLevel = (int)data[1];
+
+			if (string.IsNullOrEmpty (targetFramework))
+				Assert.Ignore ($"Test for API level {apiLevel} was skipped as it matched the default or latest stable API level.");
+
 			const string runtimeIdentifier = "android-arm";
 			var proj = new XASdkProject {
+				TargetFramework = targetFramework,
 				IsRelease = isRelease
 			};
 			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
+
+			var preview = IsPreviewFrameworkVersion (targetFramework);
+			if (preview) {
+				proj.SetProperty ("EnablePreviewFeatures", "true");
+			}
+
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Publish (), "first `dotnet publish` should succeed");
-			dotnet.AssertHasNoWarnings ();
+			// NOTE: Preview API levels emit XA4211
+			if (!preview) {
+				dotnet.AssertHasNoWarnings ();
+			}
+
+			var refDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Ref.{apiLevel}")).LastOrDefault ();
+			var expectedMonoAndroidRefPath = Path.Combine (refDirectory, "ref", "net6.0", "Mono.Android.dll");
+			Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRefPath), $"Build should be using {expectedMonoAndroidRefPath}");
+
+			var runtimeApiLevel = (apiLevel == XABuildConfig.AndroidDefaultTargetDotnetApiLevel && apiLevel < XABuildConfig.AndroidLatestStableApiLevel) ? XABuildConfig.AndroidLatestStableApiLevel : apiLevel;
+			var runtimeDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Runtime.{runtimeApiLevel}.{runtimeIdentifier}")).LastOrDefault ();
+			var expectedMonoAndroidRuntimePath = Path.Combine (runtimeDirectory, "runtimes", runtimeIdentifier, "lib", "net6.0", "Mono.Android.dll");
+			Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRuntimePath), $"Build should be using {expectedMonoAndroidRuntimePath}");
 
 			var publishDirectory = Path.Combine (FullProjectDirectory, proj.OutputPath, runtimeIdentifier, "publish");
 			var apk = Path.Combine (publishDirectory, $"{proj.PackageName}.apk");
@@ -773,14 +838,17 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void MauiTargetFramework ([Values ("net6.0-android", "net6.0-android31", "net6.0-android31.0", "net6.0-android32.0")] string targetFramework)
+		[TestCaseSource (nameof (DotNetTargetFrameworks))]
+		public void MauiTargetFramework (string targetFramework, int apiLevel)
 		{
+			if (string.IsNullOrEmpty (targetFramework))
+				Assert.Ignore ($"Test for API level {apiLevel} was skipped as it matched the default or latest stable API level.");
+
 			var library = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
 			};
-			// Re-enable when we have unstable API 33
-			// bool preview = targetFramework.Contains("33");
-			bool preview = false;
+
+			var preview = IsPreviewFrameworkVersion (targetFramework);
 			if (preview) {
 				library.SetProperty ("EnablePreviewFeatures", "true");
 			}


### PR DESCRIPTION
The Microsoft.Android `@(KnownFrameworkReference)` will now delcare
targeting and runtime pack metadata that is based on the
`$(TargetPlatformVersion)` of the project file.  The only exception to
this rule is when '$(TargetPlatformVersion)' == '31.0'; in this case the
project will use an API 31 ref pack with API 32 runtime packs.  The
inline `Microsoft.Android.Sdk.BundledVersions.targets` file content
has been moved into a separate file to improve the readability of the
`@(KnownFrameworkReference)` element.

Breakdown of supported `$(TargetFramework)` -> ref/runtime pack used:

| `$(TargetFramework)` | Targeting Pack | Runtime Pack |
| -------------------- | -------------- | ------------ |
| net6.0-android     | Microsoft.Android.Ref.31 | Microsoft.Android.Runtime.32 |
| net6.0-android31.0 | Microsoft.Android.Ref.31 | Microsoft.Android.Runtime.32 |
| net6.0-android32.0 | Microsoft.Android.Ref.32 | Microsoft.Android.Runtime.32 |
| net6.0-android33.0 | Microsoft.Android.Ref.33 | Microsoft.Android.Runtime.33 |

Tests have been updated accordingly, and they will now use a dynamic
test case source that should make sure we don't miss any coverage when
making future updates to `$(AndroidDefaultTargetDotnetApiLevel)`,
`$(AndroidLatestStableApiLevel)`, and `$(AndroidLatestUnstableApiLevel)`.

If an unsupported `$(TargetFramework)` is used in a project file the
following errors will now be displayed:

    "test.csproj" (_GenerateRestoreGraphProjectEntry target) (1:5) ->
       (ProcessFrameworkReferences target) ->
         C:\Program Files\dotnet\sdk\6.0.300-preview.22211.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error : NETSDKZZZZ: Error getting pack version: Pack 'Microsoft.Android.Ref.25' was not present in workload manifests.
         C:\Program Files\dotnet\sdk\6.0.300-preview.22211.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error : NETSDKZZZZ: Error getting pack version: Pack 'Microsoft.Android.Runtime.25.android-arm' was not present in workload manifests.
         C:\Program Files\dotnet\sdk\6.0.300-preview.22211.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error : NETSDKZZZZ: Error getting pack version: Pack 'Microsoft.Android.Runtime.25.android-arm64' was not present in workload manifests.
         C:\Program Files\dotnet\sdk\6.0.300-preview.22211.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error : NETSDKZZZZ: Error getting pack version: Pack 'Microsoft.Android.Runtime.25.android-x86' was not present in workload manifests.
         C:\Program Files\dotnet\sdk\6.0.300-preview.22211.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error : NETSDKZZZZ: Error getting pack version: Pack 'Microsoft.Android.Runtime.25.android-x64' was not present in workload manifests.

Additionally, the build has been updated to produce a reference pack for
the API level declared in `$(AndroidDefaultTargetDotnetApiLevel)`, if it
is not the same as `$(AndroidLatestStableApiLevel)`.  This will allow
the default `net6.0-android` target framework to use an up to date
Mono.Android.dll, instead of an older preview version from NuGet.org.