### PR TITLE
Bump to xamarin/xamarin-android-tools/main@20f6112

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>2.0.3</LibZipSharpVersion>
+    <LibZipSharpVersion>2.0.4</LibZipSharpVersion>
     <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -318,10 +318,10 @@
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.DefaultOutputPaths.targets" />
   </ItemGroup>
   <ItemGroup>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libZipSharpNative.dll" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libZipSharpNative.pdb" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libZipSharpNative.dll" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libZipSharpNative.pdb" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86\libZipSharpNative.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86\libZipSharpNative.pdb" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libZipSharpNative.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat"  ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\as.exe" />


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android-tools/compare/fc3c2ac...20f6112
Changes: https://github.com/xamarin/LibZipSharp/compare/2.0.3...2.0.4

* Add support for writing `android:roundIcon` to Android manifest
* Bump LibZipSharp to 2.0.4

Other changes:

* The paths to `libZipSharpNative.dll` changed to `x86` and `x64`.