### PR TITLE
[Xamarin.Android.Build.Tasks] fix @(LibraryProjectZip) and NuGets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -66,6 +66,9 @@ This item group populates the Build Action drop-down in IDEs.
       <Bind>true</Bind>
       <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
     </AndroidLibrary>
+    <LibraryProjectZip>
+      <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
+    </LibraryProjectZip>
     <AndroidJavaSource>
       <Bind Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Bind>
     </AndroidJavaSource>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -304,6 +304,10 @@ public class JavaSourceTest {
 				MetadataValues = "Link=x86\\libfoo.so",
 				BinaryContent = () => Array.Empty<byte> (),
 			});
+			proj.OtherBuildItems.Add (new AndroidItem.LibraryProjectZip ("..\\baz.aar") {
+				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
+				MetadataValues = "Bind=false",
+			});
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary (default (Func<string>)) {
 				Update = () => "nopack.aar",
 				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
@@ -318,16 +322,17 @@ public class JavaSourceTest {
 			using var nupkg = ZipHelper.OpenZip (nupkgPath);
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/{proj.ProjectName}.dll");
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/{proj.ProjectName}.aar");
+			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/bar.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/bar.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/sub/directory/bar.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/sub/directory/bar.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/nopack.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
 
+			//TODO: this issue is not fixed in net6.0-android MSBuild targets
 			if (dotnetVersion != "net6.0") {
-				//TODO: this issue is not fixed in net6.0-android MSBuild targets
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/bar.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, "content/bar.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, "content/sub/directory/bar.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/sub/directory/bar.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, "content/nopack.aar");
-				nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
+				nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/baz.aar");
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/652

In .NET 6, `@(AndroidLibrary)` defaults to `%(Pack)` being true, while
`@(LibraryProjectZip)` mistakenly does not. This would be an issue if
you migrated a project using `@(LibraryProjectZip)` and were not
relying on the default wildcards that would use:

    <AndroidLibrary Include="**/*.aar" />

Let's set this value by default, to ease migration to .NET 6.

I updated a test for this scenario and fixed some assertions that are
working since 2ca2a103 was merged.