### PR TITLE
[workload] manifest should be Microsoft.NET.Sdk.Android.Manifest-7.0.100-preview.5

### DIFF
--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -10,7 +10,7 @@ about the various Microsoft.Android workloads.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)</PackageId>
+    <PackageId>Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)</PackageId>
     <Description>Microsoft.NET.Sdk.Android workload manifest. Please do not reference directly.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Downloading our current .NET 7 workloads, extracting them to a folder,
and installing them doesn't work. Trying to update the manifest
results in:

    dotnet workload update --source C:\some\local\folder
    ...
    Failed to update the advertising manifest microsoft.net.sdk.android: microsoft.net.sdk.android.manifest-7.0.100-preview.5 is not found in NuGet feeds C:\some\local\folder"..

It appears we also need `-preview.5` in the `$(PackageId)` when using
the `7.0.100-preview.5.22273.1` .NET SDK, for this to work correctly.
We can use `$(DotNetSdkManifestsFolder)` to include the additional
info.

Our build in xamarin-android/main is working, because we copy our
manifests to folders directly.

With this change in place, we get a hilarious file name:

    Microsoft.NET.Sdk.Android.Manifest-7.0.100-preview.5.33.0.0-ci.workload-manifest-id.22.nupkg

However, it works when I test `dotnet workload` commands:

    Updated advertising manifest microsoft.net.sdk.android.