### PR TITLE
Parse cookies on redirect

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -582,12 +582,12 @@ namespace Xamarin.Android.Net
 					}
 				}
 
+				CopyHeaders (httpConnection, ret);
+				ParseCookies (ret, connectionUri);
+
 				if (disposeRet) {
 					ret.Dispose ();
 					ret = null!;
-				} else {
-					CopyHeaders (httpConnection, ret);
-					ParseCookies (ret, connectionUri);
 				}
 
 				// We don't want to pass the authorization header onto the next location


### PR DESCRIPTION
When using the `AllowAutoRedirect` feature of `AndroidMessageHandler` to automatically follow 3xx redirects, the cookies that are returned together with the redirection are not processed. If the redirection target requires the cookies returned by the first request, the call will fail.

This change fixes this behavior and always processes the cookies before the redirection takes place. Fixes #3954.