### PR TITLE
[workload] AutoImport.props supports future .NET versions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,17 +16,13 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
-  <PropertyGroup>
-    <_DefaultJavaSourceJarPattern>**\*-source.jar;**\*-sources.jar;**\*-src.jar</_DefaultJavaSourceJarPattern>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Include="Android.App" Platform="Android" />
     <Using Include="Android.Widget" Platform="Android" />
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
     <!-- Default Resource file inclusion -->
     <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
@@ -44,10 +40,10 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />
     <!-- Default Java or native libraries -->
-    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(_DefaultJavaSourceJarPattern)" />
+    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*-source.jar;**\*-sources.jar;**\*-src.jar" />
     <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-    <JavaSourceJar        Include="$(_DefaultJavaSourceJarPattern)"   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <JavaSourceJar        Include="**\*-source.jar;**\*-sources.jar;**\*-src.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -812,7 +812,7 @@ namespace Xamarin.Android.Build.Tests
 		public void XamarinLegacySdk ()
 		{
 			var proj = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.1.0-alpha4",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha1",
 				Sources = {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6988

One problem we hit when trying to build `net6.0-android` projects from
a .NET 7 SDK & Android workload, was that we ended up importing *two*
`AutoImport.props` files.

These are imported for any pack in `WorkloadManifest.json` declared as
an SDK:

    "packs": {
      "Microsoft.Android.Sdk": {
        "kind": "sdk",

So the way this has to work:

* Any `<ItemGroup>` must be conditioned so that
  `$(TargetFrameworkVersion)` matches the .NET SDK version expected.

* Never use an MSBuild property in `AutoImport.props`. Properties are
  evaluated in the first pass and `$(TargetFrameworkVersion)` will be
  blank...

I removed `$(_DefaultJavaSourceJarPattern)` and just duplicated the
value where it was used.

I used `[MSBuild]::VersionEquals()` for all checks, because the value
is `v6.0` and the helper method properly handles this case for us.

When this change ships in a .NET 6 servicing release, we can then
update our .NET 7 packages to rely on this change. Currently, #6988 is
declaring the .NET 6 Microsoft.Android.Sdk as a "framework", which
hacks around the problem.