### PR TITLE
[build] Only build .NET Mono.Android.Export once

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -57,8 +57,8 @@
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-  <!-- Only build the 'net6.0' version of 'Mono.Android.Export.dll' for the latest stable Android version or higher. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidLatestStableApiLevel)' ">
+  <!-- Only build the 'net6.0' version of 'Mono.Android.Export.dll' for the latest stable Android version. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' != '$(AndroidLatestStableApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
 


### PR DESCRIPTION
The `Microsoft.Android.Ref` and `Microsoft.Android.Runtime` packs always
include the latest stable version:

    <_AndroidRuntimePackAssemblies Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />

We shouldn't need to build this more than once.