### PR TITLE
[AOT] Fix for a compatibility issue between AOT and LLVM 14

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs
@@ -293,23 +293,27 @@ namespace Xamarin.Android.Tasks
 				libs.Add (Path.Combine (androidLibPath, "libm.so"));
 
 				ldFlags.Append ($"\\\"{string.Join ("\\\";\\\"", libs)}\\\"");
+			} else {
+				if (ldFlags.Length > 0) {
+					ldFlags.Append (' ');
+				}
+
+				//
+				// This flag is needed for Mono AOT to work correctly with the LLVM 14 `lld` linker due to the following change:
+				//
+				//   The AArch64 port now supports adrp+ldr and adrp+add optimizations. --no-relax can suppress the optimization.
+				//
+				// Without the flag, `lld` will modify AOT-generated code in a way that the Mono runtime doesn't support. Until
+				// the runtime issue is fixed, we need to pass this flag then.
+				//
+				ldFlags.Append ("--no-relax");
 			}
 
-			if (ldFlags.Length > 0) {
-				ldFlags.Append (' ');
-			}
-
-			//
-			// This flag is needed for Mono AOT to work correctly with the LLVM 14 `lld` linker due to the following change:
-			//
-			//   The AArch64 port now supports adrp+ldr and adrp+add optimizations. --no-relax can suppress the optimization.
-			//
-			// Without the flag, `lld` will modify AOT-generated code in a way that the Mono runtime doesn't support. Until
-			// the runtime issue is fixed, we need to pass this flag then.
-			//
-			ldFlags.Append ("--no-relax");
 			if (StripLibraries) {
-				ldFlags.Append (" -s");
+				if (ldFlags.Length > 0) {
+					ldFlags.Append (' ');
+				}
+				ldFlags.Append ("-s");
 			}
 
 			return ldFlags.ToString ();


### PR DESCRIPTION
Context: https://releases.llvm.org/14.0.0/tools/lld/docs/ReleaseNotes.html#elf-improvements
Context: 16bbf6f0b0cd49f96f73197d28e8faf31aa9e499

After switching to LLVM 14 we noticed that all `arm64` apps which use
AOT, crash with the following assertion from the Mono runtime:

    * Assertion at /__w/1/s/src/mono/mono/mini/tramp-arm64.c:53, condition `((ins >> 24) & 0x1f) == 0x10' not met

After investigation, it turns out that one of the LLVM 14 changes for
the `aarch64` architecture in the `lld` linker was an optimization which
modifies generated code in the following fashion (`-` is the "good"
code, `+` is the "bad" one):

     -   13a44: 30 01 00 b0          adrp    x16, 0x38000 <.text+0x148>
     -   13a48: 10 e2 3e 91          add     x16, x16, #4024         // =4024
     +   13a44: 1f 20 03 d5          nop
     +   13a48: 90 ab 12 10          adr     x16, #152944

Mono AOT generates a pair of instructions, `adrp` and `add` and, at the
runtime, it expects to find the exact code that was generated (runtime
disassembles the binary code and looks for specific patterns), but
instead it finds a `nop` and an `adr` instructions, which eventually
triggers the above assertion.

Until Mono runtime code is fixed, we can work around this issue by
passing the `--no-relax` flag to the native linker.