### PR TITLE
[ci] Add JI prepare step to nightly test runs

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -109,13 +109,15 @@ stages:
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:
-        displayName: install required brew tools and prepare java.interop
-        arguments: --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes
-
-    - template: yaml-templates/run-xaprepare.yaml
-      parameters:
         displayName: install emulator
         arguments: --s=EmulatorTestDependencies
+
+    - template: yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        project: Xamarin.Android.sln
+        arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) -m:1 -v:n
+        displayName: prepare java.interop $(XA.Build.Configuration)
+        continueOnError: false
 
     - script: echo "##vso[task.setvariable variable=Java8SdkDirectory]$JAVA_HOME_8_X64"
       displayName: set Java8SdkDirectory


### PR DESCRIPTION
Commit e52c1315 broke our nightly runs of Mono.Android-Tests as it moved
the Java.Interop prepare step out of xaprepare.  Fix the nightly test
runs by preparing Java.Interop before building Mono.Android-Tests.