### PR TITLE
[Mono.Android] add JNINativeWrapper "built-in" delegates for RC 2

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -92,6 +92,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static int Wrap_JniMarshal_PPL_I (this _JniMarshal_PPL_I callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static IntPtr Wrap_JniMarshal_PPL_L (this _JniMarshal_PPL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -115,6 +126,17 @@ namespace Android.Runtime
 		}
 
 		internal static bool Wrap_JniMarshal_PPL_Z (this _JniMarshal_PPL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPJ_Z (this _JniMarshal_PPJ_Z callback, IntPtr jnienv, IntPtr klazz, long p0)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
 			try {
@@ -191,7 +213,29 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static IntPtr Wrap_JniMarshal_PPLL_L (this _JniMarshal_PPLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static bool Wrap_JniMarshal_PPLL_Z (this _JniMarshal_PPLL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
+		internal static bool Wrap_JniMarshal_PPIL_Z (this _JniMarshal_PPIL_Z callback, IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
 			try {
@@ -345,6 +389,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static bool Wrap_JniMarshal_PPLZZL_Z (this _JniMarshal_PPLZZL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1, bool p2, IntPtr p3)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2, p3);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static void Wrap_JniMarshal_PPLIIII_V (this _JniMarshal_PPLIIII_V callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1, int p2, int p3, int p4)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -395,12 +450,16 @@ namespace Android.Runtime
 					return new _JniMarshal_PPI_I (Unsafe.As<_JniMarshal_PPI_I> (dlg).Wrap_JniMarshal_PPI_I);
 				case nameof (_JniMarshal_PPI_J):
 					return new _JniMarshal_PPI_J (Unsafe.As<_JniMarshal_PPI_J> (dlg).Wrap_JniMarshal_PPI_J);
+				case nameof (_JniMarshal_PPL_I):
+					return new _JniMarshal_PPL_I (Unsafe.As<_JniMarshal_PPL_I> (dlg).Wrap_JniMarshal_PPL_I);
 				case nameof (_JniMarshal_PPL_L):
 					return new _JniMarshal_PPL_L (Unsafe.As<_JniMarshal_PPL_L> (dlg).Wrap_JniMarshal_PPL_L);
 				case nameof (_JniMarshal_PPL_V):
 					return new _JniMarshal_PPL_V (Unsafe.As<_JniMarshal_PPL_V> (dlg).Wrap_JniMarshal_PPL_V);
 				case nameof (_JniMarshal_PPL_Z):
 					return new _JniMarshal_PPL_Z (Unsafe.As<_JniMarshal_PPL_Z> (dlg).Wrap_JniMarshal_PPL_Z);
+				case nameof (_JniMarshal_PPJ_Z):
+					return new _JniMarshal_PPJ_Z (Unsafe.As<_JniMarshal_PPJ_Z> (dlg).Wrap_JniMarshal_PPJ_Z);
 				case nameof (_JniMarshal_PPII_V):
 					return new _JniMarshal_PPII_V (Unsafe.As<_JniMarshal_PPII_V> (dlg).Wrap_JniMarshal_PPII_V);
 				case nameof (_JniMarshal_PPLI_V):
@@ -413,8 +472,12 @@ namespace Android.Runtime
 					return new _JniMarshal_PPLF_V (Unsafe.As<_JniMarshal_PPLF_V> (dlg).Wrap_JniMarshal_PPLF_V);
 				case nameof (_JniMarshal_PPLI_L):
 					return new _JniMarshal_PPLI_L (Unsafe.As<_JniMarshal_PPLI_L> (dlg).Wrap_JniMarshal_PPLI_L);
+				case nameof (_JniMarshal_PPLL_L):
+					return new _JniMarshal_PPLL_L (Unsafe.As<_JniMarshal_PPLL_L> (dlg).Wrap_JniMarshal_PPLL_L);
 				case nameof (_JniMarshal_PPLL_Z):
 					return new _JniMarshal_PPLL_Z (Unsafe.As<_JniMarshal_PPLL_Z> (dlg).Wrap_JniMarshal_PPLL_Z);
+				case nameof (_JniMarshal_PPIL_Z):
+					return new _JniMarshal_PPIL_Z (Unsafe.As<_JniMarshal_PPIL_Z> (dlg).Wrap_JniMarshal_PPIL_Z);
 				case nameof (_JniMarshal_PPIIL_V):
 					return new _JniMarshal_PPIIL_V (Unsafe.As<_JniMarshal_PPIIL_V> (dlg).Wrap_JniMarshal_PPIIL_V);
 				case nameof (_JniMarshal_PPLII_I):
@@ -441,6 +504,8 @@ namespace Android.Runtime
 					return new _JniMarshal_PPIIII_V (Unsafe.As<_JniMarshal_PPIIII_V> (dlg).Wrap_JniMarshal_PPIIII_V);
 				case nameof (_JniMarshal_PPLLLL_V):
 					return new _JniMarshal_PPLLLL_V (Unsafe.As<_JniMarshal_PPLLLL_V> (dlg).Wrap_JniMarshal_PPLLLL_V);
+				case nameof (_JniMarshal_PPLZZL_Z):
+					return new _JniMarshal_PPLZZL_Z (Unsafe.As<_JniMarshal_PPLZZL_Z> (dlg).Wrap_JniMarshal_PPLZZL_Z);
 				case nameof (_JniMarshal_PPLIIII_V):
 					return new _JniMarshal_PPLIIII_V (Unsafe.As<_JniMarshal_PPLIIII_V> (dlg).Wrap_JniMarshal_PPLIIII_V);
 				case nameof (_JniMarshal_PPZIIII_V):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -47,6 +47,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0",
 	},
 	new {
+		Type = "_JniMarshal_PPL_I",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
+		Return = "int",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
 		Type = "_JniMarshal_PPL_L",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
 		Return = "IntPtr",
@@ -61,6 +67,12 @@ var delegateTypes = new [] {
 	new {
 		Type = "_JniMarshal_PPL_Z",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0",
+	},
+	new {
+		Type = "_JniMarshal_PPJ_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, long p0",
 		Return = "bool",
 		Invoke = "jnienv, klazz, p0",
 	},
@@ -101,8 +113,20 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1",
 	},
 	new {
+		Type = "_JniMarshal_PPLL_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
 		Type = "_JniMarshal_PPLL_Z",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1",
+		Return = "bool",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
+		Type = "_JniMarshal_PPIL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, IntPtr p1",
 		Return = "bool",
 		Invoke = "jnienv, klazz, p0, p1",
 	},
@@ -182,6 +206,12 @@ var delegateTypes = new [] {
 		Type = "_JniMarshal_PPLLLL_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr p3",
 		Return = "void",
+		Invoke = "jnienv, klazz, p0, p1, p2, p3",
+	},
+	new {
+		Type = "_JniMarshal_PPLZZL_Z",
+		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, bool p1, bool p2, IntPtr p3",
+		Return = "bool",
 		Invoke = "jnienv, klazz, p0, p1, p2, p3",
 	},
 	new {


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/6133#discussion_r851405705

`dotnet new maui` is logging on startup:

    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPJ_Z': Boolean n_ContainsItem_J(IntPtr, IntPtr, Int64)

This was probably introduced at:

https://github.com/dotnet/maui/commit/003744a722f3cbbe91284c617a76db1ab7660c51#diff-e8c9ed1d734bd47f7e75df934b4090d131ee6391aeeaa0cb84afb5de18c180f8R71

Then I tried `dotnet new maui-blazor`:

    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPIL_Z': Boolean n_OnKeyDown_ILandroid_view_KeyEvent_(IntPtr, IntPtr, Int32, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLL_L': IntPtr n_ShouldInterceptRequest_Landroid_webkit_WebView_Landroid_webkit_WebResourceRequest_(IntPtr, IntPtr, IntPtr, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPLZZL_Z': Boolean n_OnCreateWindow_Landroid_webkit_WebView_ZZLandroid_os_Message_(IntPtr, IntPtr, IntPtr, Boolean, Boolean, IntPtr)
    Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPL_I': Int32 n_Read_arrayB(IntPtr, IntPtr, IntPtr)

These changes for `maui-blazor` on a Pixel 5:

    Before:
    48.78ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
    After:
     8.98ms Mono.Android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)