### PR TITLE
[Mono.Android] preserve public methods for GetJniHandleConverterForType

### DIFF
--- a/src-ThirdParty/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+++ b/src-ThirdParty/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+ 
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -84,7 +84,7 @@ namespace Java.Interop {
 			return null;
 		}
 
-		static Func<IntPtr, JniHandleOwnership, object> GetJniHandleConverterForType (Type t)
+		static Func<IntPtr, JniHandleOwnership, object> GetJniHandleConverterForType ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type t)
 		{
 			MethodInfo m = t.GetMethod ("FromJniHandle", BindingFlags.Static | BindingFlags.Public)!;
 			return (Func<IntPtr, JniHandleOwnership, object>) Delegate.CreateDelegate (

--- a/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
+++ b/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\IJniNameProviderAttribute.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' or '$(TargetFramework)' == 'netstandard2.0' ">
+    <Compile Include="$(ThirdPartySourcePath)System.Diagnostics.CodeAnalysis/DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(ThirdPartySourcePath)System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(ThirdPartySourcePath)System.Diagnostics.CodeAnalysis/DynamicDependencyAttribute.cs" />
     <Compile Include="$(ThirdPartySourcePath)System.Runtime.CompilerServices/UnconditionalSuppressMessageAttribute.cs" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6895

In some cases an app with a single `HttpClient` request can crash with:

    android.runtime.JavaProxyThrowable: System.ArgumentNullException: ArgumentNull_Generic Arg_ParamName_Name, method
    at System.Delegate.CreateDelegate(Type , Object , MethodInfo , Boolean , Boolean )
    at System.Delegate.CreateDelegate(Type , MethodInfo , Boolean )
    at System.Delegate.CreateDelegate(Type , MethodInfo )
    at Java.Interop.JavaConvert.GetJniHandleConverterForType(Type )
    at Java.Interop.JavaConvert.GetJniHandleConverter(Type )
    at Java.Interop.JavaConvert.FromJniHandle[IList`1](IntPtr , JniHandleOwnership , Boolean& )
    at Java.Interop.JavaConvert.FromJniHandle[IList`1](IntPtr , JniHandleOwnership )
    at Android.Runtime.JavaDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.IList`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Get(String )
    at Android.Runtime.JavaDictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.IList`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].get_Item(String )
    at Xamarin.Android.Net.AndroidMessageHandler.CopyHeaders(HttpURLConnection , HttpResponseMessage )
    at Xamarin.Android.Net.AndroidMessageHandler.DoProcessRequest(HttpRequestMessage , URL , HttpURLConnection , CancellationToken , RequestRedirectionState )
    at Xamarin.Android.Net.AndroidMessageHandler.SendAsync(HttpRequestMessage , CancellationToken )
    at System.Net.Http.HttpClient.GetStringAsyncCore(HttpRequestMessage , CancellationToken )
    at XamarinAndroid.MainActivity.OnCreate(Bundle savedInstanceState)
    at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object )
    at Android.App.SyncContext.<>c__DisplayClass2_0.<Post>b__0()
    at Java.Lang.Thread.RunnableImplementor.Run()
    at Java.Lang.IRunnableInvoker.n_Run(IntPtr , IntPtr )
    at Android.Runtime.JNINativeWrapper.Wrap_JniMarshal_PP_V(_JniMarshal_PP_V , IntPtr , IntPtr )
    at mono.java.lang.RunnableImplementor.n_run(Native Method)
    at mono.java.lang.RunnableImplementor.run(RunnableImplementor.java:30)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7870)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)

In this case, `JavaDictionary<,>.FromJniHandle()` was linked away, and
we access it via reflection:

https://github.com/xamarin/xamarin-android/blob/9f3ee589d9a8cf9eb0d9d0dbe6c6e6acc8fc7f96/src/Mono.Android/Java.Interop/JavaConvert.cs#L87-L92

This works in Xamarin.Android due to:

https://github.com/xamarin/xamarin-android/blob/0ab3db079d43d47ad1bc522e28e65204542fea60/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/Mono.Android.xml#L25-L28

We actually get a linker warning for this:

    src\Mono.Android\Java.Interop\JavaConvert.cs(89,4):
    warning IL2070: Java.Interop.JavaConvert.GetJniHandleConverterForType(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String,BindingFlags)'. The parameter 't' of method 'Java.Interop.JavaConvert.GetJniHandleConverterForType(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Adding `[DynamicallyAccessedMembers]` preserves these methods, and the
warning goes away. This seems like a safe option, as we shouldn't need
to keep updating a list of types like we did in Xamarin.Android.

I tried updating `InstallAndRunTests.CustomLinkDescriptionPreserve()`,
but some usage of types is preserving `FromJniHandle()`. I couldn't
get the test to fail...

Long term, we should get the linker warnings to zero and make our
build fail if new warnings are ever introduced. Tracking this in:

https://github.com/xamarin/xamarin-android/issues/5652