### PR TITLE
[MSBuildDeviceIntegration] Make Debugging Test work under .NET 6+.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -54,7 +54,7 @@ variables:
 - name: RunAllTests
   value: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
 - name: DotNetNUnitCategories
-  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != Debugger & TestCategory != SystemApplication'
+  value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != SystemApplication'
 - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -32,7 +32,8 @@ namespace Xamarin.Android.Build.Tests
 </manifest>";
 		}
 
-		int FindTextInFile (string file, string text) {
+		int FindTextInFile (string file, string text)
+		{
 			int lineNumber = 1;
 			foreach (var line in File.ReadAllLines (file)) {
 				if (line.Contains (text)) {


### PR DESCRIPTION
When running the `ApplicationRunsWithDebuggerAndBreaks` unit test under
.NEt 6 we see the following test failure.

```
Error Message:
     Should have hit 2 breakpoints. Only hit 1
  Expected: 2
  But was:  1
```

This is because we are using code like this

```
session.Breakpoints = new BreakpointStore {
   { Path.Combine (Root, appBuilder.ProjectDirectory, "MainActivity.cs"),  19 },
}
```

The line number is hard coded. Now under .NET 6 we seem to be getting a
slightly different file compared to running under Legacy. The usings are
missing. As a result the line numbers have changed. It turns out that
line 19 in this `MainActivity.cs` file is a blank line. Not the
`base.OnCreate (bundle);` which we are expecting. So the breakpoint never
hits.

So lets update these tests to `lookup` the line we want to break on, rather
than hardcoding it. This way if the file does change slightly , as long
as the expected bit of code is present we can find the line number we
want to break on.