### PR TITLE
[apksigner] Serialize gradlew: depend on java-source-utils

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -375,7 +375,6 @@
     <ProjectReference Include="..\..\build-tools\create-android-api\create-android-api.csproj" ReferenceOutputAssembly="false" />
     <!-- Explicitly pass the target framework of the project so we don't have conflicts with the multiple targets in this file. -->
     <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472"/>
-    <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=$(DotNetTargetFramework)" />
     <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net472" />
     <ProjectReference Include="..\..\src\java-runtime\java-runtime.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />

--- a/src/apksigner/apksigner.csproj
+++ b/src/apksigner/apksigner.csproj
@@ -16,23 +16,11 @@
     <None Include="build\libs\apksigner.jar" CopyToOutputDirectory="PreserveNewest" Link="apksigner.jar" />
   </ItemGroup>
 
-  <Target Name="_BuildGradle"
-      BeforeTargets="GetCopyToOutputDirectoryItems"
-      Inputs="$(MSBuildThisFile);build.gradle"
-      Outputs="build\libs\apksigner.jar">
-    <Exec
-        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
-        WorkingDirectory="$(MSBuildThisFileDirectory)"
-    />
-    <Touch Files="build\libs\apksigner.jar" />
-  </Target>
+  <ItemGroup>
+    <!-- There isn't an actual dependency here, but we can only build one 'gradlew' project
+         at a time, and adding <ProjectReference> between them ensures they run sequentially. -->
+    <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="False" SkipGetTargetFrameworkProperties="True" AdditionalProperties="TargetFramework=$(DotNetTargetFramework)" />
+  </ItemGroup>
 
-  <Target Name="_CleanGradle" BeforeTargets="Clean">
-    <Exec
-        Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
-        WorkingDirectory="$(MSBuildThisFileDirectory)"
-    />
-  </Target>
+  <Import Project="apksigner.targets" />
 </Project>

--- a/src/apksigner/apksigner.targets
+++ b/src/apksigner/apksigner.targets
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <Target Name="_BuildGradle"
+      BeforeTargets="GetCopyToOutputDirectoryItems"
+      Inputs="$(MSBuildThisFile);build.gradle"
+      Outputs="build\libs\apksigner.jar">
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+    <Touch Files="build\libs\apksigner.jar" />
+  </Target>
+
+  <Target Name="_CleanGradle" BeforeTargets="Clean">
+    <Exec
+        Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Context: 944f88a8b6f1c30eaf43f56cfbebf0f8cd7a547f

Commit 944f88a8 enabled parallel builds by removing `dotnet build -m:1`
usage, which allows for faster incremental builds.

One of the problems encountered was around `gradlew` usage: `gradlew`
doesn't support multiple concurrent executions, and will *block*
waiting for other `gradlew` builds to complete, which can result in
timeouts and failed builds.

Commit 944f88a8 fixed this by "serializing" all projects which
involve `gradlew`:

  * `r8.csproj` is the "entrypoint"
  * `r8.csproj` references `manifestmerger.csproj`
  * `manifestmerger.csproj` references `apksigner.csproj`

This arrangement would cause `dotnet build` to sequentially build
`r8.csproj`, `manifestmerger.csproj`, and `apksigner.csproj`, ensuring
that only one `gradlew` command was run at a time.

Unfortunately, we overlooked
`external/Java.Interop/tools/java-source-utils/java-source-utils.csproj`.
Thus, we occasionally see the Windows build fail:

	Timeout waiting to connect to the Gradle daemon.
	…
	…/java-source-utils.targets(10,5): error MSB3073: The command
	  ""C:\a\_work\1\s\external\Java.Interop\build-tools\gradle\gradlew" …"
	  exited with code 1.

Update `apksigner.csproj` to reference `java-source-utils.csproj`,
extending the "sequential order" of `gradlew`-using projects.
This should make the Windows build more reliable.

Additionally, move the `<Target/>`s out of `apksigner.csproj` and
into `apksigner.targets`.  This is more consistent with other
projects, and reduces the likelihood of VSMac rewriting (and removing
the formatting of) `apksigner.csproj`.