### PR TITLE
[One .NET] update the .NET 6 packs used in .NET 7

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.301</AndroidNet6Version>
+    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.415</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,17 +16,13 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
-  <PropertyGroup>
-    <_DefaultJavaSourceJarPattern>**\*-source.jar;**\*-sources.jar;**\*-src.jar</_DefaultJavaSourceJarPattern>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Include="Android.App" Platform="Android" />
     <Using Include="Android.Widget" Platform="Android" />
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) ">
     <!-- Default Resource file inclusion -->
     <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
@@ -44,10 +40,10 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />
     <!-- Default Java or native libraries -->
-    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(_DefaultJavaSourceJarPattern)" />
+    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*-source.jar;**\*-sources.jar;**\*-src.jar" />
     <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-    <JavaSourceJar        Include="$(_DefaultJavaSourceJarPattern)"   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <JavaSourceJar        Include="**\*-source.jar;**\*-sources.jar;**\*-src.jar"   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <AndroidJavaSource    Include="**\*.java" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -43,7 +43,7 @@
       }
     },
     "Microsoft.Android.Sdk.NET6": {
-      "kind": "framework",
+      "kind": "sdk",
       "version": "@NET6_VERSION@",
       "alias-to": {
         "osx-x64": "Microsoft.Android.Sdk.Darwin",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -908,7 +908,7 @@ public class JavaSourceTest {
 		public void XamarinLegacySdk ([Values ("net6.0", "net7.0")] string dotnetVersion)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.1.0-alpha4",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha1",
 				Sources = {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/releases/tag/6.0.400
Context: https://github.com/xamarin/xamarin-android/pull/7023

MAUI SR 1 shipped along with a new .NET 6 Android workload. We should
be able to use these packs in .NET 7. This would occur when building
`net6.0-android` apps with a .NET 7 SDK.

Since #7023 is in that release, we can:

* Specify the .NET 6 packs as `sdk` where appropriate.
* Condition `AutoImport.props` to apply for .NET 7-only.
* We also need to remove `$(_DefaultJavaSourceJarPattern)` like we did
  in .NET 6.