### PR TITLE
[XABT] Port class-parse/generator response file space fix from 67ce902c.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tasks
 					WriteLine (sw, $"\"{doc}\"");
 			}
 
-			cmd.AppendSwitch ($"@{responseFile}");
+			cmd.AppendSwitch ($"\"@{responseFile}\"");
 
 			return cmd.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -236,8 +236,8 @@ namespace Xamarin.Android.Tasks
 					WriteLine (sw, "--use-legacy-java-resolver=true");
 			}
 
-			cmd.AppendSwitch (ApiXmlInput);
-			cmd.AppendSwitch ($"@{responseFile}");
+			cmd.AppendSwitch ($"\"{ApiXmlInput}\"");
+			cmd.AppendSwitch ($"\"@{responseFile}\"");
 			return cmd.ToString ();
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/8049

There was a bug causing response files to not work when trying to bind Java libraries in a path containing a space, since the CLI argument given to `class-parse`/`generator` was not properly quoted.

This has been fixed in PR https://github.com/xamarin/xamarin-android/pull/5926, however this is a .NET 7 only PR.

Pull the fix out of that PR and port it to the `6.0.4xx` branch so it will go into a .NET 6 servicing release.