### PR TITLE
[build] Version .NET VS manifest file

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -85,7 +85,7 @@
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
-        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion)"
+        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFrameworkVersion)"
     />
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -85,7 +85,7 @@
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
-        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFrameworkVersion)"
+        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFramework)"
     />
   </Target>
 

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetName>Microsoft.NET.Sdk.Android.Workload</TargetName>
+    <TargetName>Microsoft.NET.Sdk.Android.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
As part of supporting .NET 6 projects with our .NET 7 workload, we will
want to be able to insert both .NET 6 and .NET 7 workload packs into VS.

Historically, we have replaced the [VS manifest file][0] every time we
update our workload.  For .NET 7 we will likely want two VS manifests
side by side, one which contains our .NET 6 packs and one for .NET 7.

Add a version to the .NET VS manifest file to support this potential
side by side scenario.

[0]: https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/.corext/Configs/dotnet-workloads-components.json&version=GBmain&line=10&lineEnd=11&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents