### PR TITLE
[build] Copy .NET build output to ref/runtime dirs

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -65,7 +65,13 @@
     <_XABinRelativeInstallPrefix>lib\xamarin.android</_XABinRelativeInstallPrefix>
     <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)bin\$(Configuration)\$(_XABinRelativeInstallPrefix)\</XAInstallPrefix>
     <_MonoAndroidNETOutputRoot>$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\</_MonoAndroidNETOutputRoot>
-    <MicrosoftAndroidSdkPackDir>$(BuildOutputDirectory)packs\$(MicrosoftAndroidSdkPackName)\$(AndroidPackVersion)\</MicrosoftAndroidSdkPackDir>
+    <_MonoAndroidNETDefaultOutDir>$(_MonoAndroidNETOutputRoot)$(AndroidApiLevel)\</_MonoAndroidNETDefaultOutDir>
+    <MicrosoftAndroidRefPackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Ref.$(AndroidApiLevel)\$(AndroidPackVersion)\ref\$(DotNetTargetFramework)\</MicrosoftAndroidRefPackDir>
+    <MicrosoftAndroidArmPackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidApiLevel).android-arm\$(AndroidPackVersion)\runtimes\android-arm\</MicrosoftAndroidArmPackDir>
+    <MicrosoftAndroidArm64PackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidApiLevel).android-arm64\$(AndroidPackVersion)\runtimes\android-arm64\</MicrosoftAndroidArm64PackDir>
+    <MicrosoftAndroidx86PackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidApiLevel).android-x86\$(AndroidPackVersion)\runtimes\android-x86\</MicrosoftAndroidx86PackDir>
+    <MicrosoftAndroidx64PackDir>$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidApiLevel).android-x64\$(AndroidPackVersion)\runtimes\android-x64\</MicrosoftAndroidx64PackDir>
+    <MicrosoftAndroidSdkPackDir>$(BuildOutputDirectory)lib\packs\$(MicrosoftAndroidSdkPackName)\$(AndroidPackVersion)\</MicrosoftAndroidSdkPackDir>
     <MicrosoftAndroidSdkOutDir>$(MicrosoftAndroidSdkPackDir)\tools\</MicrosoftAndroidSdkOutDir>
     <MingwDependenciesRootDirectory Condition=" '$(MingwDependenciesRootDirectory)' == '' ">$(MSBuildThisFileDirectory)\bin\Build$(Configuration)\mingw-deps</MingwDependenciesRootDirectory>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>

--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -62,34 +62,13 @@ on Windows, many of the concepts should still apply:
 
 [xamdevsummit]: https://youtu.be/8qaQleb6Tbk
 
-# Creating installers
+# Creating a local .NET android Workload
 
-Once `make all` or `make jenkins` have completed, macOS (.pkg)
-and Windows (.vsix) installer files can be built with:
-
-    make create-installers
-
-Commercial installers will be created by this command if the
-`make prepare-external-git-dependencies` command was ran before building.
-
-A .NET 6 Workload installer is also created at
-`Microsoft.NET.Workload.Android-*.pkg`, you can run `make
-create-workload-installers` if you only want to create the .NET 6
-installer.
-
-# Creating a local .NET 6 Workload
-
-`make prepare` provisions a specific build of .NET 6 to
+`make prepare` provisions a specific build of .NET to
 `bin/$(Configuration)/dotnet`.
 
-Once `make all` or `make jenkins` have completed, you can build the .NET 6
-packages with:
-
-    make pack-dotnet
-
-Several `.nupkg` files will be output in `./bin/BuildDebug/nuget-unsigned`,
-but this is only part of the story. Your local
-`bin/$(Configuration)/dotnet/packs` directory will be populated with a
+Once `make all` or `make jenkins` have completed, your local
+`bin/$(Configuration)/lib/packs` directory will be populated with a
 local Android "workload" in `Microsoft.Android.Sdk.$(HostOS)` matching
 your operating system.
 
@@ -112,6 +91,25 @@ Using the `dotnet-local` script will execute the `dotnet` provisioned in
 `bin/$(Configuration)/dotnet` and will use the locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
+
+# Creating installers
+
+Once `make all` or `make jenkins` have completed, macOS (.pkg),
+Windows (.vsix), and .NET android workload .nupkg files
+can be built with:
+
+    make create-installers
+
+Alternatively, .NET android workload packs can be built with:
+
+    make create-nupkgs
+    # -or-
+    make pack-dotnet
+
+Several `.nupkg` files will be output in `./bin/Build$(Configuration)/nuget-unsigned`.
+
+Commercial installers will be created by this command if the
+`make prepare-external-git-dependencies` command was ran before building.
 
 # Building Unit Tests
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -91,19 +91,17 @@ So for example:
 [windows_path]: https://www.java.com/en/download/help/path.xml
 [set_alias]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-alias?view=powershell-6
 
-# Creating a local .NET 6 Workload
+# Creating a local .NET android Workload
 
-`msbuild Xamarin.Android.sln /t:Prepare` provisions a specific build
-of .NET 6 to `bin\$(Configuration)\dotnet`.
+`dotnet msbuild Xamarin.Android.sln -t:Prepare` provisions a
+specific build of .NET to `bin\$(Configuration)\dotnet`.
 
-Once `msbuild Xamarin.Android.sln /t:Build` is complete, you can build
-the .NET 6 packages with:
+Once the prepare target is complete, you can set up a local
+.NET android workload install with:
 
-    dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -m:1
+    dotnet-local.cmd build Xamarin.Android.sln -t:BuildDotNet -m:1
 
-Several `.nupkg` files will be output in `.\bin\BuildDebug\nuget-unsigned`,
-but this is only part of the story. Your local
-`bin\$(Configuration)\dotnet\packs` directory will be
+Your local `bin\$(Configuration)\lib\packs` directory will be
 populated with a local Android "workload" in
 `Microsoft.Android.Sdk.$(HostOS)` matching your operating system.
 
@@ -130,6 +128,19 @@ Using the `dotnet-local` script will execute the `dotnet` provisioned in
 `bin\$(Configuration)\dotnet` and will use the locally built binaries.
 
 See the [One .NET Documentation](../../guides/OneDotNet.md) for further details.
+
+# Creating installers
+
+Once `dotnet msbuild Xamarin.Android.sln -t:Prepare` is complete,
+.NET android workload packs can be built with:
+
+    dotnet-local.cmd build Xamarin.Android.sln -t:BuildDotNet,PackDotNet -m:1
+
+Several `.nupkg` files will be output in `.\bin\Build$(Configuration)\nuget-unsigned`.
+
+Commercial packages will be created by this command if the
+`dotnet-local.cmd build Xamarin.Android.sln -t:BuildExternal`
+command was ran before building.
 
 # Building Unit Tests
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ _PREPARE_ARGS =
 
 all:
 	$(call DOTNET_BINLOG,all) $(MSBUILD_FLAGS) $(SOLUTION) -m:1
+	$(call DOTNET_BINLOG,setup-workload) -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj
 	$(call MSBUILD_BINLOG,all,$(_SLN_BUILD)) /restore $(MSBUILD_FLAGS) tools/xabuild/xabuild.csproj
 
 -include bin/Build$(CONFIGURATION)/rules.mk

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -115,7 +115,7 @@ stages:
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&
-        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/$(XA.Build.Configuration)/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/bin/*.pdb
+        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/$(XA.Build.Configuration)/lib/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/bin/*.pdb
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb/
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy Windows toolchain pdb files
@@ -208,7 +208,7 @@ stages:
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
-          -t:PackDotNet -c $(XA.Build.Configuration) -m:1 -v:n
+          -t:BuildDotNet,PackDotNet -c $(XA.Build.Configuration) -m:1 -v:n
           -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog
         displayName: Build Solution
         continueOnError: false

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -57,12 +57,12 @@
   </Target>
 
   <Target Name="_CreateDefaultRefPack"
-      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
+      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="_CreatePreviewPacks"
-      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
+      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
     <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
@@ -95,7 +95,6 @@
       <_WLManifest Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.NET.Sdk.Android.Manifest-*.nupkg" />
     </ItemGroup>
     <PropertyGroup>
-      <_WLPackVersion>@(_WLManifest->'%(Filename)'->Replace('Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand).', ''))</_WLPackVersion>
       <_SdkManifestsFolder>$(DotNetPreviewPath)sdk-manifests\$(DotNetSdkManifestsFolder)\</_SdkManifestsFolder>
     </PropertyGroup>
     <Unzip
@@ -119,7 +118,7 @@
 
     <!-- dotnet workload install android -->
     <PropertyGroup>
-      <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
+      <_TempDirectory>$(IntermediateOutputPath).xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
     </PropertyGroup>
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
@@ -137,7 +136,6 @@
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; workload install @(_InstallArguments, ' ')"
         WorkingDirectory="$(_TempDirectory)"
-        EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
     />
     <RemoveDir Directories="$(_TempDirectory)" />
   </Target>
@@ -203,5 +201,90 @@
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
     />
   </Target>
+
+  <!-- Targets for setting up a local workload test environment without needing to pack .nupkg files -->
+  <ItemGroup>
+    <_FrameworkListInputs  Include="$(MicrosoftAndroidRefPackDir)**" />
+    <_FrameworkListOutputs Include="$(BuildOutputDirectory)lib\packs\Microsoft.Android.Ref.$(AndroidDefaultTargetDotnetApiLevel)\$(AndroidPackVersion)\data\FrameworkList.xml" />
+    <_FrameworkListOutputs Include="$(BuildOutputDirectory)lib\packs\Microsoft.Android.Ref.$(AndroidLatestStableApiLevel)\$(AndroidPackVersion)\data\FrameworkList.xml" />
+    <_FrameworkListOutputs Include="$(BuildOutputDirectory)lib\packs\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel)\$(AndroidPackVersion)\data\FrameworkList.xml" />
+    <_RuntimeListInputs  Include="$(MicrosoftAndroidArmPackDir)**" />
+    <_RuntimeListInputs  Include="$(MicrosoftAndroidArm64PackDir)**" />
+    <_RuntimeListInputs  Include="$(MicrosoftAndroidx86PackDir)**" />
+    <_RuntimeListInputs  Include="$(MicrosoftAndroidx64PackDir)**" />
+    <_RuntimeListOutputs Include="@(AndroidSupportedTargetJitAbi->'$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidDefaultTargetDotnetApiLevel).%(AndroidRID)\$(AndroidPackVersion)\data\RuntimeList.xml')" AndroidRID="%(AndroidRID)" />
+    <_RuntimeListOutputs Include="@(AndroidSupportedTargetJitAbi->'$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidLatestStableApiLevel).%(AndroidRID)\$(AndroidPackVersion)\data\RuntimeList.xml')" AndroidRID="%(AndroidRID)" />
+    <_RuntimeListOutputs Include="@(AndroidSupportedTargetJitAbi->'$(BuildOutputDirectory)lib\packs\Microsoft.Android.Runtime.$(AndroidLatestUnstableApiLevel).%(AndroidRID)\$(AndroidPackVersion)\data\RuntimeList.xml')" AndroidRID="%(AndroidRID)" />
+    <_TemplatesInputs Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\**" />
+    <_TemplatesOutputs Include="$(BuildOutputDirectory)lib\template-packs\Microsoft.Android.Templates.$(AndroidPackVersion).nupkg" />
+  </ItemGroup>
+
+  <Target Name="CreateLocalRuntimeLists"
+      Inputs="$(MSBuildThisFile);@(_RuntimeListInputs)"
+      Outputs="@(_RuntimeListOutputs)">
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj"
+        Properties="FrameworkListFile=%(_RuntimeListOutputs.Identity);AndroidRID=%(_RuntimeListOutputs.AndroidRID)"
+        Targets="_GetRuntimePackItems;_GenerateFrameworkListFile"
+    />
+  </Target>
+
+  <Target Name="CreateLocalFrameworkLists"
+      Inputs="$(MSBuildThisFile);@(_FrameworkListInputs)"
+      Outputs="@(_FrameworkListOutputs)">
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj"
+        Properties="FrameworkListFile=%(_FrameworkListOutputs.Identity)"
+        Targets="_GetTargetingPackItems;_GenerateFrameworkListFile"
+    />
+  </Target>
+
+  <Target Name="PackAndCopyTemplates"
+      Inputs="@(_TemplatesInputs)"
+      Outputs="@(_TemplatesOutputs)">
+    <ItemGroup>
+      <_PackProps Include="-v:n -c $(Configuration)" />
+      <_PackProps Include="-p:IncludeSymbols=False" />
+      <_PackProps Include="-p:OutputPath=$(DotNetPreviewPath)template-packs" />
+      <_PackProps Include="-p:TemplatePackVersion=$(AndroidPackVersion)" />
+    </ItemGroup>
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_PackProps, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+  </Target>
+
+  <Target Name="InstallManifestAndDependencies">
+    <PropertyGroup>
+      <_LocalSdkManifestsFolder>$(BuildOutputDirectory)lib\sdk-manifests\$(DotNetSdkManifestsFolder)\</_LocalSdkManifestsFolder>
+      <_LocalAndroidManifestFolder>$(_LocalSdkManifestsFolder)microsoft.net.sdk.android\</_LocalAndroidManifestFolder>
+      <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)android.deps.workload\</_EmptyWorkloadDir>
+      <_EmptyWorkloadJsonContent>
+<![CDATA[
+{"version": "0.0.1", "workloads": { "android-deps": { "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ] } } }
+]]>
+      </_EmptyWorkloadJsonContent>
+    </PropertyGroup>
+    <MakeDir Directories="$(_LocalAndroidManifestFolder)" />
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj"
+        Properties="WorkloadManifestJsonPath=$(_LocalAndroidManifestFolder)WorkloadManifest.json;WorkloadManifestTargetsPath=$(_LocalAndroidManifestFolder)WorkloadManifest.targets;WorkloadVersion=$(AndroidPackVersion)"
+        Targets="_GenerateXAWorkloadContent"
+    />
+    <!-- Create empty workload to install dotnet/runtime dependencies -->
+    <MakeDir Directories="$(_EmptyWorkloadDir)" />
+    <WriteLinesToFile
+        File="$(_EmptyWorkloadDir)WorkloadManifest.json"
+        Lines="$(_EmptyWorkloadJsonContent)"
+        Overwrite="true"
+    />
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-deps --configfile &quot;$(XamarinAndroidSourcePath)NuGet.config&quot; --skip-manifest-update --verbosity diag"
+        EnvironmentVariables="DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=$(BuildOutputDirectory)lib\sdk-manifests"
+        WorkingDirectory="$(XamarinAndroidSourcePath)"
+    />
+  </Target>
+
+  <PropertyGroup>
+    <ConfigureLocalWorkloadDependsOn Condition="'$(RunningOnCI)' != 'true'">CreateLocalFrameworkLists;CreateLocalRuntimeLists;PackAndCopyTemplates;InstallManifestAndDependencies</ConfigureLocalWorkloadDependsOn>
+  </PropertyGroup>
+  <Target Name="ConfigureLocalWorkload" DependsOnTargets="$(ConfigureLocalWorkloadDependsOn)" />
 
 </Project>

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -4,7 +4,7 @@ Microsoft.Android.Ref.proj
 
 This project file is used to create the Microsoft.Android.Ref.[API] NuGet, which is the
 targeting pack containing reference assemblies and other compile time assets required
-by projects that use the Microsoft.Android framework in .NET 5.
+by projects that use the Microsoft.Android framework in .NET 6+.
 ***********************************************************************************************
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
@@ -27,23 +27,23 @@ by projects that use the Microsoft.Android framework in .NET 5.
   <Target Name="_GetTargetingPackItems"
       DependsOnTargets="AssembleApiDocs;_GetLicense">
     <PropertyGroup>
-      <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
+      <FrameworkListFile Condition="'$(FrameworkListFile)' == ''">$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
     </PropertyGroup>
 
     <ItemGroup>
       <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net7.0\ref\Java.Interop.dll" />
-      <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\ref\Mono.Android.dll" />
+      <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETDefaultOutDir)ref\Mono.Android.dll" />
       <!-- Always include stable Mono.Android.Export.dll -->
-      <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)\ref\Mono.Android.Export.dll" />
+      <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\ref\Mono.Android.Export.dll" />
       <FrameworkListFileClass Include="@(_AndroidRefPackAssemblies->'%(Filename)%(Extension)')" Profile="Android" />
     </ItemGroup>
 
     <ItemGroup>
       <_PackageFiles Include="@(_AndroidRefPackAssemblies)" PackagePath="$(_AndroidRefPackAssemblyPath)" TargetPath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\Java.Interop.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\Mono.Android.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
-      <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(_MonoAndroidNETDefaultOutDir)Java.Interop.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(_MonoAndroidNETDefaultOutDir)mono.android.jar" PackagePath="$(_AndroidRefPackAssemblyPath)" />
+      <_PackageFiles Include="$(_MonoAndroidNETDefaultOutDir)mono.android.dex" PackagePath="$(_AndroidRefPackAssemblyPath)" />
     </ItemGroup>
   </Target>
 

--- a/build-tools/create-packs/Microsoft.Android.Runtime.proj
+++ b/build-tools/create-packs/Microsoft.Android.Runtime.proj
@@ -4,7 +4,7 @@ Microsoft.Android.Runtime.proj
 
 This project file is used to create Microsoft.Android.Runtime.[API].[RID] NuGets, which are
 runtime packs that contain the assets required for a self-contained publish of
-projects that use the Microsoft.Android framework in .NET 5.
+projects that use the Microsoft.Android framework in .NET 6+.
 ***********************************************************************************************
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
@@ -29,14 +29,14 @@ projects that use the Microsoft.Android framework in .NET 5.
   <Target Name="_GetRuntimePackItems"
       DependsOnTargets="_GetLicense">
     <PropertyGroup>
-      <FrameworkListFile>$(IntermediateOutputPath)$(AndroidRID)\RuntimeList.xml</FrameworkListFile>
+      <FrameworkListFile Condition="'$(FrameworkListFile)' == ''">$(IntermediateOutputPath)$(AndroidRID)\RuntimeList.xml</FrameworkListFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\Java.Interop.dll" />
-      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\Mono.Android.dll" />
+      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETDefaultOutDir)Java.Interop.dll" />
+      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETDefaultOutDir)Mono.Android.dll" />
       <!-- Always include stable Mono.Android.Export.dll -->
-      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />
+      <_AndroidRuntimePackAssemblies Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\Mono.Android.Export.dll" />
       <_AndroidRuntimePackAssets Include="$(MicrosoftAndroidSdkOutDir)lib\$(AndroidRID)\libmono-android.debug.so" />
       <_AndroidRuntimePackAssets Include="$(MicrosoftAndroidSdkOutDir)lib\$(AndroidRID)\libmono-android.release.so" />
       <_AndroidRuntimePackAssets Include="$(MicrosoftAndroidSdkOutDir)lib\$(AndroidRID)\libxamarin-debug-app-helper.so" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -21,18 +21,17 @@ core workload SDK packs imported by WorkloadManifest.targets.
 
   <PropertyGroup>
     <BeforePack>
+      _GetDefaultPackageVersion;
       _GenerateXASdkContent;
       $(BeforePack);
     </BeforePack>
   </PropertyGroup>
 
   <Target Name="_GenerateXASdkContent"
-      DependsOnTargets="ConstructInstallerItems;_GenerateBundledVersions;_GetLicense">
+      DependsOnTargets="ConstructInstallerItems;_GetLicense">
     <ItemGroup>
       <AndroidSdkBuildTools Include="@(MSBuildItemsWin)"  PackagePath="tools\$([System.IO.Path]::GetDirectoryName('%(MSBuildItemsWin.RelativePath)'))"  Condition=" '%(MSBuildItemsWin.ExcludeFromAndroidNETSdk)' != 'true' and '$(HostOS)' == 'Windows' " />
       <AndroidSdkBuildTools Include="@(MSBuildItemsUnix)" PackagePath="tools\$([System.IO.Path]::GetDirectoryName('%(MSBuildItemsUnix.RelativePath)'))" Condition=" '%(MSBuildItemsUnix.ExcludeFromAndroidNETSdk)' != 'true' and ('$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin') " />
-      <_AndroidApiInfo Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" />
-      <_AndroidApiInfo Include="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml" Condition="Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml')" />
     </ItemGroup>
 
     <GenerateUnixFilePermissions
@@ -60,28 +59,22 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" PackagePath="PreserveLists" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\**" PackagePath="targets" />
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\profiled-aot\dotnet.aotprofile" PackagePath="targets" />
-      <_PackageFiles Include="@(_AndroidApiInfo)" DirectoryName="$([System.IO.Path]::GetDirectoryName ('%(Identity)'))" PackagePath="data\$([System.IO.Path]::GetFileName ('%(_PackageFiles.DirectoryName)'))" />
       <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <_PackageFiles Include="$(MSBuildThisFileDirectory)\linux-README.md" PackagePath="\README.md" Condition=" '$(HostOS)' == 'Linux' " />
+      <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" PackagePath="data\$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)" />
+      <_PackageFiles
+          Include="$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\AndroidApiInfo.xml"
+          PackagePath="data\$(DotNetAndroidTargetFramework)$(AndroidDefaultTargetDotnetApiLevel)"
+          Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\AndroidApiInfo.xml') "
+      />
+      <_PackageFiles
+          Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml"
+          PackagePath="data\$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)"
+          Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidLatestUnstableApiLevel)\AndroidApiInfo.xml') "
+      />
       <None Include="$(MSBuildThisFileDirectory)SignList.xml" CopyToOutputDirectory="PreserveNewest" />
       <None Include="$(MSBuildThisFileDirectory)SignVerifyIgnore.txt" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
-  </Target>
-
-  <!-- Generate and include this file in our SDK for now, but we may eventually want to migrate to:
-       https://github.com/dotnet/installer/blob/d98f5f18bce44014aeacd2f99923b4779d89459d/src/redist/targets/GenerateBundledVersions.targets
-       -->
-  <Target Name="_GenerateBundledVersions"
-      DependsOnTargets="_GetDefaultPackageVersion" >
-    <PropertyGroup>
-      <BundledVersionsFileName>Microsoft.Android.Sdk.BundledVersions.targets</BundledVersionsFileName>
-    </PropertyGroup>
-
-    <ReplaceFileContents
-        SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"
-        DestinationFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\$(BundledVersionsFileName)"
-        Replacements="@ANDROID_PACK_VERSION_LONG@=$(AndroidPackVersionLong);@ANDROID_LATEST_STABLE_API_LEVEL@=$(AndroidLatestStableApiLevel);@DOTNET_TARGET_FRAMEWORK@=$(DotNetTargetFramework)" >
-    </ReplaceFileContents>
   </Target>
 
 </Project>

--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -23,19 +23,19 @@ about the various Microsoft.Android workloads.
     </BeforePack>
   </PropertyGroup>
 
-  <!-- FIXME: Temporarily Generate WorkloadManifest.targets and WorkloadManifest.json files inline while content is trivial. -->
   <Target Name="_GenerateXAWorkloadContent"
       DependsOnTargets="_GetDefaultPackageVersion;_GetLicense">
     <PropertyGroup>
-      <WorkloadManifestJsonPath>$(OutputPath)workload-manifest\WorkloadManifest.json</WorkloadManifestJsonPath>
-      <WorkloadManifestTargetsPath>$(OutputPath)workload-manifest\WorkloadManifest.targets</WorkloadManifestTargetsPath>
+      <WorkloadManifestJsonPath Condition="'$(WorkloadManifestJsonPath)' == ''">$(OutputPath)workload-manifest\WorkloadManifest.json</WorkloadManifestJsonPath>
+      <WorkloadManifestTargetsPath Condition="'$(WorkloadManifestTargetsPath)' == ''">$(OutputPath)workload-manifest\WorkloadManifest.targets</WorkloadManifestTargetsPath>
+      <WorkloadVersion Condition="'$(WorkloadVersion)' == ''">$(AndroidPackVersionLong)</WorkloadVersion>
     </PropertyGroup>
 
     <MakeDir Directories="$(OutputPath)workload-manifest" />
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.json"
         DestinationFile="$(WorkloadManifestJsonPath)"
-        Replacements="@WORKLOAD_VERSION@=$(AndroidPackVersionLong);@NET6_VERSION@=$(AndroidNet6Version)">
+        Replacements="@WORKLOAD_VERSION@=$(WorkloadVersion);@NET6_VERSION@=$(AndroidNet6Version)">
     </ReplaceFileContents>
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.targets"

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -51,13 +51,13 @@
   <Target Name="_GenerateMsxDocXmls"
       DependsOnTargets="_FindFrameworkDirs;_FindDocSourceFiles"
       Inputs="@(_MsxDocSourceFile)"
-      Outputs="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml');@(_MsxDocAssembly->'$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\%(Identity).xml')">
+      Outputs="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml');@(_MsxDocAssembly->'$(_MonoAndroidNETDefaultOutDir)%(Identity).xml')">
     <Exec Command="$(ManagedRuntime) &quot;$(MicrosoftAndroidSdkOutDir)mdoc.exe&quot; --debug export-msxdoc -o &quot;$(_LatestStableFrameworkDir)%(_MsxDocAssembly.Identity).xml&quot; &quot;%(_MsxDocAssembly.SourceDir)&quot;" />
     <Copy
         SourceFiles="$(_LatestStableFrameworkDir)%(_MsxDocAssembly.Identity).xml"
-        DestinationFolder="$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\"
+        DestinationFolder="$(_MonoAndroidNETDefaultOutDir)"
     />
-    <Touch Files="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml');@(_MsxDocAssembly->'$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\%(Identity).xml')" />
+    <Touch Files="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml');@(_MsxDocAssembly->'$(_MonoAndroidNETDefaultOutDir)%(Identity).xml')" />
   </Target>
   <Target Name="_GenerateMsxDocXmlRedirects"
       DependsOnTargets="_FindFrameworkDirs"

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -28,4 +28,5 @@ leeroy: leeroy-all framework-assemblies
 
 leeroy-all:
 	$(call DOTNET_BINLOG,leeroy-all) $(SOLUTION) -m:1 $(_MSBUILD_ARGS)
+	$(call DOTNET_BINLOG,setup-workload) -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj
 	$(call MSBUILD_BINLOG,leeroy-all,$(_SLN_BUILD)) /restore tools/xabuild/xabuild.csproj /p:Configuration=$(CONFIGURATION) $(_MSBUILD_ARGS)

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -15,10 +15,14 @@
         WorkingDirectory="$(_Root)external\Java.Interop"
     />
   </Target>
-  <Target Name="PackDotNet"
+  <Target Name="BuildDotNet"
       DependsOnTargets="PrepareJavaInterop">
     <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ConfigureLocalWorkload" />
+  </Target>
+  <Target Name="PackDotNet">
+    <!-- Build extra versions of Mono.Android.dll if necessary -->
     <MSBuild
          Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
          Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,8 +1,12 @@
 @echo off
 SET ROOT=%~dp0
 IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
+    SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Release\lib\sdk-manifests
+    SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Release\lib
     call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
+    SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Debug\lib\sdk-manifests
+    SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Debug\lib
     call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 ROOT=$(dirname "${BASH_SOURCE}")
+FULLROOT=$(pwd)
 if [[ -x "${ROOT}/bin/Release/dotnet/dotnet" ]]; then
-    exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
+    DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Release/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Release/lib exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
 elif [[ -x "${ROOT}/bin/Debug/dotnet/dotnet" ]]; then
-    exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
+    DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Debug/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Debug/lib exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
 else
     echo "You need to run 'make prepare' first."
 fi

--- a/src/Microsoft.Android.Templates/Directory.Build.targets
+++ b/src/Microsoft.Android.Templates/Directory.Build.targets
@@ -9,7 +9,8 @@
   <Target Name="_GetDefaultPackageVersion"
       DependsOnTargets="GetXAVersionInfo" >
     <PropertyGroup>
-      <PackageVersion>$(AndroidPackVersionLong)+sha.$(XAVersionHash)</PackageVersion>
+      <TemplatePackVersion Condition="'$(TemplatePackVersion)' == ''">$(AndroidPackVersionLong)+sha.$(XAVersionHash)</TemplatePackVersion>
+      <PackageVersion>$(TemplatePackVersion)</PackageVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
-    <OutputPath>$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\</OutputPath>
+    <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
@@ -57,9 +57,46 @@
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
   <!-- Only build the .NET 6+ version of 'Mono.Android.Export.dll' for the latest stable Android version. -->
   <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' != '$(AndroidLatestStableApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
+
+  <!-- Copy .NET ref/runtime assemblies to bin/$(Configuration)/dotnet/packs folder -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' == '$(AndroidLatestStableApiLevel)' ">
+    <BuildDependsOn>
+      $(BuildDependsOn);
+      _CopyToPackDirs;
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CopyToPackDirs" >
+    <Copy
+        SourceFiles="$(OutputPath)ref\Mono.Android.Export.dll"
+        DestinationFolder="$(MicrosoftAndroidRefPackDir)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.Export.dll"
+        DestinationFolder="$(MicrosoftAndroidArmPackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.Export.dll"
+        DestinationFolder="$(MicrosoftAndroidArm64PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.Export.dll"
+        DestinationFolder="$(MicrosoftAndroidx86PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.Export.dll"
+        DestinationFolder="$(MicrosoftAndroidx64PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
 
 </Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -34,7 +34,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
     <DefineConstants Condition=" '$(AndroidApiLevel)' &gt; '$(AndroidLatestStableApiLevel)' ">$(DefineConstants);ANDROID_UNSTABLE</DefineConstants>
-    <OutputPath>$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidApiLevel)\</OutputPath>
+    <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IncludeAndroidJavadoc)' == 'True' ">
@@ -386,9 +386,58 @@
   <Target Name="GetTargetPath" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
   <!-- Only build the .NET 6+ version of 'Mono.Android.dll' for the default API level that is supported or higher. -->
   <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidDefaultTargetDotnetApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &gt;= '$(AndroidDefaultTargetDotnetApiLevel)' ">
+    <BuildDependsOn>
+      $(BuildDependsOn);
+      _CopyToPackDirs;
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CopyToPackDirs" >
+    <ItemGroup>
+      <_RefExtras Include="$(OutputPath)*.*" Exclude="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_RefExtras)"
+        DestinationFolder="$(MicrosoftAndroidRefPackDir)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)ref\Mono.Android.dll;$(JavaInteropSourceDirectory)\bin\$(Configuration)-net7.0\ref\Java.Interop.dll"
+        DestinationFolder="$(MicrosoftAndroidRefPackDir)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        DestinationFolder="$(MicrosoftAndroidArmPackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        DestinationFolder="$(MicrosoftAndroidArm64PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        DestinationFolder="$(MicrosoftAndroidx86PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        DestinationFolder="$(MicrosoftAndroidx64PackDir)lib\$(DotNetTargetFramework)"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)AndroidApiInfo.xml"
+        DestinationFolder="$(MicrosoftAndroidSdkPackDir)data\$(DotNetAndroidTargetFramework)$(AndroidApiLevel)"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -19,6 +19,8 @@
       _CopyExtractedMultiDexJar;
       _BuildMonoScripts;
       _CopyExtraPackageContent;
+      _GenerateBundledVersions;
+      _CopyNetSdkTargets;
       _CopyVSExtensionTargets;
     </BuildDependsOn>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidSdkDirectory)</_AndroidSdkLocation>
@@ -357,9 +359,39 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Generate and include this file in our SDK for now, but we may eventually want to migrate to:
+       https://github.com/dotnet/installer/blob/d98f5f18bce44014aeacd2f99923b4779d89459d/src/redist/targets/GenerateBundledVersions.targets
+       -->
+  <Target Name="_GenerateBundledVersions"
+      DependsOnTargets="GetXAVersionInfo">
+    <ReplaceFileContents
+        SourceFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"
+        DestinationFile="$(MSBuildThisFileDirectory)\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.BundledVersions.targets"
+        Replacements="@ANDROID_PACK_VERSION_LONG@=$(AndroidPackVersionLong);@ANDROID_LATEST_STABLE_API_LEVEL@=$(AndroidLatestStableApiLevel);@DOTNET_TARGET_FRAMEWORK@=$(DotNetTargetFramework)" >
+    </ReplaceFileContents>
+  </Target>
+
+  <Target Name="_CopyNetSdkTargets">
+    <ItemGroup>
+      <_SdkDirFiles Include="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\**" />
+      <_SdkTargetsDirFiles Include="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\targets\**" />
+      <_SdkTargetsDirFiles Include="$(XamarinAndroidSourcePath)src\profiled-aot\dotnet.aotprofile" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_SdkDirFiles)"
+        DestinationFolder="$(MicrosoftAndroidSdkPackDir)Sdk"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_SdkTargetsDirFiles)"
+        DestinationFolder="$(MicrosoftAndroidSdkPackDir)targets"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
+
   <ItemGroup>
-    <_VSExtensionTargets Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Xamarin.Android.Sdk.props" />
-    <_VSExtensionTargets Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Xamarin.Android.Sdk.targets" />
+    <_VSExtensionTargets Include="$(MSBuildThisFileDirectory)MSBuild\Xamarin\Xamarin.Android.Sdk.props" />
+    <_VSExtensionTargets Include="$(MSBuildThisFileDirectory)MSBuild\Xamarin\Xamarin.Android.Sdk.targets" />
   </ItemGroup>
   <Target Name="_CopyVSExtensionTargets"
       Inputs="@(_VSExtensionTargets)"

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <Target Name="_BuildRuntimes" BeforeTargets="Build"
-      DependsOnTargets="_GenerateIncludeFiles;_ConfigureRuntimes;_BuildAndroidRuntimes;_BuildAndroidAnalyzerRuntimes;_BuildHostRuntimes">
+      DependsOnTargets="_GenerateIncludeFiles;_ConfigureRuntimes;_BuildAndroidRuntimes;_BuildAndroidAnalyzerRuntimes;_BuildHostRuntimes;_CopyToPackDirs">
   </Target>
   <Target Name="_TestPinvokeTables" Condition=" '$(HostOS)' == 'Linux' And '$(RunningOnCI)' == 'true' ">
     <Exec
@@ -301,6 +301,35 @@
         ContinueOnError="ErrorAndContinue"
         Command="$(ClangTidy) -p $(MSBuildThisFileDirectory)%(_CompileCommandsDir.Identity) *.cc > ..\..\..\bin\Build$(Configuration)\clang-tidy.%(_CompileCommandsDir.LogTag).log"
         WorkingDirectory="$(MSBuildThisFileDirectory)\jni"
+    />
+  </Target>
+
+  <Target Name="_CopyToPackDirs">
+    <ItemGroup>
+      <_ArmRuntimePackFiles   Include="$(OutputPath)\android-arm\*.*" />
+      <_Arm64RuntimePackFiles Include="$(OutputPath)\android-arm64\*.*" />
+      <_x86RuntimePackFiles   Include="$(OutputPath)\android-x86\*.*" />
+      <_x64RuntimePackFiles   Include="$(OutputPath)\android-x64\*.*" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_ArmRuntimePackFiles)"
+        DestinationFolder="$(MicrosoftAndroidArmPackDir)native"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_Arm64RuntimePackFiles)"
+        DestinationFolder="$(MicrosoftAndroidArm64PackDir)native"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_x86RuntimePackFiles)"
+        DestinationFolder="$(MicrosoftAndroidx86PackDir)native"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_x64RuntimePackFiles)"
+        DestinationFolder="$(MicrosoftAndroidx64PackDir)native"
+        SkipUnchangedFiles="true"
     />
   </Target>
 </Project>


### PR DESCRIPTION
Build steps have been updated to circumvent the need to pack and install
.nupkgs to test local build changes against .NET 7 +.

Projects which produce content required for our Ref and Runtime packs
have been updated to copy their outputs to a `packs` directory.  This
directory follows the structure that dotnet workload resolution expects.
The version of these local packs has been simplified compared to CI, it
will not include commit distance or any semver metadata.

A new `ConfigureLocalWorkload` target has been added to run a couple of
extra steps that are required to set up the local workload.  This
includes generating workload manifest, target, and FrameworkList files,
installing mono/runtime dependencies, and creating the templates pack.

A new `BuildDotNet` target has been added (primarily for Windows) which
will only build one API level and call this new target.  The `make all`
and `make jenkins` rules will also now run `ConfigureLocalWorkload` by
default.

The `dotnet-local` scripts have been updated to set the variables needed
to resolve `sdk-manifests` and `packs` content from a non default path.

After running `make` or the `BuildDotNet` target, the `dotnet-local`
scripts can be used to build and run a template:

    .\dotnet-local.cmd new android -o androidnet
    .\dotnet-local.cmd build -t:Run androidnet\androidnet.csproj