### PR TITLE
[Xamarin.Android.sln] Fix issues preventing parallel builds.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <!-- Ensure command-line apps can use a newer .NET -->
     <RollForward>Major</RollForward>
+    <!-- We don't need to be warned that we are using a preview .NET -->
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(MSBuildRuntimeType)' == 'Core' ">

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -208,7 +208,7 @@ stages:
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
-          -t:BuildDotNet,PackDotNet -c $(XA.Build.Configuration) -m:1 -v:n
+          -t:BuildDotNet,PackDotNet -c $(XA.Build.Configuration) -v:n
           -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog
         displayName: Build Solution
         continueOnError: false

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\external\Java.Interop\tools\class-parse\class-parse.csproj" ReferenceOutputAssembly="False" />
     <ProjectReference Include="..\api-xml-adjuster\api-xml-adjuster.csproj" ReferenceOutputAssembly="False" />
     <ProjectReference Include="..\api-merge\api-merge.csproj" ReferenceOutputAssembly="False" />
+    <ProjectReference Include="..\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="False" SkipGetTargetFrameworkProperties="True" AdditionalProperties="TargetFramework=net472" />
   </ItemGroup>
   
   <PropertyGroup>
@@ -116,6 +117,17 @@
     <Exec
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(ApiMerge) -config=$(_ConfigurationFile) -config-input-dir=$(_ConfigurationInputBaseDirectory) -config-output-dir=$(_ConfigurationOutputBaseDirectory)" />
         
+  </Target>
+  
+  <!-- Generates 'JNIEnv.g.cs' file. We do this here because it should only run once, not per-TF.  -->
+  <Target Name="_BuildJNIEnv"
+      BeforeTargets="Build"
+      Inputs="..\..\bin\Build$(Configuration)\jnienv-gen.exe"
+      Outputs="../../src/Mono.Android/Android.Runtime/JNIEnv.g.cs">
+    <Exec
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) &quot;../../bin/Build$(Configuration)/jnienv-gen.exe&quot; -o ../../src/Mono.Android/Android.Runtime/JNIEnv.g.cs --use-java-interop"
+    />
+    <Touch Files="../../src/Mono.Android/Android.Runtime/JNIEnv.g.cs" />
   </Target>
 
   <!-- Clean up generated API files -->

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -27,6 +27,6 @@ endif
 leeroy: leeroy-all framework-assemblies
 
 leeroy-all:
-	$(call DOTNET_BINLOG,leeroy-all) $(SOLUTION) -m:1 $(_MSBUILD_ARGS)
+	$(call DOTNET_BINLOG,leeroy-all) $(SOLUTION) $(_MSBUILD_ARGS)
 	$(call DOTNET_BINLOG,setup-workload) -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj
 	$(call MSBUILD_BINLOG,leeroy-all,$(_SLN_BUILD)) /restore tools/xabuild/xabuild.csproj /p:Configuration=$(CONFIGURATION) $(_MSBUILD_ARGS)

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.ILLink" Version="$(MicrosoftNETILLinkTasksPackageVersion)" />
     <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="all" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
+    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" ReferenceOutputAssembly="False" />
 
     <Compile Include="..\Xamarin.Android.Build.Tasks\obj\$(Configuration)\Profile.g.cs" Link="Profile.g.cs" />
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -374,7 +374,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\build-tools\create-android-api\create-android-api.csproj" ReferenceOutputAssembly="false" />
     <!-- Explicitly pass the target framework of the project so we don't have conflicts with the multiple targets in this file. -->
-    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472"/>
     <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=$(DotNetTargetFramework)" />
     <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -33,6 +33,10 @@
       </_GlobalProperties>
     </PropertyGroup>
     <MSBuild
+        Projects="$(JavaInteropFullPath)\build-tools\jnienv-gen\jnienv-gen.csproj"
+        Properties="TargetFramework=net472;"
+    />
+    <MSBuild
         Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop-MonoAndroid.csproj"
         Properties="$(_GlobalProperties)"
     />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -30,9 +30,6 @@
       <_GlobalProperties>
         JavaInteropProfile=Net45;
         XAInstallPrefix=$(XAInstallPrefix);
-        TargetFrameworkIdentifier=MonoAndroid;
-        TargetFrameworkVersion=v1.0;
-        TargetFrameworkRootPath=$(XAInstallPrefix)xbuild-frameworks;
       </_GlobalProperties>
     </PropertyGroup>
     <MSBuild
@@ -118,17 +115,6 @@
         Command="&quot;$(JavaPath)&quot; -jar &quot;$(_JavaSourceUtilsJar)&quot; @(_JSIArg, ' ')"
     />
     <Touch Files="$(_AndroidJavadocXml)" />
-  </Target>
-  
-  <!-- Generates 'JNIEnv.g.cs' file -->
-  <Target Name="_BuildJNIEnv"
-      BeforeTargets="CoreCompile"
-      Inputs="..\..\bin\Build$(Configuration)\jnienv-gen.exe"
-      Outputs="Android.Runtime\JNIEnv.g.cs">
-    <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) &quot;../../bin/Build$(Configuration)/jnienv-gen.exe&quot; -o Android.Runtime/JNIEnv.g.cs --use-java-interop"
-    />
-    <Touch Files="Android.Runtime\JNIEnv.g.cs" />
   </Target>
   
   <!-- Copies common 'api-X.xml' to the 'obj' directory.

--- a/src/manifestmerger/manifestmerger.csproj
+++ b/src/manifestmerger/manifestmerger.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
   
   <Import Project="..\..\Configuration.props" />
+
+  <ItemGroup>
+    <!-- There isn't an actual dependency here, but we can only build one 'gradlew' project
+         at a time, and adding <ProjectReference> between them ensures they run sequentially. -->
+    <ProjectReference Include="..\apksigner\apksigner.csproj" ReferenceOutputAssembly="False" />
+  </ItemGroup>
   
   <Import Project="manifestmerger.targets" />
 </Project>

--- a/src/r8/r8.csproj
+++ b/src/r8/r8.csproj
@@ -8,6 +8,12 @@
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
   </PropertyGroup>
   
+  <ItemGroup>
+    <!-- There isn't an actual dependency here, but we can only build one 'gradlew' project
+         at a time, and adding <ProjectReference> between them ensures they run sequentially. -->
+    <ProjectReference Include="..\manifestmerger\manifestmerger.csproj" ReferenceOutputAssembly="False" />
+  </ItemGroup>
+
   <Import Project="..\..\Configuration.props" />
   <Import Project="r8.targets" />
 </Project>

--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools.JavadocToMDoc</RootNamespace>
     <AssemblyName>javadoc-to-mdoc</AssemblyName>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>

--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools.JavadocToMDoc</RootNamespace>
     <AssemblyName>javadoc-to-mdoc</AssemblyName>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>


### PR DESCRIPTION
There are several known issues that cause errors when attempting to `dotnet build Xamarin.Android.sln` without `-m:1`.  With these fixes, the build *seems* to be buildable without `-m:1`.  

Testing conducted is 4 consecutive CI builds without errors.  Note that due to the unpredictability of race-condition errors appearing, this is not a guarantee that all issues are fixed.  We will simply have to run with this and fix any additional errors as they appear.

Fixes:

- Use `create-android-api` to build `JNIEnv.g.cs` only once, since it is not TargetFramework dependent.  Prevents sharing violation when multiple `Mono.Android.csproj` builds attempt to create it simultaneously.
  - `System.IO.IOException: The process cannot access the file 'C:\a\_work\1\s\src\Mono.Android\Android.Runtime\JNIEnv.g.cs' because it is being used by another process.`
- `Microsoft.Android.Sdk.ILLink.csproj` needs a dependency on `Xamarin.Android.Build.Tasks.csproj` so that `Xamarin.Android.Build.Tasks\obj\$(Configuration)\Profile.g.cs` is available for compile.
  - `CSC error CS2001: Source file 'C:\code\xamarin-android\src\Microsoft.Android.Sdk.ILLink\..\Xamarin.Android.Build.Tasks\obj\Debug\Profile.g.cs' could not be found. [C:\code\xamarin-android\src\Microsoft.Android.Sdk.ILLink\Microsoft.Android.Sdk.ILLink.csproj]`
- Add a project reference to `jnienv-gen.csproj` from `Java.Interop-MonoAndroid.csproj`.  This ensures `jnienv-gen.exe` is available when building `Java.Interop-MonoAndroid.csproj`. 
  - https://github.com/xamarin/java.interop/pull/990
- Add project references between `apksigner`/`r8`/`manifestmerger`.  `gradlew` hits an issue when running multiple copies simultaneously.  While there isn't an actual dependency between these, it forces them to build sequentially.
  - `org.gradle.launcher.daemon.client.DaemonConnectionException: Timeout waiting to connect to the Gradle daemon.` and `The file lock is held by a different Gradle process.`