### PR TITLE
[ci] Move TargetFramework vars to variables.yaml

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -77,10 +77,6 @@ variables:
     value: VSEng-Xamarin-RedmondMac-Android-Untrusted
   - name: MacBuildPoolImage
     value: ''
-  - name: DotNetTargetFramework
-    value: 'net6.0'
-  - name: DotNetStableTargetFramework
-    value: 'net6.0'
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -31,3 +31,7 @@ variables:
   value: VSEngSS-MicroBuild2022-1ES
 - name: TeamName
   value: XamarinAndroid
+- name: DotNetTargetFramework
+  value: net6.0
+- name: DotNetStableTargetFramework
+  value: net6.0


### PR DESCRIPTION
The $(DotNetStableTargetFramework) and $(DotNetTargetFramework) yaml
variables added in commit b5ce08d4 have been moved into to the variables
template.  This will allow all pipelines to access these variables.