### PR TITLE
Workaround FirstChanceExceptionEventArgs being trimmed

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6626, remove once https://github.com/dotnet/runtime/pull/68265 lands -->
+	<assembly fullname="System.Private.CoreLib">
+		<type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs">
+			<method signature="System.Void .ctor(System.Exception)" />
+		</type>
+	</assembly>
+</linker>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6626