### PR TITLE
Revert "[ci] Use nuget-msi-convert/job/v3.yml (#7032)"

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1374,7 +1374,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v3.yml@yaml
+  - template: nuget-msi-convert/job/v2.yml@yaml
     parameters:
       yamlResourceName: yaml
       dependsOn: sign_net_mac_win
@@ -1383,6 +1383,8 @@ stages:
         !*Darwin*
       propsArtifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
+      runInParallel: false
+      useDateTimeVersion: true
       postConvertSteps:
       - task: DownloadPipelineArtifact@2
         inputs:


### PR DESCRIPTION
This reverts commit 45997f29c4da1ab0e791f5c0eceb6aff2f2c98e8.

Our build has been broken since commit fd47b027, as the recently updated
MSI tooling throws an error when a workload pack is missing:

    nuget-msi-convert\convert-v3\convert.proj(76,5): Error : System.IO.FileNotFoundException: Could not load file or assembly 'D:\a\_work\1\a\nugets\Microsoft.Android.Sdk.Windows.32.0.301.nupkg'. The system cannot find the file specified.
    File name: 'D:\a\_work\1\a\nugets\Microsoft.Android.Sdk.Windows.32.0.301.nupkg'

We don't yet have a good solution for how to handle VS insertions for
the .NET 6 SDK packs that our workload now depends on.  Revert the MSI
tooling update to fix the build while this is being investigated.