### PR TITLE
Fix Local DotNet builds

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -54,5 +54,11 @@
     <Folder Include="Java.Interop\" />
     <Folder Include="Utilities\" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)PreserveLists\*.xml">
+      <Link>..\PreserveLists\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="..\tools\GenerateResxSource.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>


### PR DESCRIPTION
Commit c21e78ca allowed us to use `dotnet` workloads without having
to call `make pack-dotnet`. We overlooked the copying of the ILLink
PreserveLists xml files into the pack build locations though. As a
result when building an app locally we see the following error

```
error XAGPM7009: System.InvalidOperationException: Unable to find the required Android.Runtime.JNIEnv method tokens
```

This is because the required methods are being linked out by the ILLink
process. This commit makes sure we copy over the PreserveLists xml files
into the packs locations.

This was fine on CI because we always call `make pack-dotnet` as part
of the build process.