### PR TITLE
[One .NET] proper default value for $(UseNativeHttpHandler)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -91,7 +91,8 @@
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
     <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <StartupHookSupport Condition="'$(StartupHookSupport)' == ''">false</StartupHookSupport>
-    <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler>
+    <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == '' and ('$(AndroidHttpClientHandlerType)' == '' or '$(AndroidHttpClientHandlerType)' == 'Xamarin.Android.Net.AndroidMessageHandler' or '$(AndroidHttpClientHandlerType)' == 'Xamarin.Android.Net.AndroidClientHandler')">true</UseNativeHttpHandler>
+    <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">false</UseNativeHttpHandler>
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -215,12 +215,23 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (envvars.ContainsKey (httpClientHandlerVarName), $"Environment should contain '{httpClientHandlerVarName}'.");
 				Assert.AreEqual (expectedDefaultValue, envvars[httpClientHandlerVarName]);
 
+				var runtime_config_json = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.runtimeconfig.json");
+				if (Builder.UseDotNet) {
+					FileAssert.Exists (runtime_config_json);
+					StringAssertEx.Contains ("\"System.Net.Http.UseNativeHttpHandler\": false", File.ReadAllLines (runtime_config_json), $"{runtime_config_json} should contain System.Net.Http.UseNativeHttpHandler=false");
+				}
+
 				proj.SetProperty ("AndroidHttpClientHandlerType", expectedUpdatedValue);
 				Assert.IsTrue (b.Build (proj), "Second build should have succeeded.");
 				envFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediateOutputDir, supportedAbis, true);
 				envvars = EnvironmentHelper.ReadEnvironmentVariables (envFiles);
 				Assert.IsTrue (envvars.ContainsKey (httpClientHandlerVarName), $"Environment should contain '{httpClientHandlerVarName}'.");
 				Assert.AreEqual (expectedUpdatedValue, envvars[httpClientHandlerVarName]);
+
+				if (Builder.UseDotNet) {
+					FileAssert.Exists (runtime_config_json);
+					StringAssertEx.Contains ("\"System.Net.Http.UseNativeHttpHandler\": true", File.ReadAllLines (runtime_config_json), $"{runtime_config_json} should contain System.Net.Http.UseNativeHttpHandler=true");
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/6949
Fixes: https://github.com/dotnet/maui/issues/6174

The linker feature switch `$(UseNativeHttpHandler)` defaults to:

    <UseNativeHttpHandler Condition="'$(UseNativeHttpHandler)' == ''">true</UseNativeHttpHandler

If you set `$(AndroidHttpClientHandlerType)` to something else other
than the default, like `System.Net.Http.HttpClientHandler`, you would
actually need to toggle this switch yourself for things to work
properly.

We should only default `$(UseNativeHttpHandler)` to `true` if:

* `$(AndroidHttpClientHandlerType)` is blank
* `$(AndroidHttpClientHandlerType)` is `Xamarin.Android.Net.AndroidMessageHandler`
* `$(AndroidHttpClientHandlerType)` is `Xamarin.Android.Net.AndroidClientHandler`

Otherwise, `$(UseNativeHttpHandler)` defaults to `false`.

I updated a test around this scenario, to verify the feature flag is
set in `runtimeconfig.json`.