### PR TITLE
[debugger] Trying to fix debug 2 assemblies with similar names

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -242,7 +242,7 @@ EmbeddedAssemblies::load_bundled_assembly (
 	if (have_and_want_debug_symbols) {
 		uint32_t base_name_length = assembly.name_length - 3; // we need the trailing dot
 		for (XamarinAndroidBundledAssembly& debug_file : *bundled_debug_data) {
-			if (debug_file.name_length < base_name_length) {
+			if (debug_file.name_length - 3 != base_name_length) {
 				continue;
 			}
 

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -242,7 +242,7 @@ EmbeddedAssemblies::load_bundled_assembly (
 	if (have_and_want_debug_symbols) {
 		uint32_t base_name_length = assembly.name_length - 3; // we need the trailing dot
 		for (XamarinAndroidBundledAssembly& debug_file : *bundled_debug_data) {
-			if (debug_file.name_length - 3 != base_name_length) {
+			if (debug_file.name_length != assembly.name_length) {
 				continue;
 			}
 


### PR DESCRIPTION
First assembly loaded is named: chromebookdebuggerissue.Android.dll
And the second one is name: chromebookdebuggerissue.dll

```
if (strncmp ("chromebookdebuggerissue.Android", "chromebookdebuggerissue", (long unsigned int) 23) != 0)
    printf("skipping\n");
else
    printf("using\n");
```
It does this comparison and then uses the PDB of chromebookdebuggerissue.Android.dll as symbol of chromebookdebuggerissue.dll.

Fixes #7089 

