### PR TITLE
[jit-times] add method name sorting, more switches

### DIFF
--- a/tools/jit-times/Program.cs
+++ b/tools/jit-times/Program.cs
@@ -17,6 +17,7 @@ namespace jittimes {
 			Unsorted,
 			Self,
 			Total,
+			Method,
 		};
 
 		static SortKind sortKind = SortKind.Self;
@@ -38,13 +39,16 @@ namespace jittimes {
 				{ "m|method=",
 					"Process only methods whose names match {TYPE-REGEX}.",
 				  v => methodNameRegexes.Add (new Regex (v)) },
-				{ "s",
+				{ "s|sort-self-times",
 					"Sort by self times. (this is default ordering)",
 				  v => sortKind = SortKind.Self },
-				{ "t",
+				{ "t|sort-total-times",
 					"Sort by total times.",
 				  v => sortKind = SortKind.Total },
-				{ "u",
+				{ "n|sort-methods",
+					"Sort by method names.",
+				  v => sortKind = SortKind.Method },
+				{ "u|unsorted",
 					"Show unsorted results.",
 				  v => sortKind = SortKind.Unsorted },
 				{ "v|verbose",
@@ -210,6 +214,9 @@ namespace jittimes {
 				break;
 			case SortKind.Total:
 				enumerable = methods.OrderByDescending (p => p.Value.total);
+				break;
+			case SortKind.Method:
+				enumerable = methods.OrderByDescending (p => p.Value.method);
 				break;
 			default:
 				throw new InvalidOperationException ("unknown sort order");


### PR DESCRIPTION
We needed to sort methods by name to compare JIT times for .NET 6 vs .NET 7.

I added a feature for this and the long-form of switches.

Help output is now:

    > jit-times --help
    Usage: jit-times.exe OPTIONS* <methods-file>

    Processes JIT methods file from XA app with debug.mono.log=timing enabled

    Copyright 2019 Microsoft Corporation

    Options:
    -h, --help, -?             Show this message and exit
    -m, --method=TYPE-REGEX    Process only methods whose names match TYPE-REGEX.
    -s, --sort-self-times      Sort by self times. (this is default ordering)
    -t, --sort-total-times     Sort by total times.
    -n, --sort-methods         Sort by method names.
    -u, --unsorted             Show unsorted results.
    -v, --verbose              Output information about progress during the run
                                of the tool