### PR TITLE
Bump to xamarin/android-api-docs@5c4bf28f

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/android-api-docs"]
     path = external/android-api-docs
     url = https://github.com/xamarin/android-api-docs
-    branch = master
+    branch = main
 [submodule "external/apksig"]
     path = external/apksig
     url = https://android.googlesource.com/platform/tools/apksig


### PR DESCRIPTION
Changes: https://github.com/xamarin/android-api-docs/compare/a7e914965a0e80c9454149399551d87a18997b2e...5c4bf28f9fa75e9bf96a6f80f879e22f906aaf06

  * xamarin/android-api-docs@5c4bf28f: Merge pull request 32 from xamarin/dabritch-config
  * xamarin/android-api-docs@4e096ef2: Master becomes main.
  * xamarin/android-api-docs@b1743ec3: Update docs using xamarin/java.interop@d3f0c5c