### PR TITLE
[monodroid] Fix compilation with Xcode 13.2

### DIFF
--- a/src/monodroid/jni/timing-internal.hh
+++ b/src/monodroid/jni/timing-internal.hh
@@ -9,6 +9,13 @@
 #include <type_traits>
 #include <vector>
 
+#include "cpp-util.hh"
+#include "logger.hh"
+#include "startup-aware-lock.hh"
+#include "strings.hh"
+#include "util.hh"
+#include "shared-constants.hh"
+
 #undef HAVE_CONCEPTS
 
 // Xcode has supports for concepts only since 12.5, however
@@ -18,13 +25,6 @@
 #define HAVE_CONCEPTS
 #include <concepts>
 #endif // __has_include && ndef __APPLE__
-
-#include "cpp-util.hh"
-#include "logger.hh"
-#include "startup-aware-lock.hh"
-#include "strings.hh"
-#include "util.hh"
-#include "shared-constants.hh"
 
 namespace xamarin::android::internal
 {


### PR DESCRIPTION
Apple Clang from Xcode 13.2 appears to have a bug which causes it to
fail with the following error when concepts in `timing-internal.hh` are
used:

    timing-internal.hh(436,4): error GB0476C6D: no matching function for call to 'calculate_interval' [/Users/peter/source/xamarin-android/src/monodroid/monodroid.csproj]
                          calculate_interval (event.start, event.end, interval, total_ns);
                                 ^~~~~~~~~~~~~~~~~~
    timing-internal.hh:264:28: note: candidate template ignored: constraints not satisfied [with P = xamarin::android::internal::TimingEventPoint, I = xamarin::android::internal::TimingInterval]
                         force_inline static void calculate_interval (P const& start, P const& end, I &result, uint64_t& total_ns) noexcept
                                                  ^
    timing-internal.hh:260:12: note: because 'xamarin::android::internal::TimingEventPoint' does not satisfy 'TimingPointType'
                         template<TimingPointType P, TimingIntervalType I>

Fix the error by moving compatibility detection code after other
headears are include.  The issue was caused by the fact that
`timing-internal.hh` included `startup-aware-lock.hh` which included
`globals.hh`, which included `embedded-assemblies.hh` and the last
header **also** defines `HAVE_CONCEPTS`, so it overrode our detection in
`timing-internal.hh`