### PR TITLE
[One .NET] add win-arm64 support to the workload

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -322,6 +322,8 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libZipSharpNative.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libZipSharpNative.pdb" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm64\libZipSharpNative.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm64\libZipSharpNative.pdb" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat"  ExcludeFromAndroidNETSdk="true" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\binutils\bin\as.exe" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -38,6 +38,7 @@
         "osx-arm64": "Microsoft.Android.Sdk.Darwin",
         "win-x86": "Microsoft.Android.Sdk.Windows",
         "win-x64": "Microsoft.Android.Sdk.Windows",
+        "win-arm64": "Microsoft.Android.Sdk.Windows",
         "linux-x64": "Microsoft.Android.Sdk.Linux"
       }
     },
@@ -49,6 +50,7 @@
         "osx-arm64": "Microsoft.Android.Sdk.Darwin",
         "win-x86": "Microsoft.Android.Sdk.Windows",
         "win-x64": "Microsoft.Android.Sdk.Windows",
+        "win-arm64": "Microsoft.Android.Sdk.Windows",
         "linux-x64": "Microsoft.Android.Sdk.Linux"
       }
     },


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1544836

I'll manually test this when the build is done. It might be worth writing a doc on testing on `win-arm64`.