### PR TITLE
Disable C++20 concepts when building for macOS

### DIFF
--- a/src/monodroid/jni/timing-internal.hh
+++ b/src/monodroid/jni/timing-internal.hh
@@ -11,11 +11,13 @@
 
 #undef HAVE_CONCEPTS
 
-// Xcode has supports for concepts only since 12.5
-#if __has_include (<concepts>)
+// Xcode has supports for concepts only since 12.5, however
+// even in 13.2 support for them appears buggy. Disable for
+// now
+#if __has_include (<concepts>) && !defined(__APPLE__)
 #define HAVE_CONCEPTS
 #include <concepts>
-#endif // __has_include
+#endif // __has_include && ndef __APPLE__
 
 #include "cpp-util.hh"
 #include "logger.hh"


### PR DESCRIPTION
Context: 1efa0cf46c9079fc06669a4434f597faf47504af

It appears that Apple clang in Xcode 13.2 still has problems
with support for C++20 concepts, resulting in problems building
the recently committed timing code:

    timing-internal.hh(433,4): error GD3D6EBB4: no matching function for call to 'calculate_interval'
                          calculate_interval (event.start, event.end, interval, total_ns);

This could also be fixed by using `std::remove_reference_t`, but
it would make the code unnecessarily less readable.  With Android
being the primary target and compliation for it working properly,
I think it's OK to disable concepts for macOS in this instance.