### PR TITLE
Fix TrimEnd for _AndroidTargetingPackId in Microsoft.Android.Sdk.BundledVersions.in.targets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -12,7 +12,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <XamarinAndroidVersion>@ANDROID_PACK_VERSION_LONG@</XamarinAndroidVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <_AndroidTargetingPackId>$(TargetPlatformVersion.TrimEnd('.0'))</_AndroidTargetingPackId>
+    <_AndroidTargetingPackId Condition="$(TargetPlatformVersion.EndsWith('.0'))">$(TargetPlatformVersion.Substring(0, $(TargetPlatformVersion.LastIndexOf('.0'))))</_AndroidTargetingPackId>
+    <_AndroidTargetingPackId Condition="'$(_AndroidTargetingPackId)' == ''">$(TargetPlatformVersion)</_AndroidTargetingPackId>
     <_AndroidRuntimePackId Condition=" '$(_AndroidTargetingPackId)' &lt; '@ANDROID_LATEST_STABLE_API_LEVEL@' ">@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidRuntimePackId>
     <_AndroidRuntimePackId Condition=" '$(_AndroidRuntimePackId)' == '' ">$(_AndroidTargetingPackId)</_AndroidRuntimePackId>
   </PropertyGroup>


### PR DESCRIPTION
We can't use `TrimEnd` here since it will use the `TrimEnd(char[])` overload so it'd trim **all** `.` and `0` chars from the end, not the whole string `.0`. 
This results in `30.0` being trimmed to just `3` instead of the expected `30`.

See https://github.com/dotnet/sdk/issues/25370 for more details, I first thought it's a dotnet SDK issue but it turned out to be an XA issue.

/cc @pjcollins 