### PR TITLE
[templates] add INTERNET permission

### DIFF
--- a/src/Microsoft.Android.Templates/android/AndroidManifest.xml
+++ b/src/Microsoft.Android.Templates/android/AndroidManifest.xml
@@ -2,4 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
   </application>
+  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/6576
Context: https://github.com/dotnet/maui/pull/6673

Debug builds on Android automatically add the `INTERNET` permission,
because otherwise debugging wouldn't work! This definitely adds some
confusion if you switch to a `Release` build and start getting
exceptions in your `HttpClient` calls.

We should just add the `INTERNET` premission to the Android templates,
as nearly every modern app will use the internet. Customers can simply
remove the permission if they don't want it.