### PR TITLE
$(AndroidPackVersionSuffix)=preview.7; net7 is 33.0.0.preview.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>33.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/7.0.1xx-preview6
Context: https://github.com/xamarin/xamarin-android/pull/7127

We branched for .NET 7 Preview 6, and there is already a Maestro bump for .NET 7 Preview 7.

Let's update xamarin-android/main's version number.