### PR TITLE
[xaprepare] Add ref to System.Private.Uri 4.3.2

### DIFF
--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -54,9 +54,9 @@
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
     <PackageReference Include="Mono.Unix" Version="7.0.0-final.1.21369.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" Condition=" '$(MSBuildRuntimeType)' == 'Core' " />
   </ItemGroup>
 
   <Import Project="xaprepare.targets" Condition=" $(MSBuildToolsPath.IndexOf('omnisharp')) &lt; 0 " />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112013/alert/2548260?typeId=6317076

I noticed that xaprepare was pulling in an out of date version of
`System.Private.Uri` through its `System.Net.Http` PackageReference.
Adding an explicit reference to version 4.3.2 of System.Private.Uri
should fix a few component governance issues.  I also think that the
`Microsoft.NETFramework.ReferenceAssemblies` reference should no longer
be needed now that the project is targeting `net6.0`.