### PR TITLE
[Mono.Android] Move API xml file generation to dedicated project.

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32530.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build-Tools", "Build-Tools", "{E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}"
 EndProject
@@ -134,7 +134,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jnienv-gen", "external\Java
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "check-boot-times", "build-tools\check-boot-times\check-boot-times.csproj", "{D28957BF-5E66-4D60-B528-22820C60AC82}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "java-interop", "external\Java.Interop\src\java-interop\java-interop.csproj", "{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "java-interop", "external\Java.Interop\src\java-interop\java-interop.csproj", "{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.Generator", "external\Java.Interop\src\Java.Interop.Tools.Generator\Java.Interop.Tools.Generator.csproj", "{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096}"
 EndProject
@@ -154,19 +154,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.JavaType
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "relnote-gen", "tools\relnote-gen\relnote-gen.csproj", "{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Runtime.Environment", "external\Java.Interop\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj", "{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Runtime.Environment", "external\Java.Interop\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj", "{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "create-android-api", "build-tools\create-android-api\create-android-api.csproj", "{BA4D889D-066B-4C2C-A973-09E319CBC396}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 5
-		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{66cf299a-ce95-4131-bcd8-db66e30c4bf7}*SharedItemsImports = 5
-		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{74598f5c-b8cc-4ce6-8ee2-ab9ca1400076}*SharedItemsImports = 13
-		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d1295a8f-4f42-461d-a046-564476c10002}*SharedItemsImports = 5
-		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d18fcf91-8876-48a0-a693-2dc1e7d3d80a}*SharedItemsImports = 5
-		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 5
-		external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 5
-		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{fe789f04-5e95-42c5-aef1-e33f8df06b3f}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
 		Release|AnyCPU = Release|AnyCPU
@@ -388,6 +380,10 @@ Global
 		{D28957BF-5E66-4D60-B528-22820C60AC82}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{D28957BF-5E66-4D60-B528-22820C60AC82}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{D28957BF-5E66-4D60-B528-22820C60AC82}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
 		{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096}.Release|AnyCPU.ActiveCfg = Release|Any CPU
@@ -412,10 +408,6 @@ Global
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Debug|AnyCPU.Build.0 = Debug|anycpu
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Release|AnyCPU.ActiveCfg = Release|anycpu
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34}.Release|AnyCPU.Build.0 = Release|anycpu
-		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
-		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
-		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{DA50FC92-7FE7-48B5-BDB6-CDA57B37BB51}.Debug|AnyCPU.ActiveCfg = Debug|anycpu
 		{DA50FC92-7FE7-48B5-BDB6-CDA57B37BB51}.Debug|AnyCPU.Build.0 = Debug|anycpu
 		{DA50FC92-7FE7-48B5-BDB6-CDA57B37BB51}.Release|AnyCPU.ActiveCfg = Release|anycpu
@@ -432,6 +424,10 @@ Global
 		{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{BA4D889D-066B-4C2C-A973-09E319CBC396}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{BA4D889D-066B-4C2C-A973-09E319CBC396}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{BA4D889D-066B-4C2C-A973-09E319CBC396}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{BA4D889D-066B-4C2C-A973-09E319CBC396}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -492,6 +488,7 @@ Global
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{D28957BF-5E66-4D60-B528-22820C60AC82} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{2CE4CD4B-B7B7-4EAE-A9BE-2699824D6096} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{86A8DEFE-7ABB-4097-9389-C249581E243D} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{9A9EF774-6EA6-414F-9D2F-DCD66C56B92A} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
@@ -499,13 +496,23 @@ Global
 		{88B746FF-8D6E-464D-9D66-FF2ECCF148E0} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{1A273ED2-AE84-48E9-9C23-E978C2D0CB34} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{DA50FC92-7FE7-48B5-BDB6-CDA57B37BB51} = {864062D3-A415-4A6F-9324-5820237BA058}
-		{1FED3F23-1175-42AA-BE87-EF1E8DB52F8B} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{4EFCED6E-9A6B-453A-94E4-CE4B736EC684} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{D8E14B43-E929-4C18-9FA6-2C3DC47EFC17} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{C0E44558-FEE3-4DD3-986A-3F46DD1BF41B} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{BA4D889D-066B-4C2C-A973-09E319CBC396} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 5
+		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{66cf299a-ce95-4131-bcd8-db66e30c4bf7}*SharedItemsImports = 5
+		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{74598f5c-b8cc-4ce6-8ee2-ab9ca1400076}*SharedItemsImports = 13
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d1295a8f-4f42-461d-a046-564476c10002}*SharedItemsImports = 5
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d18fcf91-8876-48a0-a693-2dc1e7d3d80a}*SharedItemsImports = 5
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 5
+		external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 5
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{fe789f04-5e95-42c5-aef1-e33f8df06b3f}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/api-merge/merge-configuration.xml
+++ b/build-tools/api-merge/merge-configuration.xml
@@ -24,20 +24,20 @@
     <File Path="api-Tiramisu.xml.in" Level="33" />
   </Inputs>
   <Outputs>
-    <File Path="android-19\mcw\api.xml" LastLevel="19" />
-    <File Path="android-20\mcw\api.xml" LastLevel="20" />
-    <File Path="android-21\mcw\api.xml" LastLevel="21" />
-    <File Path="android-22\mcw\api.xml" LastLevel="22" />
-    <File Path="android-23\mcw\api.xml" LastLevel="23" />
-    <File Path="android-24\mcw\api.xml" LastLevel="24" />
-    <File Path="android-25\mcw\api.xml" LastLevel="25" />
-    <File Path="android-26\mcw\api.xml" LastLevel="26" />
-    <File Path="android-27\mcw\api.xml" LastLevel="27" />
-    <File Path="android-28\mcw\api.xml" LastLevel="28" />
-    <File Path="android-29\mcw\api.xml" LastLevel="29" />
-    <File Path="android-30\mcw\api.xml" LastLevel="30" />
-    <File Path="android-31\mcw\api.xml" LastLevel="31" />
-    <File Path="android-32\mcw\api.xml" LastLevel="32" />
-    <File Path="android-Tiramisu\mcw\api.xml" LastLevel="33" />
+    <File Path="api-19.xml" LastLevel="19" />
+    <File Path="api-20.xml" LastLevel="20" />
+    <File Path="api-21.xml" LastLevel="21" />
+    <File Path="api-22.xml" LastLevel="22" />
+    <File Path="api-23.xml" LastLevel="23" />
+    <File Path="api-24.xml" LastLevel="24" />
+    <File Path="api-25.xml" LastLevel="25" />
+    <File Path="api-26.xml" LastLevel="26" />
+    <File Path="api-27.xml" LastLevel="27" />
+    <File Path="api-28.xml" LastLevel="28" />
+    <File Path="api-29.xml" LastLevel="29" />
+    <File Path="api-30.xml" LastLevel="30" />
+    <File Path="api-31.xml" LastLevel="31" />
+    <File Path="api-32.xml" LastLevel="32" />
+    <File Path="api-Tiramisu.xml" LastLevel="33" />
   </Outputs>
 </Configuration>

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -16,6 +16,5 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="api-xml-adjuster.targets" />
 
 </Project>

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -1,13 +1,30 @@
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<Project Sdk="Microsoft.Build.NoTargets">
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunParallelCmds" />
-  <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')" />
 
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
+
+  <PropertyGroup>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\Java.Interop\tools\class-parse\class-parse.csproj" ReferenceOutputAssembly="False" />
+    <ProjectReference Include="..\api-xml-adjuster\api-xml-adjuster.csproj" ReferenceOutputAssembly="False" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_OutputPath>$(_TopDir)\bin\Build$(Configuration)\</_OutputPath>
   </PropertyGroup>
 
+  <!-- First we need to figure out all the needed API levels.
+       This is done by looking at which levels are included in 'Mono.Android.Apis.projitems'
+       and looking for matching 'api-X.params.txt' files. -->
   <Target Name="_DefineApiFiles">
     <ItemGroup>
       <_Api
@@ -21,12 +38,18 @@
     </CreateItem>
   </Target>
 
-  <Target Name="_ClassParsePrepare"
-      DependsOnTargets="_DefineApiFiles">
+  <!-- Next we need to run class-parse on each platform's 'android.jar' in order
+       to produce the 'api-X.xml.class-parse' files. -->
+  <Target Name="_ClassParse"
+      BeforeTargets="_AdjustApiXml"
+      DependsOnTargets="_DefineApiFiles"
+      Inputs="@(ApiFileDefinition->'%(ParameterDescription)')"
+      Outputs="@(ApiFileDefinition->'%(ClassParseXml)')">
+      
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
-    <MakeDir Directories="$(_OutputPath)api" />
+    
     <ItemGroup>
       <_ClassParseCommands
           Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
@@ -35,23 +58,28 @@
         <Arguments>$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;</Arguments>
       </_ClassParseCommands>
     </ItemGroup>
-  </Target>
-  <Target Name="_ClassParse"
-      BeforeTargets="_AdjustApiXml"
-      DependsOnTargets="_ClassParsePrepare"
-      Inputs="@(ApiFileDefinition->'%(ParameterDescription)')"
-      Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
+    
+    <MakeDir Directories="$(_OutputPath)api" />
+    
     <RunParallelCmds
         Commands="@(_ClassParseCommands)"
         ManagedRuntime="$(ManagedRuntime)"
         ManagedRuntimeArguments="$(ManagedRuntimeArgs)"
       />
   </Target>
-  <Target Name="_AdjustApiXmlPrepare"
-      DependsOnTargets="_DefineApiFiles">
+  
+  <!-- Run api-xml-adjuster on each 'api-X.xml.class-parse' file, which runs some fixups
+       on the Java API and marks overrides, producing 'api-X.xml.in' files. -->
+  <Target Name="_AdjustApiXml"
+      BeforeTargets="Build"
+      DependsOnTargets="_DefineApiFiles"
+      Inputs="@(ApiFileDefinition->'%(ClassParseXml)')"
+      Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
+
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>
+    
     <ItemGroup>
       <_AdjustApiXmlPrepareCommands
           Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
@@ -60,12 +88,7 @@
         <Arguments>%(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)</Arguments>
       </_AdjustApiXmlPrepareCommands>
     </ItemGroup>
-  </Target>
-  <Target Name="_AdjustApiXml"
-      AfterTargets="Build"
-      DependsOnTargets="_AdjustApiXmlPrepare"
-      Inputs="@(ApiFileDefinition->'%(ClassParseXml)')"
-      Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
+
     <RunParallelCmds
         Commands="@(_AdjustApiXmlPrepareCommands)"
         ManagedRuntime="$(ManagedRuntime)"
@@ -73,12 +96,13 @@
       />
   </Target>
 
+  <!-- Clean up generated API files -->
   <Target Name="_CleanApiXml"
-      BeforeTargets="Clean">
+      BeforeTargets="Clean"
+      DependsOnTargets="_DefineApiFiles">
 
     <Delete Files="%(ApiFileDefinition.ApiAdjustedXml)" />
     <Delete Files="%(ApiFileDefinition.ClassParseXml)" />
-
   </Target>
-
+  
 </Project>

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -8,10 +8,6 @@
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
 
-  <PropertyGroup>
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\external\Java.Interop\tools\class-parse\class-parse.csproj" ReferenceOutputAssembly="False" />
     <ProjectReference Include="..\api-xml-adjuster\api-xml-adjuster.csproj" ReferenceOutputAssembly="False" />
@@ -19,8 +15,7 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
-    <_OutputPath>$(_TopDir)\bin\Build$(Configuration)\</_OutputPath>
+    <_OutputPath>$(XamarinAndroidSourcePath)\bin\Build$(Configuration)\</_OutputPath>
   </PropertyGroup>
 
   <!-- First we need to figure out all the needed API levels.
@@ -29,13 +24,13 @@
   <Target Name="_DefineApiFiles">
     <ItemGroup>
       <_Api
-          Condition=" Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Id).params.txt') "
+          Condition=" Exists('$(XamarinAndroidSourcePath)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Id).params.txt') "
           Include="@(AndroidApiInfo)">
       </_Api>
     </ItemGroup>
     
     <CreateItem Include="@(_Api)"
-        AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(_Api.Id).params.txt;ClassParseXml=$(_OutputPath)api\api-%(_Api.Id).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(_Api.Id).xml.in;MergedXml=$(_OutputPath)api\api-%(_Api.Id).xml">
+        AdditionalMetadata="ParameterDescription=$(XamarinAndroidSourcePath)\src\Mono.Android\Profiles\api-%(_Api.Id).params.txt;ClassParseXml=$(_OutputPath)api\api-%(_Api.Id).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(_Api.Id).xml.in;MergedXml=$(_OutputPath)api\api-%(_Api.Id).xml">
       <Output TaskParameter="Include" ItemName="ApiFileDefinition"/>
     </CreateItem>
     
@@ -56,12 +51,12 @@
       Outputs="@(ApiFileDefinition->'%(ClassParseXml)')">
       
     <PropertyGroup>
-      <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
+      <ClassParse>$(XamarinAndroidSourcePath)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
     
     <ItemGroup>
       <_ClassParseCommands
-          Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
+          Condition="Exists('$(XamarinAndroidSourcePath)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
           Include="@(ApiFileDefinition)">
         <Command>$(ClassParse)</Command>
         <Arguments>$(AndroidSdkDirectory)\platforms\android-%(ApiFileDefinition.Id)\android.jar -platform=%(ApiFileDefinition.Id) -parameter-names=&quot;%(ApiFileDefinition.ParameterDescription)&quot; -o=&quot;%(ApiFileDefinition.ClassParseXml)&quot;</Arguments>
@@ -85,12 +80,12 @@
       Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
 
     <PropertyGroup>
-      <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
+      <ApiXmlAdjuster>$(XamarinAndroidSourcePath)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>
     
     <ItemGroup>
       <_AdjustApiXmlPrepareCommands
-          Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
+          Condition="Exists('$(XamarinAndroidSourcePath)\src\Mono.Android\Profiles\api-%(ApiFileDefinition.Id).params.txt')"
           Include="@(ApiFileDefinition)">
         <Command>$(ApiXmlAdjuster)</Command>
         <Arguments>%(ApiFileDefinition.ClassParseXml) %(ApiFileDefinition.ApiAdjustedXml)</Arguments>

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\external\Java.Interop\tools\class-parse\class-parse.csproj" ReferenceOutputAssembly="False" />
     <ProjectReference Include="..\api-xml-adjuster\api-xml-adjuster.csproj" ReferenceOutputAssembly="False" />
+    <ProjectReference Include="..\api-merge\api-merge.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
   
   <PropertyGroup>
@@ -32,10 +33,18 @@
           Include="@(AndroidApiInfo)">
       </_Api>
     </ItemGroup>
+    
     <CreateItem Include="@(_Api)"
-        AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(_Api.Id).params.txt;ClassParseXml=$(_OutputPath)api\api-%(_Api.Id).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(_Api.Id).xml.in">
+        AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(_Api.Id).params.txt;ClassParseXml=$(_OutputPath)api\api-%(_Api.Id).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(_Api.Id).xml.in;MergedXml=$(_OutputPath)api\api-%(_Api.Id).xml">
       <Output TaskParameter="Include" ItemName="ApiFileDefinition"/>
     </CreateItem>
+    
+    <!-- We don't generate 'api.xml' files for older API levels we no longer ship -->
+    <ItemGroup>
+      <_MergedXmlFiles
+          Condition=" %(ApiFileDefinition.Level) >= 19  "
+          Include="@(ApiFileDefinition)" />
+    </ItemGroup>
   </Target>
 
   <!-- Next we need to run class-parse on each platform's 'android.jar' in order
@@ -71,7 +80,6 @@
   <!-- Run api-xml-adjuster on each 'api-X.xml.class-parse' file, which runs some fixups
        on the Java API and marks overrides, producing 'api-X.xml.in' files. -->
   <Target Name="_AdjustApiXml"
-      BeforeTargets="Build"
       DependsOnTargets="_DefineApiFiles"
       Inputs="@(ApiFileDefinition->'%(ClassParseXml)')"
       Outputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')">
@@ -95,6 +103,25 @@
         ManagedRuntimeArguments="$(ManagedRuntimeArgs)"
       />
   </Target>
+  
+  <!-- Merges various 'api-X.xml.in' files into single 'api.xml' file -->
+  <Target Name="_GenerateApiDescription"
+      BeforeTargets="Build"
+      DependsOnTargets="_AdjustApiXml"
+      Inputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')"
+      Outputs="@(_MergedXmlFiles->'%(MergedXml)')">
+    
+    <PropertyGroup>
+      <ApiMerge>..\..\bin\Build$(Configuration)\api-merge.exe</ApiMerge>
+      <_ConfigurationFile>..\..\bin\Build$(Configuration)\merge-configuration.xml</_ConfigurationFile>
+      <_ConfigurationInputBaseDirectory>..\..\bin\Build$(Configuration)\api\</_ConfigurationInputBaseDirectory>
+      <_ConfigurationOutputBaseDirectory>..\..\bin\Build$(Configuration)\api\</_ConfigurationOutputBaseDirectory>
+    </PropertyGroup>
+    
+    <Exec
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)" />
+        
+  </Target>
 
   <!-- Clean up generated API files -->
   <Target Name="_CleanApiXml"
@@ -103,6 +130,7 @@
 
     <Delete Files="%(ApiFileDefinition.ApiAdjustedXml)" />
     <Delete Files="%(ApiFileDefinition.ClassParseXml)" />
+    <Delete Files="%(_MergedXmlFiles.MergedXml)" />
   </Target>
   
 </Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -375,7 +375,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\build-tools\create-android-api\create-android-api.csproj" ReferenceOutputAssembly="false" />
     <!-- Explicitly pass the target framework of the project so we don't have conflicts with the multiple targets in this file. -->
-    <ProjectReference Include="..\..\build-tools\api-merge\api-merge.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472"/>
     <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -373,7 +373,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\build-tools\api-xml-adjuster\api-xml-adjuster.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
+    <ProjectReference Include="..\..\build-tools\create-android-api\create-android-api.csproj" ReferenceOutputAssembly="false" />
     <!-- Explicitly pass the target framework of the project so we don't have conflicts with the multiple targets in this file. -->
     <ProjectReference Include="..\..\build-tools\api-merge\api-merge.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckApiCompatibility" />
+  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunParallelCmds" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
   <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
   <ItemGroup>
@@ -15,6 +16,8 @@
         SkipGetTargetFrameworkProperties="True"
     />
   </ItemGroup>
+  
+  <!-- Builds the 'monoandroid1.0' version of 'Java.Interop.dll' -->
   <Target Name="_BuildJavaInterop"
       BeforeTargets="BeforeResolveReferences"
       Condition=" '$(TargetFramework)' == 'monoandroid10' "
@@ -42,6 +45,8 @@
         DestinationFolder="$(OutputPath)\..\v1.0"
     />
   </Target>
+  
+  <!-- Creates 'AssemblyInfo.cs' with appropriate version information -->
   <Target Name="_BuildAssemblyInfo_cs"
       DependsOnTargets="GetXAVersionInfo"
       BeforeTargets="CoreCompile"
@@ -62,11 +67,14 @@
         Replacements="@PACKAGE_VERSION@=$(_PackageVersion);@PACKAGE_VERSION_BUILD@=$(_PackageVersionBuild);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch);@API_LEVEL@=$(AndroidApiLevel);@MIN_API_LEVEL@=$(AndroidMinimumDotNetApiLevel)">
     </ReplaceFileContents>
   </Target>
+  
+  <!-- Pulls documentation from JavaDoc -->
   <PropertyGroup>
     <_JavaSourceUtilsJar>$(XAInstallPrefix)xbuild\Xamarin\Android\java-source-utils.jar</_JavaSourceUtilsJar>
     <_AndroidStableSrcDir>$(AndroidSdkDirectory)\platforms\android-$(AndroidLatestStableApiLevel)\src</_AndroidStableSrcDir>
     <_AndroidJavadocXml>..\..\bin\Build$(Configuration)\android-javadoc.xml</_AndroidJavadocXml>
   </PropertyGroup>
+  
   <Target Name="_BuildAndroidJavadocXml"
       Condition=" '$(IncludeAndroidJavadoc)' == 'True' "
       BeforeTargets="CoreCompile"
@@ -108,6 +116,8 @@
     />
     <Touch Files="$(_AndroidJavadocXml)" />
   </Target>
+  
+  <!-- Generates 'JNIEnv.g.cs' file -->
   <Target Name="_BuildJNIEnv"
       BeforeTargets="CoreCompile"
       Inputs="..\..\bin\Build$(Configuration)\jnienv-gen.exe"
@@ -117,6 +127,8 @@
     />
     <Touch Files="Android.Runtime\JNIEnv.g.cs" />
   </Target>
+  
+  <!-- Merges various 'api-*.xml.in' files into single 'api.xml' file -->
   <Target Name="_GenerateApiDescription"
       BeforeTargets="_GenerateBinding"
       DependsOnTargets="ResolveReferences"
@@ -136,6 +148,8 @@
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)"
     />
   </Target>
+  
+  <!-- Runs 'generator' -->
   <Target Name="_GenerateBinding"
       BeforeTargets="CoreCompile"
       Inputs="$(MSBuildThisFileFullPath);metadata;enumflags;map.csv;methodmap.csv;$(IntermediateOutputPath)mcw\api.xml"
@@ -201,6 +215,8 @@
   <ItemGroup>
     <JavaCallableWrapperSource Include="java\**\*.java" />
   </ItemGroup>
+  
+  <!-- Generates 'FrameworkList.xml' file -->
   <Target Name="_GenerateFrameworkList"
       BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"
       Condition=" '$(TargetFramework)' == 'monoandroid10' "
@@ -217,6 +233,8 @@
        Overwrite="True"
    />
   </Target>
+  
+  <!-- Generates 'AndroidApiInfo.xml' file -->
   <Target Name="_GenerateAndroidApiInfo"
       BeforeTargets="_GenerateFrameworkList"
       Inputs="$(MSBuildProjectFullPath);..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems"
@@ -241,10 +259,14 @@
        Overwrite="True"
    />
   </Target>
+  
+  <!-- Removes entire 'obj' directory on Clean -->
   <Target Name="_CleanBinding"
       AfterTargets="Clean">
     <RemoveDir Directories="$(IntermediateOutputPath)" />
   </Target>
+  
+  <!-- Runs ApiCompat to prevent API breakage -->
   <PropertyGroup>
     <ApiCompatibilityDir>../../tests/api-compatibility</ApiCompatibilityDir>
   </PropertyGroup>
@@ -277,6 +299,7 @@
     </ItemGroup>
   </Target>
 
+  <!-- Generate documentation using MDoc -->
   <Target Name="UpdateExternalDocumentation">
     <MSBuild Projects="$(MSBuildThisFileDirectory)Mono.Android.csproj"
         Properties="TargetFramework=monoandroid10"
@@ -343,5 +366,5 @@
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>
-
+  
 </Project>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckApiCompatibility" />
-  <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunParallelCmds" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
   <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
   <ItemGroup>
@@ -132,12 +131,26 @@
     <Touch Files="Android.Runtime\JNIEnv.g.cs" />
   </Target>
   
+  <!-- Copies common 'api-X.xml' to the 'obj' directory.
+       This is needed because 'generator' writes intermediate files like 'api-X.xml.fixed' next to the source
+       'api-X.xml' and multiple profiles are using the source, so these files will clobber each other. -->
+  <Target Name="_CopyXmlLocal"     
+      Inputs="$(_ApiXmlLocation)api-$(AndroidPlatformId).xml"
+      Outputs="$(IntermediateOutputPath)mcw\api-$(AndroidPlatformId).xml">
+      
+    <Copy
+        SourceFiles="$(_ApiXmlLocation)api-$(AndroidPlatformId).xml"
+        DestinationFolder="$(IntermediateOutputPath)mcw\"
+    />
+
+  </Target>
+  
   <!-- Runs 'generator' -->
   <Target Name="_GenerateBinding"
       BeforeTargets="CoreCompile"
-      Inputs="$(MSBuildThisFileFullPath);metadata;enumflags;map.csv;methodmap.csv;$(_ApiXmlLocation)api-$(AndroidPlatformId).xml"
+      DependsOnTargets="_CopyXmlLocal"
+      Inputs="$(MSBuildThisFileFullPath);metadata;enumflags;map.csv;methodmap.csv;$(IntermediateOutputPath)mcw\api-$(AndroidPlatformId).xml"
       Outputs="$(IntermediateOutputPath)mcw\Mono.Android.projitems">
-    <MakeDir Directories="$(IntermediateOutputPath)mcw" />
     <PropertyGroup>
       <_PlatformIdVersions>$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\data\api-versions.xml</_PlatformIdVersions>
       <_AndroidPlatformAnnotations>$(AndroidSdkDirectory)/platforms/android-$(AndroidPlatformId)/data/annotations.zip</_AndroidPlatformAnnotations>
@@ -167,7 +180,7 @@
       <_Annotations Condition=" '$(_AnnotationsZip)' != '' ">"--annotations=$(_AnnotationsZip)"</_Annotations>
       <_Assembly>--assembly="Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"</_Assembly>
       <_TypeMap>--type-map-report=$(IntermediateOutputPath)mcw\type-mapping.txt</_TypeMap>
-      <_Api>$(_ApiXmlLocation)api-$(AndroidPlatformId).xml</_Api>
+      <_Api>$(IntermediateOutputPath)mcw\api-$(AndroidPlatformId).xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>
       <_WithJavadocXml Condition=" '$(IncludeAndroidJavadoc)' == 'True' ">"--doc-comment-verbosity=$(AndroidJavadocVerbosity)" "--with-javadoc-xml=$(_AndroidJavadocXml)"</_WithJavadocXml>
       <_FullIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -17,6 +17,10 @@
     />
   </ItemGroup>
   
+  <PropertyGroup>
+    <_ApiXmlLocation>..\..\bin\Build$(Configuration)\api\</_ApiXmlLocation>
+  </PropertyGroup>
+  
   <!-- Builds the 'monoandroid1.0' version of 'Java.Interop.dll' -->
   <Target Name="_BuildJavaInterop"
       BeforeTargets="BeforeResolveReferences"
@@ -128,31 +132,10 @@
     <Touch Files="Android.Runtime\JNIEnv.g.cs" />
   </Target>
   
-  <!-- Merges various 'api-*.xml.in' files into single 'api.xml' file -->
-  <Target Name="_GenerateApiDescription"
-      BeforeTargets="_GenerateBinding"
-      DependsOnTargets="ResolveReferences"
-      Inputs="..\..\bin\Build$(Configuration)\api\api-$(AndroidPlatformId).xml.in"
-      Outputs="$(IntermediateOutputPath)mcw\api.xml">
-    <MakeDir Directories="$(IntermediateOutputPath)mcw" />
-    <ItemGroup>
-      <_AndroidProfile Include="..\..\bin\Build$(Configuration)\api\api-*.xml.in" />
-    </ItemGroup>
-    <PropertyGroup>
-      <ApiMerge>..\..\bin\Build$(Configuration)\api-merge.exe</ApiMerge>
-      <_ConfigurationFile>..\..\bin\Build$(Configuration)\merge-configuration.xml</_ConfigurationFile>
-      <_ConfigurationInputBaseDirectory>..\..\bin\Build$(Configuration)\api\</_ConfigurationInputBaseDirectory>
-      <_ConfigurationOutputBaseDirectory>$(IntermediateOutputPath)\..\</_ConfigurationOutputBaseDirectory>
-    </PropertyGroup>
-    <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)"
-    />
-  </Target>
-  
   <!-- Runs 'generator' -->
   <Target Name="_GenerateBinding"
       BeforeTargets="CoreCompile"
-      Inputs="$(MSBuildThisFileFullPath);metadata;enumflags;map.csv;methodmap.csv;$(IntermediateOutputPath)mcw\api.xml"
+      Inputs="$(MSBuildThisFileFullPath);metadata;enumflags;map.csv;methodmap.csv;$(_ApiXmlLocation)api-$(AndroidPlatformId).xml"
       Outputs="$(IntermediateOutputPath)mcw\Mono.Android.projitems">
     <MakeDir Directories="$(IntermediateOutputPath)mcw" />
     <PropertyGroup>
@@ -184,7 +167,7 @@
       <_Annotations Condition=" '$(_AnnotationsZip)' != '' ">"--annotations=$(_AnnotationsZip)"</_Annotations>
       <_Assembly>--assembly="Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"</_Assembly>
       <_TypeMap>--type-map-report=$(IntermediateOutputPath)mcw\type-mapping.txt</_TypeMap>
-      <_Api>$(IntermediateOutputPath)mcw\api.xml</_Api>
+      <_Api>$(_ApiXmlLocation)api-$(AndroidPlatformId).xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>
       <_WithJavadocXml Condition=" '$(IncludeAndroidJavadoc)' == 'True' ">"--doc-comment-verbosity=$(AndroidJavadocVerbosity)" "--with-javadoc-xml=$(_AndroidJavadocXml)"</_WithJavadocXml>
       <_FullIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>


### PR DESCRIPTION
*One* issue with running `dotnet build Xamarin.Android.sln` without `-m:1` is that it attempts to run our Android API extraction process multiple times simultaneously.  This results in file locking issues:

```
C:\code\xamarin-android\src\Mono.Android\Mono.Android.targets(409,5): "C:\code\xamarin-android\src\Mono.Android\..\..\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe C:\Users\jopobst\android-toolchain\sdk\platforms\android-26\android.jar -platform=26 -parameter-names="C:\code\xamarin-android\src\Mono.Android\..\..\src\Mono.Android\Profiles\api-26.params.txt" -o="C:\code\xamarin-android\src\Mono.Android\..\..\bin\BuildDebug\api\api-26.xml.class-parse"" failed with code: -532462766  Error output: 
Unhandled Exception: System.IO.IOException: The process cannot access the file 'C:\code\xamarin-android\bin\BuildDebug\api\api-26.xml.class-parse' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding)
   at Xamarin.Android.Tools.App.Main(String[] args) in C:\code\xamarin-android\external\Java.Interop\tools\class-parse\Program.cs:line 68 [C:\code\xamarin-android\src\Mono.Android\Mono.Android.csproj]
```

This seems to be a result of running the process as an `AfterTargets="Build"` target in `api-xml-adjuster.csproj`.  By moving it to a `NoTargets` project, we can eliminate MSBuild trying to run it multiple times.  Thus, the process has been moved to the new `create-android-api.csproj` project.

Also, move the `api-merge` step from `Mono.Android.targets`.  This currently runs twice, once for `monoandroid10` and once for `net7.0`, however the output is not dependent on `TargetFramework`.  Instead of generating:
- `src\Mono.Android\obj\Debug\monoandroid10\android-32\mcw\api.xml`
- `src\Mono.Android\obj\Debug\net7.0\android-32\mcw\api.xml`

we will now generate:
- `bin\Build$(Configuration)\api\api-32.xml`

Calling `api-merge` only once saves ~25s from build time.

Note that `generator` writes intermediate files (eg: `api.xml.fixed`) to the directory containing `api.xml`, so `Mono.Android.targets` will copy the `api-X.xml` file to its eg: `obj\Debug\net7.0\android-32\mcw` directory to work from.  Without this, both `monoadroid10` and `net7.0` would write to the common location, causing possible conflicts.

Additionally, let VS2022 rewrite `Xamarin.Android.sln` to its preferred format in order to add the new project.