### PR TITLE
[build] enable the dotnet7 feed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,11 +28,9 @@
     <!-- NuGet package version numbers. See Documentation/guides/OneDotNet.md.
          Rules:
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
-         * Reset patch version (third number) to 100 every time either major or minor version is bumped.
-         * Bump last two digits of the patch version for service releases.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>33.0.100</AndroidPackVersion>
+    <AndroidPackVersion>33.0.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
   </PropertyGroup>
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1429,6 +1429,12 @@ stages:
         artifactName: vs-msi-nugets
         downloadPath: $(Build.StagingDirectory)\nuget-signed
 
+    - task: NuGetAuthenticate@0
+      displayName: authenticate with azure artifacts
+      inputs:
+        nuGetServiceConnections: $(DotNetFeedCredential)
+        forceReinstallCredentialProvider: true
+
     - task: NuGetCommand@2
       displayName: push nupkgs
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -59,10 +59,10 @@ variables:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage
   - name: DotNetFeedCredential
-    value: dotnet6-internal-dnceng-internal-feed
+    value: dotnet7-internal-dnceng-internal-feed
 - ${{ if ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - name: DotNetFeedCredential
-    value: dnceng-dotnet6
+    value: dnceng-dotnet7
 - ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Real
@@ -1436,9 +1436,7 @@ stages:
         packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: $(DotNetFeedCredential)
-      condition: false
-      # NET7TODO: Enable once we have access to the dnceng-dotnet7 feed.
-      #condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
+      condition: and(succeeded(), eq(variables['PushXAPackages'], 'true'))
 
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1429,12 +1429,6 @@ stages:
         artifactName: vs-msi-nugets
         downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-    - task: NuGetAuthenticate@0
-      displayName: authenticate with azure artifacts
-      inputs:
-        nuGetServiceConnections: $(DotNetFeedCredential)
-        forceReinstallCredentialProvider: true
-
     - task: NuGetCommand@2
       displayName: push nupkgs
       inputs:

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -171,7 +171,7 @@
     <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />


### PR DESCRIPTION
We should now have access to use the `dnceng-dotnet7` connection in DevDiv's AzDO instance.