### PR TITLE
[tests] update to Xamarin.Build.Download 0.11.2

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -53,9 +53,8 @@ variables:
   value: $[and(ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
 - name: RunAllTests
   value: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
-  # XamarinBuildDownload disabled, due to: https://github.com/dotnet/runtime/issues/68734
 - name: DotNetNUnitCategories
-  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication & TestCategory != XamarinBuildDownload'
+  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
 - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -472,7 +472,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_Build_Download = new Package {
 			Id = "Xamarin.Build.Download",
-			Version = "0.11.0",
+			Version = "0.11.2",
 		};
 		// NOTE: old version required for some tests
 		public static Package Xamarin_Build_Download_0_4_11 = new Package {


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/68734
Context: https://github.com/xamarin/XamarinComponents/pull/1368

We have a newer Xamarin.Build.Download package that shouldn't suffer
from the duplicate `ZipArchive.CreateEntry()` issue were are hitting
in .NET 7.

Let's use it, and enable previously failing tests.