### PR TITLE
Add FabricBot to xamarin-android

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,548 @@
+[
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "need-info"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add comment when 'need-info' is applied to issue",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "timezoneOffset": -5
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "need-info"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 7
+          }
+        }
+      ],
+      "taskName": "[Idle Issue Management] Close stale 'need-info' issues",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "need-info"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "admin"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Idle Issue Management] Replace 'need-info' with 'need-attention' label when the customer comments on an issue",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "need-info"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "need-attention"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "noActivitySince",
+                "parameters": {
+                  "days": 7
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "need-info"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+      "actions": [
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "need-info"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "need-attention"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            10,
+            22
+          ],
+          "timezoneOffset": -5
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isClosed",
+          "parameters": {}
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 30
+          }
+        },
+        {
+          "name": "isUnlocked",
+          "parameters": {}
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        }
+      ],
+      "taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
+      "actions": [
+        {
+          "name": "lockIssue",
+          "parameters": {
+            "reason": "resolved"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/.github/fabricbot_readme.md
+++ b/.github/fabricbot_readme.md
@@ -1,0 +1,31 @@
+FabricBot readme
+================
+
+[FabricBot][0] is an automated tool that responds to changes in issues, PRs, or
+runs on a schedule. It can modify issues and PRs by adding/removing labels,
+adding comments, or performing other operations.
+
+Those rules are all defined in the associated
+[fabricbot.json](/.github/fabricbot.json) file in this folder.
+
+While you can _try_ to edit this file manually, you can instead use the Fabric
+Bot editor UI to modify the file in a more reliable manner:
+
+1. Download the [fabricbot.json](/.github/fabricbot.json) file to your local disk
+2. Go to https://portal.fabricbot.ms/bot/ (don't log in!)
+3. Click **Choose File** and select the JSON file that you downloaded
+4. And press Submit to load the file and launch the FabricBot rules editor
+5. In this UI you can:
+   - View all existing rules
+   - Click **Add Task** in the upper-right corner to add a new task. This is
+     where you can see the various capabilities of FabricBot
+6. And then click around in the tool to see the various abilities and options
+
+Don't worry, you can click all you want, because that UI won't save anything
+to anywhere. You can export the rules and download the generated JSON file.
+But don't worry about accidentally changing the FabricBot rules in this repo 😊
+
+If you want to save your changes, click the **Export configuration** file, and
+upload the new file to the repo's rules at `/.github/fabricbot.json`.
+
+[0]: https://1esdocs.azurewebsites.net/datainsights/merlinbot/extensions/Fabricbot_Overview.html


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/blob/6676f816f2f34c951d42a689c8d7a54870bbed54/.github/fabricbot.json
Context: https://portal.fabricbot.ms/bot/

I got the xamarin-android repo onboarded to use [FabricBot][0], all
that is missing is a `.github/fabricbot.json` file.

I brought over the current rules the xamarin-macios repo is using.

In general, the rules are:

1. If we apply `need-info` to an issue, a bot comments saying they
   have 7 days to respond.

2. `need-info` issues are closed after 7 days.

3. If someone responds to a `need-info` issue, the `need-attention`
   label is added and `need-info` removed.

4. The bot will respond to comments on issues closed more than 7 days
   ago, suggesting to open a new issue.

5. Lock issues closed without activity over 30 days.

We can do much more with this bot, but this is a good starting point.

[0]: https://1esdocs.azurewebsites.net/datainsights/merlinbot/extensions/Fabricbot_Overview.html