### PR TITLE
[build] Add Directory.Build.props to PrepareWindows.targets

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Prepare" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>


### PR DESCRIPTION
After merging commit b5ce08d4 we started seeing a new issue during
prepare on Windows:

    xaprepare -> C:\a\_work\1\s\build-tools\xaprepare\xaprepare\bin\Release\net6.0\xaprepare.dll
    Could not execute because the specified command or file was not found.
    Possible reasons for this include:
        * You misspelled a built-in dotnet command.
        * You intended to execute a .NET program, but dotnet-C:\a\_work\1\s\build-tools\scripts\..\xaprepare\xaprepare\bin\Release\\xaprepare.dll does not exist.
        * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
    C:\a\_work\1\s\build-tools\scripts\PrepareWindows.targets(34,5): error MSB3073: The command "dotnet "C:\a\_work\1\s\build-tools\scripts\..\xaprepare\xaprepare\bin\Release\\xaprepare.dll" --no-emoji --run-mode=CI -v:d -a" exited with code 1. [C:\a\_work\1\s\Xamarin.Android.sln]

It looks like Directory.Build.props is not imported early enough (or at
all), and as a result we try to run an invalid path to xaprepare.dll.
Fix this by importing Directory.Build.props at the top of
PrepareWindows.targets.