### PR TITLE
[One .NET] fix missing libaot-* files when building in IDEs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -40,7 +40,20 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
 
   <Target Name="_AndroidAot"
       Condition=" '$(AotAssemblies)' == 'true' and '$(RuntimeIdentifier)' != '' "
-      DependsOnTargets="_CreatePropertiesCache;_AndroidAotInputs"
+      DependsOnTargets="_CreatePropertiesCache;_AndroidAotInputs;_AndroidAotCompilation">
+    <ReadLinesFromFile File="$(_AndroidStampDirectory)_AndroidAot.stamp">
+      <Output TaskParameter="Lines" ItemName="_AotCompiledAssemblies" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <FileWrites Include="@(_AotCompiledAssemblies)" />
+      <ResolvedFileToPublish
+          Include="@(_AotCompiledAssemblies)"
+          ArchiveFileName="libaot-$([System.IO.Path]::GetFileNameWithoutExtension('%(_AotCompiledAssemblies.Identity)')).so"
+      />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AndroidAotCompilation"
       Inputs="@(_AndroidAotInputs)"
       Outputs="$(_AndroidStampDirectory)_AndroidAot.stamp">
     <ItemGroup>
@@ -94,15 +107,13 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
         LdFlags="$(_LdFlags)"
         WorkingDirectory="$(MSBuildProjectDirectory)"
         AotArguments="$(AndroidAotAdditionalArguments)">
-      <Output TaskParameter="CompiledAssemblies" ItemName="_AotCompiledAssemblies" />
+      <Output TaskParameter="CompiledAssemblies" ItemName="_MonoAOTCompiledAssemblies" />
       <Output TaskParameter="FileWrites"         ItemName="FileWrites" />
     </MonoAOTCompiler>
-    <Touch Files="$(_AndroidStampDirectory)_AndroidAot.stamp" AlwaysCreate="true" />
-    <ItemGroup>
-      <ResolvedFileToPublish
-          Include="@(_AotCompiledAssemblies->'%(LibraryFile)')"
-          ArchiveFileName="libaot-$([System.IO.Path]::GetFileNameWithoutExtension('%(_AotCompiledAssemblies.LibraryFile)')).so"
-      />
-    </ItemGroup>
+    <WriteLinesToFile
+        File="$(_AndroidStampDirectory)_AndroidAot.stamp"
+        Lines="@(_MonoAOTCompiledAssemblies->'%(LibraryFile)')"
+        Overwrite="true"
+    />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -484,5 +484,32 @@ namespace "+ libName + @" {
 			}
 		}
 
+		[Test]
+		[Category ("AOT")]
+		public void AotAssembliesInIDE ()
+		{
+			string supportedAbis = "arm64-v8a";
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				AotAssemblies = true,
+			};
+			proj.SetAndroidSupportedAbis (supportedAbis);
+			using var b = CreateApkBuilder ();
+			Assert.IsTrue (b.RunTarget (proj, target: "Build"));
+
+			// .apk won't exist yet
+			var apk = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+			FileAssert.DoesNotExist (apk);
+
+			Assert.IsTrue (b.RunTarget (proj, target: "SignAndroidPackage"));
+			FileAssert.Exists (apk);
+
+			using var zipFile = ZipHelper.OpenZip (apk);
+			foreach (var abi in supportedAbis.Split (';')) {
+				var path = $"lib/{abi}/libaot-Mono.Android.dll.so";
+				var entry = ZipHelper.ReadFileFromZip (zipFile, path);
+				Assert.IsNotNull (entry, $"{path} should be in {apk}", abi);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -1024,7 +1024,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			appBuilder.AssertTargetIsSkipped ("CoreCompile");
 			if (isRelease) {
 				appBuilder.AssertTargetIsSkipped ("_RemoveRegisterAttribute");
-				appBuilder.AssertTargetIsSkipped ("_AndroidAot");
+				appBuilder.AssertTargetIsSkipped ("_AndroidAotCompilation");
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/maui-profiling/issues/16#issuecomment-1158183178

Building a .NET 6 Android application in `Release` mode inside Visual
Studio results in `libaot-*.so` files missing from the `.apk`.
However, it works fine at the command-line! This also appears to not
be an issue in Xamarin.Android. I could reproduce this issue in a test.

Reviewing our MSBuild targets, this happens because the list of files
are returned by the `<MonoAOTCompiler/>` task:

    <MonoAOTCompiler ...>
      <Output TaskParameter="CompiledAssemblies" ItemName="_AotCompiledAssemblies" />
      <Output TaskParameter="FileWrites"         ItemName="FileWrites" />
    </MonoAOTCompiler>

The IDE does a `Build`, then `Install` in two steps. `Build` runs the
AOT compiler, but `Install` (runs `SignAndroidPackage`) signs and
creates an `.apk` file.

What's happening is:

* `Build` produces `libaot-*.so` files
* The `_AndroidAot` target is *skipped* during `Install`, and no files
  make it to the `.apk`!

When an MSBuild target is skipped all tasks are skipped, and only
`<ItemGroup>` or `<PropertyGroup>` elements are actually evaluated.

To solve this problem, let's save the output of the
`<MonoAOTCompiler/>` MSBuild task to file. We use the file contents as
the list of files, so it does not matter if MSBuild targets are
skipped or not. We also should use this list of files in `FileWrites`.