### PR TITLE
[release/6.0.3xx] Bump to 32.0.301

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,9 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>32.0.301</AndroidPackVersion>
+    <AndroidPackVersionPatchIndex>$(AndroidPackVersion.LastIndexOf("."))</AndroidPackVersionPatchIndex>
+    <AndroidPackVersionMajorMinor>$(AndroidPackVersion.Substring(0,$(AndroidPackVersionPatchIndex)))</AndroidPackVersionMajorMinor>
+    <AndroidPackVersionPatch>$(AndroidPackVersion.Substring($([MSBuild]::Add($(AndroidPackVersionPatchIndex), 1))))</AndroidPackVersionPatch>
     <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
          * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>32.0.300</AndroidPackVersion>
+    <AndroidPackVersion>32.0.301</AndroidPackVersion>
     <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
   </PropertyGroup>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -85,7 +85,7 @@
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
-        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion)"
+        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidPackVersionLong);@WORKLOAD_VERSION@=$(AndroidMSIVersion)"
     />
   </Target>
 

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -85,8 +85,8 @@
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(XAVersionBranch)' == 'main' or $(XAVersionBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
-      <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>
+      <AndroidPackVersionLong>$([MSBuild]::Add($(AndroidPackVersion), $(PackVersionCommitCount)))</AndroidPackVersionLong>
+      <AndroidMSIVersion>$(AndroidPackVersionLong).0</AndroidMSIVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -85,7 +85,7 @@
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(XAVersionBranch)' == 'main' or $(XAVersionBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <AndroidPackVersionLong>$([MSBuild]::Add($(AndroidPackVersion), $(PackVersionCommitCount)))</AndroidPackVersionLong>
+      <AndroidPackVersionLong>$(AndroidPackVersionMajorMinor).$([MSBuild]::Add($(AndroidPackVersionPatch), $(PackVersionCommitCount)))</AndroidPackVersionLong>
       <AndroidMSIVersion>$(AndroidPackVersionLong).0</AndroidMSIVersion>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Make our .NET pack versioning stable by updating it to 32.0.301.  The
third number will continue to increase as new commits land in this
branch.  32.0.301.0 will be used for the MSI generation tooling as it
expects a four part version.