### PR TITLE
[xaprepare] Download and install dotnet ourselves, with caching

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -206,7 +206,7 @@ namespace Xamarin.Android.Prepare
 					continue;
 				}
 
-				string[] parts = line.Split (':', 3, StringSplitOptions.RemoveEmptyEntries);
+				string[] parts = line.Split (":", 3, StringSplitOptions.RemoveEmptyEntries);
 				if (parts.Length < 3) {
 					Log.WarningLine ($"dotnet-install URL line has unexpected number of parts. Expected 3, got {parts.Length}");
 					Log.WarningLine ($"Line: {line}");

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -160,7 +160,7 @@ namespace Xamarin.Android.Prepare
 			}
 
 			args = new List<string> {
-				dotnetScriptPath, "--version", version, "--install-dir", dotnetPath, "--verbose", "--dry-run"
+				dotnetScriptPath, "--version", version, "--install-dir", dotnetPath, "--verbose"
 			};
 
 			if (runtimeOnly) {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -22,9 +22,6 @@ namespace Xamarin.Android.Prepare
 			dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
 			var dotnetTool = Path.Combine (dotnetPath, "dotnet");
 
-			// Always delete the bin/$(Configuration)/dotnet/ directory
-			Utilities.DeleteDirectory (dotnetPath);
-
 			if (!await InstallDotNetAsync (context, dotnetPath, BuildToolVersion)) {
 				Log.ErrorLine ($"Installation of dotnet SDK {BuildToolVersion} failed.");
 				return false;
@@ -65,68 +62,188 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		async Task<bool> InstallDotNetAsync (Context context, string dotnetPath, string version, bool runtimeOnly = false)
+		async Task<bool> DownloadDotNetInstallScript (Context context, string dotnetScriptPath, Uri dotnetScriptUrl)
 		{
-			if (Directory.Exists (Path.Combine (dotnetPath, "sdk", version)) && !runtimeOnly) {
-				Log.Status ($"dotnet SDK version ");
-				Log.Status (version, ConsoleColor.Yellow);
-				Log.StatusLine (" already installed in: ", Path.Combine (dotnetPath, "sdk", version), tailColor: ConsoleColor.Cyan);
-				return true;
-			}
-
-			if (Directory.Exists (Path.Combine (dotnetPath, "shared", "Microsoft.NETCore.App", version)) && runtimeOnly) {
-				Log.Status ($"dotnet runtime version ");
-				Log.Status (version, ConsoleColor.Yellow);
-				Log.StatusLine (" already installed in: ", Path.Combine (dotnetPath, "shared", "Microsoft.NETCore.App", version), tailColor: ConsoleColor.Cyan);
-				return true;
-			}
-
-			Uri dotnetScriptUrl = Configurables.Urls.DotNetInstallScript;
-			string dotnetScriptPath = Path.Combine (dotnetPath, Path.GetFileName (dotnetScriptUrl.LocalPath));
-			if (File.Exists (dotnetScriptPath))
-				Utilities.DeleteFile (dotnetScriptPath);
+			string tempDotnetScriptPath = dotnetScriptPath + "-tmp";
+			Utilities.DeleteFile (tempDotnetScriptPath);
 
 			Log.StatusLine ("Downloading dotnet-install...");
 
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (dotnetScriptUrl);
 			if (!success) {
-				if (status == HttpStatusCode.NotFound)
-					Log.ErrorLine ("dotnet-install URL not found");
-				else
-					Log.ErrorLine ("Failed to obtain dotnet-install size. HTTP status code: {status} ({(int)status})");
-				return false;
+				string message;
+				if (status == HttpStatusCode.NotFound) {
+					message = "dotnet-install URL not found";
+				} else {
+					message = $"Failed to obtain dotnet-install size. HTTP status code: {status} ({(int)status})";
+				}
+
+				if (!ReportAndCheckCached (message)) {
+					return false;
+				}
 			}
 
 			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
 			Log.StatusLine ($"  {context.Characters.Link} {dotnetScriptUrl}", ConsoleColor.White);
-			await Download (context, dotnetScriptUrl, dotnetScriptPath, "dotnet-install", Path.GetFileName (dotnetScriptUrl.LocalPath), downloadStatus);
+			await Download (context, dotnetScriptUrl, tempDotnetScriptPath, "dotnet-install", Path.GetFileName (dotnetScriptUrl.LocalPath), downloadStatus);
 
-			if (!File.Exists (dotnetScriptPath)) {
-				Log.ErrorLine ($"Download of dotnet-install from {dotnetScriptUrl} failed");
+			if (!File.Exists (tempDotnetScriptPath)) {
+				return ReportAndCheckCached ($"Download of dotnet-install from {dotnetScriptUrl} failed");
+			}
+
+			Utilities.CopyFile (tempDotnetScriptPath, dotnetScriptPath);
+			Utilities.DeleteFile (tempDotnetScriptPath);
+			return true;
+
+			bool ReportAndCheckCached (string message)
+			{
+				if (File.Exists (dotnetScriptPath)) {
+					Log.WarningLine (message);
+					Log.WarningLine ($"Using cached installation script found in {dotnetScriptPath}");
+					return true;
+				}
+
+				Log.ErrorLine (message);
+				Log.ErrorLine ($"Cached installation script not found in {dotnetScriptPath}");
+				return false;
+			}
+		}
+
+		async Task<bool> DownloadDotNetArchive (Context context, string archiveDestinationPath, Uri archiveUrl)
+		{
+			Log.StatusLine ("Downloading dotnet archive...");
+
+			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
+			if (!success) {
+				string message;
+				if (status == HttpStatusCode.NotFound) {
+					Log.ErrorLine ($"dotnet archive URL {archiveUrl} not found");
+				} else {
+					Log.ErrorLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");
+				}
+
 				return false;
 			}
 
-			var type = runtimeOnly ? "runtime" : "SDK";
-			Log.StatusLine ($"Installing dotnet {type} '{version}'...");
+			string tempArchiveDestinationPath = archiveDestinationPath + "-tmp";
+			Utilities.DeleteFile (tempArchiveDestinationPath);
 
+			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
+			Log.StatusLine ($"  {context.Characters.Link} {archiveUrl}", ConsoleColor.White);
+			await Download (context, archiveUrl, tempArchiveDestinationPath, "dotnet archive", Path.GetFileName (archiveUrl.LocalPath), downloadStatus);
+
+			if (!File.Exists (tempArchiveDestinationPath)) {
+				return false;
+			}
+
+			Utilities.CopyFile (tempArchiveDestinationPath, archiveDestinationPath);
+			Utilities.DeleteFile (tempArchiveDestinationPath);
+
+			return true;
+		}
+
+		string[] GetInstallationScriptArgs (string version, string dotnetPath, string dotnetScriptPath, bool onlyGetUrls, bool runtimeOnly)
+		{
+			List<string> args;
 			if (Context.IsWindows) {
-				var args = new List<string> {
+				args = new List<string> {
 					"-NoProfile", "-ExecutionPolicy", "unrestricted", "-file", dotnetScriptPath,
 					"-Version", version, "-InstallDir", dotnetPath, "-Verbose"
 				};
-				if (runtimeOnly)
+				if (runtimeOnly) {
 					args.AddRange (new string [] { "-Runtime", "dotnet" });
+				}
+				if (onlyGetUrls) {
+					args.Add ("-DryRun");
+				}
 
-				return Utilities.RunCommand ("powershell.exe", args.ToArray ());
-			} else {
-				var args = new List<string> {
-					dotnetScriptPath, "--version", version, "--install-dir", dotnetPath, "--verbose"
-				};
-				if (runtimeOnly)
-					args.AddRange (new string [] { "-Runtime", "dotnet" });
-
-				return Utilities.RunCommand ("bash", args.ToArray ());
+				return args.ToArray ();
 			}
+
+			args = new List<string> {
+				dotnetScriptPath, "--version", version, "--install-dir", dotnetPath, "--verbose", "--dry-run"
+			};
+
+			if (runtimeOnly) {
+				args.AddRange (new string [] { "-Runtime", "dotnet" });
+			}
+			if (onlyGetUrls) {
+				args.Add ("--dry-run");
+			}
+
+			return args.ToArray ();
+		}
+
+		async Task<bool> InstallDotNetAsync (Context context, string dotnetPath, string version, bool runtimeOnly = false)
+		{
+			string cacheDir = context.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
+
+			// Always delete the bin/$(Configuration)/dotnet/ directory
+			Utilities.DeleteDirectory (dotnetPath);
+
+			Uri dotnetScriptUrl = Configurables.Urls.DotNetInstallScript;
+			string scriptFileName = Path.GetFileName (dotnetScriptUrl.LocalPath);
+			string cachedDotnetScriptPath = Path.Combine (cacheDir, scriptFileName);
+			if (!await DownloadDotNetInstallScript (context, cachedDotnetScriptPath, dotnetScriptUrl)) {
+				return false;
+			}
+
+			string dotnetScriptPath = Path.Combine (dotnetPath, scriptFileName);
+			Utilities.CopyFile (cachedDotnetScriptPath, dotnetScriptPath);
+
+			var type = runtimeOnly ? "runtime" : "SDK";
+
+			Log.StatusLine ($"Discovering download URLs for dotnet {type} '{version}'...");
+			string scriptCommand = Context.IsWindows ? "powershell.exe" : "bash";
+			string[] scriptArgs = GetInstallationScriptArgs (version, dotnetPath, dotnetScriptPath, onlyGetUrls: true, runtimeOnly: runtimeOnly);
+			string scriptReply = Utilities.GetStringFromStdout (scriptCommand, scriptArgs);
+			var archiveUrls = new List<string> ();
+
+			foreach (string l in scriptReply.Split (new char[] { '\n' })) {
+				string line = l.Trim ();
+
+				if (!line.StartsWith ("dotnet-install: URL #", StringComparison.OrdinalIgnoreCase)) {
+					continue;
+				}
+
+				string[] parts = line.Split (':', 3, StringSplitOptions.RemoveEmptyEntries);
+				if (parts.Length < 3) {
+					Log.WarningLine ($"dotnet-install URL line has unexpected number of parts. Expected 3, got {parts.Length}");
+					Log.WarningLine ($"Line: {line}");
+					continue;
+				}
+
+				archiveUrls.Add (parts[2].Trim ());
+			}
+
+			if (archiveUrls.Count == 0) {
+				Log.WarningLine ("No dotnet archive URLs discovered, attempting to run the installation script");
+				scriptArgs = GetInstallationScriptArgs (version, dotnetPath, dotnetScriptPath, onlyGetUrls: false, runtimeOnly: runtimeOnly);
+				return Utilities.RunCommand (scriptCommand, scriptArgs);
+			}
+
+			string? archivePath = null;
+			foreach (string url in archiveUrls) {
+				var archiveUrl = new Uri (url);
+				string archiveDestinationPath = Path.Combine (cacheDir, Path.GetFileName (archiveUrl.LocalPath));
+
+				if (File.Exists (archiveDestinationPath)) {
+					archivePath = archiveDestinationPath;
+					break;
+				}
+
+				if (await DownloadDotNetArchive (context, archiveDestinationPath, archiveUrl)) {
+					archivePath = archiveDestinationPath;
+					break;
+				}
+			}
+
+			if (String.IsNullOrEmpty (archivePath)) {
+				return false;
+			}
+
+			Log.StatusLine ($"Installing dotnet {type} '{version}'...");
+			return await Utilities.Unpack (archivePath, dotnetPath);
 		}
 
 		bool TestDotNetSdk (string dotnetTool)

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -115,7 +115,6 @@ namespace Xamarin.Android.Prepare
 
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
 			if (!success) {
-				string message;
 				if (status == HttpStatusCode.NotFound) {
 					Log.ErrorLine ($"dotnet archive URL {archiveUrl} not found");
 				} else {
@@ -199,6 +198,7 @@ namespace Xamarin.Android.Prepare
 			string scriptReply = Utilities.GetStringFromStdout (scriptCommand, scriptArgs);
 			var archiveUrls = new List<string> ();
 
+			char[] fieldSplitChars = new char[] { ':' };
 			foreach (string l in scriptReply.Split (new char[] { '\n' })) {
 				string line = l.Trim ();
 
@@ -206,7 +206,7 @@ namespace Xamarin.Android.Prepare
 					continue;
 				}
 
-				string[] parts = line.Split (":", 3, StringSplitOptions.RemoveEmptyEntries);
+				string[] parts = line.Split (fieldSplitChars, 3);
 				if (parts.Length < 3) {
 					Log.WarningLine ($"dotnet-install URL line has unexpected number of parts. Expected 3, got {parts.Length}");
 					Log.WarningLine ($"Line: {line}");

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Prepare
 					message = $"Failed to obtain dotnet-install size. HTTP status code: {status} ({(int)status})";
 				}
 
-				ReportAndCheckCached (message, quietOnError: true); // size check isn't critical, just warn
+				return ReportAndCheckCached (message, quietOnError: true);
 			}
 
 			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
@@ -116,10 +116,13 @@ namespace Xamarin.Android.Prepare
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
 			if (!success) {
 				if (status == HttpStatusCode.NotFound) {
-					Log.WarningLine ($"dotnet archive URL {archiveUrl} not found");
+					Log.ErrorLine ($"dotnet archive URL {archiveUrl} not found");
+					return false;
 				} else {
 					Log.WarningLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");
 				}
+
+				return false;
 			}
 
 			string tempArchiveDestinationPath = archiveDestinationPath + "-tmp";

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -78,9 +78,7 @@ namespace Xamarin.Android.Prepare
 					message = $"Failed to obtain dotnet-install size. HTTP status code: {status} ({(int)status})";
 				}
 
-				if (!ReportAndCheckCached (message)) {
-					return false;
-				}
+				ReportAndCheckCached (message, quietOnError: true); // size check isn't critical, just warn
 			}
 
 			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
@@ -95,7 +93,7 @@ namespace Xamarin.Android.Prepare
 			Utilities.DeleteFile (tempDotnetScriptPath);
 			return true;
 
-			bool ReportAndCheckCached (string message)
+			bool ReportAndCheckCached (string message, bool quietOnError = false)
 			{
 				if (File.Exists (dotnetScriptPath)) {
 					Log.WarningLine (message);
@@ -103,8 +101,10 @@ namespace Xamarin.Android.Prepare
 					return true;
 				}
 
-				Log.ErrorLine (message);
-				Log.ErrorLine ($"Cached installation script not found in {dotnetScriptPath}");
+				if (!quietOnError) {
+					Log.ErrorLine (message);
+					Log.ErrorLine ($"Cached installation script not found in {dotnetScriptPath}");
+				}
 				return false;
 			}
 		}
@@ -116,12 +116,10 @@ namespace Xamarin.Android.Prepare
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
 			if (!success) {
 				if (status == HttpStatusCode.NotFound) {
-					Log.ErrorLine ($"dotnet archive URL {archiveUrl} not found");
+					Log.WarningLine ($"dotnet archive URL {archiveUrl} not found");
 				} else {
-					Log.ErrorLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");
+					Log.WarningLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");
 				}
-
-				return false;
 			}
 
 			string tempArchiveDestinationPath = archiveDestinationPath + "-tmp";


### PR DESCRIPTION
Context: https://github.com/dotnet/install-scripts/issues/15
Context: https://dot.net/v1/dotnet-install.sh
Context: https://dot.net/v1/dotnet-install.ps1

We've been installing dotnet versions using the Unix shell and Windows
powershell scripts, which work fine.  However, they do not cache the
downloaded archive and therefore we end up re-downloading the same
archive over and over again on CI servers as well as locally.
Additionally, if one finds themselves without internet connection,
there's no way to install the required version of dotnet.

The installation scripts don't provide a way to cache the payloads and
they appear to be in maintenance mode, so there's rather no chance to
add caching support to them.

Instead of relying on the scripts, we can do the downloading and
installation ourselves, which lets us take the first step towards fully
"offline" builds (and smaller downloads on CI servers).

With this commit, we will cache both the scripts and the payloads and we
will perform the installation ourselves.  Scripts are still used to
obtain the download URL(s) for dotnet and as a fallback should our
attempt to download dotnet archives fail.