### PR TITLE
[monodroid] Remove unused JNI function declarations

### DIFF
--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -87,12 +87,6 @@ JNIEXPORT void JNICALL Java_mono_android_Runtime_propagateUncaughtException
 JNIEXPORT void JNICALL Java_mono_android_Runtime_dumpTimingData
   (JNIEnv *, jclass);
 
-JNIEXPORT void JNICALL Java_helloandroid_MainActivity_n_1onCreate__Landroid_os_Bundle_2
-  (JNIEnv *, jclass, jobject);
-
-JNIEXPORT jobject JNICALL Java_helloandroid_MainActivity_n_1onCreateView__Landroid_view_View_2Ljava_lang_String_2Landroid_content_Context_2Landroid_util_AttributeSet_2
-  (JNIEnv *env, jclass klass, jobject view, jstring name, jobject context, jobject attrs);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Context: e1af9587bb98d4c249bbc392ceccc2b53ffff155

e1af9587 was the first commit in a series to implement marshal
methods.  Part of that were two JNI function declarations declared in
the `src/jni/monodroid/mono_android_Runtime.h` header file that
I thought would be silently ignored.  I missed the fact that the file
is regenerated whenever `monodroid.csproj` is built and so every time
that happens one would find themselves with a modifications that
weren't part of their work.

Remove the declarations to fix the issue.