### PR TITLE
[release/6.0.4xx] fix designer tests

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -64,7 +64,9 @@ steps:
   inputs:
     command: restore
     projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
-    restoreArguments: --configfile ${{ parameters.xaSourcePath }}/NuGet.config -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
+    restoreArguments: -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/restore-Xamarin.Android.Build.Tests.binlog
+    nugetConfigPath: ${{ parameters.xaSourcePath }}/NuGet.config
+    feedsToUse: config
 
 - task: DotNetCoreCLI@2
   displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6880

Partially backports 16680700.

Update our `DotNetCoreCLI@2` use in `setup-test-environment.yaml` to
work around a "bizarre" CI error:

	"C:\Program Files\dotnet\dotnet.exe" restore
	  C:\a\_work\1\s\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.csproj
	  --configfile C:\a\_work\1\Nuget\tempNuGet_5963650.config
	  --verbosity Detailed
	  --configfile C:\a\_work\1\s\xamarin-android/NuGet.config
	  -bl:C:\a\_work\1\s\xamarin-android/bin/TestRelease/restore-Xamarin.Android.Build.Tests.binlog
	Option '--configfile' only accepts a single argument but 2 were provided.

It appears that `restoreArguments: --configfile …` can no longer be
used with the [`DotNetCoreCLI@2`][0] task, and instead the
`nugetConfigPath` and `feedsToUse: config` inputs must be used instead.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops