### PR TITLE
[Microsoft.Android.Templates] Remove preview language

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/template.json
@@ -3,8 +3,8 @@
   "author": "Microsoft",
   "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidBinding",
-  "name": "Android Java Library Binding (Preview)",
-  "description": "A project for creating a .NET 6 Android class library that binds to a native Java library",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
   "shortName": "android-bindinglib",
   "tags": {
     "language": "C#",

--- a/src/Microsoft.Android.Templates/android/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/template.json
@@ -3,8 +3,8 @@
   "author": "Microsoft",
   "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidApp",
-  "name": "Android Application (Preview)",
-  "description": "A project for creating a .NET 6 Android application",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
   "shortName": "android",
   "tags": {
     "language": "C#",

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/template.json
@@ -3,8 +3,8 @@
   "author": "Microsoft",
   "classifications": [ "Android", "Mobile" ],
   "identity": "Microsoft.Android.AndroidLib",
-  "name": "Android Class Library (Preview)",
-  "description": "A project for creating a .NET 6 Android class library",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
   "shortName": "androidlib",
   "tags": {
     "language": "C#",


### PR DESCRIPTION
Removes the "(Preview)" string from the title of our .NET templates.