### PR TITLE
 Fix Windows Build Error on Prepare

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Android.Prepare
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
 			if (!success) {
 				if (status == HttpStatusCode.NotFound) {
-					Log.ErrorLine ($"dotnet archive URL {archiveUrl} not found");
+					Log.WarningLine ($"dotnet archive URL {archiveUrl} not found");
 					return false;
 				} else {
 					Log.WarningLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");


### PR DESCRIPTION
We are seeing the Prepare step fail on windows machines on CI. This
is because `dotnet` is interpreting the Errors we are emitting when
downloading the `dotnet` sdk as actual errors. This results in the
`dotnet` process exiting with an ExitCode of -1.

The thing is these are not really errors they are warnings. So lets
just use `LogWarning` instead to get around this issue.