### PR TITLE
[ci] Run BCL tests on src/monodroid changes

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -106,6 +106,7 @@ namespace Xamarin.Android.Prepare
 				if (file.Contains ("src/monodroid")) {
 					testAreas.Add ("MSBuildDevice");
 					testAreas.Add ("Designer");
+					testAreas.Add ("BCL");
 				}
 
 				if (file.Contains ("src/proguard")) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/7091

We have a couple of BCL tests that seemingly started to fail after
commit e1af9587 landed.  Unfortunately PR #7004 didn't run the BCL test
stage, which may have caught this issue sooner.  Update the triggers for
the BCL tests to include changes to src/monodroid.