### PR TITLE
[xaprepare] Allow using git from $PATH

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -10,13 +10,7 @@ namespace Xamarin.Android.Prepare
 			new HomebrewProgram ("automake"),
 			new HomebrewProgram ("ccache"),
 			new HomebrewProgram ("cmake"),
-
-			new HomebrewProgram ("git") {
-				MinimumVersion = "2.20.0",
-			},
-
 			new HomebrewProgram ("make"),
-
 			new HomebrewProgram ("ninja"),
 			new HomebrewProgram ("p7zip", "7za"),
 
@@ -30,11 +24,26 @@ namespace Xamarin.Android.Prepare
 			MinimumVersion = "7.0.0_2",
 		};
 
+		static readonly HomebrewProgram git = new HomebrewProgram ("git") {
+			MinimumVersion = "2.20.0",
+		};
+
 		protected override void InitializeDependencies ()
 		{
 			Dependencies.AddRange (programs);
 			if (!Context.Instance.NoMingwW64)
 				Dependencies.Add (mingw);
+
+			// Allow using git from $PATH if it has the right version
+			(bool success, string bv) = Utilities.GetProgramVersion (git.Name);
+			if (success && Version.TryParse (bv, out Version gitVersion)
+				&& Version.TryParse (git.MinimumVersion, out Version gitMinVersion)) {
+				if (gitVersion < gitMinVersion)
+					Dependencies.Add (git);
+
+			} else {
+				Dependencies.Add (git);
+			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -36,8 +36,8 @@ namespace Xamarin.Android.Prepare
 
 			// Allow using git from $PATH if it has the right version
 			(bool success, string bv) = Utilities.GetProgramVersion (git.Name);
-			if (success && Version.TryParse (bv, out Version gitVersion)
-				&& Version.TryParse (git.MinimumVersion, out Version gitMinVersion)) {
+			if (success && Version.TryParse (bv, out Version gitVersion) &&
+					Version.TryParse (git.MinimumVersion, out Version gitMinVersion)) {
 				if (gitVersion < gitMinVersion)
 					Dependencies.Add (git);
 


### PR DESCRIPTION
Our macOS Azure Pipelines agents recently updated their brew install of
git causing version detection and installation to fail:

    Installing git
    | ==> Downloading https://ghcr.io/v2/homebrew/core/git/manifests/2.36.0
    | ==> Downloading https://ghcr.io/v2/homebrew/core/git/blobs/sha256:5739e703f9ad34dba01e343d76f363143f740bf6e05c945c8f19a073546c6ce5
    | ==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:5739e703f9ad34dba01e343d76f363143f740bf6e05c945c8f19a073546c6ce5?se=2022-04-22T07%3A30%3A00Z&sig=wRs9k0qfZuGMtVfu4PUL%2FB8VV1fR28Hka%2FyOGMP%2Bqg8%3D&sp=r&spr=https&sr=b&sv=2019-12-12
    | ==> Pouring git--2.36.0.big_sur.bottle.tar.gz
    | The formula built, but is not symlinked into /usr/local
    stderr | Error: The `brew link` step did not complete successfully
    | Could not symlink etc/bash_completion.d/git-completion.bash
    | Target /usr/local/etc/bash_completion.d/git-completion.bash
    | is a symlink belonging to git@2.35.1. You can unlink it:
    |   brew unlink git@2.35.1

A fallback has been added to allow detection and use of git in $PATH
if it has the right version.  This should be more flexible than having
to check for version 2.35.1 explicitly, or unlink and reinstall git.