### PR TITLE
[Mono.Android.Export] Fix build warnings.

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -12,6 +12,9 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- Ignore "unused member" warnings from code that originates from Mono.CodeGeneration -->
+    <NoWarn>$(NoWarn);CS0169;CS0414;CS0649</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">

--- a/src/Mono.Android.Export/Properties/AssemblyInfo.cs
+++ b/src/Mono.Android.Export/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
@@ -9,6 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
 [assembly: AssemblyMetadata ("IsTrimmable", "True")]
+[assembly: SupportedOSPlatform ("Android21.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Eliminate warnings from `Mono.Android.Export.csproj`.

- Fix 27 warnings of `warning CA1416: This call site is reachable on all platforms.` by specifying that this assembly relies on the `Android21.0` platform because it relies on `Mono.Android.dll`.
- Suppress 9 warnings of `warning CS0649: Field 'CodeTry.condition' is never assigned to, and will always have its default value null` and similar because this is "external" code we have imported from Mono, and I doubt we're going to fix them.