### PR TITLE
[tests] make CheckIncludedAssemblies NonParallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -67,6 +67,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[NonParallelizable] // Commonly fails NuGet restore
 		public void CheckIncludedAssemblies ([Values (false, true)] bool usesAssemblyStores)
 		{
 			var proj = new XamarinAndroidApplicationProject {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7135#issuecomment-1171544462
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6356930&view=ms.vss-test-web.build-test-results-tab&runId=45761434&resultId=100052&paneView=debug

On a PR, I noticed CheckIncludedAssemblies fail three times in a row with:

    (Restore target) ->
    /Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(131,5):
    error : Could not find file '/Users/runner/.nuget/packages/system.runtime.interopservices.windowsruntime/4.0.1/q3bg64o1.8br'.

We've seen this in the past, and adding `[NonParallelizable]` seems to
workaround it.

This is happening on `Legacy` test lanes only, so I think it's fine to
add this for now. It might not be an issue at all in .NET 6+.