### PR TITLE
Revert "Workaround FirstChanceExceptionEventArgs being trimmed"

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
+++ b/src/Microsoft.Android.Sdk.ILLink/PreserveLists/System.Private.CoreLib.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<linker>
-	<!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6626, remove once https://github.com/dotnet/runtime/pull/68265 lands -->
-	<assembly fullname="System.Private.CoreLib">
-		<type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs">
-			<method signature="System.Void .ctor(System.Exception)" />
-		</type>
-	</assembly>
-</linker>


### PR DESCRIPTION
Reverts xamarin/xamarin-android#6953

The fix for this issue is backported to dotnet/runtime 6.0 now so we can revert the workaround.