### PR TITLE
Update 'build.cmd' to use 'dotnet build'.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,23 +8,23 @@ IF ERRORLEVEL 1 CALL:FAILED_CASE
 IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 :Prepare_CASE
-    msbuild Xamarin.Android.sln /t:Prepare
+    dotnet build Xamarin.Android.sln -t:Prepare -nr:false
     GOTO END_CASE
 :PrepareExternal_CASE
-    msbuild Xamarin.Android.sln /t:PrepareExternal
+    dotnet build Xamarin.Android.sln -t:PrepareExternal -nr:false
     GOTO END_CASE
 :Build_CASE
-    msbuild Xamarin.Android.sln
-    msbuild tools/xabuild/xabuild.csproj
+    dotnet-local.cmd build Xamarin.Android.sln  -nr:false
+    dotnet-local.cmd build tools/xabuild/xabuild.csproj -nr:false
     GOTO END_CASE
 :Pack_CASE
-    msbuild Xamarin.Android.sln /t:PackDotNet
+    dotnet-local.cmd build  Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE
 :DEFAULT_CASE
-    msbuild Xamarin.Android.sln /t:Prepare
-    msbuild Xamarin.Android.sln
-    msbuild tools/xabuild/xabuild.csproj
-    msbuild Xamarin.Android.sln /t:PackDotNet
+    dotnet build Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet-local.cmd build Xamarin.Android.sln -nr:false
+    dotnet-local.cmd build tools/xabuild/xabuild.csproj -nr:false
+    dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE
 :FAILED_CASE
     echo "Failed to find an instance of Visual Studio. Please check it is correctly installed."


### PR DESCRIPTION
Our 'build.cmd' file was using `msbuild`. We have switched over to
using `dotnet` for most of our CI systems. So we should switch this
over as well.