### PR TITLE
[tests] fix missing .binlog attachments from CodeBehindTests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -601,7 +601,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 			} catch {
 				CopyLogs (testInfo, false);
-				foreach (var file in Directory.GetFiles (testInfo.OutputDirectory, "*.log", SearchOption.AllDirectories)) {
+				foreach (var file in Directory.GetFiles (testInfo.OutputDirectory, "*.*log", SearchOption.AllDirectories)) {
 					TestContext.AddTestAttachment (file);
 				}
 				throw;


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6296209&view=ms.vss-test-web.build-test-results-tab&runId=44135466&resultId=100131&paneView=attachments

It looks like we only uploaded `*.log` as attachments in this test.

Let's expand to `*.*log` and pickup `.binlog` files as well.