### PR TITLE
[Xamarin.Android.Build.Tasks] fix r8 and aapt_rules.txt

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -152,7 +152,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_UpdateAndroidResgenAapt2">
   <PropertyGroup>
     <AndroidAapt2LinkExtraArgs Condition=" $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAapt2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAapt2LinkExtraArgs) </AndroidAapt2LinkExtraArgs>
-    <_Aapt2ProguardRules Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)aapt_rules.txt</_Aapt2ProguardRules>
   </PropertyGroup>
   <Aapt2Link
       Condition=" '$(_AndroidResourceDesignerFile)' != '' "
@@ -176,12 +175,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-      ProguardRuleOutput="$(_Aapt2ProguardRules)"
   />
-  <ItemGroup Condition=" '$(_Aapt2ProguardRules)' != '' And Exists('$(_Aapt2ProguardRules)') ">
-    <ProguardConfiguration Include="$(_Aapt2ProguardRules)" />
-    <FileWrites Include="$(_Aapt2ProguardRules)" />
-  </ItemGroup>
   <ItemGroup>
     <FileWrites Include="$(IntermediateOutputPath)R.txt" Condition=" Exists ('$(IntermediateOutputPath)R.txt') " />
   </ItemGroup>
@@ -213,6 +207,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <PropertyGroup>
     <_ProtobufFormat Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</_ProtobufFormat>
     <_ProtobufFormat Condition=" '$(_ProtobufFormat)' == '' ">False</_ProtobufFormat>
+    <_Aapt2ProguardRules Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)aapt_rules.txt</_Aapt2ProguardRules>
   </PropertyGroup>
   <Aapt2Link
       AndroidManifestFile="$(_AndroidManifestAbs)"
@@ -242,6 +237,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
+      ProguardRuleOutput="$(_Aapt2ProguardRules)"
   />
+  <ItemGroup Condition=" '$(_Aapt2ProguardRules)' != '' And Exists('$(_Aapt2ProguardRules)') ">
+    <ProguardConfiguration Include="$(_Aapt2ProguardRules)" />
+    <FileWrites Include="$(_Aapt2ProguardRules)" />
+  </ItemGroup>
 </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1152,7 +1152,10 @@ namespace UnamedProject
 
 					var aapt_rules = Path.Combine (intermediate, "aapt_rules.txt");
 					FileAssert.Exists (aapt_rules);
-					Assert.IsTrue (StringAssertEx.ContainsText (File.ReadAllLines (aapt_rules), $"-keep class {toolbar_class}"), $"`{toolbar_class}` should exist in `{aapt_rules}`!");
+					var lines = File.ReadAllLines (aapt_rules);
+					Assert.IsTrue (StringAssertEx.ContainsText (lines, $"-keep class {toolbar_class}"), $"`{toolbar_class}` should exist in `{aapt_rules}`!");
+					var activity_class = $"{proj.PackageName}.MainActivity";
+					Assert.IsTrue (StringAssertEx.ContainsText (lines, $"-keep class {activity_class}"), $"`{activity_class}` should exist in `{aapt_rules}`!");
 				}
 
 				var dexFile = Path.Combine (intermediate, "android", "bin", "classes.dex");


### PR DESCRIPTION
If you attempt to use r8 in a `dotnet new maui` project:

    > dotnet new maui
    > dotnet build -f net6.0-android -c Release -p:AndroidLinkTool=r8

Running the app crashes with:

    java.lang.ClassNotFoundException: Didn't find class "androidx.startup.InitializationProvider" on path: DexPathList...

This is listed in the `AndroidManifest.xml`:

    <provider android:name="androidx.startup.InitializationProvider" android:authorities="com.companyname.foo.androidx-startup" android:exported="false" tools:node="merge">
      <meta-data android:name="androidx.lifecycle.ProcessLifecycleInitializer" android:value="androidx.startup" />
      <meta-data android:name="androidx.emoji2.text.EmojiCompatInitializer" android:value="androidx.startup" />
    </provider>

So that brings up the questions:

1. How does this work in Android Studio projects?

2. Why doesn't this work in Xamarin.Android/.NET 6?

It appears that aapt2 is responsible for generating a proguard rules
for the contents of `AndroidManifest.xml`:

    > aapt2 link --help
    aapt2 link [options] -o arg --manifest arg files...
    ...
    --proguard arg                                    Output file for generated Proguard rules.

We were passing this switch during the `_UpdateAndroidResgenAapt2`
MSBuild target (for `Resource.designer.cs`) but *not* the
`_CreateBaseApkWithAapt2` MSBuild target (for the actual `.apk`).

Moving the logic for passing `ProguardRuleOutput` to the second target
results in a lot more rules!

    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:11
    -keep class androidx.core.app.CoreComponentFactory { <init>(); }
    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:20
    -keep class androidx.startup.InitializationProvider { <init>(); }
    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:18
    -keep class crc640a8d9a12ddbf2cf2.EnergySaverBroadcastReceiver { <init>(); }
    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:12
    -keep class crc64808a40cc7e533249.MainActivity { <init>(); }
    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:11
    -keep class crc64808a40cc7e533249.MainApplication { <init>(); }
    # Referenced at C:\src\foo\obj\Release\net6.0-android\android\manifest\AndroidManifest.xml:19
    -keep class mono.MonoRuntimeProvider { <init>(); }

This appears to solve the missing class in `dotnet new maui` projects.

I updated a test to verify that `aapt_rules.txt` includes the
`MainActivity`, which should be a resonable test going forward.