### PR TITLE
Fix loading of refonly assemblies for "classic" apps

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -500,7 +500,7 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyLoadContextGCHandle alc_gchan
 MonoAssembly*
 EmbeddedAssemblies::open_from_bundles_refonly (MonoAssemblyName *aname, [[maybe_unused]] char **assemblies_path, [[maybe_unused]] void *user_data)
 {
-	constexpr bool ref_only = false;
+	constexpr bool ref_only = true;
 
 	return embeddedAssemblies.open_from_bundles (aname, ref_only /* loader_data */, nullptr /* error */, ref_only);
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7091
Context: https://github.com/xamarin/xamarin-android/commit/e1af9587bb98d4c249bbc392ceccc2b53ffff155

e1af958 refactored a handful of `MonoImage` loading methods and
during that process, I mistakenly made reference-only assemblies
to be loaded in a "full" way which broke a number of BCL tests.

Fix the issue by making sure reference-only assemblies are really
loaded as such.