### PR TITLE
[XABT] Support testing with dotnet packs override

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -189,8 +189,6 @@ namespace Xamarin.Android.Build.Tests
 </manifest>";
 			}
 			using (var b = CreateApkBuilder (path)) {
-				if (!b.CrossCompilerAvailable (supportedAbis))
-					Assert.Ignore ($"Cross compiler for {supportedAbis} was not available");
 				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
 					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 				b.ThrowOnBuildFailure = false;
@@ -259,8 +257,6 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
 			proj.SetProperty ("AndroidUseAssemblyStore", usesAssemblyBlobs.ToString ());
 			using (var b = CreateApkBuilder (path)) {
-				if (!b.CrossCompilerAvailable (supportedAbis))
-					Assert.Ignore ("Cross compiler was not available");
 				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
 					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 				b.ThrowOnBuildFailure = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -288,7 +288,7 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.AndroidClassParser = "class-parse";
 
 			using (var bindingBuilder = CreateDllBuilder ("temp/BindingCustomJavaApplicationClass/MultiDexBinding")) {
-				string multidexJar = Path.Combine (bindingBuilder.AndroidMSBuildDirectory, "android-support-multidex.jar");
+				string multidexJar = Path.Combine (TestEnvironment.AndroidMSBuildDirectory, "android-support-multidex.jar");
 				binding.Jars.Add (new AndroidItem.EmbeddedJar (() => multidexJar));
 				bindingBuilder.Build (binding);
 				var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -49,8 +49,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void BuildBasicApplication ([ValueSource (nameof (SupportedTargetFrameworks))] string tfv, [Values (true, false)] bool isRelease)
 		{
-			AssertTargetFrameworkVersionSupported (tfv);
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 				TargetFrameworkVersion = tfv,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -34,11 +34,7 @@ namespace Xamarin.Android.Build.Tests
 				Directory.Delete (Path.Combine (Root, path), recursive: true);
 
 			var engine = new MockBuildEngine (TestContext.Out, errors: errors, messages: messages);
-
-			var outPath = TestEnvironment.IsRunningOnCI ? TestEnvironment.MonoAndroidToolsDirectory
-				: new Uri (Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android")).LocalPath;
-			var frameworksPath = TestEnvironment.IsRunningOnCI ? Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, "v1.0")
-				: new Uri (Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid", "v1.0")).LocalPath;
+			var frameworksPath = Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, "v1.0");
 			var androidSdk = CreateFauxAndroidSdkDirectory (Path.Combine (path, "Sdk"), "24.0.1", new[]
 			{
 				new ApiInfo { Id = "23", Level = 23, Name = "Marshmallow", FrameworkVersion = "v6.0", Stable = true },
@@ -53,7 +49,7 @@ namespace Xamarin.Android.Build.Tests
 				AndroidNdkPath = null,
 				AndroidSdkPath = androidSdk,
 				JavaSdkPath = javaSdk,
-				MonoAndroidToolsPath = outPath,
+				MonoAndroidToolsPath = TestEnvironment.AndroidMSBuildDirectory,
 				ReferenceAssemblyPaths = new string[] {
 					frameworksPath,
 				},

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1072,8 +1072,6 @@ namespace Lib2
 			if (!string.IsNullOrEmpty (androidAotMode))
 			    proj.SetProperty ("AndroidAotMode", androidAotMode);
 			using (var b = CreateApkBuilder (path)) {
-				if (!b.CrossCompilerAvailable (supportedAbis))
-					Assert.Ignore ($"Cross compiler for {supportedAbis} was not available");
 				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
 					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidDotnetToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidDotnetToolTests.cs
@@ -32,17 +32,17 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void ShouldUseFullToolPath ()
 		{
-			var dotnetDir = AndroidSdkResolver.GetDotNetPreviewPath ();
+			var dotnetDir = TestEnvironment.DotNetPreviewDirectory;
 			var dotnetPath = Path.Combine (dotnetDir, (TestEnvironment.IsWindows ? "dotnet.exe" : "dotnet"));
 			var classParseTask = new ClassParseTestTask {
 				BuildEngine = engine,
 				NetCoreRoot = dotnetDir,
-				ToolPath = Builder.UseDotNet ? TestEnvironment.DotNetAndroidSdkToolsDirectory : AndroidMSBuildDirectory,
+				ToolPath = TestEnvironment.AndroidMSBuildDirectory,
 				ToolExe = Builder.UseDotNet ? "class-parse.dll" : "class-parse.exe",
 			};
 
 			Assert.True (classParseTask.Execute (), "Task should have succeeded.");
-			var expectedTool = Builder.UseDotNet ? dotnetPath : Path.Combine (AndroidMSBuildDirectory, "class-parse.exe");
+			var expectedTool = Builder.UseDotNet ? dotnetPath : Path.Combine (TestEnvironment.AndroidMSBuildDirectory, "class-parse.exe");
 			Assert.IsTrue (messages.Any (m => m.Message.StartsWith (expectedTool)), "Task did not use expected tool path.");
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				var ndkDir = AndroidNdkPath;
 				var sdkDir = AndroidSdkPath;
 				NdkTools ndk = NdkTools.Create (ndkDir, log: log);
-				ndk.OSBinPath = SetUp.OSBinDirectory;
+				ndk.OSBinPath = TestEnvironment.OSBinDirectory;
 				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir, AndroidSdkResolver.GetJavaSdkPath ());
 				var platforms = ndk.GetSupportedPlatforms ();
 				Assert.AreNotEqual (0, platforms.Count (), "No platforms found");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -443,7 +443,6 @@ namespace Xamarin.Android.Build.Tests {
 			proj.TargetSdkVersion = "19";
 			using (var b = CreateApkBuilder ()) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
-				AssertTargetFrameworkVersionSupported (proj.TargetFrameworkVersion);
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -21,7 +21,8 @@ namespace Xamarin.Android.Build.Tests
 		public static ConcurrentDictionary<string, string> TestPackageNames = new ConcurrentDictionary<string, string> ();
 
 		[SetUpFixture]
-		public class SetUp {
+		public class SetUp
+		{
 			public static string DeviceAbi {
 				get;
 				private set;
@@ -32,42 +33,9 @@ namespace Xamarin.Android.Build.Tests
 				private set;
 			}
 
-			public static bool CommercialBuildAvailable {
-				get;
-				private set;
-			}
-
-			public static string AndroidMSBuildDirectory {
-				get;
-				private set;
-			}
-
-			public static string OSBinDirectory {
-				get;
-				private set;
-			}
-
 			public static string TestDirectoryRoot {
 				get;
 				private set;
-			}
-
-			static SetUp ()
-			{
-				using (var builder = new Builder ()) {
-					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
-					AndroidMSBuildDirectory = builder.AndroidMSBuildDirectory;
-				}
-
-				string osSubdirName;
-				if (TestEnvironment.IsLinux) {
-					osSubdirName = "Linux";
-				} else if (TestEnvironment.IsMacOS) {
-					osSubdirName = "Darwin";
-				} else {
-					osSubdirName = String.Empty;
-				}
-				OSBinDirectory = Path.Combine (AndroidMSBuildDirectory, osSubdirName);
 			}
 
 			[OneTimeSetUp]
@@ -133,6 +101,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 		}
+
 		protected bool IsWindows => TestEnvironment.IsWindows;
 
 		protected bool IsMacOS => TestEnvironment.IsMacOS;
@@ -149,7 +118,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		public static bool CommercialBuildAvailable => SetUp.CommercialBuildAvailable;
+		public static bool CommercialBuildAvailable => TestEnvironment.CommercialBuildAvailable;
 
 		/// <summary>
 		/// Checks if a commercial Xamarin.Android is available
@@ -166,8 +135,6 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 		}
-
-		public static string AndroidMSBuildDirectory => SetUp.AndroidMSBuildDirectory;
 
 		char [] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=' };
 
@@ -219,16 +186,6 @@ namespace Xamarin.Android.Build.Tests
 					!string.Equals (aotMode, "Normal", StringComparison.OrdinalIgnoreCase)) {
 				Assert.Ignore ($"AotMode={aotMode} is not yet supported in .NET 6+");
 			}
-		}
-
-		protected static void AssertTargetFrameworkVersionSupported (string targetFrameworkVersion)
-		{
-			if (Builder.UseDotNet)
-				return; // N/A in .NET 6
-			if (!Version.TryParse (targetFrameworkVersion.TrimStart ('v'), out var version) || version <= new Version (11, 0))
-				return; // TFV is 11.0 or less
-			if (!TestEnvironment.IsUsingJdk11)
-				Assert.Ignore ("Test is only supported when using JDK 11.");
 		}
 
 		protected static void WaitFor(int milliseconds)
@@ -590,9 +547,8 @@ namespace Xamarin.Android.Build.Tests
 		protected string GetPathToAapt2 ()
 		{
 			var exe = IsWindows ? "aapt2.exe" : "aapt2";
-			var path = Path.Combine (AndroidMSBuildDirectory, IsWindows ? "" : (IsMacOS ? "Darwin" : "Linux"));
-			if (File.Exists (Path.Combine (path, exe)))
-				return path;
+			if (File.Exists (Path.Combine (TestEnvironment.OSBinDirectory, exe)))
+				return TestEnvironment.OSBinDirectory;
 			return GetPathToLatestBuildTools (exe);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Android.Build.Tests
 				"--filetype=asm " +
 				"--relocation-model=pic";
 
-			string llc = Path.Combine (BaseTest.SetUp.OSBinDirectory, "binutils", "bin", $"llc{executableExtension}");
+			string llc = Path.Combine (TestEnvironment.OSBinDirectory, "binutils", "bin", $"llc{executableExtension}");
 			string outputFilePath = Path.ChangeExtension (llvmIrFilePath, ".s");
 			RunCommand (llc, $"{assemblerOptions} -o \"{outputFilePath}\" \"{llvmIrFilePath}\"");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -840,12 +840,12 @@ public class JavaSourceTest {
 			}
 
 			if (dotnetVersion != "net6.0") {
-				var refDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Ref.{apiLevel}")).LastOrDefault ();
+				var refDirectory = Directory.GetDirectories (Path.Combine (TestEnvironment.DotNetPreviewPacksDirectory, $"Microsoft.Android.Ref.{apiLevel}")).LastOrDefault ();
 				var expectedMonoAndroidRefPath = Path.Combine (refDirectory, "ref", dotnetVersion, "Mono.Android.dll");
 				Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRefPath), $"Build should be using {expectedMonoAndroidRefPath}");
 
 				var runtimeApiLevel = (apiLevel == XABuildConfig.AndroidDefaultTargetDotnetApiLevel && apiLevel < XABuildConfig.AndroidLatestStableApiLevel) ? XABuildConfig.AndroidLatestStableApiLevel : apiLevel;
-				var runtimeDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Runtime.{runtimeApiLevel}.{runtimeIdentifier}")).LastOrDefault ();
+				var runtimeDirectory = Directory.GetDirectories (Path.Combine (TestEnvironment.DotNetPreviewPacksDirectory, $"Microsoft.Android.Runtime.{runtimeApiLevel}.{runtimeIdentifier}")).LastOrDefault ();
 				var expectedMonoAndroidRuntimePath = Path.Combine (runtimeDirectory, "runtimes", runtimeIdentifier, "lib", dotnetVersion, "Mono.Android.dll");
 				Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRuntimePath), $"Build should be using {expectedMonoAndroidRuntimePath}");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -84,11 +84,6 @@ namespace Xamarin.ProjectTools
 			return JavaSdkVersionString;
 		}
 
-		public static string GetDotNetPreviewPath ()
-		{
-			return Path.Combine (XABuildPaths.PrefixDirectory, "dotnet");
-		}
-
 		static string RunPathsTargets (string target)
 		{
 			var targets = Path.Combine (XABuildPaths.TopDirectory, "build-tools", "scripts", "Paths.targets");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -46,13 +46,18 @@ namespace Xamarin.ProjectTools
 			bool succeeded;
 
 			using (var p = new Process ()) {
-				p.StartInfo.FileName = Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "dotnet");
+				p.StartInfo.FileName = Path.Combine (TestEnvironment.DotNetPreviewDirectory, "dotnet");
 				p.StartInfo.Arguments = string.Join (" ", args);
 				p.StartInfo.CreateNoWindow = true;
 				p.StartInfo.UseShellExecute = false;
 				p.StartInfo.RedirectStandardOutput = true;
 				p.StartInfo.RedirectStandardError = true;
 				p.StartInfo.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
+				if (TestEnvironment.UseLocalBuildOutput) {
+					p.StartInfo.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", TestEnvironment.WorkloadManifestOverridePath);
+					p.StartInfo.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
+				}
+
 				// Ensure any variable alteration from DotNetXamarinProject.Construct is cleared.
 				if (!Builder.UseDotNet && !TestEnvironment.IsWindows) {
 					p.StartInfo.SetEnvironmentVariable ("MSBUILD_EXE_PATH", null);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -154,7 +154,7 @@ namespace Xamarin.ProjectTools
 		public RuntimeInfo [] GetSupportedRuntimes ()
 		{
 			var runtimeInfo = new List<RuntimeInfo> ();
-			foreach (var file in Directory.EnumerateFiles (Path.Combine (AndroidMSBuildDirectory, "lib"), "libmono-android.*.so", SearchOption.AllDirectories)) {
+			foreach (var file in Directory.EnumerateFiles (Path.Combine (TestEnvironment.AndroidMSBuildDirectory, "lib"), "libmono-android.*.so", SearchOption.AllDirectories)) {
 				string fullFilePath = Path.GetFullPath (file);
 				DirectoryInfo parentDir = Directory.GetParent (fullFilePath);
 				if (parentDir == null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -46,23 +47,7 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public static bool IsRunningOnCI {
-			get {
-				string runningOnCiValue = Environment.GetEnvironmentVariable ("RUNNINGONCI");
-				bool.TryParse (runningOnCiValue, out bool isRunningOnCi);
-				return isRunningOnCi;
-			}
-		}
-
-		public static bool IsRunningOnHostedAzureAgent {
-			get {
-				string agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
-				bool hasHostedAgentName = !string.IsNullOrEmpty (agentNameValue) && agentNameValue.ToUpperInvariant ().Contains ("AZURE PIPELINES");
-				string serverTypeValue = Environment.GetEnvironmentVariable ("SYSTEM_SERVERTYPE");
-				bool isHostedServerType = !string.IsNullOrEmpty (serverTypeValue) && serverTypeValue.ToUpperInvariant ().Contains ("HOSTED");
-				return hasHostedAgentName || isHostedServerType;
-			}
-		}
+		static readonly string LocalMonoAndroidToolsDirectory = Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
 
 		public static readonly string MacOSInstallationRoot = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
 
@@ -76,8 +61,19 @@ namespace Xamarin.ProjectTools
 			return visualStudioInstance = MSBuildLocator.QueryLatest ();
 		}
 
+		/// <summary>
+		/// The MonoAndroid framework (and other reference assemblies) directory within a local build tree. Contains v1.0, v9.0, etc,
+		/// e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid.<br/>
+		/// If a local build tree can not be found, or if it is empty, this will return the system installation location instead:<br/>
+		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid <br/>
+		///	macOS:    Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild-frameworks/MonoAndroid
+		/// </summary>
 		public static string MonoAndroidFrameworkDirectory {
 			get {
+				var frameworkLibDir = Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");
+				if (Directory.Exists (frameworkLibDir) && Directory.EnumerateDirectories (frameworkLibDir, "v*", SearchOption.TopDirectoryOnly).Any ())
+					return frameworkLibDir;
+
 				if (IsWindows) {
 					VisualStudioInstance vs = GetVisualStudioInstance ();
 					return Path.Combine (vs.VisualStudioRootPath, "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework", "MonoAndroid");
@@ -87,32 +83,103 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public static string MonoAndroidToolsDirectory {
+		/// <summary>
+		/// The MonoAndroidTools directory within a local build tree, e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android.<br/>
+		/// If a local build tree can not be found, or if it is empty, this will return the system installation or .NET sandbox location instead:<br/>
+		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android <br/>
+		///	macOS:    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android<br/>
+		///	Windows (dotnet):  bin\Debug\dotnet\packs\Microsoft.Android.Sdk.Windows\$(Latest)\tools<br/>
+		///	macOS (dotnet):    bin/Debug/dotnet/packs/Microsoft.Android.Sdk.Darwin/$(Latest)/tools
+		/// </summary>
+		public static string AndroidMSBuildDirectory {
 			get {
-				if (IsWindows) {
-					VisualStudioInstance vs = GetVisualStudioInstance ();
-					return Path.Combine (vs.VisualStudioRootPath, "MSBuild", "Xamarin", "Android");
+				if (Builder.UseDotNet) {
+					if (!Directory.Exists (DotNetPreviewAndroidSdkDirectory)) {
+						throw new DirectoryNotFoundException ($"Unable to locate a Microsoft.Android.Sdk in either '{DefaultPacksDir}' or '{LocalPacksDir}'.");
+					}
+					return Path.Combine (DotNetPreviewAndroidSdkDirectory, "tools");
+				}
+
+				if (UseLocalBuildOutput) {
+					return LocalMonoAndroidToolsDirectory;
 				} else {
-					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
+					if (IsWindows) {
+						VisualStudioInstance vs = GetVisualStudioInstance ();
+						return Path.Combine (vs.VisualStudioRootPath, "MSBuild", "Xamarin", "Android");
+					} else {
+						return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
+					}
 				}
 			}
 		}
 
-		static string _dotNetAndroidSdkDirectory;
-		public static string DotNetAndroidSdkDirectory {
-			get {
-				if (!string.IsNullOrEmpty (_dotNetAndroidSdkDirectory)) {
-					return _dotNetAndroidSdkDirectory;
-				}
-				var sdkName = IsMacOS ? "Microsoft.Android.Sdk.Darwin" :
-					IsWindows ? "Microsoft.Android.Sdk.Windows" :
-					"Microsoft.Android.Sdk.Linux";
+		public static string DotNetPreviewDirectory => Path.Combine (XABuildPaths.PrefixDirectory, "dotnet");
 
-				var directories = from d in Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", sdkName))
-								  let version = ParseVersion (d)
-								  orderby version descending
-								  select d;
-				return _dotNetAndroidSdkDirectory = directories.FirstOrDefault ();
+		public static string DotNetPreviewPacksDirectory => UseLocalBuildOutput ? LocalPacksDir : DefaultPacksDir;
+
+		public static string DotNetPreviewAndroidSdkDirectory => UseLocalBuildOutput ? LocalDotNetAndroidSdkDirectory : DefaultDotNetAndroidSdkDirectory;
+
+		public static string WorkloadPackOverridePath => Path.Combine (XABuildPaths.PrefixDirectory, "lib");
+
+		public static string WorkloadManifestOverridePath => Path.Combine (WorkloadPackOverridePath, "sdk-manifests");
+
+		static string DefaultPacksDir => Path.Combine (DotNetPreviewDirectory, "packs");
+
+		static string LocalPacksDir => Path.Combine (WorkloadPackOverridePath, "packs");
+
+		static string _defaultDotNetAndroidSdkDirectory;
+		static string DefaultDotNetAndroidSdkDirectory {
+			get {
+				if (!string.IsNullOrEmpty (_defaultDotNetAndroidSdkDirectory)) {
+					return _defaultDotNetAndroidSdkDirectory;
+				}
+				return _defaultDotNetAndroidSdkDirectory = GetDotNetAndroidSdkDir (DefaultPacksDir);
+			}
+		}
+
+		static string _localDotNetAndroidSdkDirectory;
+		static string LocalDotNetAndroidSdkDirectory {
+			get {
+				if (!string.IsNullOrEmpty (_localDotNetAndroidSdkDirectory)) {
+					return _localDotNetAndroidSdkDirectory;
+				}
+				return _localDotNetAndroidSdkDirectory = GetDotNetAndroidSdkDir (LocalPacksDir);
+			}
+		}
+
+		static string GetDotNetAndroidSdkDir (string packsDirectory)
+		{
+			var sdkName = IsMacOS ? "Microsoft.Android.Sdk.Darwin" :
+				IsWindows ? "Microsoft.Android.Sdk.Windows" :
+				"Microsoft.Android.Sdk.Linux";
+
+			var sdkDir = Path.Combine (packsDirectory, sdkName);
+			if (!Directory.Exists (sdkDir))
+				return string.Empty;
+
+			var dirs = from d in Directory.GetDirectories (sdkDir)
+				   let version = ParseVersion (d)
+				   orderby version descending
+				   select d;
+
+			return dirs.FirstOrDefault ();
+		}
+
+		public static bool UseLocalBuildOutput {
+			get {
+				var msbuildDir = Builder.UseDotNet ? Path.Combine (LocalDotNetAndroidSdkDirectory, "tools") : LocalMonoAndroidToolsDirectory;
+				return Directory.Exists (msbuildDir) && File.Exists (Path.Combine (msbuildDir, "Xamarin.Android.Build.Tasks.dll"));
+			}
+		}
+
+		public static bool CommercialBuildAvailable => File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+
+		public static string OSBinDirectory {
+			get {
+				var osSubdirName = IsMacOS ? "Darwin" :
+					IsLinux ? "Linux" :
+					string.Empty;
+				return Path.Combine (AndroidMSBuildDirectory, osSubdirName);
 			}
 		}
 
@@ -126,12 +193,6 @@ namespace Xamarin.ProjectTools
 			if (Version.TryParse (folderName, out var v))
 				return v;
 			return new Version (0, 0);
-		}
-
-		public static string DotNetAndroidSdkToolsDirectory {
-			get {
-				return Path.Combine (DotNetAndroidSdkDirectory, "tools");
-			}
 		}
 
 		public static bool IsUsingJdk8 => AndroidSdkResolver.GetJavaSdkVersionString ().Contains ("1.8.0");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -165,6 +165,11 @@ namespace Xamarin.ProjectTools
 			return dirs.FirstOrDefault ();
 		}
 
+		/// <summary>
+		/// Tests will attempt to run against local build output directories by default,
+		///  and fall back to `dotnet/packs` or a legacy system install location if a local build does not exist.
+		/// This will always return false for our tests running in CI.
+		/// </summary>
 		public static bool UseLocalBuildOutput {
 			get {
 				var msbuildDir = Builder.UseDotNet ? Path.Combine (LocalDotNetAndroidSdkDirectory, "tools") : LocalMonoAndroidToolsDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/FileSystemUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/FileSystemUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -47,7 +47,7 @@ namespace Xamarin.ProjectTools
 
 			bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
-			string dotnet = Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), isWindows ? "dotnet.exe" : "dotnet");
+			string dotnet = Path.Combine (TestEnvironment.DotNetPreviewDirectory, isWindows ? "dotnet.exe" : "dotnet");
 
 			if (File.Exists (dotnet)) {
 				var psi = new ProcessStartInfo (dotnet) {

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -23,17 +23,7 @@ namespace Xamarin.Android.Build.Tests
 
 		void SetTargetFrameworkAndManifest(XamarinAndroidApplicationProject proj, Builder builder)
 		{
-			string apiLevel;
-			proj.TargetFrameworkVersion = builder.LatestTargetFrameworkVersion (out apiLevel);
-
-			// TODO: We aren't sure how to support preview bindings in .NET6 yet.
-			if (Builder.UseDotNet && apiLevel == "31") {
-				apiLevel = "30";
-				proj.TargetFrameworkVersion = "v11.0";
-			}
-
-			AssertTargetFrameworkVersionSupported (proj.TargetFrameworkVersion);
-
+			builder.LatestTargetFrameworkVersion (out string apiLevel);
 			proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{proj.PackageName}"">
 	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -130,7 +130,7 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 		{
 			// 09-22 14:21:07.064 12786 12786 I MonoDroid:   at UnnamedProject.MainActivity.OnCreate (Android.OS.Bundle bundle) [0x00051] in <b3164619c4824e379aecfb7335bd4cce>:0
 			Assert.IsTrue (ObfuscatedStackRegex.IsMatch (File.ReadAllText (logcatFilePath)), "Original logcat output did not contain obfuscated crash info.");
-			var monoSymbolicate = IsWindows ? Path.Combine (TestEnvironment.MonoAndroidToolsDirectory, "mono-symbolicate.exe") : "mono-symbolicate";
+			var monoSymbolicate = IsWindows ? Path.Combine (TestEnvironment.AndroidMSBuildDirectory, "mono-symbolicate.exe") : "mono-symbolicate";
 			var symbolicatedOutput = RunProcess (monoSymbolicate, $"\"{symbolArchivePath}\" \"{logcatFilePath}\"");
 			File.WriteAllText (Path.Combine (Path.GetDirectoryName (logcatFilePath), "mono-symbol.log"), symbolicatedOutput);
 			Assert.IsFalse (ObfuscatedStackRegex.IsMatch (symbolicatedOutput), "Symbolicated logcat output did contain obfuscated crash info.");
@@ -172,7 +172,7 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			Assert.IsTrue (didParse, $"Unable to parse {proj.TargetSdkVersion} as an int.");
 			SymbolicateAndAssert (archivePath, logcatPath, new string [] {
 				Path.Combine (Root, builder.ProjectDirectory, "MainActivity.cs:32"),
-				Directory.Exists (builder.BuildOutputDirectory)
+				TestEnvironment.UseLocalBuildOutput
 					? Path.Combine ("src", "Mono.Android", "obj", XABuildPaths.Configuration, "monoandroid10", $"android-{apiLevel}", "mcw", "Android.App.Activity.cs:")
 					: $"src/Mono.Android/obj/Release/monoandroid10/android-{apiLevel}/mcw/Android.App.Activity.cs:",
 			}) ;
@@ -269,7 +269,7 @@ namespace Library1 {
 				SymbolicateAndAssert (archivePath, logcatPath, new string [] {
 					Path.Combine (Root, lb.ProjectDirectory, "Class1.cs:12"),
 					Path.Combine (Root, builder.ProjectDirectory, "MainActivity.cs:23"),
-					Directory.Exists (builder.BuildOutputDirectory)
+					TestEnvironment.UseLocalBuildOutput
 						? Path.Combine ("src", "Mono.Android", "obj", XABuildPaths.Configuration, "monoandroid10", $"android-{apiLevel}", "mcw", "Android.App.Activity.cs:")
 						: $"src/Mono.Android/obj/Release/monoandroid10/android-{apiLevel}/mcw/Android.App.Activity.cs:",
 				});


### PR DESCRIPTION
Adds support to the desktop MSBuild tests to find and use build output
in the `bin/$(Configuration)/lib/packs` folder.  This is an extension
of the changes in commits b1232a2b and c21e78ca which allowed local
builds to skip .nupkg packing and installing.

The `Xamarin.Android.Build.Tests` and `MSBuildDeviceIntegration` test
suites will now attempt to run against local build outputs by default,
and fall back to `dotnet/packs` or a legacy system install location if
a local build does not exist.