### PR TITLE
[ci] Remove `-m:1` from Windows `-t:Prepare` step.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -201,7 +201,7 @@ stages:
       displayName: Prepare Solution
       inputs:
         projects: Xamarin.Android.sln
-        arguments: '-c $(XA.Build.Configuration) -target:Prepare -m:1 -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
+        arguments: '-c $(XA.Build.Configuration) -target:Prepare -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
 
     # Build, pack .nupkgs, and extract workload packs to dotnet preview test directory
     - task: DotNetCoreCLI@2


### PR DESCRIPTION
Mac doesn't use `-m:1` when calling the prepare step, so Windows shouldn't need it either.

It doesn't really save any time, but it will help ensure we don't add something that requires it in the future.