### PR TITLE
[tests] fix DotNetBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -634,7 +634,7 @@ namespace Xamarin.Android.Build.Tests
 			var helper = new ArchiveAssemblyHelper (apkPath, usesAssemblyStore, rids);
 			helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
 			helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !CommercialBuildAvailable && !isRelease);
-			helper.AssertContainsEntry ($"assemblies/System.Linq.dll",        shouldContainEntry: expectEmbeddedAssembies);
+			helper.AssertContainsEntry ($"assemblies/Mono.Android.dll",        shouldContainEntry: expectEmbeddedAssembies);
 			helper.AssertContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
 			foreach (var abi in rids.Select (AndroidRidAbiHelper.RuntimeIdentifierToAbi)) {
 				helper.AssertContainsEntry ($"lib/{abi}/libmonodroid.so");
@@ -646,7 +646,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 				if (aot) {
 					helper.AssertContainsEntry ($"lib/{abi}/libaot-{proj.ProjectName}.dll.so");
-					helper.AssertContainsEntry ($"lib/{abi}/libaot-System.Linq.dll.so");
+					helper.AssertContainsEntry ($"lib/{abi}/libaot-Mono.Android.dll.so");
 				}
 			}
 		}


### PR DESCRIPTION
Some tests are failing on xamarin-android/main, such as:

    bin\Release\net6.0-android\com.xamarin.dotnetbuild-Signed.apk should contain assemblies/System.Linq.dll
    Expected: True
    But was:  False

Trying locally, this fails because:

1. It is a `Debug` build
2. Fast Deployment is off

These only fail on the Windows lane because it doesn't include our
internal bits from xamarin/monodroid. If Fast Deployment was used (as
on other test lanes), then this assertion would get skipped.

To solve this problem, let's just assert against a *different* file.
If `System.Linq.dll` is sometimes arhitecture-specific, let's just
assert `Mono.Android.dll` instead. The tests now pass.