### PR TITLE
$(AndroidPackVersionSuffix)=preview.6; net7 is 33.0.0.preview.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>33.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
We are already on .NET 7 Preview 6, so let's update our version number
to match. If we get packages ready in time for preview 5, we can do
that on a release branch.