### PR TITLE
Improve error message when no assemblies are found

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -917,9 +917,16 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 #endif // def NET6
 
 	if (!have_mono_mkbundle_init && user_assemblies_count == 0 && androidSystem.count_override_assemblies () == 0 && !is_running_on_desktop) {
+#if defined (DEBUG)
 		log_fatal (LOG_DEFAULT, "No assemblies found in '%s' or '%s'. Assuming this is part of Fast Deployment. Exiting...",
 		           androidSystem.get_override_dir (0),
 		           (AndroidSystem::MAX_OVERRIDES > 1 && androidSystem.get_override_dir (1) != nullptr) ? androidSystem.get_override_dir (1) : "<unavailable>");
+#else
+		log_fatal (LOG_DEFAULT, "No assemblies (or assembly blobs) were found in the application APK file(s)");
+#endif
+		log_fatal (LOG_DEFAULT, "Make sure that all entries in the APK directory named `assemblies/` are STORED (not compressed)");
+		log_fatal (LOG_DEFAULT, "If Android Gradle Plugin's minification feature is enabled, it is likely all the entries in `assemblies/` are compressed");
+
 		abort ();
 	}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6838
Context: https://github.com/xamarin/xamarin-android/issues/6838#issuecomment-1110816027
Context: https://github.com/xamarin/xamarin-android/issues/6838#issuecomment-1110880771

Android Gradle Plugin 4.1.0 introduced ZIP file minification, using a
utility named [`zipflinger`][0] which recompresses the APK/AAB archive
including contents of the `assemblies/` directory (which contains
managed assemblies, assembly blobs, runtime config blob etc).

This has the unfortunate effect that no assemblies are found, because of
[this check][1] in our code.  The check silently ignores all entries
which are compressed (that is, they don't use the `STORE` ZIP
compression mode) and, in effect, no assemblies are mapped/loaded,
leading to this confusing error message:

    A/monodroid: No assemblies found in '(null)' or '<unavailable>'. Assuming this is part of Fast Deployment. Exiting...

The [check][1] is designed to optimize the loading process, because it
allows us to skip comparing names of an unknown number of **compressed**
entries in the APK, so modifying it to do that regardless of compression
mode would result in performance degradation during startup for all
applications, not just those which enable AGP minification feature.

Instead, improve the error message suggesting where the problem might
be.

[0]: https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-master-dev/zipflinger/
[1]: https://github.com/xamarin/xamarin-android/blob/e50b457fa236e6fc127eadc0cfa527934a03e7de/src/monodroid/jni/embedded-assemblies-zip.cc#L60-L62