### PR TITLE
[CheckApiCompat] Extract Mono.Android.zip per TF

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
@@ -114,14 +114,15 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (ApiLevel == LastStableApiLevel) {
 
 				// Check xamarin-android-api-compatibility reference directory exists
-				var referenceContractPath = new DirectoryInfo (Path.Combine (ApiCompatibilityPath, "reference"));
-				if (!referenceContractPath.Exists) {
-					Log.LogWarning ($"CheckApiCompatibility Warning: Skipping reference contract check.\n{referenceContractPath.FullName} does not exist.");
+				var referenceContractPath = new DirectoryInfo (Path.Combine (ApiCompatibilityPath, "reference", TargetFramework));
+				if (!referenceContractPath.Parent.Exists) {
+					Log.LogWarning ($"CheckApiCompatibility Warning: Skipping reference contract check.\n{referenceContractPath.Parent.FullName} does not exist.");
 					return !Log.HasLoggedErrors;
 				}
 
 				// Before validate, check that zip files were decompressed.
-				var zipFiles = Directory.GetFiles (referenceContractPath.FullName, "*.zip");
+				referenceContractPath.Create ();
+				var zipFiles = Directory.GetFiles (referenceContractPath.Parent.FullName, "*.zip");
 				foreach (var zipFile in zipFiles) {
 					var zipDateTime = File.GetLastWriteTimeUtc (zipFile);
 					using (var zip = ZipArchive.Open (zipFile, FileMode.Open)) {


### PR DESCRIPTION
We've been seeing file sharing issues occasionally during the build:

        33>_CheckApiCompatibility:
            CheckApiCompatibility for ApiLevel: v13.0
        33>/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): warning : # jonp: TargetFramework=monoandroid10 [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
        33>_CheckApiCompatibility:
            CheckApiCompatibility for ApiLevel: v13.0
        33>/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): warning : # jonp: TargetFramework=net7.0 [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
        33>_CheckApiCompatibility:
            Extracting: /Users/runner/work/1/s/xamarin-android/tests/api-compatibility/reference/Mono.Android.dll
        33>_CheckApiCompatibility:
            Extracting: /Users/runner/work/1/s/xamarin-android/tests/api-compatibility/reference/Mono.Android.dll
        33>/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018: The "CheckApiCompatibility" task failed unexpectedly. [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018: System.IO.IOException: The process cannot access the file '/Users/runner/work/1/s/xamarin-android/tests/api-compatibility/reference/Mono.Android.dll' because it is being used by another process. [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Init(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Int64& fileLength, UnixFileMode& filePermissions) [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Func`4 createOpenException) [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at System.IO.File.Create(String path) [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at Xamarin.Android.Tools.BootstrapTasks.CheckApiCompatibility.Execute() in /Users/runner/work/1/s/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs:line 132 [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
    /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.targets(270,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj]
        33>Done Building Project "/Users/runner/work/1/s/xamarin-android/src/Mono.Android/Mono.Android.csproj" (Build target(s)) -- FAILED.

During the parallel `monoandroid10` and `net7.0` builds of Mono.Android,
the content of `tests/api-compatibility/reference/Mono.Android.zip` is
extracted into the same destination ~simultaneously.

Fix this by extracting `Mono.Android.zip` into `$(TargetFramework)`
specific directories such as:

    tests/api-compatibility/reference/monoandroid10/Mono.Android.dll
    tests/api-compatibility/reference/net7.0/Mono.Android.dll