### PR TITLE
Better timing infrastructure

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -305,6 +305,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\K4os.Compression.LZ4.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\K4os.Hash.xxHash.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\ELFSharp.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\ManifestOverlays\Timing.xml" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.AvailableItems.targets" />

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -148,13 +148,8 @@ namespace Android.Runtime {
 #endif
 		internal static unsafe void Initialize (JnienvInitializeArgs* args)
 		{
-			bool logTiming = (args->logCategories & (uint)LogCategories.Timing) != 0;
 			IntPtr total_timing_sequence = IntPtr.Zero;
 			IntPtr partial_timing_sequence = IntPtr.Zero;
-			if (logTiming) {
-				total_timing_sequence = monodroid_timing_start ("JNIEnv.Initialize start");
-				partial_timing_sequence = monodroid_timing_start (null);
-			}
 
 			LogAssemblyCategory = (args->logCategories & (uint)LogCategories.Assembly) != 0;
 
@@ -202,10 +197,6 @@ namespace Android.Runtime {
 #if !MONOANDROID1_0
 			SynchronizationContext.SetSynchronizationContext (Android.App.Application.SynchronizationContext);
 #endif
-
-			if (logTiming) {
-				monodroid_timing_stop (total_timing_sequence, "JNIEnv.Initialize end");
-			}
 		}
 
 		internal static void Exit ()

--- a/src/Xamarin.Android.Build.Tasks/ManifestOverlays/Timing.xml
+++ b/src/Xamarin.Android.Build.Tasks/ManifestOverlays/Timing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <application>
+    <receiver android:name="mono.android.app.DumpTimingData" tools:node="replace">
+        <intent-filter>
+          <action android:name="mono.android.app.DUMP_TIMING_DATA"/>
+        </intent-filter>
+      </receiver>
+  </application>
+</manifest>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -8,7 +8,7 @@
       "Size": 54979
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88930
+      "Size": 88763
     },
     "assemblies/rc.bin": {
       "Size": 1083
@@ -23,13 +23,13 @@
       "Size": 2415
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3553
+      "Size": 3550
     },
     "classes.dex": {
-      "Size": 347336
+      "Size": 347628
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382272
+      "Size": 483840
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4693664
@@ -44,7 +44,7 @@
       "Size": 146816
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 9272
+      "Size": 9232
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
@@ -80,5 +80,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2987924
+  "PackageSize": 3020692
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -5,34 +5,34 @@
       "Size": 2604
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 67947
+      "Size": 67948
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 257171
+      "Size": 257194
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769010
+      "Size": 769016
     },
     "assemblies/System.Core.dll": {
-      "Size": 28190
+      "Size": 28198
     },
     "assemblies/System.dll": {
-      "Size": 9178
+      "Size": 9180
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2871
+      "Size": 2879
     },
     "classes.dex": {
-      "Size": 349528
+      "Size": 349820
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
     },
-    "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 296448
-    },
     "lib/arm64-v8a/libmono-native.so": {
       "Size": 750976
+    },
+    "lib/arm64-v8a/libmonodroid.so": {
+      "Size": 392576
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4030448
@@ -41,7 +41,7 @@
       "Size": 65512
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 19864
+      "Size": 19872
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
@@ -74,5 +74,5 @@
       "Size": 1724
     }
   },
-  "PackageSize": 4015828
+  "PackageSize": 4044500
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -11,7 +11,7 @@
       "Size": 61933
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 445196
+      "Size": 445015
     },
     "assemblies/mscorlib.dll": {
       "Size": 3892
@@ -119,7 +119,7 @@
       "Size": 1914
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117242
+      "Size": 117240
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 5942
@@ -188,10 +188,10 @@
       "Size": 40005
     },
     "classes.dex": {
-      "Size": 3460008
+      "Size": 3460300
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 382272
+      "Size": 483840
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4693664
@@ -206,7 +206,7 @@
       "Size": 146816
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 98480
+      "Size": 98440
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1961,5 +1961,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8360269
+  "PackageSize": 8393037
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -5,124 +5,124 @@
       "Size": 3140
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7207
+      "Size": 7215
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68912
+      "Size": 68913
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 568333
+      "Size": 567718
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68430
+      "Size": 68432
     },
     "assemblies/mscorlib.dll": {
-      "Size": 915391
+      "Size": 915405
     },
     "assemblies/System.Core.dll": {
-      "Size": 164044
+      "Size": 164046
     },
     "assemblies/System.dll": {
-      "Size": 388860
+      "Size": 388864
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 12356
+      "Size": 12365
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 110637
+      "Size": 110642
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 15681
+      "Size": 15683
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 186653
+      "Size": 186660
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26585
+      "Size": 26593
     },
     "assemblies/System.Xml.dll": {
-      "Size": 395652
+      "Size": 395657
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 116887
+      "Size": 116898
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7689
+      "Size": 7697
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6640
+      "Size": 6648
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 125325
+      "Size": 125328
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7357
+      "Size": 7367
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18264
+      "Size": 18272
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131924
+      "Size": 131930
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15422
+      "Size": 15426
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43130
+      "Size": 43135
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6708
+      "Size": 6715
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7055
+      "Size": 7062
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7186
+      "Size": 7193
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4862
+      "Size": 4872
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13578
+      "Size": 13585
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102322
+      "Size": 102327
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6265
+      "Size": 6268
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11261
+      "Size": 11272
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19415
+      "Size": 19424
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524728
+      "Size": 524736
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384861
+      "Size": 384872
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56878
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55795
+      "Size": 55801
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43489
+      "Size": 43497
     },
     "classes.dex": {
-      "Size": 3461960
+      "Size": 3462252
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
     },
-    "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 296448
-    },
     "lib/arm64-v8a/libmono-native.so": {
       "Size": 750976
+    },
+    "lib/arm64-v8a/libmonodroid.so": {
+      "Size": 392576
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 4030448
@@ -131,7 +131,7 @@
       "Size": 65512
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 104920
+      "Size": 104928
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -145,10 +145,10 @@
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
     },
-    "META-INF/androidx.appcompat_appcompat.version": {
+    "META-INF/androidx.appcompat_appcompat-resources.version": {
       "Size": 6
     },
-    "META-INF/androidx.appcompat_appcompat-resources.version": {
+    "META-INF/androidx.appcompat_appcompat.version": {
       "Size": 6
     },
     "META-INF/androidx.arch.core_core-runtime.version": {
@@ -196,10 +196,10 @@
     "META-INF/androidx.legacy_legacy-support-v4.version": {
       "Size": 6
     },
-    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
+    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
       "Size": 6
     },
-    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
+    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
       "Size": 6
     },
     "META-INF/androidx.lifecycle_lifecycle-runtime.version": {
@@ -235,10 +235,10 @@
     "META-INF/androidx.transition_transition.version": {
       "Size": 6
     },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
       "Size": 6
     },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
       "Size": 6
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
@@ -255,6 +255,12 @@
     },
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
+    },
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
     },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
@@ -352,6 +358,9 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
+    "res/animator-v21/design_appbar_state_list_animator.xml": {
+      "Size": 1216
+    },
     "res/animator/design_fab_hide_motion_spec.xml": {
       "Size": 796
     },
@@ -379,14 +388,38 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
-    "res/animator-v21/design_appbar_state_list_animator.xml": {
-      "Size": 1216
+    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 464
     },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
+    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 500
     },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
+    "res/color-v23/abc_btn_colored_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_color_highlight_material.xml": {
+      "Size": 544
+    },
+    "res/color-v23/abc_tint_btn_checkable.xml": {
+      "Size": 624
+    },
+    "res/color-v23/abc_tint_default.xml": {
+      "Size": 1120
+    },
+    "res/color-v23/abc_tint_edittext.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_seek_thumb.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_tint_spinner.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_switch_track.xml": {
+      "Size": 664
+    },
+    "res/color-v23/design_tint_password_toggle.xml": {
+      "Size": 376
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -490,10 +523,10 @@
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
-    "res/color/mtrl_tabs_icon_color_selector.xml": {
+    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
       "Size": 464
     },
-    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
+    "res/color/mtrl_tabs_icon_color_selector.xml": {
       "Size": 464
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
@@ -511,227 +544,11 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 464
-    },
-    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_btn_colored_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_color_highlight_material.xml": {
-      "Size": 544
-    },
-    "res/color-v23/abc_tint_btn_checkable.xml": {
-      "Size": 624
-    },
-    "res/color-v23/abc_tint_default.xml": {
-      "Size": 1120
-    },
-    "res/color-v23/abc_tint_edittext.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_seek_thumb.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_tint_spinner.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_switch_track.xml": {
-      "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
-    },
-    "res/drawable/abc_btn_borderless_material.xml": {
-      "Size": 588
-    },
-    "res/drawable/abc_btn_check_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_check_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_btn_colored_material.xml": {
-      "Size": 344
-    },
-    "res/drawable/abc_btn_default_mtrl_shape.xml": {
-      "Size": 932
-    },
-    "res/drawable/abc_btn_radio_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_radio_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_cab_background_internal_bg.xml": {
-      "Size": 372
-    },
-    "res/drawable/abc_cab_background_top_material.xml": {
-      "Size": 336
-    },
-    "res/drawable/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable/abc_edit_text_material.xml": {
-      "Size": 868
-    },
-    "res/drawable/abc_ic_ab_back_material.xml": {
-      "Size": 692
-    },
-    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
-      "Size": 1000
-    },
-    "res/drawable/abc_ic_clear_material.xml": {
-      "Size": 684
-    },
-    "res/drawable/abc_ic_go_search_api_material.xml": {
-      "Size": 640
-    },
-    "res/drawable/abc_ic_menu_overflow_material.xml": {
-      "Size": 792
-    },
-    "res/drawable/abc_ic_search_api_material.xml": {
-      "Size": 812
-    },
-    "res/drawable/abc_ic_voice_search_api_material.xml": {
-      "Size": 828
-    },
-    "res/drawable/abc_item_background_holo_dark.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_item_background_holo_light.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_list_divider_material.xml": {
-      "Size": 480
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_holo_dark.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_list_selector_holo_light.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_seekbar_thumb_material.xml": {
-      "Size": 1100
-    },
-    "res/drawable/abc_seekbar_tick_mark_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_seekbar_track_material.xml": {
-      "Size": 1408
-    },
-    "res/drawable/abc_spinner_textfield_background_material.xml": {
-      "Size": 1160
-    },
-    "res/drawable/abc_switch_thumb_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_tab_indicator_material.xml": {
-      "Size": 468
-    },
-    "res/drawable/abc_text_cursor_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_textfield_search_material.xml": {
-      "Size": 756
-    },
-    "res/drawable/abc_vector_test.xml": {
-      "Size": 612
-    },
-    "res/drawable/btn_checkbox_checked_mtrl.xml": {
-      "Size": 2688
-    },
-    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
-      "Size": 2660
-    },
-    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_radio_off_mtrl.xml": {
-      "Size": 1728
-    },
-    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/btn_radio_on_mtrl.xml": {
-      "Size": 1656
-    },
-    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/design_bottom_navigation_item_background.xml": {
-      "Size": 784
-    },
-    "res/drawable/design_fab_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/design_password_eye.xml": {
-      "Size": 464
-    },
-    "res/drawable/design_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/ic_mtrl_chip_checked_black.xml": {
-      "Size": 600
-    },
-    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
-      "Size": 940
-    },
-    "res/drawable/ic_mtrl_chip_close_circle.xml": {
-      "Size": 808
-    },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/mtrl_tabs_default_indicator.xml": {
-      "Size": 628
-    },
-    "res/drawable/navigation_empty_icon.xml": {
-      "Size": 516
-    },
-    "res/drawable/notification_bg.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_bg_low.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_icon_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/notification_tile_bg.xml": {
-      "Size": 304
-    },
-    "res/drawable/tooltip_frame_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/tooltip_frame_light.xml": {
-      "Size": 484
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
     },
     "res/drawable-anydpi-v21/design_ic_visibility.xml": {
       "Size": 540
-    },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -874,11 +691,11 @@
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-hdpi-v4/design_ic_visibility.png": {
-      "Size": 470
-    },
     "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
       "Size": 507
+    },
+    "res/drawable-hdpi-v4/design_ic_visibility.png": {
+      "Size": 470
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 4762
@@ -889,11 +706,11 @@
     "res/drawable-hdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 225
     },
-    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
-      "Size": 212
-    },
     "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 225
+    },
+    "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
+      "Size": 212
     },
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
@@ -1084,11 +901,11 @@
     "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
-    },
     "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
       "Size": 351
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility.png": {
+      "Size": 309
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200
@@ -1099,11 +916,11 @@
     "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 223
     },
-    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
-      "Size": 215
-    },
     "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 223
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
+      "Size": 215
     },
     "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 98
@@ -1312,11 +1129,11 @@
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
     },
-    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
-      "Size": 593
-    },
     "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
       "Size": 629
+    },
+    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
+      "Size": 593
     },
     "res/drawable-xhdpi-v4/icon.png": {
       "Size": 7462
@@ -1327,11 +1144,11 @@
     "res/drawable-xhdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 252
     },
-    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
-      "Size": 221
-    },
     "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
       "Size": 247
+    },
+    "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
+      "Size": 221
     },
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
@@ -1477,11 +1294,11 @@
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
-      "Size": 868
-    },
     "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 884
+    },
+    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
+      "Size": 868
     },
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 13092
@@ -1564,14 +1381,206 @@
     "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
-      "Size": 1155
-    },
     "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
       "Size": 1201
     },
+    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
+      "Size": 1155
+    },
     "res/drawable-xxxhdpi-v4/icon.png": {
       "Size": 20118
+    },
+    "res/drawable/abc_btn_borderless_material.xml": {
+      "Size": 588
+    },
+    "res/drawable/abc_btn_check_material_anim.xml": {
+      "Size": 816
+    },
+    "res/drawable/abc_btn_check_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_btn_colored_material.xml": {
+      "Size": 344
+    },
+    "res/drawable/abc_btn_default_mtrl_shape.xml": {
+      "Size": 932
+    },
+    "res/drawable/abc_btn_radio_material_anim.xml": {
+      "Size": 816
+    },
+    "res/drawable/abc_btn_radio_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_cab_background_internal_bg.xml": {
+      "Size": 372
+    },
+    "res/drawable/abc_cab_background_top_material.xml": {
+      "Size": 336
+    },
+    "res/drawable/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable/abc_edit_text_material.xml": {
+      "Size": 868
+    },
+    "res/drawable/abc_ic_ab_back_material.xml": {
+      "Size": 692
+    },
+    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
+      "Size": 1000
+    },
+    "res/drawable/abc_ic_clear_material.xml": {
+      "Size": 684
+    },
+    "res/drawable/abc_ic_go_search_api_material.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_ic_menu_overflow_material.xml": {
+      "Size": 792
+    },
+    "res/drawable/abc_ic_search_api_material.xml": {
+      "Size": 812
+    },
+    "res/drawable/abc_ic_voice_search_api_material.xml": {
+      "Size": 828
+    },
+    "res/drawable/abc_item_background_holo_dark.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_item_background_holo_light.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_list_divider_material.xml": {
+      "Size": 480
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_holo_dark.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_list_selector_holo_light.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_ratingbar_indicator_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_small_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_seekbar_thumb_material.xml": {
+      "Size": 1100
+    },
+    "res/drawable/abc_seekbar_tick_mark_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_seekbar_track_material.xml": {
+      "Size": 1408
+    },
+    "res/drawable/abc_spinner_textfield_background_material.xml": {
+      "Size": 1160
+    },
+    "res/drawable/abc_switch_thumb_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_tab_indicator_material.xml": {
+      "Size": 468
+    },
+    "res/drawable/abc_text_cursor_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_textfield_search_material.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_vector_test.xml": {
+      "Size": 612
+    },
+    "res/drawable/btn_checkbox_checked_mtrl.xml": {
+      "Size": 2688
+    },
+    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
+      "Size": 2660
+    },
+    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_radio_off_mtrl.xml": {
+      "Size": 1728
+    },
+    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/btn_radio_on_mtrl.xml": {
+      "Size": 1656
+    },
+    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/design_bottom_navigation_item_background.xml": {
+      "Size": 784
+    },
+    "res/drawable/design_fab_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/design_password_eye.xml": {
+      "Size": 464
+    },
+    "res/drawable/design_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/ic_mtrl_chip_checked_black.xml": {
+      "Size": 600
+    },
+    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
+      "Size": 940
+    },
+    "res/drawable/ic_mtrl_chip_close_circle.xml": {
+      "Size": 808
+    },
+    "res/drawable/mtrl_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/mtrl_tabs_default_indicator.xml": {
+      "Size": 628
+    },
+    "res/drawable/navigation_empty_icon.xml": {
+      "Size": 516
+    },
+    "res/drawable/notification_bg_low.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_bg.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_icon_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/notification_tile_bg.xml": {
+      "Size": 304
+    },
+    "res/drawable/tooltip_frame_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/tooltip_frame_light.xml": {
+      "Size": 484
+    },
+    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
+      "Size": 400
+    },
+    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
+      "Size": 400
     },
     "res/interpolator/btn_checkbox_checked_mtrl_animation_interpolator_0.xml": {
       "Size": 316
@@ -1600,20 +1609,53 @@
     "res/interpolator/mtrl_fast_out_slow_in.xml": {
       "Size": 144
     },
-    "res/interpolator/mtrl_linear.xml": {
-      "Size": 132
-    },
     "res/interpolator/mtrl_linear_out_slow_in.xml": {
       "Size": 136
     },
-    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
-      "Size": 400
+    "res/interpolator/mtrl_linear.xml": {
+      "Size": 132
     },
-    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
+      "Size": 528
     },
-    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
-      "Size": 400
+    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
+      "Size": 528
+    },
+    "res/layout-v16/notification_template_custom_big.xml": {
+      "Size": 3208
+    },
+    "res/layout-v21/abc_screen_toolbar.xml": {
+      "Size": 1504
+    },
+    "res/layout-v21/fallbacktoolbardonotuse.xml": {
+      "Size": 496
+    },
+    "res/layout-v21/notification_action_tombstone.xml": {
+      "Size": 1228
+    },
+    "res/layout-v21/notification_action.xml": {
+      "Size": 1052
+    },
+    "res/layout-v21/notification_template_custom_big.xml": {
+      "Size": 2456
+    },
+    "res/layout-v21/notification_template_icon_group.xml": {
+      "Size": 988
+    },
+    "res/layout-v21/toolbar.xml": {
+      "Size": 496
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
+    "res/layout-v26/abc_screen_toolbar.xml": {
+      "Size": 1560
+    },
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
+    },
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
     },
     "res/layout/abc_action_bar_title_item.xml": {
       "Size": 872
@@ -1633,11 +1675,11 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 840
     },
-    "res/layout/abc_activity_chooser_view.xml": {
-      "Size": 1684
-    },
     "res/layout/abc_activity_chooser_view_list_item.xml": {
       "Size": 1304
+    },
+    "res/layout/abc_activity_chooser_view.xml": {
+      "Size": 1684
     },
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1536
@@ -1678,11 +1720,11 @@
     "res/layout/abc_screen_content_include.xml": {
       "Size": 548
     },
-    "res/layout/abc_screen_simple.xml": {
-      "Size": 832
-    },
     "res/layout/abc_screen_simple_overlay_action_mode.xml": {
       "Size": 792
+    },
+    "res/layout/abc_screen_simple.xml": {
+      "Size": 832
     },
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1452
@@ -1717,11 +1759,11 @@
     "res/layout/design_bottom_sheet_dialog.xml": {
       "Size": 1184
     },
-    "res/layout/design_layout_snackbar.xml": {
-      "Size": 528
-    },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1444
+    },
+    "res/layout/design_layout_snackbar.xml": {
+      "Size": 528
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -1732,9 +1774,6 @@
     "res/layout/design_menu_item_action_area.xml": {
       "Size": 320
     },
-    "res/layout/design_navigation_item.xml": {
-      "Size": 536
-    },
     "res/layout/design_navigation_item_header.xml": {
       "Size": 440
     },
@@ -1744,11 +1783,14 @@
     "res/layout/design_navigation_item_subheader.xml": {
       "Size": 564
     },
-    "res/layout/design_navigation_menu.xml": {
-      "Size": 528
+    "res/layout/design_navigation_item.xml": {
+      "Size": 536
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
+    },
+    "res/layout/design_navigation_menu.xml": {
+      "Size": 528
     },
     "res/layout/design_text_input_password_icon.xml": {
       "Size": 564
@@ -1765,17 +1807,17 @@
     "res/layout/main.xml": {
       "Size": 544
     },
-    "res/layout/mtrl_layout_snackbar.xml": {
-      "Size": 528
-    },
     "res/layout/mtrl_layout_snackbar_include.xml": {
       "Size": 1404
     },
-    "res/layout/notification_action.xml": {
-      "Size": 1156
+    "res/layout/mtrl_layout_snackbar.xml": {
+      "Size": 528
     },
     "res/layout/notification_action_tombstone.xml": {
       "Size": 1332
+    },
+    "res/layout/notification_action.xml": {
+      "Size": 1156
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -1783,17 +1825,17 @@
     "res/layout/notification_media_cancel_action.xml": {
       "Size": 744
     },
-    "res/layout/notification_template_big_media.xml": {
-      "Size": 1696
-    },
     "res/layout/notification_template_big_media_custom.xml": {
       "Size": 3044
+    },
+    "res/layout/notification_template_big_media_narrow_custom.xml": {
+      "Size": 3216
     },
     "res/layout/notification_template_big_media_narrow.xml": {
       "Size": 1824
     },
-    "res/layout/notification_template_big_media_narrow_custom.xml": {
-      "Size": 3216
+    "res/layout/notification_template_big_media.xml": {
+      "Size": 1696
     },
     "res/layout/notification_template_icon_group.xml": {
       "Size": 392
@@ -1801,11 +1843,11 @@
     "res/layout/notification_template_lines_media.xml": {
       "Size": 2872
     },
-    "res/layout/notification_template_media.xml": {
-      "Size": 1292
-    },
     "res/layout/notification_template_media_custom.xml": {
       "Size": 2756
+    },
+    "res/layout/notification_template_media.xml": {
+      "Size": 1292
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -1837,51 +1879,9 @@
     "res/layout/toolbar.xml": {
       "Size": 452
     },
-    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
-      "Size": 528
-    },
-    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 528
-    },
-    "res/layout-v16/notification_template_custom_big.xml": {
-      "Size": 3208
-    },
-    "res/layout-v21/abc_screen_toolbar.xml": {
-      "Size": 1504
-    },
-    "res/layout-v21/fallbacktoolbardonotuse.xml": {
-      "Size": 496
-    },
-    "res/layout-v21/notification_action.xml": {
-      "Size": 1052
-    },
-    "res/layout-v21/notification_action_tombstone.xml": {
-      "Size": 1228
-    },
-    "res/layout-v21/notification_template_custom_big.xml": {
-      "Size": 2456
-    },
-    "res/layout-v21/notification_template_icon_group.xml": {
-      "Size": 988
-    },
-    "res/layout-v21/toolbar.xml": {
-      "Size": 496
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
-    },
-    "res/layout-v26/abc_screen_toolbar.xml": {
-      "Size": 1560
-    },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
-    },
     "resources.arsc": {
       "Size": 341040
     }
   },
-  "PackageSize": 9533598
+  "PackageSize": 9562270
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -182,6 +182,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <None Include="ManifestOverlays\Timing.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <_SharedRuntimeAssemblies Include="@(MonoProfileAssembly->'$(_SharedRuntimeBuildPath)v1.0\%(Identity)')" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\Mono.Data.Sqlite.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\Mono.Posix.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1488,6 +1488,12 @@ because xbuild doesn't support framework reference assemblies.
     Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
     Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml"
   >
+  <ItemGroup>
+    <AndroidManifestOverlay
+        Include="$(MSBuildThisFileDirectory)\ManifestOverlays\Timing.xml"
+        Condition=" '$(_AndroidFastTiming)' == 'True' "
+    />
+  </ItemGroup>
   <ManifestMerger
       ToolPath="$(JavaToolPath)"
       JavaOptions="$(JavaOptions)"

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -35,6 +35,11 @@ public class MonoPackageManager {
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
 
+				android.content.IntentFilter dumpTimingDataFilter = new android.content.IntentFilter (
+						"mono.android.app.DUMP_TIMING_DATA"
+				);
+				context.registerReceiver (new mono.android.app.DumpTimingData (), dumpTimingDataFilter);
+
 				Locale locale       = Locale.getDefault ();
 				String language     = locale.getLanguage () + "-" + locale.getCountry ();
 				String filesDir     = context.getFilesDir ().getAbsolutePath ();

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -35,11 +35,6 @@ public class MonoPackageManager {
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
 
-				android.content.IntentFilter dumpTimingDataFilter = new android.content.IntentFilter (
-						"mono.android.app.DUMP_TIMING_DATA"
-				);
-				context.registerReceiver (new mono.android.app.DumpTimingData (), dumpTimingDataFilter);
-
 				Locale locale       = Locale.getDefault ();
 				String language     = locale.getLanguage () + "-" + locale.getCountry ();
 				String filesDir     = context.getFilesDir ().getAbsolutePath ();

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -23,6 +23,7 @@ public class Runtime {
 	public static native void switchToContext (int contextID);
 	public static native void destroyContexts (int[] contextIDs);
 	public static native void propagateUncaughtException (Thread javaThread, Throwable javaException);
+	public static native void dumpTimingData ();
 }
 
 final class XamarinUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {

--- a/src/java-runtime/java/mono/android/app/DumpTimingData.java
+++ b/src/java-runtime/java/mono/android/app/DumpTimingData.java
@@ -1,0 +1,8 @@
+package mono.android.app;
+
+public class DumpTimingData extends android.content.BroadcastReceiver {
+	@Override
+	public void onReceive (android.content.Context context, android.content.Intent intent) {
+		mono.android.Runtime.dumpTimingData ();
+	}
+}

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -480,6 +480,7 @@ set(XAMARIN_MONODROID_SOURCES
   ${SOURCES_DIR}/osbridge.cc
   ${SOURCES_DIR}/shared-constants.cc
   ${SOURCES_DIR}/timezones.cc
+  ${SOURCES_DIR}/timing-internal.cc
   ${SOURCES_DIR}/util.cc
   ${JAVA_INTEROP_SRC_PATH}/java-interop.cc
   ${JAVA_INTEROP_SRC_PATH}/java-interop-mono.cc

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -43,11 +43,13 @@
 #include "util.hh"
 #include "globals.hh"
 #include "cpp-util.hh"
+#include "timing-internal.hh"
 
 #include "java-interop-dlfcn.h"
 
 using namespace microsoft::java_interop;
 using namespace xamarin::android;
+using namespace xamarin::android::internal;
 
 //
 // The communication between xs and the app works as follows:
@@ -236,9 +238,10 @@ Debug::start_connection (char *options)
 void
 Debug::start_debugging_and_profiling ()
 {
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		total_time.mark_start ();
+	size_t total_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		total_time_index = internal_timing->start_event (TimingEventKind::DebugStart);
+	}
 
 	char *connect_args = nullptr;
 	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args) > 0) {
@@ -257,9 +260,8 @@ Debug::start_debugging_and_profiling ()
 	}
 	delete[] connect_args;
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
-		Timing::info (total_time, "Debug::start_debugging_and_profiling: end");
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index);
 	}
 }
 

--- a/src/monodroid/jni/logger.hh
+++ b/src/monodroid/jni/logger.hh
@@ -24,6 +24,7 @@ void init_reference_logging (const char *override_dir);
 typedef enum _LogTimingCategories {
 	LOG_TIMING_DEFAULT = 0,
 	LOG_TIMING_BARE = 1 << 0,
+	LOG_TIMING_FAST_BARE = 1 << 1,
 } LogTimingCategories;
 
 extern unsigned int log_timing_categories;
@@ -45,4 +46,8 @@ enum class LogLevel : unsigned int
 	Fatal   = 0x07,
 	Silent  = 0x08
 };
+
+// A slightly faster alternative to other log functions as it doesn't parse the message
+// for format placeholders nor it uses variable arguments
+void log_write (LogCategories category, LogLevel level, const char *message) noexcept;
 #endif

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -39,6 +39,14 @@ JNIEXPORT void JNICALL Java_mono_android_Runtime_register
 JNIEXPORT void JNICALL Java_mono_android_Runtime_notifyTimeZoneChanged
   (JNIEnv *, jclass);
 
+/*
+ * Class:     mono_android_Runtime
+ * Method:    dumpTimingData
+ * Signature: ()V
+*/
+JNIEXPORT void JNICALL Java_mono_android_Runtime_dumpTimingData
+  (JNIEnv *, jclass);
+
 #if !defined (ANDROID)
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1939,7 +1939,7 @@ MonodroidRuntime::load_assemblies (load_assemblies_context_type ctx, bool preloa
 		internal_timing->end_event (total_time_index, true /* uses-more_info */);
 
 		static_local_string<SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10> more_info;
-		more_info.append (static_cast<size_t>(i + 1));
+		more_info.append (static_cast<uint64_t>(i + 1));
 		internal_timing->add_more_info (total_time_index, more_info);
 	}
 }

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -89,6 +89,7 @@
 #include "build-info.hh"
 #include "monovm-properties.hh"
 #include "startup-aware-lock.hh"
+#include "timing-internal.hh"
 
 #ifndef WINDOWS
 #include "xamarin_getifaddrs.h"
@@ -797,7 +798,7 @@ MonodroidRuntime::mono_runtime_init ([[maybe_unused]] dynamic_local_string<PROPE
 	// TESTING UBSAN: integer overflow
 	//log_warn (LOG_DEFAULT, "Let us have an overflow: %d", INT_MAX + 1);
 
-	bool log_methods = utils.should_log (LOG_TIMING) && !(log_timing_categories & LOG_TIMING_BARE);
+	bool log_methods = FastTiming::enabled () && !FastTiming::is_bare_mode ();
 	if (XA_UNLIKELY (log_methods)) {
 		std::unique_ptr<char> jit_log_path {utils.path_combine (androidSystem.get_override_dir (0), "methods.txt")};
 		jit_log = utils.monodroid_fopen (jit_log_path.get (), "a");
@@ -901,9 +902,10 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 	gather_bundled_assemblies (runtimeApks, &user_assemblies_count, have_split_apks);
 
 #if defined (NET6)
-	timing_period blob_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		blob_time.mark_start ();
+	size_t blob_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		blob_time_index = internal_timing->start_event (TimingEventKind::RuntimeConfigBlob);
+	}
 
 	if (embeddedAssemblies.have_runtime_config_blob ()) {
 		runtime_config_args.kind = 1;
@@ -911,9 +913,8 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 		monovm_runtimeconfig_initialize (&runtime_config_args, cleanup_runtime_config, nullptr);
 	}
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		blob_time.mark_end ();
-		Timing::info (blob_time, "Register runtimeconfig binary blob");
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (blob_time_index);
 	}
 #endif // def NET6
 
@@ -942,7 +943,7 @@ MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks
 
 		constexpr char DOMAIN_NAME[] = "MonoAndroidDomain";
 		constexpr size_t DOMAIN_NAME_LENGTH = sizeof(DOMAIN_NAME) - 1;
-		constexpr size_t DOMAIN_NAME_TOTAL_SIZE = DOMAIN_NAME_LENGTH + MAX_INTEGER_DIGIT_COUNT_BASE10;
+		constexpr size_t DOMAIN_NAME_TOTAL_SIZE = DOMAIN_NAME_LENGTH + SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10;
 
 		static_local_string<DOMAIN_NAME_TOTAL_SIZE + 1> domain_name (DOMAIN_NAME_TOTAL_SIZE);
 		domain_name.append (DOMAIN_NAME);
@@ -1184,11 +1185,12 @@ MonodroidRuntime::init_android_runtime (
 
 	osBridge.initialize_on_runtime_init (env, runtimeClass);
 
-	log_info (LOG_DEFAULT, "Calling into managed runtime init");
+	log_debug (LOG_DEFAULT, "Calling into managed runtime init");
 
-	timing_period partial_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		partial_time.mark_start ();
+	size_t native_to_managed_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		native_to_managed_index = internal_timing->start_event (TimingEventKind::NativeToManagedTransition);
+	}
 
 #if defined (NET6) && defined (ANDROID)
 	MonoError error;
@@ -1203,9 +1205,8 @@ MonodroidRuntime::init_android_runtime (
 	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 #endif // ndef NET6 && ndef ANDROID
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		partial_time.mark_end ();
-		Timing::info (partial_time, "Runtime.init: end native-to-managed transition");
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (native_to_managed_index);
 	}
 }
 
@@ -1856,9 +1857,10 @@ MonodroidRuntime::disable_external_signal_handlers (void)
 inline void
 MonodroidRuntime::load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jstring_wrapper &assembly)
 {
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		total_time.mark_start ();
+	size_t total_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		total_time_index = internal_timing->start_event (TimingEventKind::AssemblyLoad);
+	}
 
 	const char *assm_name = assembly.get_cstr ();
 	MonoAssemblyName *aname = mono_assembly_name_new (assm_name);
@@ -1868,9 +1870,12 @@ MonodroidRuntime::load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jst
 
 	mono_assembly_name_free (aname);
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
-		TIMING_LOG_INFO (total_time, "Assembly load (ALC): %s", assm_name);
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index, true /* uses_more_info */);
+
+		dynamic_local_string<SENSIBLE_PATH_MAX> more_info { " (ALC): " };
+		more_info.append_c (assm_name);
+		internal_timing->add_more_info (total_time_index, more_info);
 	}
 }
 #endif // NET6
@@ -1878,9 +1883,10 @@ MonodroidRuntime::load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jst
 inline void
 MonodroidRuntime::load_assembly (MonoDomain *domain, jstring_wrapper &assembly)
 {
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		total_time.mark_start ();
+	size_t total_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		total_time_index = internal_timing->start_event (TimingEventKind::AssemblyLoad);
+	}
 
 	const char *assm_name = assembly.get_cstr ();
 	MonoAssemblyName *aname = mono_assembly_name_new (assm_name);
@@ -1903,20 +1909,25 @@ MonodroidRuntime::load_assembly (MonoDomain *domain, jstring_wrapper &assembly)
 
 	mono_assembly_name_free (aname);
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
-		TIMING_LOG_INFO (total_time, "Assembly load (domain): %s", assm_name);
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index, true /* uses_more_info */);
+
+		dynamic_local_string<SENSIBLE_PATH_MAX> more_info { " (domain): " };
+		more_info.append_c (assm_name);
+		internal_timing->add_more_info (total_time_index, more_info);
 	}
 }
 
 inline void
 MonodroidRuntime::load_assemblies (load_assemblies_context_type ctx, bool preload, jstring_array_wrapper &assemblies)
 {
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		total_time.mark_start ();
+	size_t total_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		total_time_index = internal_timing->start_event (TimingEventKind::AssemblyPreload);
+	}
 
-	for (size_t i = 0; i < assemblies.get_length (); ++i) {
+	size_t i = 0;
+	for (i = 0; i < assemblies.get_length (); ++i) {
 		jstring_wrapper &assembly = assemblies [i];
 		load_assembly (ctx, assembly);
 		// only load the first "main" assembly if we are not preloading.
@@ -1924,10 +1935,12 @@ MonodroidRuntime::load_assemblies (load_assemblies_context_type ctx, bool preloa
 			break;
 	}
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index, true /* uses-more_info */);
 
-		TIMING_LOG_INFO (total_time, "Finished loading assemblies: preloaded %u assemblies", assemblies.get_length ());
+		static_local_string<SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10> more_info;
+		more_info.append (i + 1);
+		internal_timing->add_more_info (total_time_index, more_info);
 	}
 }
 
@@ -2142,10 +2155,13 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	std::unique_ptr<char[]> mono_log_mask (mono_log_mask_raw);
 	std::unique_ptr<char[]> mono_log_level (mono_log_level_raw);
 
-	timing_period total_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+	// If fast logging is disabled, log messages immediately
+	FastTiming::initialize ((log_timing_categories & LOG_TIMING_FAST_BARE) == 0);
+
+	size_t total_time_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
 		timing = new Timing ();
-		total_time.mark_start ();
+		total_time_index = internal_timing->start_event (TimingEventKind::TotalRuntimeInit);
 	}
 
 	jstring_array_wrapper applicationDirs (env, appDirs);
@@ -2234,7 +2250,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	androidSystem.setup_process_args (runtimeApks);
 #if !defined (NET6)
 	// JIT stats based on perf counters are disabled in dotnet/mono
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)) && !(log_timing_categories & LOG_TIMING_BARE)) {
+	if (XA_UNLIKELY (FastTiming::enabled () && !FastTiming::is_bare_mode ())) {
 		mono_counters_enable (static_cast<int>(XA_LOG_COUNTERS));
 
 		dynamic_local_string<SENSIBLE_PATH_MAX> counters_path;
@@ -2329,16 +2345,15 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	__android_log_print (ANDROID_LOG_INFO, "*jonp*", "debug.mono.extra=%s", runtime_args);
 #endif
 
-	timing_period partial_time;
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		partial_time.mark_start ();
+	size_t mono_runtime_init_index;
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		mono_runtime_init_index = internal_timing->start_event (TimingEventKind::MonoRuntimeInit);
+	}
 
 	mono_runtime_init (runtime_args);
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		partial_time.mark_end ();
-
-		Timing::info (partial_time, "Runtime.init: Mono runtime init");
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (mono_runtime_init_index);
 	}
 
 	jstring_array_wrapper assemblies (env, assembliesJava);
@@ -2373,16 +2388,14 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 #endif // def ANDROID
 	}
 
-	startup_in_progress = false;
-
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
-
-		Timing::info (total_time, "Runtime.init: end, total time");
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index);
 #if !defined (NET6)
 		dump_counters ("## Runtime.init: end");
 #endif // ndef NET6
 	}
+
+	startup_in_progress = false;
 }
 
 #if !defined (NET6)
@@ -2464,17 +2477,15 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 force_inline void
 MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods)
 {
-	timing_period total_time;
+	size_t total_time_index;
 
-	dynamic_local_string<SENSIBLE_TYPE_NAME_LENGTH> type;
-
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
-		total_time.mark_start ();
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		total_time_index = internal_timing->start_event (TimingEventKind::RuntimeRegister);
+	}
 
 	jsize managedType_len = env->GetStringLength (managedType);
 	const jchar *managedType_ptr = env->GetStringChars (managedType, nullptr);
-
-	jsize methods_len = env->GetStringLength (methods);
+	int methods_len = env->GetStringLength (methods);
 	const jchar *methods_ptr = env->GetStringChars (methods, nullptr);
 
 #if !defined (NET6) || !defined (ANDROID)
@@ -2511,20 +2522,29 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring manag
 	env->ReleaseStringChars (methods, methods_ptr);
 	env->ReleaseStringChars (managedType, managedType_ptr);
 
-	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
-		total_time.mark_end ();
+	if (XA_UNLIKELY (FastTiming::enabled ())) {
+		internal_timing->end_event (total_time_index, true /* uses_more_info */);
 
+		dynamic_local_string<SENSIBLE_TYPE_NAME_LENGTH> type;
 		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
 		type.assign (mt_ptr, strlen (mt_ptr));
 		env->ReleaseStringUTFChars (managedType, mt_ptr);
 
-		log_info_nocheck (LOG_TIMING, "Runtime.register: registering type `%s`", type.get ());
-
-		Timing::info (total_time, "Runtime.register: end time");
+		internal_timing->add_more_info (total_time_index, type);
 #if !defined (NET6)
 		dump_counters ("## Runtime.register: type=%s\n", type.get ());
 #endif
 	}
+}
+
+JNIEXPORT void
+JNICALL Java_mono_android_Runtime_dumpTimingData ([[maybe_unused]] JNIEnv *env, [[maybe_unused]] jclass klass)
+{
+	if (internal_timing == nullptr) {
+		return;
+	}
+
+	internal_timing->dump ();
 }
 
 JNIEXPORT void

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1938,7 +1938,7 @@ MonodroidRuntime::load_assemblies (load_assemblies_context_type ctx, bool preloa
 	if (XA_UNLIKELY (FastTiming::enabled ())) {
 		internal_timing->end_event (total_time_index, true /* uses-more_info */);
 
-		static_local_string<SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10> more_info;
+		static_local_string<SharedConstants::INTEGER_BASE10_BUFFER_SIZE> more_info;
 		more_info.append (static_cast<uint64_t>(i + 1));
 		internal_timing->add_more_info (total_time_index, more_info);
 	}

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1939,7 +1939,7 @@ MonodroidRuntime::load_assemblies (load_assemblies_context_type ctx, bool preloa
 		internal_timing->end_event (total_time_index, true /* uses-more_info */);
 
 		static_local_string<SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10> more_info;
-		more_info.append (i + 1);
+		more_info.append (static_cast<size_t>(i + 1));
 		internal_timing->add_more_info (total_time_index, more_info);
 	}
 }

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1873,7 +1873,10 @@ MonodroidRuntime::load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jst
 	if (XA_UNLIKELY (FastTiming::enabled ())) {
 		internal_timing->end_event (total_time_index, true /* uses_more_info */);
 
-		dynamic_local_string<SENSIBLE_PATH_MAX> more_info { " (ALC): " };
+		constexpr char PREFIX[] = " (ALC): ";
+		constexpr size_t PREFIX_SIZE = sizeof(PREFIX) - 1;
+
+		dynamic_local_string<SENSIBLE_PATH_MAX + PREFIX_SIZE> more_info { PREFIX };
 		more_info.append_c (assm_name);
 		internal_timing->add_more_info (total_time_index, more_info);
 	}
@@ -1912,7 +1915,10 @@ MonodroidRuntime::load_assembly (MonoDomain *domain, jstring_wrapper &assembly)
 	if (XA_UNLIKELY (FastTiming::enabled ())) {
 		internal_timing->end_event (total_time_index, true /* uses_more_info */);
 
-		dynamic_local_string<SENSIBLE_PATH_MAX> more_info { " (domain): " };
+		constexpr char PREFIX[] = " (domain): ";
+		constexpr size_t PREFIX_SIZE = sizeof(PREFIX) - 1;
+
+		dynamic_local_string<SENSIBLE_PATH_MAX + PREFIX_SIZE> more_info { PREFIX };
 		more_info.append_c (assm_name);
 		internal_timing->add_more_info (total_time_index, more_info);
 	}

--- a/src/monodroid/jni/pinvoke-override-api.cc
+++ b/src/monodroid/jni/pinvoke-override-api.cc
@@ -205,7 +205,7 @@ _monodroid_timezone_get_default_id ()
 }
 
 static void
-_monodroid_counters_dump (const char *format, va_list args)
+_monodroid_counters_dump ([[maybe_unused]] const char *format, [[maybe_unused]] va_list args)
 {
 #if !defined (NET6)
 	monodroidRuntime.dump_counters_v (format, args);
@@ -220,7 +220,7 @@ monodroid_timing_start (const char *message)
 
 	managed_timing_sequence *ret = timing->get_available_sequence ();
 	if (message != nullptr) {
-		log_info (LOG_TIMING, message);
+		log_write (LOG_TIMING, LogLevel::Info, message);
 	}
 	ret->period.mark_start ();
 

--- a/src/monodroid/jni/shared-constants.hh
+++ b/src/monodroid/jni/shared-constants.hh
@@ -69,6 +69,7 @@ namespace xamarin::android::internal
 
 		// 64-bit unsigned or 64-bit signed with sign
 		static constexpr size_t MAX_INTEGER_DIGIT_COUNT_BASE10 = 21;
+		static constexpr size_t INTEGER_BASE10_BUFFER_SIZE = MAX_INTEGER_DIGIT_COUNT_BASE10 + 1;
 
 		// Documented in NDK's <android/log.h> comments
 		static constexpr size_t MAX_LOGCAT_MESSAGE_LENGTH = 1023;

--- a/src/monodroid/jni/shared-constants.hh
+++ b/src/monodroid/jni/shared-constants.hh
@@ -66,6 +66,12 @@ namespace xamarin::android::internal
 		static constexpr size_t APP_DIRS_FILES_DIR_INDEX = 0;
 		static constexpr size_t APP_DIRS_CACHE_DIR_INDEX = 1;
 		static constexpr size_t APP_DIRS_DATA_DIR_INDEX = 2;
+
+		// 64-bit unsigned or 64-bit signed with sign
+		static constexpr size_t MAX_INTEGER_DIGIT_COUNT_BASE10 = 21;
+
+		// Documented in NDK's <android/log.h> comments
+		static constexpr size_t MAX_LOGCAT_MESSAGE_LENGTH = 1023;
 	};
 }
 #endif // __SHARED_CONSTANTS_HH

--- a/src/monodroid/jni/strings.hh
+++ b/src/monodroid/jni/strings.hh
@@ -758,7 +758,7 @@ namespace xamarin::android::internal
 					"Attempt to store too much data in a buffer (capacity: %u; exceeded by: %u)",
 					buffer.size (), needed_space - buffer.size ()
 				);
-				exit (1);
+				abort ();
 			}
 		}
 

--- a/src/monodroid/jni/strings.hh
+++ b/src/monodroid/jni/strings.hh
@@ -11,13 +11,12 @@
 #include "platform-compat.hh"
 #include "logger.hh"
 #include "helpers.hh"
+#include "shared-constants.hh"
 
 namespace xamarin::android::internal
 {
 	static constexpr size_t SENSIBLE_TYPE_NAME_LENGTH = 128;
 	static constexpr size_t SENSIBLE_PATH_MAX = 256;
-	// 64-bit unsigned or 64-bit signed with sign
-	static constexpr size_t MAX_INTEGER_DIGIT_COUNT_BASE10 = 21;
 
 #if DEBUG
 	static constexpr bool BoundsCheck = true;
@@ -467,42 +466,42 @@ namespace xamarin::android::internal
 
 		force_inline string_base& append (int16_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (buffer.get (), i);
 			return *this;
 		}
 
 		force_inline string_base& append (uint16_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (i);
 			return *this;
 		}
 
 		force_inline string_base& append (int32_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (i);
 			return *this;
 		}
 
 		force_inline string_base& append (uint32_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (i);
 			return *this;
 		}
 
 		force_inline string_base& append (int64_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (i);
 			return *this;
 		}
 
 		force_inline string_base& append (uint64_t i) noexcept
 		{
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			append_integer (i);
 			return *this;
 		}
@@ -522,7 +521,7 @@ namespace xamarin::android::internal
 		}
 
 		template<size_t Size>
-		force_inline string_base& assign (const char (&s)[Size]) const noexcept
+		force_inline string_base& assign (const char (&s)[Size]) noexcept
 		{
 			return assign (s, Size - 1);
 		}
@@ -683,9 +682,9 @@ namespace xamarin::android::internal
 		{
 			static_assert (std::is_integral_v<Integer>);
 
-			resize_for_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+			resize_for_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			if constexpr (BoundsCheck) {
-				ensure_have_extra (MAX_INTEGER_DIGIT_COUNT_BASE10);
+				ensure_have_extra (SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10);
 			}
 
 			if (i == 0) {
@@ -696,8 +695,8 @@ namespace xamarin::android::internal
 				return;
 			}
 
-			TChar temp_buf[MAX_INTEGER_DIGIT_COUNT_BASE10 + 1];
-			TChar *p = temp_buf + MAX_INTEGER_DIGIT_COUNT_BASE10;
+			TChar temp_buf[SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10 + 1];
+			TChar *p = temp_buf + SharedConstants::MAX_INTEGER_DIGIT_COUNT_BASE10;
 			*p = NUL;
 			TChar *end = p;
 
@@ -757,7 +756,7 @@ namespace xamarin::android::internal
 				log_fatal (
 					LOG_DEFAULT,
 					"Attempt to store too much data in a buffer (capacity: %u; exceeded by: %u)",
-					buffer.size (), (idx + length) - buffer.size ()
+					buffer.size (), needed_space - buffer.size ()
 				);
 				exit (1);
 			}
@@ -787,13 +786,20 @@ namespace xamarin::android::internal
 		using base = string_base<MaxStackSize, static_local_storage<MaxStackSize, TChar>, TChar>;
 
 	public:
-		explicit static_local_string (size_t initial_size) noexcept
+		explicit static_local_string (size_t initial_size = 0) noexcept
 			: base (initial_size)
 		{}
 
 		explicit static_local_string (const string_segment &token) noexcept
 			: base (token)
 		{}
+
+		template<size_t N>
+		explicit static_local_string (const char (&str)[N])
+			: base (N)
+		{
+			append (str);
+		}
 	};
 
 	template<size_t MaxStackSize, typename TChar = char>
@@ -809,6 +815,13 @@ namespace xamarin::android::internal
 		explicit dynamic_local_string (const string_segment &token) noexcept
 			: base (token)
 		{}
+
+		template<size_t N>
+		explicit dynamic_local_string (const char (&str)[N])
+			: base (N)
+		{
+			base::append (str);
+		}
 	};
 }
 #endif // __STRINGS_HH

--- a/src/monodroid/jni/timing-internal.cc
+++ b/src/monodroid/jni/timing-internal.cc
@@ -1,0 +1,88 @@
+#include "timing-internal.hh"
+#include "util.hh"
+
+using namespace xamarin::android;
+using namespace xamarin::android::internal;
+
+namespace xamarin::android::internal {
+	FastTiming *internal_timing = nullptr;
+}
+
+bool FastTiming::is_enabled = false;
+bool FastTiming::immediate_logging = false;
+TimingEvent FastTiming::init_time {};
+
+void
+FastTiming::really_initialize (bool log_immediately) noexcept
+{
+	internal_timing = new FastTiming ();
+	is_enabled = true;
+	immediate_logging = log_immediately;
+
+	if (immediate_logging) {
+		return;
+	}
+
+	log_write (LOG_TIMING, LogLevel::Info, "[2/1] To get timing results, send the mono.android.app.DUMP_TIMING_DATA intent to the application");
+}
+
+void
+FastTiming::dump () noexcept
+{
+	if (immediate_logging) {
+		return;
+	}
+
+	StartupAwareLock lock { event_vector_realloc_mutex };
+	size_t entries = next_event_index.load ();
+
+	log_write (LOG_TIMING, LogLevel::Info, "[2/2] Performance measurement results");
+	if (entries == 0) {
+		log_write (LOG_TIMING, LogLevel::Info, "[2/3] No events logged");
+		return;
+	}
+
+	dynamic_local_string<SharedConstants::MAX_LOGCAT_MESSAGE_LENGTH, char> message;
+
+	// Values are in nanoseconds
+	uint64_t total_assembly_load_time = 0;
+	uint64_t total_java_to_managed_time = 0;
+	uint64_t total_managed_to_java_time = 0;
+	uint64_t total_ns;
+
+	format_and_log (init_time, message, total_ns, true /* indent */);
+	for (size_t i = 0; i < entries; i++) {
+		TimingEvent const& event = events[i];
+		format_and_log (event, message, total_ns, true /* indent */);
+
+		switch (event.kind) {
+			case TimingEventKind::AssemblyLoad:
+				total_assembly_load_time += total_ns;
+				break;
+
+			case TimingEventKind::JavaToManaged:
+				total_java_to_managed_time += total_ns;
+				break;
+
+			case TimingEventKind::ManagedToJava:
+				total_managed_to_java_time += total_ns;
+				break;
+
+			default:
+				// Ignore other kinds
+				break;
+		}
+	}
+
+	uint32_t sec, ms, ns;
+	log_write (LOG_TIMING, LogLevel::Info, "[2/4] Accumulated performance results");
+
+	ns_to_time (total_assembly_load_time, sec, ms, ns);
+	log_info_nocheck (LOG_TIMING, "  [2/5] Assembly load: %u:%u::%u", sec, ms, ns);
+
+	ns_to_time (total_java_to_managed_time, sec, ms, ns);
+	log_info_nocheck (LOG_TIMING, "  [2/6] Java to Managed lookup: %u:%u::%u", sec, ms, ns);
+
+	ns_to_time (total_managed_to_java_time, sec, ms, ns);
+	log_info_nocheck (LOG_TIMING, "  [2/7] Managed to Java lookup: %u:%u::%u", sec, ms, ns);
+}

--- a/src/monodroid/jni/timing-internal.hh
+++ b/src/monodroid/jni/timing-internal.hh
@@ -1,0 +1,488 @@
+#if !defined (__TIMING_INTERNAL_HH)
+#define __TIMING_INTERNAL_HH
+
+#include <atomic>
+#include <array>
+#include <charconv>
+#include <ctime>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#undef HAVE_CONCEPTS
+
+// Xcode has supports for concepts only since 12.5
+#if __has_include (<concepts>)
+#define HAVE_CONCEPTS
+#include <concepts>
+#endif // __has_include
+
+#include "cpp-util.hh"
+#include "logger.hh"
+#include "startup-aware-lock.hh"
+#include "strings.hh"
+#include "util.hh"
+#include "shared-constants.hh"
+
+namespace xamarin::android::internal
+{
+#if defined (ANDROID) || defined (__linux__) || defined (__linux)
+	using timestruct = timespec;
+#else
+	using timestruct = timeval;
+#endif
+
+#if defined (ANDROID)
+	// bionic should use `time_t` in the timespec struct, but it uses `long` instead
+	using time_type = long;
+#else
+	using time_type = time_t;
+#endif
+
+	// Events should never change their assigned values and no values should be reused.
+	// Values are used by the test runner to determine what measurement was taken.
+	//
+	// At the same time, the list should be kept sorted alphabetically for easier reading -
+	// values therefore might be out of order, but always unique.
+	enum class TimingEventKind
+	{
+		AssemblyDecompression     = 0,
+		AssemblyLoad              = 1,
+		AssemblyPreload           = 2,
+		DebugStart                = 3,
+		Init                      = 4,
+		JavaToManaged             = 5,
+		ManagedToJava             = 6,
+		MonoRuntimeInit           = 7,
+		NativeToManagedTransition = 8,
+		RuntimeConfigBlob         = 9,
+		RuntimeRegister           = 10,
+		TotalRuntimeInit          = 11,
+		Unspecified               = 12,
+	};
+
+	struct TimingEventPoint
+	{
+		time_t   sec;
+		uint64_t ns;
+	};
+
+	struct TimingInterval
+	{
+		time_t   sec;
+		uint32_t ms;
+		uint32_t ns;
+	};
+
+	struct TimingEvent
+	{
+		bool             before_managed;
+		TimingEventPoint start;
+		TimingEventPoint end;
+		TimingEventKind  kind;
+		std::string      more_info;
+	};
+
+#if defined (HAVE_CONCEPTS)
+	template<typename T>
+	concept TimingPointType = requires (T a) {
+		{ a.sec } -> std::same_as<time_t&>;
+		{ a.ns } -> std::same_as<uint64_t&>;
+	};
+
+	template<typename T>
+	concept TimingIntervalType = requires (T a) {
+		{ a.sec } -> std::same_as<time_t&>;
+		{ a.ms } -> std::same_as<uint32_t&>;
+		{ a.ns } -> std::same_as<uint32_t&>;
+	};
+#endif
+
+	class FastTiming final
+	{
+		// Number of TimingEvent entries in the event vector allocated at the
+		// time of class instantiation.  It's an arbitrary value, but it should
+		// be large enough to not require any dynamic reallocation of memory at
+		// the run time.
+		static constexpr size_t INITIAL_EVENT_VECTOR_SIZE = 4096;
+		static constexpr uint32_t ns_in_millisecond = 1000000;
+		static constexpr uint32_t ms_in_second = 1000;
+		static constexpr uint32_t ns_in_second = ms_in_second * ns_in_millisecond;
+
+	protected:
+		FastTiming () noexcept
+		{
+			events.reserve (INITIAL_EVENT_VECTOR_SIZE);
+		}
+
+	public:
+		force_inline static bool enabled () noexcept
+		{
+			return is_enabled;
+		}
+
+		force_inline static bool is_bare_mode () noexcept
+		{
+			return
+				(log_timing_categories & LOG_TIMING_BARE) == LOG_TIMING_BARE ||
+				(log_timing_categories & LOG_TIMING_FAST_BARE) == LOG_TIMING_FAST_BARE;
+		}
+
+		force_inline static void initialize (bool log_immediately) noexcept
+		{
+			if (XA_LIKELY (!utils.should_log (LOG_TIMING))) {
+				return;
+			}
+
+			mark (init_time.start);
+			really_initialize (log_immediately);
+			mark (init_time.end);
+
+			init_time.before_managed = true;
+			init_time.kind = TimingEventKind::Init;
+
+			if (!immediate_logging) {
+				return;
+			}
+
+			log (init_time, false /* skip_log_if_more_info_missing */);
+		}
+
+		// std::vector<T> isn't used in a conventional manner here. We treat it as if it was a standard array and we
+		// don't take advantage of any emplacement functionality, merely using vector's ability to resize itself when
+		// needed.  The reason for this is speed - we can atomically increase index into the array and relatively
+		// quickly check whether it's within the boundaries.  We can then safely use thus indexed element without
+		// worrying about concurrency.  Emplacing a new element in the vector would require holding the mutex, something
+		// that's fairly costly and has unpredictable effect on time spent acquiring and holding the lock (the OS can
+		// preempt us at this point)
+		force_inline size_t start_event (TimingEventKind kind = TimingEventKind::Unspecified) noexcept
+		{
+			size_t index = next_event_index.fetch_add (1);
+
+			if (XA_UNLIKELY (index >= events.capacity ())) {
+				StartupAwareLock lock (event_vector_realloc_mutex);
+				if (index >= events.size ()) { // don't increase unnecessarily, if another thread has already done that
+					// Double the vector size. We should, in theory, check for integer overflow here, but it's more
+					// likely we'll run out of memory way, way, way before that happens
+					size_t old_size = events.capacity ();
+					events.reserve (old_size << 1);
+					log_warn (LOG_TIMING, "Reallocated timing event buffer from %zu to %zu", old_size, events.size ());
+				}
+			}
+
+			TimingEvent &ev = events[index];
+			mark (ev.start);
+			ev.kind = kind;
+			ev.before_managed = MonodroidRuntime::is_startup_in_progress ();
+
+			return index;
+		}
+
+		force_inline void end_event (size_t event_index, bool uses_more_info = false) noexcept
+		{
+			if (XA_UNLIKELY (!is_valid_event_index (event_index, __PRETTY_FUNCTION__))) {
+				return;
+			}
+
+			mark (events[event_index].end);
+			log (events[event_index], uses_more_info /* skip_log_if_more_info_missing */);
+		}
+
+		template<size_t MaxStackSize, typename TStorage, typename TChar = char>
+		force_inline void add_more_info (size_t event_index, string_base<MaxStackSize, TStorage, TChar> const& str) noexcept
+		{
+			if (XA_UNLIKELY (!is_valid_event_index (event_index, __PRETTY_FUNCTION__))) {
+				return;
+			}
+
+			events[event_index].more_info.assign (str.get (), str.length ());
+			log (events[event_index], false /* skip_log_if_more_info_missing */);
+		}
+
+		force_inline void add_more_info (size_t event_index, const char* str) noexcept
+		{
+			if (XA_UNLIKELY (!is_valid_event_index (event_index, __PRETTY_FUNCTION__))) {
+				return;
+			}
+
+			events[event_index].more_info.assign (str, strlen (str));
+			log (events[event_index], false /* skip_log_if_more_info_missing */);
+		}
+
+		force_inline static void get_time (time_t &seconds_out, uint64_t& ns_out) noexcept
+		{
+			int ret;
+			timestruct tv_ctm;
+
+#if defined (ANDROID) || defined (__linux__) || defined (__linux)
+			ret = clock_gettime (CLOCK_MONOTONIC, &tv_ctm);
+			ns_out = ret == 0 ? static_cast<uint64_t>(tv_ctm.tv_nsec) : 0;
+#else
+			ret = gettimeofday (&tv_ctm, static_cast<timestruct*> (nullptr));
+			ns_out = ret == 0 ? tv_ctm.tv_usec * 1000LL : 0;
+#endif
+			seconds_out = ret == 0 ? tv_ctm.tv_sec : 0;
+		}
+
+#if defined (HAVE_CONCEPTS)
+		template<TimingPointType P, TimingIntervalType I>
+#else
+		template<typename P, typename I>
+#endif
+		force_inline static void calculate_interval (P const& start, P const& end, I &result) noexcept
+		{
+			uint64_t nsec;
+			if (end.ns < start.ns) {
+				result.sec = end.sec - start.sec - 1;
+				if (result.sec < 0) {
+					result.sec = 0;
+				}
+				nsec = 1000000000ULL + end.ns - start.ns;
+			} else {
+				result.sec = end.sec - start.sec;
+				nsec = end.ns - start.ns;
+			}
+
+			result.ms = static_cast<uint32_t>(nsec / ns_in_millisecond);
+			if (result.ms >= ms_in_second) {
+				result.sec += result.ms / ms_in_second;
+				result.ms = result.ms % ms_in_second;
+			}
+
+			result.ns = static_cast<uint32_t>(nsec  % ns_in_millisecond);
+		}
+
+#if defined (HAVE_CONCEPTS)
+		template<TimingPointType P, TimingIntervalType I>
+#else
+		template<typename P, typename I>
+#endif
+		force_inline static void calculate_interval (P const& start, P const& end, I &result, uint64_t& total_ns) noexcept
+		{
+			calculate_interval (start, end, result);
+			total_ns =
+				(static_cast<uint64_t>(result.sec) * static_cast<uint64_t>(ns_in_second)) +
+				(static_cast<uint64_t>(result.ms) * static_cast<uint64_t>(ns_in_millisecond)) +
+				static_cast<uint64_t>(result.ns);
+		}
+
+		void dump () noexcept;
+
+	private:
+		static void really_initialize (bool log_immediately) noexcept;
+		static void* timing_signal_thread (void *arg) noexcept;
+
+		force_inline static void mark (TimingEventPoint &point) noexcept
+		{
+			get_time (point.sec, point.ns);
+		}
+
+		force_inline bool is_valid_event_index (size_t index, const char *method_name) noexcept
+		{
+			if (XA_UNLIKELY (index >= events.capacity ())) {
+				log_warn (LOG_TIMING, "Invalid event index passed to method '%s'", method_name);
+				return false;
+			}
+
+			return true;
+		}
+
+		template<size_t BufferSize>
+		force_inline static void append_event_kind_description (TimingEventKind kind, dynamic_local_string<BufferSize, char>& message) noexcept
+		{
+			switch (kind) {
+				case TimingEventKind::AssemblyDecompression: {
+					constexpr char desc[] = "LZ4 decompression time for ";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::AssemblyLoad: {
+					constexpr char desc[] = "Assembly load";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::AssemblyPreload: {
+					constexpr char desc[] = "Finished preloading, number of loaded assemblies: ";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::DebugStart: {
+					constexpr char desc[] = "Debug::start_debugging_and_profiling: end";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::Init: {
+					constexpr char desc[] = "XATiming: init time";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::JavaToManaged: {
+					constexpr char desc[] = "Typemap.java_to_managed: end, total time";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::ManagedToJava: {
+					constexpr char desc[] = "Typemap.managed_to_java: end, total time";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::MonoRuntimeInit: {
+					constexpr char desc[] = "Runtime.init: Mono runtime init";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::NativeToManagedTransition: {
+					constexpr char desc[] = "Runtime.init: end native-to-managed transition";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::RuntimeConfigBlob: {
+					constexpr char desc[] = "Register runtimeconfig binary blob";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::RuntimeRegister: {
+					constexpr char desc[] = "Runtime.register: end time. Registered type: ";
+					message.append (desc);
+					return;
+				}
+
+				case TimingEventKind::TotalRuntimeInit: {
+					constexpr char desc[] = "Runtime.init: end, total time";
+					message.append (desc);
+					return;
+				}
+
+				default: {
+					constexpr char desc[] = "Unknown timing event";
+					message.append (desc);
+					return;
+				}
+			}
+		}
+
+		//
+		// Message format is as follows: <OPTIONAL_INDENT>[STAGE/EVENT] <MESSAGE>; elapsed s:ms::ns
+		//
+		//  STAGE is one of:
+		//    0 - native init (before managed code runs)
+		//    1 - managed code enabled
+		//    2 - events summary (see the `dump()` function)
+		//
+		//  EVENT is one of:
+		//    for stages 0 and 1, it's the value of the TimingEventKind member
+		//    for stage 2 see the `dump()` function
+		//
+		// The [STAGE/EVENT] format is meant to help the test runner application, so that it can parse logcat without
+		// having to be kept in sync with the actual wording used for the event message.
+		//
+		template<size_t BufferSize>
+		force_inline static void format_and_log (TimingEvent const& event, TimingInterval const& interval, dynamic_local_string<BufferSize, char>& message, bool indent = false) noexcept
+		{
+			constexpr char INDENT[] = "  ";
+			constexpr char NATIVE_INIT_TAG[] = "[0/";
+			constexpr char MANAGED_TAG[] = "[1/";
+
+			message.clear ();
+			if (indent) {
+				message.append (INDENT);
+			}
+
+			if (event.before_managed) {
+				message.append (NATIVE_INIT_TAG);
+			} else {
+				message.append (MANAGED_TAG);
+			}
+
+			message.append (static_cast<uint32_t>(event.kind));
+			message.append ("] ");
+
+			append_event_kind_description (event.kind, message);
+			if (event.more_info.length () > 0) {
+				message.append (event.more_info.c_str (), event.more_info.size ());
+			}
+
+			constexpr char COLON[] = ":";
+			constexpr char TWO_COLONS[] = "::";
+
+			message.append ("; elapsed: ");
+			message.append (static_cast<uint32_t>(interval.sec));
+			message.append (COLON);
+			message.append (interval.ms);
+			message.append (TWO_COLONS);
+			message.append (interval.ns);
+
+			log_write (LOG_TIMING, LogLevel::Info, message.get ());
+		}
+
+		template<size_t BufferSize>
+		force_inline static void format_and_log (TimingEvent const& event, dynamic_local_string<BufferSize, char>& message, uint64_t& total_ns, bool indent = false) noexcept
+		{
+			TimingInterval interval;
+			calculate_interval (event.start, event.end, interval, total_ns);
+			format_and_log (event, interval, message, indent);
+		}
+
+		force_inline static void format_and_log (TimingEvent const& event) noexcept
+		{
+			TimingInterval interval;
+			calculate_interval (event.start, event.end, interval);
+
+			// `message` isn't used here, it is passed to `format_and_log` so that the `dump()` function can
+			// be slightly more efficient when dumping the event buffer.
+			dynamic_local_string<SharedConstants::MAX_LOGCAT_MESSAGE_LENGTH, char> message;
+			format_and_log (event, interval, message);
+		}
+
+		force_inline static void log (TimingEvent const& event, bool skip_log_if_more_info_missing) noexcept
+		{
+			if (!immediate_logging) {
+				return;
+			}
+
+			if (skip_log_if_more_info_missing && event.more_info.empty ()) {
+				return;
+			}
+
+			format_and_log (event);
+		}
+
+		force_inline static void ns_to_time (uint64_t total_ns, uint32_t &sec, uint32_t &ms, uint32_t &ns) noexcept
+		{
+			sec = static_cast<uint32_t>(total_ns / ns_in_second);
+			if (sec > 0) {
+				total_ns = total_ns % 1000000000ULL;
+			}
+
+			ms = static_cast<uint32_t>(total_ns / ns_in_millisecond);
+			if (ms >= 1000) {
+				sec += ms / 1000;
+				ms = ms % 1000;
+			}
+
+			ns = static_cast<uint32_t>(total_ns % ns_in_millisecond);
+		}
+
+	private:
+		std::atomic_size_t next_event_index = 0;
+		std::mutex event_vector_realloc_mutex;
+		std::vector<TimingEvent> events;
+
+		static TimingEvent init_time;
+		static bool is_enabled;
+		static bool immediate_logging;
+	};
+
+	extern FastTiming *internal_timing;
+}
+#endif // ndef __TIMING_INTERNAL_HH

--- a/src/monodroid/jni/timing-internal.hh
+++ b/src/monodroid/jni/timing-internal.hh
@@ -80,7 +80,7 @@ namespace xamarin::android::internal
 		TimingEventPoint start;
 		TimingEventPoint end;
 		TimingEventKind  kind;
-		std::string      more_info;
+		const char*      more_info;
 	};
 
 #if defined (HAVE_CONCEPTS)
@@ -174,6 +174,7 @@ namespace xamarin::android::internal
 			mark (ev.start);
 			ev.kind = kind;
 			ev.before_managed = MonodroidRuntime::is_startup_in_progress ();
+			ev.more_info = nullptr;
 
 			return index;
 		}
@@ -195,7 +196,7 @@ namespace xamarin::android::internal
 				return;
 			}
 
-			events[event_index].more_info.assign (str.get (), str.length ());
+			events[event_index].more_info = utils.strdup_new (str.get (), str.length ());
 			log (events[event_index], false /* skip_log_if_more_info_missing */);
 		}
 
@@ -205,7 +206,7 @@ namespace xamarin::android::internal
 				return;
 			}
 
-			events[event_index].more_info.assign (str, strlen (str));
+			events[event_index].more_info = utils.strdup_new (str, strlen (str));
 			log (events[event_index], false /* skip_log_if_more_info_missing */);
 		}
 
@@ -408,8 +409,8 @@ namespace xamarin::android::internal
 			message.append ("] ");
 
 			append_event_kind_description (event.kind, message);
-			if (event.more_info.length () > 0) {
-				message.append (event.more_info.c_str (), event.more_info.size ());
+			if (event.more_info != nullptr && *event.more_info != '\0') {
+				message.append (event.more_info, strlen (event.more_info));
 			}
 
 			constexpr char COLON[] = ":";
@@ -450,7 +451,7 @@ namespace xamarin::android::internal
 				return;
 			}
 
-			if (skip_log_if_more_info_missing && event.more_info.empty ()) {
+			if (skip_log_if_more_info_missing && (event.more_info == nullptr || *event.more_info == '\0')) {
 				return;
 			}
 

--- a/src/monodroid/jni/timing-internal.hh
+++ b/src/monodroid/jni/timing-internal.hh
@@ -219,7 +219,7 @@ namespace xamarin::android::internal
 			ns_out = ret == 0 ? static_cast<uint64_t>(tv_ctm.tv_nsec) : 0;
 #else
 			ret = gettimeofday (&tv_ctm, static_cast<timestruct*> (nullptr));
-			ns_out = ret == 0 ? tv_ctm.tv_usec * 1000LL : 0;
+			ns_out = ret == 0 ? static_cast<uint64_t>(tv_ctm.tv_usec * 1000LL) : 0;
 #endif
 			seconds_out = ret == 0 ? tv_ctm.tv_sec : 0;
 		}

--- a/src/monodroid/jni/xa-internal-api.cc
+++ b/src/monodroid/jni/xa-internal-api.cc
@@ -250,7 +250,7 @@ MonoAndroidInternalCalls_Impl::monodroid_timing_start (const char *message)
 
 	managed_timing_sequence *ret = timing->get_available_sequence ();
 	if (message != nullptr) {
-		log_info (LOG_TIMING, message);
+		log_write (LOG_TIMING, LogLevel::Info, message);
 	}
 	ret->period.mark_start ();
 

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Aot.apkdesc
@@ -8,16 +8,16 @@
       "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68917
+      "Size": 68911
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 565252
+      "Size": 565815
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936224
+      "Size": 936222
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
@@ -35,13 +35,13 @@
       "Size": 316112
     },
     "assemblies/System.dll": {
-      "Size": 443207
+      "Size": 443206
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 16350
+      "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113291
+      "Size": 113294
     },
     "assemblies/System.Numerics.dll": {
       "Size": 23262
@@ -53,61 +53,61 @@
       "Size": 26599
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592570
+      "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34373
+      "Size": 34374
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7696
+      "Size": 7694
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124594
+      "Size": 124587
     },
     "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6663
+      "Size": 6661
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7370
+      "Size": 7363
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18280
+      "Size": 18269
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131931
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15447
+      "Size": 15442
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43143
+      "Size": 43128
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6716
+      "Size": 6710
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7071
+      "Size": 7063
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7195
+      "Size": 7191
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4881
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13585
+      "Size": 13581
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102442
+      "Size": 102429
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6282
+      "Size": 6271
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11272
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19438
+      "Size": 19428
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 471887
@@ -116,10 +116,10 @@
       "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114915
+      "Size": 114916
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367756
+      "Size": 367737
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56584
@@ -128,298 +128,298 @@
       "Size": 55034
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43511
+      "Size": 43506
     },
     "classes.dex": {
-      "Size": 2639828
+      "Size": 2636860
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
-      "Size": 16616
+      "Size": 16532
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 354928
+      "Size": 354844
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 2743120
+      "Size": 2747252
     },
     "lib/armeabi-v7a/libaot-Mono.Security.dll.so": {
-      "Size": 209664
+      "Size": 209580
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 3935816
+      "Size": 3935732
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 1379304
+      "Size": 1379220
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 5648
+      "Size": 5564
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 21280
+      "Size": 21196
     },
     "lib/armeabi-v7a/libaot-System.Core.dll.so": {
-      "Size": 864768
+      "Size": 864684
     },
     "lib/armeabi-v7a/libaot-System.Data.dll.so": {
-      "Size": 1590664
+      "Size": 1590580
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 1773592
+      "Size": 1773508
     },
     "lib/armeabi-v7a/libaot-System.Drawing.Common.dll.so": {
-      "Size": 36528
+      "Size": 36444
     },
     "lib/armeabi-v7a/libaot-System.Net.Http.dll.so": {
-      "Size": 528832
+      "Size": 528748
     },
     "lib/armeabi-v7a/libaot-System.Numerics.dll.so": {
-      "Size": 86760
+      "Size": 86676
     },
     "lib/armeabi-v7a/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 807280
+      "Size": 807196
     },
     "lib/armeabi-v7a/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 69960
+      "Size": 69876
     },
     "lib/armeabi-v7a/libaot-System.Xml.dll.so": {
-      "Size": 2867400
+      "Size": 2867316
     },
     "lib/armeabi-v7a/libaot-System.Xml.Linq.dll.so": {
-      "Size": 124816
+      "Size": 124732
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 16920
+      "Size": 16836
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 594160
+      "Size": 594076
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 13976
+      "Size": 13892
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 18680
+      "Size": 18596
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 78928
+      "Size": 78844
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 628360
+      "Size": 628276
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 56856
+      "Size": 56772
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 180608
+      "Size": 180524
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 14264
+      "Size": 14180
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 13808
+      "Size": 13724
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 15936
+      "Size": 15852
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 6720
+      "Size": 6636
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 40792
+      "Size": 40708
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 474128
+      "Size": 474044
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 10880
+      "Size": 10796
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 30736
+      "Size": 30652
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 70864
+      "Size": 70780
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 2220224
+      "Size": 2220140
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 91592
+      "Size": 91508
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 218424
+      "Size": 218340
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 1486304
+      "Size": 1486220
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 108168
+      "Size": 108084
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 228200
+      "Size": 228116
     },
     "lib/armeabi-v7a/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 201696
+      "Size": 201612
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736396
+      "Size": 785140
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 235164
+      "Size": 312824
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
       "Size": 4456612
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48844
+      "Size": 48812
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 141260
+      "Size": 87604
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
-      "Size": 14860
+      "Size": 14776
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 312116
+      "Size": 312032
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 2408732
+      "Size": 2411712
     },
     "lib/x86/libaot-Mono.Security.dll.so": {
-      "Size": 178308
+      "Size": 178224
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 3391844
+      "Size": 3391760
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 1172140
+      "Size": 1172056
     },
     "lib/x86/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 4940
+      "Size": 4856
     },
     "lib/x86/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 17228
+      "Size": 17144
     },
     "lib/x86/libaot-System.Core.dll.so": {
-      "Size": 734556
+      "Size": 734472
     },
     "lib/x86/libaot-System.Data.dll.so": {
-      "Size": 1324044
+      "Size": 1323960
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 1491028
+      "Size": 1490944
     },
     "lib/x86/libaot-System.Drawing.Common.dll.so": {
-      "Size": 33452
+      "Size": 33368
     },
     "lib/x86/libaot-System.Net.Http.dll.so": {
-      "Size": 452348
+      "Size": 452264
     },
     "lib/x86/libaot-System.Numerics.dll.so": {
-      "Size": 74292
+      "Size": 74208
     },
     "lib/x86/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 675188
+      "Size": 675104
     },
     "lib/x86/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 59588
+      "Size": 59504
     },
     "lib/x86/libaot-System.Xml.dll.so": {
-      "Size": 2407948
+      "Size": 2407864
     },
     "lib/x86/libaot-System.Xml.Linq.dll.so": {
-      "Size": 100668
+      "Size": 100584
     },
     "lib/x86/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 14940
+      "Size": 14856
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 528244
+      "Size": 528160
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 12420
+      "Size": 12336
     },
     "lib/x86/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 16164
+      "Size": 16080
     },
     "lib/x86/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 67748
+      "Size": 67664
     },
     "lib/x86/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 568100
+      "Size": 568016
     },
     "lib/x86/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 49420
+      "Size": 49336
     },
     "lib/x86/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 158164
+      "Size": 158080
     },
     "lib/x86/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 12588
+      "Size": 12504
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 12180
+      "Size": 12096
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 13932
+      "Size": 13848
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 5908
+      "Size": 5824
     },
     "lib/x86/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 35236
+      "Size": 35152
     },
     "lib/x86/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 416692
+      "Size": 416608
     },
     "lib/x86/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 9796
+      "Size": 9712
     },
     "lib/x86/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 26748
+      "Size": 26664
     },
     "lib/x86/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 60932
+      "Size": 60848
     },
     "lib/x86/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 1835076
+      "Size": 1834992
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 81124
+      "Size": 81040
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 134180
+      "Size": 134096
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 1208028
+      "Size": 1207944
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 67724
+      "Size": 67640
     },
     "lib/x86/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 184252
+      "Size": 184168
     },
     "lib/x86/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 178404
+      "Size": 178320
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803352
+      "Size": 823560
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 306828
+      "Size": 414704
     },
     "lib/x86/libmonosgen-2.0.so": {
       "Size": 4212360
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61112
+      "Size": 60848
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 140024
+      "Size": 86400
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 26875076
+  "PackageSize": 26977476
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Bundle.apkdesc
@@ -5,49 +5,49 @@
       "Size": 3768
     },
     "classes.dex": {
-      "Size": 2974620
+      "Size": 2964300
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736396
+      "Size": 785140
     },
     "lib/armeabi-v7a/libmonodroid_bundle_app.so": {
-      "Size": 4276376
+      "Size": 4279036
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 235164
+      "Size": 312824
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456576
+      "Size": 4456612
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48844
+      "Size": 48812
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 108520
+      "Size": 68936
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803352
+      "Size": 823560
     },
     "lib/x86/libmonodroid_bundle_app.so": {
-      "Size": 4284080
+      "Size": 4278176
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 306828
+      "Size": 414704
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212336
+      "Size": 4212360
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61112
+      "Size": 60848
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 107576
+      "Size": 68740
     },
     "META-INF/android.arch.core_runtime.version": {
       "Size": 6
@@ -2993,5 +2993,5 @@
       "Size": 493672
     }
   },
-  "PackageSize": 16394230
+  "PackageSize": 16500726
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release-Profiled-Aot.apkdesc
@@ -8,16 +8,16 @@
       "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68917
+      "Size": 68911
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 565252
+      "Size": 565815
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936224
+      "Size": 936222
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
@@ -35,13 +35,13 @@
       "Size": 316112
     },
     "assemblies/System.dll": {
-      "Size": 443207
+      "Size": 443206
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 16350
+      "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113291
+      "Size": 113294
     },
     "assemblies/System.Numerics.dll": {
       "Size": 23262
@@ -53,61 +53,61 @@
       "Size": 26599
     },
     "assemblies/System.Xml.dll": {
-      "Size": 592570
+      "Size": 592571
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 34373
+      "Size": 34374
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7696
+      "Size": 7694
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 124594
+      "Size": 124587
     },
     "assemblies/Xamarin.AndroidX.AppCompat.Resources.dll": {
-      "Size": 6663
+      "Size": 6661
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7370
+      "Size": 7363
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18280
+      "Size": 18269
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131931
+      "Size": 131928
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15447
+      "Size": 15442
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43143
+      "Size": 43128
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6716
+      "Size": 6710
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7071
+      "Size": 7063
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7195
+      "Size": 7191
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4881
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13585
+      "Size": 13581
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102442
+      "Size": 102429
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6282
+      "Size": 6271
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11272
+      "Size": 11269
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19438
+      "Size": 19428
     },
     "assemblies/Xamarin.Forms.Core.dll": {
       "Size": 471887
@@ -116,10 +116,10 @@
       "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114915
+      "Size": 114916
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 367756
+      "Size": 367737
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56584
@@ -128,298 +128,298 @@
       "Size": 55034
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43511
+      "Size": 43506
     },
     "classes.dex": {
-      "Size": 2639828
+      "Size": 2636860
     },
     "lib/armeabi-v7a/libaot-FormsViewGroup.dll.so": {
-      "Size": 10536
+      "Size": 10452
     },
     "lib/armeabi-v7a/libaot-Java.Interop.dll.so": {
-      "Size": 138600
+      "Size": 138516
     },
     "lib/armeabi-v7a/libaot-Mono.Android.dll.so": {
-      "Size": 636600
+      "Size": 638228
     },
     "lib/armeabi-v7a/libaot-Mono.Security.dll.so": {
-      "Size": 17416
+      "Size": 17332
     },
     "lib/armeabi-v7a/libaot-mscorlib.dll.so": {
-      "Size": 1201760
+      "Size": 1201676
     },
     "lib/armeabi-v7a/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 205800
+      "Size": 205716
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 3632
+      "Size": 3548
     },
     "lib/armeabi-v7a/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 4264
+      "Size": 4180
     },
     "lib/armeabi-v7a/libaot-System.Core.dll.so": {
-      "Size": 302112
+      "Size": 302028
     },
     "lib/armeabi-v7a/libaot-System.Data.dll.so": {
-      "Size": 136104
+      "Size": 136020
     },
     "lib/armeabi-v7a/libaot-System.dll.so": {
-      "Size": 280208
+      "Size": 280124
     },
     "lib/armeabi-v7a/libaot-System.Drawing.Common.dll.so": {
-      "Size": 3840
+      "Size": 3756
     },
     "lib/armeabi-v7a/libaot-System.Net.Http.dll.so": {
-      "Size": 53616
+      "Size": 53532
     },
     "lib/armeabi-v7a/libaot-System.Numerics.dll.so": {
-      "Size": 5776
+      "Size": 5692
     },
     "lib/armeabi-v7a/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 86968
+      "Size": 86884
     },
     "lib/armeabi-v7a/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 8744
+      "Size": 8660
     },
     "lib/armeabi-v7a/libaot-System.Xml.dll.so": {
-      "Size": 204656
+      "Size": 204572
     },
     "lib/armeabi-v7a/libaot-System.Xml.Linq.dll.so": {
-      "Size": 18248
+      "Size": 18164
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 5312
+      "Size": 5228
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 81800
+      "Size": 81716
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 3704
+      "Size": 3620
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 5000
+      "Size": 4916
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 12400
+      "Size": 12316
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 63328
+      "Size": 63244
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 14912
+      "Size": 14828
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 30512
+      "Size": 30428
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 3520
+      "Size": 3436
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 4352
+      "Size": 4268
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 4072
+      "Size": 3988
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 3264
+      "Size": 3180
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 6704
+      "Size": 6620
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 70160
+      "Size": 70076
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 3728
+      "Size": 3644
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 10840
+      "Size": 10756
     },
     "lib/armeabi-v7a/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 16256
+      "Size": 16172
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 968864
+      "Size": 968780
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 8744
+      "Size": 8660
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 218424
+      "Size": 218340
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 710672
+      "Size": 710588
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 106880
+      "Size": 106796
     },
     "lib/armeabi-v7a/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 38520
+      "Size": 38436
     },
     "lib/armeabi-v7a/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 35584
+      "Size": 35500
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736396
+      "Size": 785140
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 235164
+      "Size": 312824
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
       "Size": 4456612
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48844
+      "Size": 48812
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 141260
+      "Size": 87604
     },
     "lib/x86/libaot-FormsViewGroup.dll.so": {
-      "Size": 9732
+      "Size": 9648
     },
     "lib/x86/libaot-Java.Interop.dll.so": {
-      "Size": 112916
+      "Size": 112832
     },
     "lib/x86/libaot-Mono.Android.dll.so": {
-      "Size": 467580
+      "Size": 468600
     },
     "lib/x86/libaot-Mono.Security.dll.so": {
-      "Size": 11356
+      "Size": 11272
     },
     "lib/x86/libaot-mscorlib.dll.so": {
-      "Size": 943060
+      "Size": 942976
     },
     "lib/x86/libaot-Newtonsoft.Json.dll.so": {
-      "Size": 146764
+      "Size": 146680
     },
     "lib/x86/libaot-Plugin.Connectivity.Abstractions.dll.so": {
-      "Size": 3180
+      "Size": 3096
     },
     "lib/x86/libaot-Plugin.Connectivity.dll.so": {
-      "Size": 3684
+      "Size": 3600
     },
     "lib/x86/libaot-System.Core.dll.so": {
-      "Size": 242292
+      "Size": 242208
     },
     "lib/x86/libaot-System.Data.dll.so": {
-      "Size": 83948
+      "Size": 83864
     },
     "lib/x86/libaot-System.dll.so": {
-      "Size": 204340
+      "Size": 204256
     },
     "lib/x86/libaot-System.Drawing.Common.dll.so": {
-      "Size": 3252
+      "Size": 3168
     },
     "lib/x86/libaot-System.Net.Http.dll.so": {
-      "Size": 36740
+      "Size": 36656
     },
     "lib/x86/libaot-System.Numerics.dll.so": {
-      "Size": 4068
+      "Size": 3984
     },
     "lib/x86/libaot-System.Runtime.Serialization.dll.so": {
-      "Size": 50524
+      "Size": 50440
     },
     "lib/x86/libaot-System.ServiceModel.Internals.dll.so": {
-      "Size": 6388
+      "Size": 6304
     },
     "lib/x86/libaot-System.Xml.dll.so": {
-      "Size": 117460
+      "Size": 117376
     },
     "lib/x86/libaot-System.Xml.Linq.dll.so": {
-      "Size": 12404
+      "Size": 12320
     },
     "lib/x86/libaot-Xamarin.AndroidX.Activity.dll.so": {
-      "Size": 4524
+      "Size": 4440
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.dll.so": {
-      "Size": 52652
+      "Size": 52568
     },
     "lib/x86/libaot-Xamarin.AndroidX.AppCompat.Resources.dll.so": {
-      "Size": 3228
+      "Size": 3144
     },
     "lib/x86/libaot-Xamarin.AndroidX.CardView.dll.so": {
-      "Size": 4300
+      "Size": 4216
     },
     "lib/x86/libaot-Xamarin.AndroidX.CoordinatorLayout.dll.so": {
-      "Size": 9644
+      "Size": 9560
     },
     "lib/x86/libaot-Xamarin.AndroidX.Core.dll.so": {
-      "Size": 35964
+      "Size": 35880
     },
     "lib/x86/libaot-Xamarin.AndroidX.DrawerLayout.dll.so": {
-      "Size": 12060
+      "Size": 11976
     },
     "lib/x86/libaot-Xamarin.AndroidX.Fragment.dll.so": {
-      "Size": 21420
+      "Size": 21336
     },
     "lib/x86/libaot-Xamarin.AndroidX.Legacy.Support.Core.UI.dll.so": {
-      "Size": 3068
+      "Size": 2984
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.Common.dll.so": {
-      "Size": 3700
+      "Size": 3616
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.LiveData.Core.dll.so": {
-      "Size": 3420
+      "Size": 3336
     },
     "lib/x86/libaot-Xamarin.AndroidX.Lifecycle.ViewModel.dll.so": {
-      "Size": 3028
+      "Size": 2944
     },
     "lib/x86/libaot-Xamarin.AndroidX.Loader.dll.so": {
-      "Size": 4732
+      "Size": 4648
     },
     "lib/x86/libaot-Xamarin.AndroidX.RecyclerView.dll.so": {
-      "Size": 46548
+      "Size": 46464
     },
     "lib/x86/libaot-Xamarin.AndroidX.SavedState.dll.so": {
-      "Size": 3276
+      "Size": 3192
     },
     "lib/x86/libaot-Xamarin.AndroidX.SwipeRefreshLayout.dll.so": {
-      "Size": 8980
+      "Size": 8896
     },
     "lib/x86/libaot-Xamarin.AndroidX.ViewPager.dll.so": {
-      "Size": 12524
+      "Size": 12440
     },
     "lib/x86/libaot-Xamarin.Forms.Core.dll.so": {
-      "Size": 765884
+      "Size": 765800
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.dll.so": {
-      "Size": 7292
+      "Size": 7208
     },
     "lib/x86/libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so": {
-      "Size": 134180
+      "Size": 134096
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.Android.dll.so": {
-      "Size": 549012
+      "Size": 548928
     },
     "lib/x86/libaot-Xamarin.Forms.Platform.dll.so": {
-      "Size": 65596
+      "Size": 65512
     },
     "lib/x86/libaot-Xamarin.Forms.Xaml.dll.so": {
-      "Size": 27620
+      "Size": 27536
     },
     "lib/x86/libaot-Xamarin.Google.Android.Material.dll.so": {
-      "Size": 26300
+      "Size": 26216
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803352
+      "Size": 823560
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 306828
+      "Size": 414704
     },
     "lib/x86/libmonosgen-2.0.so": {
       "Size": 4212360
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61112
+      "Size": 60848
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 140024
+      "Size": 86400
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -2243,5 +2243,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 16061636
+  "PackageSize": 16164036
 }

--- a/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/Xamarin.Forms_Performance_Integration-Signed-Release.apkdesc
@@ -8,16 +8,16 @@
       "Size": 7199
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68861
+      "Size": 68911
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 561736
+      "Size": 565815
     },
     "assemblies/Mono.Security.dll": {
       "Size": 68437
     },
     "assemblies/mscorlib.dll": {
-      "Size": 936263
+      "Size": 936222
     },
     "assemblies/Newtonsoft.Json.dll": {
       "Size": 319336
@@ -32,22 +32,22 @@
       "Size": 192216
     },
     "assemblies/System.Data.dll": {
-      "Size": 316113
+      "Size": 316112
     },
     "assemblies/System.dll": {
-      "Size": 443207
+      "Size": 443206
     },
     "assemblies/System.Drawing.Common.dll": {
       "Size": 16351
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 113293
+      "Size": 113294
     },
     "assemblies/System.Numerics.dll": {
       "Size": 23262
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 193453
+      "Size": 193454
     },
     "assemblies/System.ServiceModel.Internals.dll": {
       "Size": 26599
@@ -116,7 +116,7 @@
       "Size": 22005
     },
     "assemblies/Xamarin.Forms.Performance.Integration.Droid.dll": {
-      "Size": 114913
+      "Size": 114916
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
       "Size": 367737
@@ -131,43 +131,43 @@
       "Size": 43506
     },
     "classes.dex": {
-      "Size": 2652924
+      "Size": 2636860
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736396
+      "Size": 785140
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 235164
+      "Size": 312824
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456576
+      "Size": 4456612
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48844
+      "Size": 48812
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 133596
+      "Size": 77908
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803352
+      "Size": 823560
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 306828
+      "Size": 414704
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212336
+      "Size": 4212360
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61112
+      "Size": 60848
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 136588
+      "Size": 77712
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1991,5 +1991,5 @@
       "Size": 347268
     }
   },
-  "PackageSize": 12997984
+  "PackageSize": 13104480
 }

--- a/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
+++ b/tests/apk-sizes-reference/com.companyname.vsandroidapp-Signed-Release.apkdesc
@@ -2,52 +2,52 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 2896
+      "Size": 2832
     },
     "assemblies/assemblies.blob": {
-      "Size": 2027538
+      "Size": 2032015
     },
     "assemblies/assemblies.manifest": {
       "Size": 1574
     },
     "classes.dex": {
-      "Size": 2940568
+      "Size": 2923320
     },
     "lib/armeabi-v7a/libmono-btls-shared.so": {
       "Size": 1112688
     },
     "lib/armeabi-v7a/libmono-native.so": {
-      "Size": 736396
+      "Size": 785140
     },
     "lib/armeabi-v7a/libmonodroid.so": {
-      "Size": 234328
+      "Size": 311756
     },
     "lib/armeabi-v7a/libmonosgen-2.0.so": {
-      "Size": 4456576
+      "Size": 4456612
     },
     "lib/armeabi-v7a/libxa-internal-api.so": {
-      "Size": 48844
+      "Size": 48812
     },
     "lib/armeabi-v7a/libxamarin-app.so": {
-      "Size": 46844
+      "Size": 30276
     },
     "lib/x86/libmono-btls-shared.so": {
       "Size": 1459584
     },
     "lib/x86/libmono-native.so": {
-      "Size": 803352
+      "Size": 823560
     },
     "lib/x86/libmonodroid.so": {
-      "Size": 305648
+      "Size": 413476
     },
     "lib/x86/libmonosgen-2.0.so": {
-      "Size": 4212336
+      "Size": 4212360
     },
     "lib/x86/libxa-internal-api.so": {
-      "Size": 61112
+      "Size": 60848
     },
     "lib/x86/libxamarin-app.so": {
-      "Size": 45632
+      "Size": 30080
     },
     "META-INF/android.arch.core_runtime.version": {
       "Size": 6
@@ -1610,5 +1610,5 @@
       "Size": 320016
     }
   },
-  "PackageSize": 9504777
+  "PackageSize": 9603081
 }


### PR DESCRIPTION
We rely on precise (nanosecond level) performance measurements and, as
we improve various components of the code, the precision requirements
increase - especially with regards to the amount of indeterminism.  One
such source of indeterminism are the `logcat` calls which we make as the
measurements are taken.  Such calls send the message to a system daemon
which needs to acquire locks in order to put messages in the `logcat`
buffer(s).  Each such call means that the operating system schedules our
process out and an undetermined amount of time can pass before control
comes back to our thread.

In order to avoid this particular issue, this commit implements a new
timing infrastructure which can log events without incurring the cost of
`logcat` until such time as the timing is done and the information can
be logged without affecting measurements.  This is done by introducing a
new timing mode, `timing=fast-bare`, which can be used in the
`debug.mono.log` system property instead of `timing` or `timing=bare`.
The mode is similar to `timing=bare` but it postpones until a broadcast
intent is sent to the application.  This can be done using the following
command:

    adb shell broadcast -a mono.android.app.DUMP_TIMING_DATA <PACKAGE_NAME>

At this point, all the gathered events are logged.  In addition, the new
infrastructure measures the time it spent initializing itself, which can
then be subtracted from the total time to get as close to "real world"
performance of the app as possible.

In testing, I've seen that this causes timing results to be more stable
as well as saving us up to 4% time for the `Displayed` measure.