### PR TITLE
[Mono.Android] Copy Pdb and Xml files to the Packs directory

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -400,6 +400,7 @@
   <Target Name="_CopyToPackDirs" >
     <ItemGroup>
       <_RefExtras Include="$(OutputPath)*.*" Exclude="$(OutputPath)*.dll" />
+      <_SourceFiles Include="$(OutputPath)Mono.Android.*;$(OutputPath)Java.Interop.*" />
     </ItemGroup>
     <Copy
         SourceFiles="@(_RefExtras)"
@@ -412,22 +413,22 @@
         SkipUnchangedFiles="true"
     />
     <Copy
-        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        SourceFiles="@(_SourceFiles)"
         DestinationFolder="$(MicrosoftAndroidArmPackDir)lib\$(DotNetTargetFramework)"
         SkipUnchangedFiles="true"
     />
     <Copy
-        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        SourceFiles="@(_SourceFiles)"
         DestinationFolder="$(MicrosoftAndroidArm64PackDir)lib\$(DotNetTargetFramework)"
         SkipUnchangedFiles="true"
     />
     <Copy
-        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        SourceFiles="@(_SourceFiles)"
         DestinationFolder="$(MicrosoftAndroidx86PackDir)lib\$(DotNetTargetFramework)"
         SkipUnchangedFiles="true"
     />
     <Copy
-        SourceFiles="$(OutputPath)Mono.Android.dll;$(OutputPath)Java.Interop.dll"
+        SourceFiles="@(_SourceFiles)"
         DestinationFolder="$(MicrosoftAndroidx64PackDir)lib\$(DotNetTargetFramework)"
         SkipUnchangedFiles="true"
     />


### PR DESCRIPTION
Commit c21e78ca added support for running the unit tests without
the need to run `make pack-dotnet` first. This greatly reduces the
time it takes to test changes locally.

However we are missing some of the `.pdb` files for assemblies like
`Mono.Android` and `Java.Interop`. This causes some test
failures locally because these tests specifically check that these
files are fast deployed during the debug process.

So lets update the relevant code to copy over all the files for
`Mono.Android` and `Java.Interop` rather than just the assemblies.