### PR TITLE
[tests] fix SuccessfulAndroidXApp test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -601,7 +601,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 			} catch {
 				CopyLogs (testInfo, false);
-				foreach (var file in Directory.GetFiles (testInfo.OutputDirectory, "*.log", SearchOption.AllDirectories)) {
+				foreach (var file in Directory.GetFiles (testInfo.OutputDirectory, "*.*log", SearchOption.AllDirectories)) {
 					TestContext.AddTestAttachment (file);
 				}
 				throw;
@@ -695,9 +695,7 @@ namespace Xamarin.Android.Build.Tests
 			CopyRecursively (TestProjectRootDirectory, temporaryProjectPath, ignore);
 			CopyRecursively (CommonSampleLibraryRootDirectory, Path.Combine (tempRoot, CommonSampleLibraryName), ignore);
 			CopyFile (Path.Combine (XABuildPaths.TopDirectory, "Directory.Build.props"), Path.Combine (tempRoot, "Directory.Build.props" ));
-			if (Builder.UseDotNet) {
-				XASdkProject.SaveNuGetConfig (tempRoot);
-			}
+			XASdkProject.SaveNuGetConfig (tempRoot);
 			return temporaryProjectPath;
 		}
 


### PR DESCRIPTION
The `SuccessfulAndroidXApp` test fails to restore with:

    (Restore target) ->
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(131,5):
    error : Unable to resolve 'Xamarin.AndroidX.AppCompat (>= 1.4.1.1)' for 'MonoAndroid,Version=v12.0'.

I looked at 1.4.2.1 of the same NuGet, but both versions have
`monoandroid12.0` inside.

I noticed in the `.binlog`:

    NuGet Config files used:
    /Users/runner/.config/NuGet/NuGet.Config

So this test is using the machine-wide `NuGet.config` instead of the
one in the root of the `xamarin-android` repo. I made a change to use
this one, let's see if that solves anything.