### PR TITLE
[Xamarin.Android.Build.Tasks] fix --runtime and r8 at the same time

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -86,7 +86,8 @@ _ResolveAssemblies MSBuild target.
     </MSBuild>
     <!-- Properties produced by the inner build in Microsoft.Android.Sdk.ILLink.targets -->
     <PropertyGroup>
-      <_InnerIntermediateOutputPath>$(IntermediateOutputPath)%(_RIDs.Identity)\</_InnerIntermediateOutputPath>
+      <_InnerIntermediateOutputPath Condition=" '$(RuntimeIdentifier)' == '' ">$(IntermediateOutputPath)%(_RIDs.Identity)\</_InnerIntermediateOutputPath>
+      <_InnerIntermediateOutputPath Condition=" '$(RuntimeIdentifier)' != '' ">$(IntermediateOutputPath)</_InnerIntermediateOutputPath>
       <_ProguardProjectConfiguration Condition=" '$(AndroidLinkTool)' != '' ">$(_InnerIntermediateOutputPath)proguard\proguard_project_references.cfg</_ProguardProjectConfiguration>
       <_AndroidLinkFlag Condition=" '$(RuntimeIdentifier)' == '' " >$(_InnerIntermediateOutputPath)link.flag</_AndroidLinkFlag>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -29,7 +29,6 @@ namespace Xamarin.ProjectTools
 				SetProperty ("TargetFramework", "net6.0-android");
 				SetProperty ("EnableDefaultItems", "false");
 				SetProperty ("AppendTargetFrameworkToOutputPath", "false");
-				SetProperty ("AppendRuntimeIdentifierToOutputPath", "false");
 			} else {
 				AddReferences ("System"); // default
 				SetProperty ("Platform", "AnyCPU", "'$(Platform)' == ''");

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -160,16 +160,6 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			if (Builder.UseDotNet) {
-				if (usesAssemblyBlobs) {
-					expectedFiles.Add ($"{blobEntryPrefix}System.Console.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Linq.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Net.Http.dll");
-				} else {
-					expectedFiles.Add ("root/assemblies/System.Console.dll");
-					expectedFiles.Add ("root/assemblies/System.Linq.dll");
-					expectedFiles.Add ("root/assemblies/System.Net.Http.dll");
-				}
-
 				//These are random files from Google Play Services .aar files
 				expectedFiles.Add ("root/play-services-base.properties");
 				expectedFiles.Add ("root/play-services-basement.properties");
@@ -199,6 +189,11 @@ namespace Xamarin.Android.Build.Tests
 				expectedFiles.Add ($"lib/{abi}/libmonosgen-2.0.so");
 				expectedFiles.Add ($"lib/{abi}/libxamarin-app.so");
 				if (Builder.UseDotNet) {
+					if (usesAssemblyBlobs) {
+						expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
+					} else {
+						expectedFiles.Add ($"root/assemblies/{abi}/System.Private.CoreLib.dll");
+					}
 					expectedFiles.Add ($"lib/{abi}/libSystem.IO.Compression.Native.so");
 					expectedFiles.Add ($"lib/{abi}/libSystem.Native.so");
 				} else {
@@ -247,16 +242,6 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			if (Builder.UseDotNet) {
-				if (usesAssemblyBlobs) {
-					expectedFiles.Add ($"{blobEntryPrefix}System.Console.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Linq.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Net.Http.dll");
-				} else {
-					expectedFiles.Add ("base/root/assemblies/System.Console.dll");
-					expectedFiles.Add ("base/root/assemblies/System.Linq.dll");
-					expectedFiles.Add ("base/root/assemblies/System.Net.Http.dll");
-				}
-
 				//These are random files from Google Play Services .aar files
 				expectedFiles.Add ("base/root/play-services-base.properties");
 				expectedFiles.Add ("base/root/play-services-basement.properties");
@@ -286,6 +271,11 @@ namespace Xamarin.Android.Build.Tests
 				expectedFiles.Add ($"base/lib/{abi}/libmonosgen-2.0.so");
 				expectedFiles.Add ($"base/lib/{abi}/libxamarin-app.so");
 				if (Builder.UseDotNet) {
+					if (usesAssemblyBlobs) {
+						expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
+					} else {
+						expectedFiles.Add ($"base/root/assemblies/{abi}/System.Private.CoreLib.dll");
+					}
 					expectedFiles.Add ($"base/lib/{abi}/libSystem.IO.Compression.Native.so");
 					expectedFiles.Add ($"base/lib/{abi}/libSystem.Native.so");
 				} else {


### PR DESCRIPTION
If you do:

    dotnet new android
    dotnet build -c Release -r android-arm64 -p:AndroidLinkTool=r8

You'll get the warning:

    warning XA4304: ProGuard configuration file 'obj\Release\android-arm64\android-arm64\proguard\proguard_project_references.cfg' was not found.

That path has two `android-arm64` in it!

Additionally, I found this problem was hidden in our testing
infrastructure because we set `$(AppendRuntimeIdentifierToOutputPath)`
to `false` in several tests... After removing this, I could write a
test that reproduces this issue.

The fix for the issue is that `$(_InnerIntermediateOutputPath)` needs
to check if the outer build has a single `$(RuntimeIdentifier)`. If
so, we don't need to append a RID in that path.