### PR TITLE
[Xamarin.Android.Build.Tasks] @(AndroidJavaSource) & parameter names

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -57,6 +57,14 @@ It is shared between "legacy" binding projects and .NET 5 projects.
       <AnnotationsZip Include="$(IntermediateOutputPath)library_project_annotations\**\*.zip" />
     </ItemGroup>
 
+    <ItemGroup>
+      <_JavadocXml Include="@(_JavaSourceJavadocXml)" />
+      <_JavadocXml
+          Condition=" Exists('$(_AndroidIntermediateBindingClassesDocs)') "
+          Include="$(_AndroidIntermediateBindingClassesDocs)"
+      />
+    </ItemGroup>
+
     <!-- Create the .cs binding source files -->
     <BindingsGenerator
         OutputDirectory="$(GeneratedOutputPath)src"
@@ -68,7 +76,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         AnnotationsZipFiles="@(AnnotationsZip)"
         AssemblyName="$(AssemblyName)"
         JavadocVerbosity="$(AndroidJavadocVerbosity)"
-        JavadocXml="@(_JavaSourceJavadocXml);$(_AndroidIntermediateBindingClassesDocs)"
+        JavadocXml="@(_JavadocXml)"
         TransformFiles="@(TransformFile)"
         ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
         MonoAndroidFrameworkDirectories="$(_XATargetFrameworkDirectories)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -68,7 +68,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         AnnotationsZipFiles="@(AnnotationsZip)"
         AssemblyName="$(AssemblyName)"
         JavadocVerbosity="$(AndroidJavadocVerbosity)"
-        JavadocXml="@(_JavaSourceJavadocXml)"
+        JavadocXml="@(_JavaSourceJavadocXml);$(_AndroidIntermediateBindingClassesDocs)"
         TransformFiles="@(TransformFile)"
         ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
         MonoAndroidFrameworkDirectories="$(_XATargetFrameworkDirectories)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -19,6 +19,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <_AndroidIntermediateBindingJavaClassDirectory>$(IntermediateOutputPath)binding\bin\classes\</_AndroidIntermediateBindingJavaClassDirectory>
     <_AndroidIntermediateBindingJavaSourceDirectory>$(IntermediateOutputPath)binding\src</_AndroidIntermediateBindingJavaSourceDirectory>
     <_AndroidIntermediateBindingClassesZip>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName).jar</_AndroidIntermediateBindingClassesZip>
+    <_AndroidIntermediateBindingClassesDocs>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName)-docs.xml</_AndroidIntermediateBindingClassesDocs>
     <_AndroidCompileJavaStampFile>$(_AndroidStampDirectory)_CompileJava.stamp</_AndroidCompileJavaStampFile>
     <_AndroidCompileBindingJavaStampFile>$(_AndroidStampDirectory)_CompileBindingJava.stamp</_AndroidCompileBindingJavaStampFile>
   </PropertyGroup>
@@ -105,11 +106,27 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
         JavacTargetVersion="$(JavacTargetVersion)"
         JavacSourceVersion="$(JavacSourceVersion)"
     />
+    <JavaSourceUtils
+        Condition=" '@(_JavaBindingSource->Count())' != '0' "
+        JavaSourceUtilsJar="$(AndroidJavaSourceUtilsJar)"
+        InputFiles="@(_JavaBindingSource)"
+        JavadocCopyrightFile="%(_JavaBindingSource.CopyrightFile)"
+        JavadocUrlPrefix="%(_JavaBindingSource.UrlPrefix)"
+        JavadocUrlStyle="%(_JavaBindingSource.UrlStyle)"
+        JavadocDocRootUrl="%(_JavaBindingSource.DocRootUrl)"
+        JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+        JavaOptions="$(JavaOptions)"
+        JavaSdkDirectory="$(_JavaSdkDirectory)"
+        OutputJavadocXml="$(_AndroidIntermediateBindingClassesDocs)"
+        References="@(JavaSourceJar)"
+    />
     <Touch Files="$(_AndroidCompileBindingJavaStampFile)" AlwaysCreate="true" />
     <ItemGroup>
       <EmbeddedJar Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
       <AndroidJavaLibrary Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
+      <_JavaSourceJavadocXml Include="$(_AndroidIntermediateBindingClassesDocs)" Condition=" Exists('$(_AndroidIntermediateBindingClassesDocs)') " />
       <FileWrites Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
+      <FileWrites Include="$(_AndroidIntermediateBindingClassesDocs)" Condition=" Exists('$(_AndroidIntermediateBindingClassesDocs)') " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -124,7 +124,6 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <ItemGroup>
       <EmbeddedJar Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
       <AndroidJavaLibrary Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
-      <_JavaSourceJavadocXml Include="$(_AndroidIntermediateBindingClassesDocs)" Condition=" Exists('$(_AndroidIntermediateBindingClassesDocs)') " />
       <FileWrites Include="$(_AndroidIntermediateBindingClassesZip)" Condition="Exists('$(_AndroidIntermediateBindingClassesZip)')" />
       <FileWrites Include="$(_AndroidIntermediateBindingClassesDocs)" Condition=" Exists('$(_AndroidIntermediateBindingClassesDocs)') " />
     </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
@@ -151,11 +151,8 @@ namespace Xamarin.Android.Tasks
 				AppendArg (response, JavadocDocRootUrl);
 			}
 
-			var inputs  = InputFiles.Select (p => Path.GetFullPath (p.ItemSpec))
-				.Distinct (StringComparer.OrdinalIgnoreCase);
-
-			foreach (var path in inputs) {
-				AppendArg (response, path);
+			foreach (var path in InputFiles) {
+				AppendArg (response, Path.GetFullPath (path.ItemSpec));
 			}
 
 			return responseFile;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaSourceUtils.cs
@@ -151,8 +151,11 @@ namespace Xamarin.Android.Tasks
 				AppendArg (response, JavadocDocRootUrl);
 			}
 
-			foreach (var path in InputFiles) {
-				AppendArg (response, Path.GetFullPath (path.ItemSpec));
+			var inputs  = InputFiles.Select (p => Path.GetFullPath (p.ItemSpec))
+				.Distinct (StringComparer.OrdinalIgnoreCase);
+
+			foreach (var path in inputs) {
+				AppendArg (response, path);
 			}
 
 			return responseFile;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -667,6 +667,13 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 							{ "Bind", "True" },
 						},
 					},
+					new AndroidItem.AndroidJavaSource ("JavaSourceTestInterface.java") {
+						Encoding = Encoding.ASCII,
+						TextContent = () => ResourceData.JavaSourceTestInterface,
+						Metadata = {
+							{ "Bind", "True" },
+						},
+					},
 				},
 
 			};
@@ -681,6 +688,9 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 					"generated", "src", "Com.Xamarin.Android.Test.Msbuildtest.JavaSourceTestExtension.cs");
 				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have been generated.");
 				StringAssertEx.ContainsText (File.ReadAllLines (generatedCode), "public virtual unsafe string GreetWithQuestion (string name, global::Java.Util.Date date, string question)");
+				var generatedIface = Path.Combine (Root, libBuilder.ProjectDirectory, lib.IntermediateOutputPath,
+					"generated", "src", "Com.Xamarin.Android.Test.Msbuildtest.IJavaSourceTestInterface.cs");
+				StringAssertEx.ContainsText (File.ReadAllLines (generatedIface), "string GreetWithQuestion (string name, global::Java.Util.Date date, string question);");
 				Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
 				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava"), $"`_CompileBindingJava` should be skipped on second build!");
 				Assert.IsTrue (appBuilder.Build (app), "App build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestExtension.java
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestExtension.java
@@ -1,6 +1,6 @@
 // some comment
 package com.xamarin.android.test.msbuildtest;
-public class JavaSourceTestExtension extends JavaSourceJarTest implements JavaSourceTestInterface {
+public class JavaSourceTestExtension extends JavaSourceJarTest {
 	public String greetWithQuestion (String name, java.util.Date date, String question) {
 		return greet (name, date) + question;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestExtension.java
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestExtension.java
@@ -1,6 +1,6 @@
 // some comment
 package com.xamarin.android.test.msbuildtest;
-public class JavaSourceTestExtension extends JavaSourceJarTest {
+public class JavaSourceTestExtension extends JavaSourceJarTest implements JavaSourceTestInterface {
 	public String greetWithQuestion (String name, java.util.Date date, String question) {
 		return greet (name, date) + question;
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestInterface.java
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Resources/JavaSourceTestInterface.java
@@ -1,0 +1,5 @@
+package com.xamarin.android.test.msbuildtest;
+
+public interface JavaSourceTestInterface {
+	String greetWithQuestion (String name, java.util.Date date, String question);
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Android.Build.Tests
 		static Lazy<byte []> apacheHttpClient_cs = new Lazy<byte []> (() => GetResourceData ("ApacheHttpClient.cs"));
 		static Lazy<byte []> javadocCopyright = new Lazy<byte []> (() => GetResourceData ("javadoc-copyright.xml"));
 		static Lazy<byte []> javaSourceTestExtension = new Lazy<byte []> (() => GetResourceData ("JavaSourceTestExtension.java"));
+		static Lazy<byte []> javaSourceTestInterface = new Lazy<byte []> (() => GetResourceData ("JavaSourceTestInterface.java"));
 		static Lazy<byte []> remapActivityJava = new Lazy<byte []> (() => GetResourceData ("RemapActivity.java"));
 		static Lazy<byte []> remapActivityXml = new Lazy<byte []> (() => GetResourceData ("RemapActivity.xml"));
 
@@ -30,6 +31,7 @@ namespace Xamarin.Android.Build.Tests
 		public  static  byte [] JavadocCopyright => javadocCopyright.Value;
 
 		public  static  string JavaSourceTestExtension => Encoding.ASCII.GetString (javaSourceTestExtension.Value);
+		public  static  string JavaSourceTestInterface => Encoding.ASCII.GetString (javaSourceTestInterface.Value);
 		public  static  string RemapActivityJava => Encoding.UTF8.GetString (remapActivityJava.Value);
 		public  static  string RemapActivityXml => Encoding.UTF8.GetString (remapActivityXml.Value);
 


### PR DESCRIPTION
Import parameter name information when `%(AndroidJavaSource.Bind)`
is True.

This isn't particularly noticeable when `%(AndroidJavaSource.Bind)`
files are classes, but it *is* noticeable for Java *interfaces*, as
e.g. `javac -parameters` *doesn't* retain method parameter names in
interface methods.

The only reliable way to get parameter name information on interfaces
is to parse the `.java` files, i.e. by using `<JavaSourceUtils/>`.

Update the `_CompileBindingJava` target to use `<JavaSourceUtils/>`
to extract parameter names (and Javadoc) from `@(AndroidJavaSource)`
files with `%(AndroidJavaSource.Bind)`=True, and provide this
parameter name information to the `_ExportJarToXml` target, by way of
the internal `@(_JavaSourceJavadocXml)` item group.