### PR TITLE
[build] Use local .NET preview to build net7.0

### DIFF
--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -93,7 +93,7 @@ but this is only part of the story. Your local
 local Android "workload" in `Microsoft.Android.Sdk.$(HostOS)` matching
 your operating system.
 
-Create a new project with `dotnet new android`:
+Create a new project with `./dotnet-local.sh new android`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -20,7 +20,7 @@ MSBuild version 15 or later is required.
 
  5. In a [Developer Command Prompt][developer-prompt], prepare the project:
 
-        msbuild Xamarin.Android.sln /t:Prepare
+        dotnet msbuild Xamarin.Android.sln -t:Prepare
 
     This will ensure that the build dependencies are installed, perform
     `git submodule update`, download NuGet dependencies, and other
@@ -28,7 +28,7 @@ MSBuild version 15 or later is required.
 
  6. Build the project:
 
-        msbuild Xamarin.Android.sln
+        dotnet-local.cmd build Xamarin.Android.sln -m:1
 
  7. In order to use the in-tree Xamarin.Android, build xabuild:
 
@@ -38,7 +38,7 @@ MSBuild version 15 or later is required.
     Prompt][developer-prompt], build external proprietary git
     dependencies:
 
-        msbuild Xamarin.Android.sln /t:BuildExternal
+        dotnet-local.cmd build Xamarin.Android.sln -t:BuildExternal
 
     This will clone and build external proprietary components such as `monodroid`.
 
@@ -99,7 +99,7 @@ of .NET 6 to `bin\$(Configuration)\dotnet`.
 Once `msbuild Xamarin.Android.sln /t:Build` is complete, you can build
 the .NET 6 packages with:
 
-    msbuild Xamarin.Android.sln /t:PackDotNet
+    dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -m:1
 
 Several `.nupkg` files will be output in `.\bin\BuildDebug\nuget-unsigned`,
 but this is only part of the story. Your local
@@ -107,7 +107,7 @@ but this is only part of the story. Your local
 populated with a local Android "workload" in
 `Microsoft.Android.Sdk.$(HostOS)` matching your operating system.
 
-Create a new project with `dotnet new android`:
+Create a new project with `dotnet-local.cmd new android`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/Makefile
+++ b/Makefile
@@ -181,12 +181,12 @@ include build-tools/scripts/runtime-helpers.mk
 
 .PHONY: prepare
 prepare:
-	$(call DOTNET_BINLOG,prepare-run,run) $(PREPARE_MSBUILD_FLAGS) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) -- $(_PREPARE_ARGS)
-	$(call DOTNET_BINLOG,prepare-bootstrap) Xamarin.Android.BootstrapTasks.sln
+	$(call SYSTEM_DOTNET_BINLOG,prepare-run,run) $(PREPARE_MSBUILD_FLAGS) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) -- $(_PREPARE_ARGS)
+	$(call SYSTEM_DOTNET_BINLOG,prepare-bootstrap) Xamarin.Android.BootstrapTasks.sln
 
 .PHONY: prepare-help
 prepare-help:
-	$(call DOTNET_BINLOG,prepare-help,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) -- -h
+	$(call SYSTEM_DOTNET_BINLOG,prepare-help,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) -- -h
 
 .PHONY: shutdown-compiler-server
 shutdown-compiler-server:
@@ -208,11 +208,11 @@ shutdown-compiler-server:
 
 .PHONY: prepare-update-mono
 prepare-update-mono: shutdown-compiler-server
-	$(call DOTNET_BINLOG,prepare-update-mono,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) \
+	$(call SYSTEM_DOTNET_BINLOG,prepare-update-mono,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) \
 		-- -s:UpdateMono $(_PREPARE_ARGS)
 
 prepare-external-git-dependencies:
-	$(call DOTNET_BINLOG,prepare-external-git-dependencies,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) \
+	$(call SYSTEM_DOTNET_BINLOG,prepare-external-git-dependencies,run) --project "$(PREPARE_PROJECT)" --framework $(PREPARE_NET_FX) \
 		-- -s:PrepareExternalGitDependencies $(_PREPARE_ARGS)
 
 APK_SIZES_REFERENCE_DIR=tests/apk-sizes-reference

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -201,14 +201,17 @@ stages:
       displayName: Prepare Solution
       inputs:
         projects: Xamarin.Android.sln
-        arguments: '-c $(XA.Build.Configuration) -target:Prepare -m:1 -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
+        arguments: '-c $(XA.Build.Configuration) -t:Prepare --no-restore -m:1 -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
 
     # Build, pack .nupkgs, and extract workload packs to dotnet preview test directory
-    - task: DotNetCoreCLI@2
-      displayName: Build Solution
-      inputs:
-        projects: Xamarin.Android.sln
-        arguments: '-t:PackDotNet -c $(XA.Build.Configuration) -m:1 -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog'
+    - template: yaml-templates\run-dotnet-preview.yaml
+      parameters:
+        project: Xamarin.Android.sln
+        arguments: >-
+          -t:PackDotNet -c $(XA.Build.Configuration) -m:1 -v:n
+          -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog
+        displayName: Build Solution
+        continueOnError: false
 
     - task: MSBuild@1
       displayName: msbuild create-vsix
@@ -236,7 +239,6 @@ stages:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >-
-          /restore
           /t:RunJavaInteropTests
           /p:SkipJSUTests=true
           /p:TestAssembly="bin\Test$(XA.Build.Configuration)\generator-Tests.dll;bin\Test$(XA.Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(XA.Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll"

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -26,15 +26,10 @@ jobs:
 
     - template: clean.yaml
 
-    # Install a stable verison of .NET for classic tests
-    - template: use-dot-net.yaml
-      parameters:
-        version: 6.0.202
-        remove_dotnet: true
-
     - template: setup-test-environment.yaml
       parameters:
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
+        remove_dotnet: true
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -63,8 +63,8 @@ steps:
   displayName: restore NUnit.Console
   inputs:
     command: restore
-    projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
-    restoreArguments: -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
+    projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+    restoreArguments: -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.ProjectTools.binlog
     nugetConfigPath: ${{ parameters.xaSourcePath }}/NuGet.config
     feedsToUse: config
 

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -18,7 +18,7 @@ variables:
 - name: NUnit.NumberOfTestWorkers
   value: 4
 - name: DotNetSdkVersion
-  value: 7.0.100-preview.2.22153.17
+  value: 6.0.300
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -58,30 +58,30 @@
 
   <Target Name="_CreateDefaultRefPack"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="_CreatePreviewPacks"
       Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(DotNetAndroidTargetFramework)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
   </Target>
 
   <Target Name="CreateAllPacks"
       DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks;_CreateDefaultRefPack">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
+    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -10,10 +10,10 @@ create-installers: create-nupkgs create-pkg create-vsix
 create-nupkgs:
 	@echo Disk usage before create-nupkgs
 	-df -h
-	$(call DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
+	$(call SYSTEM_DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
 
 create-pkg:
-	$(call DOTNET_BINLOG,create-pkg) /t:CreatePkg \
+	$(call SYSTEM_DOTNET_BINLOG,create-pkg) /t:CreatePkg \
 		build-tools/create-pkg/create-pkg.csproj \
 		$(if $(PACKAGE_VERSION),/p:ProductVersion="$(PACKAGE_VERSION)") \
 		$(if $(PACKAGE_VERSION_REV),/p:XAVersionCommitCount="$(PACKAGE_VERSION_REV)") \

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -34,6 +34,5 @@
     />
     <Exec Command="$(ManagedToolInvocationRuntime)$(_XAPrepareExe) $(_XAPrepareStandardArgs) -a" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(_TopDir)\Xamarin.Android.BootstrapTasks.sln" Targets="Restore;Build" />
-    <MSBuild Projects="$(_TopDir)\Xamarin.Android.sln" Targets="Restore" />
   </Target>
 </Project>

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -23,7 +23,7 @@
 #   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
 
 MSBUILD       = msbuild
-DOTNET_TOOL   = dotnet
+DOTNET_TOOL   = $(topdir)/bin/$(CONFIGURATION)/dotnet/dotnet
 DOTNET_VERB   = build
 MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 
@@ -53,6 +53,11 @@ endef
 define DOTNET_BINLOG
 	$(if $(3),$(3),$(DOTNET_TOOL)) $(if $(2),$(2),$(DOTNET_VERB)) -c $(CONFIGURATION) -v:n $(MSBUILD_ARGS) \
 		-bl:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
+endef
+
+# $(call SYSTEM_DOTNET_BINLOG,name,build=$(DOTNET_VERB))
+define SYSTEM_DOTNET_BINLOG
+	$(call DOTNET_BINLOG,$(1),$(2),dotnet)
 endef
 
 else    # $(MSBUILD) != 1


### PR DESCRIPTION
Removes the need to have a .NET 7 preview installed globally to build.
A .NET 6 install is required to build and run xaprepare, which will
provision a .NET 7 preview build used for further building and testing.

Instructions to build on macOS remain unchanged:

    make prepare
    make all

or

    make jenkins

Instructions to build on Windows have been updated:

    dotnet msbuild -t:Prepare Xamarin.Android.sln
    dotnet-local.cmd -t:PackDotNet Xamarin.Android.sln

The `dotnet msbuild` command is recommended as it will not attempt a
restore.  This will allow the `Prepare` target to run against a .NET 6
install, even though `Xamarin.Android.sln` contains projects that target
net7.0.  Otherwise, attempts to dotnet build any target belonging to
`Xamarin.Android.sln` with .NET 6 will fail during restore:

    Project "C:\Users\Peter\source\pj\xamarin-android\Xamarin.Android.sln" on node 1 (Restore target(s)).
    ValidateSolutionConfiguration:
      Building solution configuration "Debug|AnyCPU".
    _GetAllRestoreProjectPathItems:
      Determining projects to restore...
    Project "C:\Users\Peter\source\pj\xamarin-android\Xamarin.Android.sln" (1) is building "C:\Users\Peter\source\pj\xamarin-android\src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj" (11:4) on node 1 (_GenerateRestoreGraphProjectEntry target(s)).
    C:\Program Files\dotnet\sdk\6.0.300\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 7.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 7.0.
