### PR TITLE
[build] Refactor net6 references in src/monodroid

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -63,19 +63,19 @@
 
   <Target Name="_CreatePreviewPacks"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks;_CreateDefaultRefPack">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -11,7 +11,6 @@ projects that use the Microsoft.Android framework in .NET 5.
 
   <PropertyGroup>
     <AndroidRID Condition=" '$(AndroidRID)' == '' ">android-arm64</AndroidRID>
-    <AndroidABI Condition=" '$(AndroidABI)' == '' ">arm64-v8a-net6</AndroidABI>
     <PackageId>Microsoft.Android.Runtime.$(AndroidApiLevel).$(AndroidRID)</PackageId>
     <Description>Microsoft.Android runtime components for API $(AndroidApiLevel). Please do not reference directly.</Description>
     <_AndroidRuntimePackAssemblyPath>runtimes\$(AndroidRID)\lib\$(DotNetTargetFramework)</_AndroidRuntimePackAssemblyPath>
@@ -39,9 +38,9 @@ projects that use the Microsoft.Android framework in .NET 5.
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\Mono.Android.dll" />
       <!-- Always include stable Mono.Android.Export.dll -->
       <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />
-      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.debug.so" />
-      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libmono-android.release.so" />
-      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidABI)\libxamarin-debug-app-helper.so" />
+      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidRID)\libmono-android.debug.so" />
+      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidRID)\libmono-android.release.so" />
+      <_AndroidRuntimePackAssets Include="$(XAInstallPrefix)xbuild\Xamarin\Android\lib\$(AndroidRID)\libxamarin-debug-app-helper.so" />
       <FrameworkListFileClass Include="@(_AndroidRuntimePackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />
       <FrameworkListFileClass Include="@(_AndroidRuntimePackAssets->'%(Filename)%(Extension)')" Profile="Android" />
     </ItemGroup>

--- a/build-tools/scripts/Ndk.projitems.in
+++ b/build-tools/scripts/Ndk.projitems.in
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <AndroidNdkVersion Condition=" '$(AndroidNdkVersion)' == '' ">@NDK_RELEASE@</AndroidNdkVersion>
     <AndroidNdkApiLevel_ArmV7a Condition=" '$(AndroidNdkApiLevel_ArmV7a)' == '' ">@NDK_ARMEABI_V7_API@</AndroidNdkApiLevel_ArmV7a>
-    <AndroidNdkApiLevel_ArmV7a_NET6 Condition=" '$(AndroidNdkApiLevel_ArmV7a_NET6)' == '' ">@NDK_ARMEABI_V7_API_NET6@</AndroidNdkApiLevel_ArmV7a_NET6>
+    <AndroidNdkApiLevel_Arm Condition=" '$(AndroidNdkApiLevel_Arm)' == '' ">@NDK_ARMEABI_V7_API_NET@</AndroidNdkApiLevel_Arm>
     <AndroidNdkApiLevel_ArmV8a Condition=" '$(AndroidNdkApiLevel_ArmV8a)' == '' ">@NDK_ARM64_V8A_API@</AndroidNdkApiLevel_ArmV8a>
-    <AndroidNdkApiLevel_ArmV8a_NET6 Condition=" '$(AndroidNdkApiLevel_ArmV8a_NET6)' == '' ">@NDK_ARM64_V8A_API_NET6@</AndroidNdkApiLevel_ArmV8a_NET6>
-    <AndroidNdkApiLevel_X86 Condition=" '$(AndroidNdkApiLevel_X86)' == '' ">@NDK_X86_API@</AndroidNdkApiLevel_X86>
-    <AndroidNdkApiLevel_X86_NET6 Condition=" '$(AndroidNdkApiLevel_X86_NET6)' == '' ">@NDK_X86_API_NET6@</AndroidNdkApiLevel_X86_NET6>
+    <AndroidNdkApiLevel_Arm64 Condition=" '$(AndroidNdkApiLevel_Arm64)' == '' ">@NDK_ARM64_V8A_API_NET@</AndroidNdkApiLevel_Arm64>
+    <AndroidNdkApiLevel_X86_Legacy Condition=" '$(AndroidNdkApiLevel_X86_Legacy)' == '' ">@NDK_X86_API@</AndroidNdkApiLevel_X86_Legacy>
+    <AndroidNdkApiLevel_X86 Condition=" '$(AndroidNdkApiLevel_X86)' == '' ">@NDK_X86_API_NET@</AndroidNdkApiLevel_X86>
     <AndroidNdkApiLevel_X86_64 Condition=" '$(AndroidNdkApiLevel_X86_64)' == '' ">@NDK_X86_64_API@</AndroidNdkApiLevel_X86_64>
-    <AndroidNdkApiLevel_X86_64_NET6 Condition=" '$(AndroidNdkApiLevel_X86_64_NET6)' == '' ">@NDK_X86_64_API_NET6@</AndroidNdkApiLevel_X86_64_NET6>
+    <AndroidNdkApiLevel_X64 Condition=" '$(AndroidNdkApiLevel_X64)' == '' ">@NDK_X86_64_API_NET@</AndroidNdkApiLevel_X64>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,28 +17,32 @@
         Include="armeabi-v7a"
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_ArmV7a)</ApiLevel>
-      <ApiLevelNET6>$(AndroidNdkApiLevel_ArmV7a_NET6)</ApiLevelNET6>
+      <ApiLevelNET>$(AndroidNdkApiLevel_Arm)</ApiLevelNET>
+      <AndroidRID>android-arm</AndroidRID>
     </AndroidSupportedTargetJitAbi>
 
     <AndroidSupportedTargetJitAbi
         Include="arm64-v8a"
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_ArmV8a)</ApiLevel>
-      <ApiLevelNET6>$(AndroidNdkApiLevel_ArmV8a_NET6)</ApiLevelNET6>
+      <ApiLevelNET>$(AndroidNdkApiLevel_Arm64)</ApiLevelNET>
+      <AndroidRID>android-arm64</AndroidRID>
     </AndroidSupportedTargetJitAbi>
 
     <AndroidSupportedTargetJitAbi
         Include="x86"
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:')) ">
-      <ApiLevel>$(AndroidNdkApiLevel_X86)</ApiLevel>
-      <ApiLevelNET6>$(AndroidNdkApiLevel_X86_NET6)</ApiLevelNET6>
+      <ApiLevel>$(AndroidNdkApiLevel_X86_Legacy)</ApiLevel>
+      <ApiLevelNET>$(AndroidNdkApiLevel_X86)</ApiLevelNET>
+      <AndroidRID>android-x86</AndroidRID>
     </AndroidSupportedTargetJitAbi>
 
     <AndroidSupportedTargetJitAbi
         Include="x86_64"
         Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:')) ">
       <ApiLevel>$(AndroidNdkApiLevel_X86_64)</ApiLevel>
-      <ApiLevelNET6>$(AndroidNdkApiLevel_X86_64_NET6)</ApiLevelNET6>
+      <ApiLevelNET>$(AndroidNdkApiLevel_X64)</ApiLevelNET>
+      <AndroidRID>android-x64</AndroidRID>
     </AndroidSupportedTargetJitAbi>
   </ItemGroup>
 </Project>

--- a/build-tools/scripts/build-monodroid
+++ b/build-tools/scripts/build-monodroid
@@ -30,20 +30,20 @@ where OPTIONS is one or more of:
 
 Each <TARGET> is a name of the monodroid runtime configuration to build. Format:
 
-   {ARCH}-[net6-][CHECKER-]{CONFIGURATION}
+   {ARCH}-[CHECKER-]{CONFIGURATION}
 
-where strings in lower case (e.g. 'net6') are to be used verbatim and the ones in
-upper case (e.g. 'ARCH') are placeholders as defined below (alternative forms for
-each value are specified in parentheses). All values are case-insensitive:
+where strings in upper case (e.g. 'ARCH') are placeholders as defined below
+(alternative forms for each value are specified in parentheses).
+All values are case-insensitive:
 
-   ARCH is one of: armeabi-v7a (arm32, armv7), arm64-v8a (arm64, armv8), x86, x86_64 (x64), host, win32, win64
+   ARCH is one of: armeabi-v7a (arm32, armv7), arm64-v8a (arm64, armv8), x86, x86_64 (x64), host, win32, win64, android-arm, android-arm64, android-x86, android-x64
    CHECKER is one of: asan, ubsan
    CONFIGURATION is one of: release, debug
 
 Examples:
 
   ${MY_NAME} arm64-release
-  ${MY_NAME} x86-net6-release host-debug
+  ${MY_NAME} android-x86-release host-debug
   ${MY_NAME} x64-ubsan-release x86-net6-asan-debug
 
 EOF

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/AbiNames.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/AbiNames.cs
@@ -149,5 +149,19 @@ namespace Xamarin.Android.Prepare
 			}
 			Log.Instance.DebugLine ();
 		}
+
+		public static string AbiToRuntimeIdentifier (string androidAbi)
+		{
+			if (androidAbi == TargetJit.AndroidArmV7a) {
+				return "android-arm";
+			} else if (androidAbi == TargetJit.AndroidArmV8a) {
+				return "android-arm64";
+			} else if (androidAbi == TargetJit.AndroidX86) {
+				return "android-x86";
+			} else if (androidAbi == TargetJit.AndroidX86_64) {
+				return "android-x64";
+			}
+			throw new InvalidOperationException ($"Unknown abi: {androidAbi}");
+		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -7,6 +7,8 @@ namespace Xamarin.Android.Prepare
 	{
 		public const string AndroidNdkVersion = "24";
 		public const string AndroidNdkPkgRevision = "24.0.8215888";
+		public const int NdkMinimumAPI = 21;
+		public const int NdkMinimumAPILegacy32 = 19;
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),
@@ -44,17 +46,12 @@ namespace Xamarin.Android.Prepare
 			new AndroidPlatform (apiName: "Tiramisu",               apiLevel: 33, platformID: "Tiramisu",  include: "v12.1.99",   framework: "v12.1.99", stable: false),
 		};
 
-		// These are here until we can drop "legacy" targets and use only .NET6+
-		public const string AndroidArmV7a_NET6 = AbiNames.TargetJit.AndroidArmV7a + "_NET6";
-		public const string AndroidArmV8a_NET6 = AbiNames.TargetJit.AndroidArmV8a + "_NET6";
-		public const string AndroidX86_NET6    = AbiNames.TargetJit.AndroidX86 + "_NET6";
-		public const string AndroidX86_64_NET6 = AbiNames.TargetJit.AndroidX86_64 + "_NET6";
-
-		public static readonly Dictionary<string, uint> NdkMinimumAPI = new Dictionary<string, uint> {
-			{ AbiNames.TargetJit.AndroidArmV7a, 19 }, { AndroidArmV7a_NET6, 21 },
-			{ AbiNames.TargetJit.AndroidArmV8a, 21 }, { AndroidArmV8a_NET6, 21 },
-			{ AbiNames.TargetJit.AndroidX86,    19 }, { AndroidX86_NET6, 21 },
-			{ AbiNames.TargetJit.AndroidX86_64, 21 }, { AndroidX86_64_NET6, 21 },
+		public static readonly Dictionary<string, uint> NdkMinimumAPIMap = new Dictionary<string, uint> {
+			{ AbiNames.TargetJit.AndroidArmV7a, NdkMinimumAPILegacy32 },
+			{ AbiNames.TargetJit.AndroidArmV8a, NdkMinimumAPI },
+			{ AbiNames.TargetJit.AndroidX86,    NdkMinimumAPILegacy32 },
+			{ AbiNames.TargetJit.AndroidX86_64, NdkMinimumAPI },
 		};
+
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/CmakeBuilds.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/CmakeBuilds.cs
@@ -20,12 +20,12 @@ namespace Xamarin.Android.Prepare
 			public string Suffix = String.Empty;
 			public string MSBuildApiLevel = String.Empty;
 			public List<string>? ExtraOptions = null;
-			public bool IsNet6 = false;
+			public bool IsDotNet = false;
 			public bool IsHost = false;
 		};
 
 		const string msbuildApiLevelLegacy = "%(AndroidSupportedTargetJitAbi.ApiLevel)";
-		const string msbuildApiLevelNet6 = "%(AndroidSupportedTargetJitAbi.ApiLevelNET6)";
+		const string msbuildApiLevel = "%(AndroidSupportedTargetJitAbi.ApiLevelNET)";
 
 		// These two are configured in CmakeBuilds.Unix.cs, Windows doesn't use them
 		public static readonly string MxeToolchainBasePath = String.Empty;
@@ -77,6 +77,7 @@ namespace Xamarin.Android.Prepare
 			"-DANDROID_NATIVE_API_LEVEL=@NATIVE_API_LEVEL@",
 			"-DANDROID_PLATFORM=android-@NATIVE_API_LEVEL@",
 			"-DANDROID_ABI=@ABI@",
+			"-DANDROID_RID=@RID@",
 			"-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=\"@OUTPUT_DIRECTORY@\"",
 			"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=\"@OUTPUT_DIRECTORY@\"",
 			"\"@SOURCE_DIRECTORY@\"",
@@ -93,17 +94,17 @@ namespace Xamarin.Android.Prepare
 			"-DANDROID_CPP_FEATURES=\"rtti exceptions\"",
 		};
 
-		const string enableNet6 = "-DENABLE_NET6=ON";
-		public static readonly List<string> Net6ExtraOptions = new List<string> {
-			enableNet6,
+		const string enableNet = "-DENABLE_NET=ON";
+		public static readonly List<string> NetExtraOptions = new List<string> {
+			enableNet,
 		};
 
-		public static readonly List<string> Net6AsanExtraOptions = new List<string> (AsanExtraOptions) {
-			enableNet6,
+		public static readonly List<string> NetAsanExtraOptions = new List<string> (AsanExtraOptions) {
+			enableNet,
 		};
 
-		public static readonly List<string> Net6UbsanExtraOptions = new List<string> (UbsanExtraOptions) {
-			enableNet6,
+		public static readonly List<string> NetUbsanExtraOptions = new List<string> (UbsanExtraOptions) {
+			enableNet,
 		};
 
 		public static readonly List<RuntimeCommand> AndroidRuntimeCommands = new List<RuntimeCommand> {
@@ -132,30 +133,30 @@ namespace Xamarin.Android.Prepare
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-Debug",
+				Suffix = "Debug",
 				Configuration = "Release",
 				BuildType = "Debug",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6ExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetExtraOptions,
+				IsDotNet = true,
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-asan-Debug",
+				Suffix = "asan-Debug",
 				Configuration = "Release",
 				BuildType = "Debug",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6AsanExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetAsanExtraOptions,
+				IsDotNet = true,
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-ubsan-Debug",
+				Suffix = "ubsan-Debug",
 				Configuration = "Release",
 				BuildType = "Debug",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6UbsanExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetUbsanExtraOptions,
+				IsDotNet = true,
 			},
 
 			// Release builds
@@ -184,30 +185,30 @@ namespace Xamarin.Android.Prepare
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-Release",
+				Suffix = "Release",
 				Configuration = "Debug",
 				BuildType = "Release",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6ExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetExtraOptions,
+				IsDotNet = true,
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-asan-Release",
+				Suffix = "asan-Release",
 				Configuration = "Debug",
 				BuildType = "Release",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6AsanExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetAsanExtraOptions,
+				IsDotNet = true,
 			},
 
 			new RuntimeCommand {
-				Suffix = "net6-ubsan-Release",
+				Suffix = "ubsan-Release",
 				Configuration = "Debug",
 				BuildType = "Release",
-				MSBuildApiLevel = msbuildApiLevelNet6,
-				ExtraOptions = Net6UbsanExtraOptions,
-				IsNet6 = true,
+				MSBuildApiLevel = msbuildApiLevel,
+				ExtraOptions = NetUbsanExtraOptions,
+				IsDotNet = true,
 			},
 		};
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
@@ -428,10 +428,10 @@ namespace Xamarin.Android.Prepare
 				 "IGNORE_PROVISION_ANDROID=true",
 				$"ANDROID_CMAKE_VERSION={GetProperty (KnownProperties.AndroidCmakeVersionPath)}",
 				 $"ANDROID_NDK_VERSION=r{BuildAndroidPlatforms.AndroidNdkVersion}",
-				$"ANDROID_SDK_VERSION_armeabi-v7a={GetMinimumApi (AbiNames.TargetJit.AndroidArmV7a)}",
-				$"ANDROID_SDK_VERSION_arm64-v8a={GetMinimumApi (AbiNames.TargetJit.AndroidArmV8a)}",
-				$"ANDROID_SDK_VERSION_x86={GetMinimumApi (AbiNames.TargetJit.AndroidX86)}",
-				$"ANDROID_SDK_VERSION_x86_64={GetMinimumApi (AbiNames.TargetJit.AndroidX86_64)}",
+				$"ANDROID_SDK_VERSION_armeabi-v7a={BuildAndroidPlatforms.NdkMinimumAPILegacy32}",
+				$"ANDROID_SDK_VERSION_arm64-v8a={BuildAndroidPlatforms.NdkMinimumAPI}",
+				$"ANDROID_SDK_VERSION_x86={BuildAndroidPlatforms.NdkMinimumAPILegacy32}",
+				$"ANDROID_SDK_VERSION_x86_64={BuildAndroidPlatforms.NdkMinimumAPI}",
 				$"ANDROID_TOOLCHAIN_DIR={GetProperty (KnownProperties.AndroidToolchainDirectory)}",
 				$"ANDROID_TOOLCHAIN_CACHE_DIR={GetProperty (KnownProperties.AndroidToolchainCacheDirectory)}",
 				$"ANDROID_TOOLCHAIN_PREFIX={toolchainsPrefix}",
@@ -479,11 +479,6 @@ namespace Xamarin.Android.Prepare
 			string GetProperty (string name)
 			{
 				return context.Properties.GetRequiredValue (name);
-			}
-
-			string GetMinimumApi (string name)
-			{
-				return BuildAndroidPlatforms.NdkMinimumAPI [name].ToString ();
 			}
 		}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -161,10 +161,10 @@ namespace Xamarin.Android.Prepare
 				{ "@NDK_VERSION_MAJOR@",         context.BuildInfo.NDKVersionMajor },
 				{ "@NDK_VERSION_MINOR@",         context.BuildInfo.NDKVersionMinor },
 				{ "@NDK_VERSION_MICRO@",         context.BuildInfo.NDKVersionMicro },
-				{ "@NDK_ARMEABI_V7_API@",        BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidArmV7a].ToString () },
-				{ "@NDK_ARM64_V8A_API@",         BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidArmV8a].ToString () },
-				{ "@NDK_X86_API@",               BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86].ToString () },
-				{ "@NDK_X86_64_API@",            BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86_64].ToString () },
+				{ "@NDK_ARMEABI_V7_API@",        BuildAndroidPlatforms.NdkMinimumAPILegacy32.ToString () },
+				{ "@NDK_ARM64_V8A_API@",         BuildAndroidPlatforms.NdkMinimumAPI.ToString () },
+				{ "@NDK_X86_API@",               BuildAndroidPlatforms.NdkMinimumAPILegacy32.ToString ().ToString () },
+				{ "@NDK_X86_64_API@",            BuildAndroidPlatforms.NdkMinimumAPI.ToString ().ToString () },
 				{ "@XA_SUPPORTED_ABIS@",         context.Properties.GetRequiredValue (KnownProperties.AndroidSupportedTargetJitAbis).Replace (':', ';') },
 				{ "@ANDROID_DEFAULT_TARGET_DOTNET_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidDefaultTargetDotnetApiLevel) },
 				{ "@ANDROID_LATEST_STABLE_API_LEVEL@", context.Properties.GetRequiredValue (KnownProperties.AndroidLatestStableApiLevel) },
@@ -187,14 +187,14 @@ namespace Xamarin.Android.Prepare
 
 			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
 				{ "@NDK_RELEASE@",               BuildAndroidPlatforms.AndroidNdkVersion },
-				{ "@NDK_ARMEABI_V7_API@",        BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidArmV7a].ToString () },
-				{ "@NDK_ARMEABI_V7_API_NET6@",   BuildAndroidPlatforms.NdkMinimumAPI [BuildAndroidPlatforms.AndroidArmV7a_NET6].ToString () },
-				{ "@NDK_ARM64_V8A_API@",         BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidArmV8a].ToString () },
-				{ "@NDK_ARM64_V8A_API_NET6@",    BuildAndroidPlatforms.NdkMinimumAPI [BuildAndroidPlatforms.AndroidArmV8a_NET6].ToString () },
-				{ "@NDK_X86_API@",               BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86].ToString () },
-				{ "@NDK_X86_API_NET6@",          BuildAndroidPlatforms.NdkMinimumAPI [BuildAndroidPlatforms.AndroidX86_NET6].ToString () },
-				{ "@NDK_X86_64_API@",            BuildAndroidPlatforms.NdkMinimumAPI [AbiNames.TargetJit.AndroidX86_64].ToString () },
-				{ "@NDK_X86_64_API_NET6@",       BuildAndroidPlatforms.NdkMinimumAPI [BuildAndroidPlatforms.AndroidX86_64_NET6].ToString () },
+				{ "@NDK_ARMEABI_V7_API@",        BuildAndroidPlatforms.NdkMinimumAPILegacy32.ToString () },
+				{ "@NDK_ARMEABI_V7_API_NET@",    BuildAndroidPlatforms.NdkMinimumAPI.ToString () },
+				{ "@NDK_ARM64_V8A_API@",         BuildAndroidPlatforms.NdkMinimumAPI.ToString ()  },
+				{ "@NDK_ARM64_V8A_API_NET@",     BuildAndroidPlatforms.NdkMinimumAPI.ToString () },
+				{ "@NDK_X86_API@",               BuildAndroidPlatforms.NdkMinimumAPILegacy32.ToString ()  },
+				{ "@NDK_X86_API_NET@",           BuildAndroidPlatforms.NdkMinimumAPI.ToString ()  },
+				{ "@NDK_X86_64_API@",            BuildAndroidPlatforms.NdkMinimumAPI.ToString ()  },
+				{ "@NDK_X86_64_API_NET@",        BuildAndroidPlatforms.NdkMinimumAPI.ToString ()  },
 			};
 
 			return new GeneratedPlaceholdersFile (

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -18,7 +18,7 @@ namespace Xamarin.ProjectTools
 		const string ConsoleLoggerError = "[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative";
 		const int DefaultBuildTimeOut = 30;
 
-		string Arm32AbiDir => UseDotNet ? "armeabi-v7a-net6" : "armeabi-v7a";
+		string Arm32AbiDir => UseDotNet ? "android-arm" : "armeabi-v7a";
 
 		/// <summary>
 		/// If true, use `dotnet build` and IShortFormProject throughout the tests

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   set(STRIP_DEBUG_DEFAULT ON)
 endif()
 
-option(ENABLE_NET6 "Enable compilation for .NET6" OFF)
+option(ENABLE_NET "Enable compilation for .NET 6+" OFF)
 option(ENABLE_TIMING "Build with timing support" OFF)
 option(STRIP_DEBUG "Strip debugging information when linking" ${STRIP_DEBUG_DEFAULT})
 option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
@@ -177,17 +177,17 @@ endif()
 
 include("${XA_BUILD_DIR}/xa_build_configuration.cmake")
 
-if(ENABLE_NET6)
+if(ENABLE_NET)
   if(ANDROID_ABI MATCHES "^arm64-v8a")
-    set(NET6_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_ARM64}")
+    set(NET_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_ARM64}")
   elseif(ANDROID_ABI MATCHES "^armeabi-v7a")
-    set(NET6_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_ARM}")
+    set(NET_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_ARM}")
   elseif(ANDROID_ABI MATCHES "^x86_64")
-    set(NET6_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_X86_64}")
+    set(NET_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_X86_64}")
   elseif(ANDROID_ABI MATCHES "^x86")
-    set(NET6_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_X86}")
+    set(NET_RUNTIME_DIR "${NETCORE_APP_RUNTIME_DIR_X86}")
   else()
-    message(FATAL "${ANDROID_ABI} is not supported for .NET6 builds")
+    message(FATAL "${ANDROID_ABI} is not supported for .NET 6+ builds")
   endif()
 endif()
 
@@ -238,8 +238,8 @@ if (WIN32)
   include_directories(BEFORE "jni/win32")
 endif()
 
-if(ENABLE_NET6)
-  include_directories("${NET6_RUNTIME_DIR}/native/include/mono-2.0")
+if(ENABLE_NET)
+  include_directories("${NET_RUNTIME_DIR}/native/include/mono-2.0")
 else()
   include_directories("${XA_BIN_DIR}/include/mono-2.0")
 endif()
@@ -270,8 +270,8 @@ add_compile_definitions(_REENTRANT)
 add_compile_definitions(JI_DLL_EXPORT)
 add_compile_definitions(MONO_DLL_EXPORT)
 
-if(ENABLE_NET6)
-  add_compile_definitions(NET6)
+if(ENABLE_NET)
+  add_compile_definitions(NET)
   add_compile_definitions(JI_NO_VISIBILITY)
 endif()
 
@@ -414,9 +414,9 @@ endif()
 
 # Library directories
 if(ANDROID)
-  if(ENABLE_NET6)
-    set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${ANDROID_ABI}-net6")
-    link_directories("${NET6_RUNTIME_DIR}/native")
+  if(ENABLE_NET)
+    set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${ANDROID_RID}")
+    link_directories("${NET_RUNTIME_DIR}/native")
   else()
     set(XA_LIBRARY_OUTPUT_DIRECTORY "${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
     link_directories("${XA_LIBRARY_OUTPUT_DIRECTORY}")
@@ -518,7 +518,7 @@ if(UNIX)
     )
 endif()
 
-if(ANDROID AND ENABLE_NET6)
+if(ANDROID AND ENABLE_NET)
   list(APPEND XAMARIN_MONODROID_SOURCES
     ${SOURCES_DIR}/monovm-properties.cc
     ${SOURCES_DIR}/pinvoke-override-api.cc
@@ -553,7 +553,7 @@ set(XAMARIN_DEBUG_APP_HELPER_SOURCES
 # Build
 configure_file(jni/host-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/host-config.h)
 
-if(NOT (ANDROID AND ENABLE_NET6))
+if(NOT (ANDROID AND ENABLE_NET))
   add_library(
     ${XAMARIN_INTERNAL_API_LIB}
     SHARED

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -655,12 +655,12 @@ AndroidSystem::setup_environment ()
 				break;
 
 			case 'i':
-#if !defined (NET6)
+#if !defined (NET)
 				aotMode = MonoAotMode::MONO_AOT_MODE_LAST;
 				aot_mode_last_is_interpreter = true;
-#else   // defined (NET6)
+#else   // defined (NET)
 				aotMode = MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
-#endif  // !defined (NET6)
+#endif  // !defined (NET)
 				break;
 
 			default:

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -101,22 +101,22 @@ namespace xamarin::android::internal
 
 		bool is_interpreter_enabled () const
 		{
-#if !defined (NET6)
+#if !defined (NET)
 			// HACK! See below
 			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_LAST && is_aot_mode_last_really_interpreter_mode ();
-#else   // defined (NET6)
+#else   // defined (NET)
 			return get_mono_aot_mode () == MonoAotMode::MONO_AOT_MODE_INTERP_ONLY;
-#endif  // !defined (NET6)
+#endif  // !defined (NET)
 		}
 
 		// Hack, see comment for `aot_mode_last_is_interpreter` at the bottom of the class declaration
 		bool is_aot_mode_last_really_interpreter_mode () const
 		{
-#if !defined(NET6)
+#if !defined(NET)
 			return aot_mode_last_is_interpreter;
-#else   // defined (NET6)
+#else   // defined (NET)
 			return false;
-#endif  // !defined (NET6)
+#endif  // !defined (NET)
 		}
 
 		void set_running_in_emulator (bool yesno)
@@ -159,7 +159,7 @@ namespace xamarin::android::internal
 		MonoAotMode aotMode = MonoAotMode::MONO_AOT_MODE_NONE;
 		bool running_in_emulator = false;
 
-#if !defined (NET6)
+#if !defined (NET)
 		// This is a hack because of the way Mono currently switches the full interpreter (no JIT) mode. In Mono
 		// **internal** headers there's an AOT mode macro, `MONO_EE_MODE_INTERP`, whose value is exactly the same as
 		// MonoAotMode::MONO_AOT_MODE_LAST.  However, we use `MonoAotMode::MONO_AOT_MODE_LAST` as a sentinel to indicate
@@ -170,7 +170,7 @@ namespace xamarin::android::internal
 		// See also: https://github.com/mono/mono/issues/18893
 		//
 		bool aot_mode_last_is_interpreter = false;
-#endif  // !defined (NET6)
+#endif  // !defined (NET)
 	};
 }
 #endif // !__ANDROID_SYSTEM_H

--- a/src/monodroid/jni/build-info.hh
+++ b/src/monodroid/jni/build-info.hh
@@ -17,13 +17,6 @@ namespace xamarin::android::internal
 		static constexpr char xa_version[] = XA_VERSION;
 		static constexpr char date[] = __DATE__;
 
-		static constexpr bool is_net6 =
-#if NET6
-			true;
-#else // def NET6
-			false;
-#endif // ndef NET6
-
 		static constexpr char kind[] =
 #if defined (DEBUG)
 			"Debug";

--- a/src/monodroid/jni/cpu-arch.hh
+++ b/src/monodroid/jni/cpu-arch.hh
@@ -10,8 +10,8 @@
 #define CPU_KIND_X86     ((unsigned short)4)
 #define CPU_KIND_X86_64  ((unsigned short)5)
 
-#if !defined(NET6)
+#if !defined(NET)
 MONO_API 
-#endif // def NET6
+#endif // def NET
 void _monodroid_detect_cpu_and_architecture (unsigned short *built_for_cpu, unsigned short *running_on_cpu, unsigned char *is64bit);
-#endif // ndef NET6
+#endif // ndef NET

--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -29,7 +29,7 @@ force_inline bool
 EmbeddedAssemblies::is_debug_file (dynamic_local_string<SENSIBLE_PATH_MAX> const& name) noexcept
 {
 	return utils.ends_with (name, ".pdb")
-#if !defined (NET6)
+#if !defined (NET)
 		|| utils.ends_with (name, ".mdb")
 #endif
 		;
@@ -65,7 +65,7 @@ EmbeddedAssemblies::zip_load_entry_common (size_t entry_index, std::vector<uint8
 		return false;
 	}
 
-#if defined (NET6)
+#if defined (NET)
 	if (application_config.have_runtime_config_blob && !runtime_config_blob_found) {
 		if (utils.ends_with (entry_name, SharedConstants::RUNTIME_CONFIG_BLOB_NAME)) {
 			runtime_config_blob_found = true;
@@ -73,7 +73,7 @@ EmbeddedAssemblies::zip_load_entry_common (size_t entry_index, std::vector<uint8
 			return false;
 		}
 	}
-#endif // def NET6
+#endif // def NET
 
 	// assemblies must be 4-byte aligned, or Bad Things happen
 	if ((state.data_offset & 0x3) != 0) {
@@ -124,7 +124,7 @@ EmbeddedAssemblies::zip_load_individual_assembly_entries (std::vector<uint8_t> c
 			continue;
 		}
 
-#if !defined(NET6)
+#if !defined(NET)
 		if (utils.ends_with (entry_name, ".config")) {
 			char *assembly_name = strdup (basename (entry_name.get ()));
 			// Remove '.config' suffix
@@ -135,7 +135,7 @@ EmbeddedAssemblies::zip_load_individual_assembly_entries (std::vector<uint8_t> c
 
 			continue;
 		}
-#endif // ndef NET6
+#endif // ndef NET
 
 		if (!utils.ends_with (entry_name, SharedConstants::DLL_EXTENSION))
 			continue;

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -151,7 +151,7 @@ EmbeddedAssemblies::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 	get_assembly_data (e.image_data, e.descriptor->data_size, "<assembly_store>", assembly_data, assembly_data_size);
 }
 
-#if defined (NET6)
+#if defined (NET)
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, MonoAssemblyLoadContextGCHandle alc_gchandle, [[maybe_unused]] MonoError *error)
 {
@@ -168,7 +168,7 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, MonoAssemblyLoad
 
 	return open_from_bundles (aname, loader, false /* ref_only */);
 }
-#endif // def NET6
+#endif // def NET
 
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, bool ref_only)
@@ -304,7 +304,7 @@ EmbeddedAssemblies::load_bundled_assembly (
 		return nullptr;
 	}
 
-#if !defined (NET6)
+#if !defined (NET)
 	// In dotnet the call is a no-op
 	mono_config_for_assembly (image);
 #endif
@@ -423,7 +423,7 @@ EmbeddedAssemblies::assembly_store_open_from_bundles (dynamic_local_string<SENSI
 		if (bba->debug_data_offset != 0) {
 			assembly_runtime_info.debug_info_data = rd.data_start + bba->debug_data_offset;
 		}
-#if !defined (NET6)
+#if !defined (NET)
 		if (bba->config_data_size != 0) {
 			assembly_runtime_info.config_data = rd.data_start + bba->config_data_offset;
 
@@ -433,7 +433,7 @@ EmbeddedAssemblies::assembly_store_open_from_bundles (dynamic_local_string<SENSI
 				utils.strdup_new (reinterpret_cast<const char*>(assembly_runtime_info.config_data))
 			);
 		}
-#endif // NET6
+#endif // NET
 
 		log_debug (
 			LOG_ASSEMBLY,
@@ -476,7 +476,7 @@ EmbeddedAssemblies::assembly_store_open_from_bundles (dynamic_local_string<SENSI
 		return nullptr;
 	}
 
-#if !defined (NET6)
+#if !defined (NET)
 	mono_config_for_assembly (image);
 #endif
 	return a;
@@ -509,19 +509,19 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, std::function<Mo
 	return a;
 }
 
-#if defined (NET6)
+#if defined (NET)
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, [[maybe_unused]] char **assemblies_path, [[maybe_unused]] void *user_data, MonoError *error)
 {
 	return embeddedAssemblies.open_from_bundles (aname, alc_gchandle, error);
 }
-#else // def NET6
+#else // def NET
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles_refonly (MonoAssemblyName *aname, [[maybe_unused]] char **assemblies_path, [[maybe_unused]] void *user_data)
 {
 	return embeddedAssemblies.open_from_bundles (aname, true);
 }
-#endif // ndef NET6
+#endif // ndef NET
 
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles_full (MonoAssemblyName *aname, [[maybe_unused]] char **assemblies_path, [[maybe_unused]] void *user_data)
@@ -533,12 +533,12 @@ void
 EmbeddedAssemblies::install_preload_hooks_for_appdomains ()
 {
 	mono_install_assembly_preload_hook (open_from_bundles_full, nullptr);
-#if !defined (NET6)
+#if !defined (NET)
 	mono_install_assembly_refonly_preload_hook (open_from_bundles_refonly, nullptr);
-#endif // ndef NET6
+#endif // ndef NET
 }
 
-#if defined (NET6)
+#if defined (NET)
 void
 EmbeddedAssemblies::install_preload_hooks_for_alc ()
 {
@@ -548,7 +548,7 @@ EmbeddedAssemblies::install_preload_hooks_for_alc ()
 		0 /* append */
 	);
 }
-#endif // def NET6
+#endif // def NET
 
 template<typename Key, typename Entry, int (*compare)(const Key*, const Entry*), bool use_precalculated_size>
 force_inline const Entry*
@@ -754,9 +754,9 @@ EmbeddedAssemblies::typemap_java_to_managed (hash_t hash, const MonoString *java
 		return nullptr;
 	}
 
-#if defined (NET6)
+#if defined (NET)
 	// MonoVM in dotnet runtime doesn't use the `domain` parameter passed to `mono_type_get_object` (since AppDomains
-	// are gone in NET6+), in fact, the function `mono_type_get_object` calls (`mono_type_get_object_checked`) itself
+	// are gone in NET 6+), in fact, the function `mono_type_get_object` calls (`mono_type_get_object_checked`) itself
 	// calls `mono_get_root_domain`. Thus, we can save on a one function call here by passing `nullptr`
 	constexpr MonoDomain *domain = nullptr;
 #else

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -22,7 +22,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/assembly.h>
 
-#if defined (NET6)
+#if defined (NET)
 #include <mono/metadata/mono-private-unstable.h>
 #endif
 
@@ -112,9 +112,9 @@ namespace xamarin::android::internal {
 		STATIC_IN_ANDROID_RELEASE const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid) noexcept;
 
 		void install_preload_hooks_for_appdomains ();
-#if defined (NET6)
+#if defined (NET)
 		void install_preload_hooks_for_alc ();
-#endif // def NET6
+#endif // def NET
 		STATIC_IN_ANDROID_RELEASE MonoReflectionType* typemap_java_to_managed (MonoString *java_type) noexcept;
 
 		/* returns current number of *all* assemblies found from all invocations */
@@ -137,7 +137,7 @@ namespace xamarin::android::internal {
 
 		void set_assemblies_prefix (const char *prefix);
 
-#if defined (NET6)
+#if defined (NET)
 		void get_runtime_config_blob (const char *& area, uint32_t& size) const
 		{
 			area = static_cast<char*>(runtime_config_blob_mmap.area);
@@ -171,9 +171,9 @@ namespace xamarin::android::internal {
 		STATIC_IN_ANDROID_RELEASE MonoReflectionType* typemap_java_to_managed (hash_t hash, const MonoString *java_type_name) noexcept;
 		size_t register_from (const char *apk_file, monodroid_should_register should_register);
 		void gather_bundled_assemblies_from_apk (const char* apk, monodroid_should_register should_register);
-#if defined (NET6)
+#if defined (NET)
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, MonoAssemblyLoadContextGCHandle alc_gchandle, MonoError *error);
-#endif // def NET6
+#endif // def NET
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, bool ref_only);
 		MonoAssembly* individual_assemblies_open_from_bundles (dynamic_local_string<SENSIBLE_PATH_MAX>& name, std::function<MonoImage*(uint8_t*, size_t, const char*)> loader, bool ref_only) noexcept;
 		MonoAssembly* assembly_store_open_from_bundles (dynamic_local_string<SENSIBLE_PATH_MAX>& name, std::function<MonoImage*(uint8_t*, size_t, const char*)> loader, bool ref_only) noexcept;
@@ -203,11 +203,11 @@ namespace xamarin::android::internal {
 
 		static md_mmap_info md_mmap_apk_file (int fd, uint32_t offset, size_t size, const char* filename);
 		static MonoAssembly* open_from_bundles_full (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
-#if defined (NET6)
+#if defined (NET)
 		static MonoAssembly* open_from_bundles (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, void *user_data, MonoError *error);
-#else // def NET6
+#else // def NET
 		static MonoAssembly* open_from_bundles_refonly (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
-#endif // ndef NET6
+#endif // ndef NET
 		static void get_assembly_data (uint8_t *data, uint32_t data_size, const char *name, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
 		static void get_assembly_data (XamarinAndroidBundledAssembly const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
 		static void get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
@@ -264,9 +264,9 @@ namespace xamarin::android::internal {
 		{
 			return
 				number_of_mapped_assembly_stores == application_config.number_of_assembly_store_files
-#if defined (NET6)
+#if defined (NET)
 				&& ((application_config.have_runtime_config_blob && runtime_config_blob_found) || !application_config.have_runtime_config_blob)
-#endif // NET6
+#endif // NET
 				;
 		}
 
@@ -311,10 +311,10 @@ namespace xamarin::android::internal {
 		size_t                 type_map_count;
 #endif // DEBUG || !ANDROID
 		const char            *assemblies_prefix_override = nullptr;
-#if defined (NET6)
+#if defined (NET)
 		md_mmap_info           runtime_config_blob_mmap{};
 		bool                   runtime_config_blob_found = false;
-#endif // def NET6
+#endif // def NET
 		uint32_t               number_of_mapped_assembly_stores = 0;
 		bool                   need_to_scan_more_apks = true;
 
@@ -323,8 +323,8 @@ namespace xamarin::android::internal {
 	};
 }
 
-#if !defined (NET6)
+#if !defined (NET)
 MONO_API int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix);
-#endif // ndef NET6
+#endif // ndef NET
 
 #endif /* INC_MONODROID_EMBEDDED_ASSEMBLIES_H */

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-counters.h>
 #include <mono/metadata/profiler.h>
 
-#if defined (NET6)
+#if defined (NET)
 // NDEBUG causes robin_map.h not to include <iostream> which, in turn, prevents indirect inclusion of <mutex>. <mutex>
 // conflicts with our std::mutex definition in cppcompat.hh
 #if !defined (NDEBUG)
@@ -43,11 +43,11 @@
 #include <mono/metadata/mono-private-unstable.h>
 #endif
 
-#if defined (NET6)
+#if defined (NET)
 // See https://github.com/dotnet/runtime/pull/67024
 // See https://github.com/xamarin/xamarin-android/issues/6935
 extern mono_bool mono_opt_aot_lazy_assembly_load;
-#endif // def NET6
+#endif // def NET
 
 namespace xamarin::android::internal
 {
@@ -68,7 +68,7 @@ namespace xamarin::android::internal
 
 	class MonodroidRuntime
 	{
-#if defined (NET6)
+#if defined (NET)
 		using pinvoke_api_map = tsl::robin_map<
 			std::string,
 			void*,
@@ -90,9 +90,9 @@ namespace xamarin::android::internal
 
 		using load_assemblies_context_type = MonoAssemblyLoadContextGCHandle;
 		static constexpr pinvoke_library_map::size_type LIBRARY_MAP_INITIAL_BUCKET_COUNT = 1;
-#else // def NET6
+#else // def NET
 		using load_assemblies_context_type = MonoDomain*;
-#endif // ndef NET6
+#endif // ndef NET
 
 #if defined (DEBUG) && !defined (WINDOWS)
 		struct RuntimeOptions {
@@ -133,7 +133,7 @@ namespace xamarin::android::internal
 			int             jniAddNativeMethodRegistrationAttributePresent;
 		};
 
-#if defined (NET6)
+#if defined (NET)
 		using jnienv_initialize_fn = void (*) (JnienvInitializeArgs*);
 		using jnienv_register_jni_natives_fn = void (*)(const jchar *typeName_ptr, int32_t typeName_len, jclass jniClass, const jchar *methods_ptr, int32_t methods_len);
 #endif
@@ -157,7 +157,7 @@ namespace xamarin::android::internal
 		static constexpr char mono_component_diagnostics_tracing_name[] = "libmono-component-diagnostics_tracing.so";
 		static constexpr hash_t mono_component_diagnostics_tracing_hash = xxhash::hash (mono_component_diagnostics_tracing_name);
 
-#if !defined (NET6)
+#if !defined (NET)
 #define MAKE_API_DSO_NAME(_ext_) "libxa-internal-api." # _ext_
 #if defined (WINDOWS)
 		static constexpr char API_DSO_NAME[] = MAKE_API_DSO_NAME (dll);
@@ -166,7 +166,7 @@ namespace xamarin::android::internal
 #else   // !defined(WINDOWS) && !defined(APPLE_OS_X)
 		static constexpr char API_DSO_NAME[] = MAKE_API_DSO_NAME (so);
 #endif  // defined(WINDOWS)
-#endif // ndef NET6
+#endif // ndef NET
 	public:
 		static constexpr int XA_LOG_COUNTERS = MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS | MONO_COUNTER_INTERP;
 
@@ -215,9 +215,9 @@ namespace xamarin::android::internal
 			monodroid_gdb_wait = yes_no;
 		}
 
-#if defined (NET6)
+#if defined (NET)
 		void propagate_uncaught_exception (JNIEnv *env, jobject javaThread, jthrowable javaException);
-#else // def NET6
+#else // def NET
 		void propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException);
 
 		FILE *get_counters () const
@@ -242,7 +242,7 @@ namespace xamarin::android::internal
 		// function
 		void dump_counters (const char *format, ...);
 		void dump_counters_v (const char *format, va_list args);
-#endif // ndef NET6
+#endif // ndef NET
 
 		char*	get_java_class_name_for_TypeManager (jclass klass);
 
@@ -260,7 +260,7 @@ namespace xamarin::android::internal
 #if defined (WINDOWS) || defined (APPLE_OS_X)
 		static const char* get_my_location (bool remove_file_name = true);
 #endif  // defined(WINDOWS) || defined(APPLE_OS_X)
-#if defined (NET6)
+#if defined (NET)
 		static void  cleanup_runtime_config (MonovmRuntimeConfigArguments *args, void *user_data);
 		static void* load_library_symbol (const char *library_name, const char *symbol_name, void **dso_handle = nullptr) noexcept;
 		static void* load_library_entry (std::string const& library_name, std::string const& entrypoint_name, pinvoke_api_map_ptr api_map) noexcept;
@@ -269,41 +269,41 @@ namespace xamarin::android::internal
 		static PinvokeEntry* find_pinvoke_address (hash_t hash, const PinvokeEntry *entries, size_t entry_count) noexcept;
 		static void* handle_other_pinvoke_request (const char *library_name, hash_t library_name_hash, const char *entrypoint_name, hash_t entrypoint_name_hash) noexcept;
 		static void* monodroid_pinvoke_override (const char *library_name, const char *entrypoint_name);
-#endif // def NET6
+#endif // def NET
 		static void* monodroid_dlopen_ignore_component_or_load (hash_t hash, const char *name, int flags, char **err) noexcept;
 		static void* monodroid_dlopen (const char *name, int flags, char **err) noexcept;
 		static void* monodroid_dlopen (const char *name, int flags, char **err, void *user_data) noexcept;
 		static void* monodroid_dlsym (void *handle, const char *name, char **err, void *user_data);
 		static void* monodroid_dlopen_log_and_return (void *handle, char **err, const char *full_name, bool free_memory, bool need_api_init = false);
 		static DSOCacheEntry* find_dso_cache_entry (hash_t hash) noexcept;
-#if !defined (NET6)
+#if !defined (NET)
 		static void  init_internal_api_dso (void *handle);
-#endif // ndef NET6
+#endif // ndef NET
 		int LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version);
 		void create_xdg_directory (jstring_wrapper& home, size_t home_len, const char *relativePath, size_t relative_path_len, const char *environmentVariableName);
 		void create_xdg_directories_and_environment (jstring_wrapper &homeDir);
 		void disable_external_signal_handlers ();
 		void lookup_bridge_info (MonoClass *klass, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
-#if defined (NET6)
+#if defined (NET)
 		void lookup_bridge_info (MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
-#else // def NET6
+#else // def NET
 		void lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
-#endif // ndef NET6
+#endif // ndef NET
 		void load_assembly (MonoDomain *domain, jstring_wrapper &assembly);
-#if defined (NET6)
+#if defined (NET)
 		void load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, jstring_wrapper &assembly);
-#endif // ndef NET6
+#endif // ndef NET
 		void load_assemblies (load_assemblies_context_type ctx, bool preload, jstring_array_wrapper &assemblies);
 
 		void set_debug_options ();
 		void parse_gdb_options ();
 		void mono_runtime_init (dynamic_local_string<PROPERTY_VALUE_BUFFER_LEN>& runtime_args);
-#if defined (NET6)
+#if defined (NET)
 		void init_android_runtime (JNIEnv *env, jclass runtimeClass, jobject loader);
-#else //def NET6
+#else //def NET
 		void init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader);
 		void setup_bundled_app (const char *dso_name);
-#endif // ndef NET6
+#endif // ndef NET
 		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode);
 
 		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value)
@@ -316,11 +316,11 @@ namespace xamarin::android::internal
 			set_environment_variable_for_directory (name, value, false, 0);
 		}
 
-#if defined (NET6)
+#if defined (NET)
 		static void monodroid_unhandled_exception (MonoObject *java_exception);
 
 		MonoClass* get_android_runtime_class ();
-#else // def NET6
+#else // def NET
 		MonoClass* get_android_runtime_class (MonoDomain *domain);
 #endif
 		MonoDomain*	create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool is_root_domain, bool have_split_apks);
@@ -345,7 +345,7 @@ namespace xamarin::android::internal
 		static const char* typemap_managed_to_java (MonoReflectionType *type, const uint8_t *mvid) noexcept;
 #endif // !def RELEASE || !def ANDROID
 
-#if defined (NET6)
+#if defined (NET)
 		static void monodroid_debugger_unhandled_exception (MonoException *ex);
 #endif
 
@@ -373,9 +373,9 @@ namespace xamarin::android::internal
 		timing_period       jit_time;
 		FILE               *jit_log;
 		MonoProfilerHandle  profiler_handle;
-#if !defined (NET6)
+#if !defined (NET)
 		FILE               *counters;
-#endif // ndef NET6
+#endif // ndef NET
 
 		/*
 		 * If set, monodroid will spin in a loop until the debugger breaks the wait by
@@ -391,7 +391,7 @@ namespace xamarin::android::internal
 		int                 current_context_id = -1;
 		static bool         startup_in_progress;
 
-#if defined (NET6)
+#if defined (NET)
 #if defined (ANDROID)
 		jnienv_register_jni_natives_fn jnienv_register_jni_natives = nullptr;
 #endif
@@ -405,10 +405,10 @@ namespace xamarin::android::internal
 		static void *system_native_library_handle;
 		static void *system_security_cryptography_native_android_library_handle;
 		static void *system_io_compression_native_library_handle;
-#else // def NET6
+#else // def NET
 		static std::mutex   api_init_lock;
 		static void        *api_dso_handle;
-#endif // !def NET6
+#endif // !def NET
 		static std::mutex   dso_handle_write_lock;
 	};
 }

--- a/src/monodroid/jni/monodroid-glue.hh
+++ b/src/monodroid/jni/monodroid-glue.hh
@@ -8,7 +8,7 @@
 #include <mono/metadata/appdomain.h>
 #include <mono/utils/mono-publib.h>
 
-#if !defined (NET6)
+#if !defined (NET)
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -17,7 +17,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // NET6
+#endif // NET
 
 int monodroid_get_system_property_from_overrides (const char *name, char ** value);
 JNIEnv* get_jnienv (void);

--- a/src/monodroid/jni/monovm-properties.hh
+++ b/src/monodroid/jni/monovm-properties.hh
@@ -1,7 +1,7 @@
 #if !defined (__MONOVM_PROPERTIES_HH)
 #define __MONOVM_PROPERTIES_HH
 
-#if defined (NET6)
+#if defined (NET)
 #include <cstring>
 #include "monodroid-glue-internal.hh"
 #include "jni-wrappers.hh"
@@ -60,5 +60,5 @@ namespace xamarin::android::internal
 		constexpr static size_t N_PROPERTY_VALUES = sizeof(_property_values) / sizeof(const char*);
 	};
 }
-#endif // def NET6
+#endif // def NET
 #endif // ndef __MONOVM_PROPERTIES_HH

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -1128,7 +1128,7 @@ OSBridge::add_monodroid_domain (MonoDomain *domain)
 	domains_list = node;
 }
 
-#if !defined (NET6) && !defined (ANDROID)
+#if !defined (NET) && !defined (ANDROID)
 void
 OSBridge::remove_monodroid_domain (MonoDomain *domain)
 {
@@ -1168,4 +1168,4 @@ OSBridge::on_destroy_contexts ()
 	if (!domains_list)
 		osBridge.clear_mono_java_gc_bridge_info ();
 }
-#endif // ndef NET6 && ndef ANDROID
+#endif // ndef NET && ndef ANDROID

--- a/src/monodroid/jni/osbridge.hh
+++ b/src/monodroid/jni/osbridge.hh
@@ -122,9 +122,9 @@ namespace xamarin::android::internal
 		void initialize_on_onload (JavaVM *vm, JNIEnv *env);
 		void initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass);
 		void add_monodroid_domain (MonoDomain *domain);
-#if !defined (NET6)
+#if !defined (NET)
 		void remove_monodroid_domain (MonoDomain *domain);
-#endif // ndef NET6
+#endif // ndef NET
 		void on_destroy_contexts ();
 
 	private:

--- a/src/monodroid/jni/pinvoke-override-api.cc
+++ b/src/monodroid/jni/pinvoke-override-api.cc
@@ -207,9 +207,9 @@ _monodroid_timezone_get_default_id ()
 static void
 _monodroid_counters_dump ([[maybe_unused]] const char *format, [[maybe_unused]] va_list args)
 {
-#if !defined (NET6)
+#if !defined (NET)
 	monodroidRuntime.dump_counters_v (format, args);
-#endif // ndef NET6
+#endif // ndef NET
 }
 
 static managed_timing_sequence*

--- a/src/monodroid/jni/shared-constants.hh
+++ b/src/monodroid/jni/shared-constants.hh
@@ -26,9 +26,9 @@ namespace xamarin::android::internal
 
 		static constexpr char DLL_EXTENSION[] = ".dll";
 
-#if defined (NET6)
+#if defined (NET)
 		static constexpr char RUNTIME_CONFIG_BLOB_NAME[] = "rc.bin";
-#endif // def NET6
+#endif // def NET
 
 #if defined (ANDROID) || defined (__linux__) || defined (__linux)
 		static constexpr char MONO_SGEN_SO[]      = "libmonosgen-2.0.so";

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -146,7 +146,7 @@ Util::monodroid_store_package_name (const char *name)
 	log_info (LOG_DEFAULT, "Generated hash 0x%s for package name %s", package_property_suffix, name);
 }
 
-#if defined (NET6)
+#if defined (NET)
 MonoAssembly*
 Util::monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const char *basename)
 {
@@ -162,7 +162,7 @@ Util::monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const
 	}
 	return assm;
 }
-#endif // def NET6
+#endif // def NET
 
 MonoAssembly *
 Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
@@ -191,7 +191,7 @@ Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
 	return assm;
 }
 
-#if !defined (NET6)
+#if !defined (NET)
 MonoObject *
 Util::monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
@@ -245,17 +245,17 @@ Util::monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendl
 
 	return mono_domain_from_appdomain (appdomain);
 }
-#endif // ndef NET6
+#endif // ndef NET
 
 MonoClass*
 Util::monodroid_get_class_from_name ([[maybe_unused]] MonoDomain *domain, const char* assembly, const char *_namespace, const char *type)
 {
-#if !defined (NET6)
+#if !defined (NET)
 	MonoDomain *current = get_current_domain ();
 
 	if (domain != current)
 		mono_domain_set (domain, FALSE);
-#endif // ndef NET6
+#endif // ndef NET
 
 	MonoClass *result;
 	MonoAssemblyName *aname = mono_assembly_name_new (assembly);
@@ -266,17 +266,17 @@ Util::monodroid_get_class_from_name ([[maybe_unused]] MonoDomain *domain, const 
 	} else
 		result = nullptr;
 
-#if !defined (NET6)
+#if !defined (NET)
 	if (domain != current)
 		mono_domain_set (current, FALSE);
-#endif // ndef NET6
+#endif // ndef NET
 
 	mono_assembly_name_free (aname);
 
 	return result;
 }
 
-#if !defined (NET6)
+#if !defined (NET)
 MonoClass*
 Util::monodroid_get_class_from_image (MonoDomain *domain, MonoImage *image, const char *_namespace, const char *type)
 {
@@ -292,7 +292,7 @@ Util::monodroid_get_class_from_image (MonoDomain *domain, MonoImage *image, cons
 
 	return result;
 }
-#endif // ndef NET6
+#endif // ndef NET
 
 jclass
 Util::get_class_from_runtime_field (JNIEnv *env, jclass runtime, const char *name, bool make_gref)

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -40,14 +40,14 @@ constexpr int FALSE = 0;
 #include "basic-utilities.hh"
 #endif
 
-#if defined (NET6)
+#if defined (NET)
 #include <mono/metadata/mono-private-unstable.h>
-#endif // def NET6
+#endif // def NET
 
 #include "java-interop-util.h"
 #include "logger.hh"
 
-#if !defined (NET6)
+#if !defined (NET)
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -66,7 +66,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // NET6
+#endif // NET
 
 #ifdef __cplusplus
 namespace xamarin::android
@@ -92,13 +92,13 @@ namespace xamarin::android
 
 		void             monodroid_store_package_name (const char *name);
 		MonoAssembly    *monodroid_load_assembly (MonoDomain *domain, const char *basename);
-#if defined (NET6)
+#if defined (NET)
 		MonoAssembly    *monodroid_load_assembly (MonoAssemblyLoadContextGCHandle alc_handle, const char *basename);
-#else // def NET6
+#else // def NET
 		MonoObject      *monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
-#endif // ndef NET6
+#endif // ndef NET
 		MonoClass       *monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type);
-#if !defined (NET6)
+#if !defined (NET)
 		MonoDomain      *monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendly_name, int shadow_copy, const char *shadow_directories);
 		MonoClass       *monodroid_get_class_from_image (MonoDomain *domain, MonoImage* image, const char *_namespace, const char *type);
 #endif
@@ -131,9 +131,9 @@ namespace xamarin::android
 
 	private:
 		//char *monodroid_strdup_printf (const char *format, va_list vargs);
-#if !defined (NET6)
+#if !defined (NET)
 		void  monodroid_property_set (MonoDomain *domain, MonoProperty *property, void *obj, void **params, MonoObject **exc);
-#endif // ndef NET6
+#endif // ndef NET
 
 		template<typename IdxType>
 		void package_hash_to_hex (IdxType idx);

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -56,9 +56,9 @@
       <_ConfigureRuntimesInputs  Include="CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="..\..\build-tools\scripts\Ndk.targets" />
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt')" />
-      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-net6-Debug\CMakeCache.txt')" />
+      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(AndroidRID)-Debug\CMakeCache.txt')" />
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')" />
-      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-net6-Release\CMakeCache.txt')" />
+      <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(AndroidRID)-Release\CMakeCache.txt')" />
       <_ConfigureRuntimesOutputs Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Debug\CMakeCache.txt')" />
       <_ConfigureRuntimesOutputs Include="@(_HostRuntime->'$(IntermediateOutputPath)%(OutputDirectory)-Release\CMakeCache.txt')" />
     </ItemGroup>
@@ -82,29 +82,29 @@
       DependsOnTargets="_FindMonoDroidSources">
     <ItemGroup>
       <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt')" />
-      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-net6-Debug\CMakeCache.txt')" />
+      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(AndroidRID)-Debug\CMakeCache.txt')" />
       <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')" />
-      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-net6-Release\CMakeCache.txt')" />
+      <_BuildAndroidRuntimesInputs  Include="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(AndroidRID)-Release\CMakeCache.txt')" />
       <_BuildAndroidRuntimesInputs  Include="@(_MonoDroidSources)" />
       <_BuildAndroidRuntimesInputs  Include="..\..\build-tools\scripts\Ndk.targets" />
       <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so')" />
-      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android.debug.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android.debug.so')" />
       <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')" />
-      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android.release.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android.release.so')" />
       <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Debug\libxamarin-app.so')" />
-      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\Debug\libxamarin-app.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\Debug\libxamarin-app.so')" />
       <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\Release\libxamarin-app.so')" />
-      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\Release\libxamarin-app.so')" />
+      <_BuildAndroidRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\Release\libxamarin-app.so')" />
     </ItemGroup>
     <ItemGroup  Condition=" '$(EnableNativeAnalyzers)' == 'true' ">
       <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.debug.so')" />
-      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android-checked+ubsan.debug.so')" />
+      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android-checked+ubsan.debug.so')" />
       <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.debug.so')" />
-      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android-checked+asan.debug.so')" />
+      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android-checked+asan.debug.so')" />
       <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+asan.release.so')" />
-      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android-checked+asan.release.so')" />
+      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android-checked+asan.release.so')" />
       <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android-checked+ubsan.release.so')" />
-      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)-net6\libmono-android-checked+ubsan.release.so')" />
+      <_BuildAndroidAnalyzerRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libmono-android-checked+ubsan.release.so')" />
     </ItemGroup>
   </Target>
 
@@ -119,7 +119,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-Debug"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-Debug"
     />
 
     <Exec
@@ -129,7 +129,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-Release"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-Release"
     />
 
     <Touch Files="@(_BuildAndroidRuntimesOutputs)" />
@@ -147,7 +147,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-asan-Debug"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-asan-Debug"
     />
 
     <Exec
@@ -157,7 +157,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-ubsan-Debug"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-ubsan-Debug"
     />
 
     <Exec
@@ -167,7 +167,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-asan-Release"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-asan-Release"
     />
 
     <Exec
@@ -177,7 +177,7 @@
 
     <Exec
         Command="$(NinjaPath) -v"
-        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-net6-ubsan-Release"
+        WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.AndroidRID)-ubsan-Release"
     />
 
     <Touch Files="@(_BuildAndroidAnalyzerRuntimesOutputs)" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -198,7 +198,7 @@ namespace Xamarin.Android.Build.Tests
 					foreach (var abi in abis) {
 						string runtimeAbiName;
 						if (Builder.UseDotNet) {
-							runtimeAbiName = $"{abi}-net6";
+							runtimeAbiName = AbiUtils.AbiToRuntimeIdentifier (abi);
 						} else {
 							runtimeAbiName = abi;
 						}


### PR DESCRIPTION
Instances of `NET6` in src/monodroid and xaprepare have been removed or
replaced with `NET`.  This should hopefully improve readability and
maintainability as we begin work on .NET 7 and beyond.

Build and output directories for One .NET versions of monodroid.csproj
have been updated to use `$(AndroidRID)` as a unique identifier, rather
than `$(AndroidAbi)-net6`.