### PR TITLE
[Xamarin.Android.Build.Tasks] Handle Empty R.txt file.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -433,7 +433,7 @@ int xml myxml 0x7f140000
 			CreateResourceDirectory (path);
 			var task = CreateTask (path);
 			task.RTxtFile = Path.Combine (Root, path, "R.txt");
-			File.WriteAllText (task.RTxtFile, string.Empty);
+			File.WriteAllText (task.RTxtFile, Environment.NewLine);
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -427,6 +427,19 @@ int xml myxml 0x7f140000
 		}
 
 		[Test]
+		public void GenerateDesignerFileFromEmptyRtxt ()
+		{
+			var path = Path.Combine ("temp", TestName + " Some Space");
+			CreateResourceDirectory (path);
+			var task = CreateTask (path);
+			task.RTxtFile = Path.Combine (Root, path, "R.txt");
+			File.WriteAllText (task.RTxtFile, string.Empty);
+			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
+			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
 		public void UpdateLayoutIdIsIncludedInDesigner ([Values(true, false)] bool useRtxt)
 		{
 			var path = Path.Combine ("temp", TestName + " Some Space");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -299,6 +299,10 @@ namespace Xamarin.Android.Tasks
 			var lines = System.IO.File.ReadLines (file);
 			foreach (var line in lines) {
 				var items = line.Split (new char [] { ' ' }, 4);
+				if (items.Length < 4) {
+					Log.LogDebugMessage ($"Ignoring '{line}' from '{file}'. It does not have the correct number of elements.");
+					continue;
+				}
 				int value = items [1] != "styleable" ? Convert.ToInt32 (items [3], 16) : -1;
 				string itemName = items [2];
 				switch (items [1]) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -297,10 +297,12 @@ namespace Xamarin.Android.Tasks
 		void ProcessRtxtFile (string file)
 		{
 			var lines = System.IO.File.ReadLines (file);
+			int lineNumber = 0;
 			foreach (var line in lines) {
+				lineNumber++;
 				var items = line.Split (new char [] { ' ' }, 4);
 				if (items.Length < 4) {
-					Log.LogDebugMessage ($"Ignoring '{line}' from '{file}'. It does not have the correct number of elements.");
+					Log.LogDebugMessage ($"'{file}:{lineNumber}' ignoring contents '{line}', it does not have the correct number of elements.");
 					continue;
 				}
 				int value = items [1] != "styleable" ? Convert.ToInt32 (items [3], 16) : -1;


### PR DESCRIPTION
Fixes https://i.azdo.io/1439405

The ManagedResourceParser was not handling the case where we do not
get four items per line. As a result it would crash with the following
error.

```
System.IndexOutOfRangeException: Index was outside of bounds of the array.
as Xamarin.And.Tasks.ManagedResourceParser.ProcessRtxtFile (System.String file)
```

If we do not get the expected four items from the line in the file we
should ignore that line. A unit test has been added to check that the
task does not fail when this happens.