### PR TITLE
[build] Fix the `dotnet-local.sh` script path resolution

### DIFF
--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-ROOT=$(dirname "${BASH_SOURCE}")
-FULLROOT=$(pwd)
+ROOT="$(dirname "${BASH_SOURCE}")"
+FULLROOT="$(cd "${ROOT}"; pwd)"
 if [[ -x "${ROOT}/bin/Release/dotnet/dotnet" ]]; then
     DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Release/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Release/lib exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
 elif [[ -x "${ROOT}/bin/Debug/dotnet/dotnet" ]]; then


### PR DESCRIPTION
Set the `FULLROOT` property to the full version of the path
where the `dotnet-local.sh` script is, not to the current
directory.  This allows invoking the script without having to
cd into the `xamarin-android` repository first.