### PR TITLE
[Mono.Android] add RequireViewById<T>() for better NRT support

### DIFF
--- a/src/Mono.Android/Android.App/Activity.cs
+++ b/src/Mono.Android/Android.App/Activity.cs
@@ -12,6 +12,18 @@ namespace Android.App {
 			return this.FindViewById (id)!.JavaCast<T> ();
 		}
 
+		// See: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=25322
+		public T RequireViewById<T> (int id)
+			where T : Android.Views.View
+		{
+			var view = FindViewById<T> (id);
+			if (view == null)
+			{
+				throw new ArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
+			}
+			return view;
+		}
+
 		public void StartActivityForResult (Type activityType, int requestCode)
 		{
 			var intent = new Android.Content.Intent (this, activityType);

--- a/src/Mono.Android/Android.App/Activity.cs
+++ b/src/Mono.Android/Android.App/Activity.cs
@@ -18,8 +18,7 @@ namespace Android.App {
 			where T : Android.Views.View
 		{
 			var view = FindViewById<T> (id);
-			if (view == null)
-			{
+			if (view == null) {
 				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this Activity");
 			}
 			return view;

--- a/src/Mono.Android/Android.App/Activity.cs
+++ b/src/Mono.Android/Android.App/Activity.cs
@@ -19,7 +19,7 @@ namespace Android.App {
 		{
 			var view = FindViewById<T> (id);
 			if (view == null) {
-				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this Activity");
+				throw new Java.Lang.IllegalArgumentException ($"Parameter 'id' of value 0x{id:X} does not reference a View of type '{typeof (T)}' inside this Activity");
 			}
 			return view;
 		}

--- a/src/Mono.Android/Android.App/Activity.cs
+++ b/src/Mono.Android/Android.App/Activity.cs
@@ -12,17 +12,19 @@ namespace Android.App {
 			return this.FindViewById (id)!.JavaCast<T> ();
 		}
 
-		// See: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=25322
+#if NET7_0_OR_GREATER || (NET6_0_OR_GREATER && ANDROID_33) || ANDROID_34
+		// See: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/Activity.java;l=3430
 		public T RequireViewById<T> (int id)
 			where T : Android.Views.View
 		{
 			var view = FindViewById<T> (id);
 			if (view == null)
 			{
-				throw new ArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
+				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this Activity");
 			}
 			return view;
 		}
+#endif // NET7_0_OR_GREATER || (NET6_0_OR_GREATER && ANDROID_33) || ANDROID_34
 
 		public void StartActivityForResult (Type activityType, int requestCode)
 		{

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -29,6 +29,20 @@ namespace Android.Views {
 			return this.FindViewById (id).JavaCast<T> ();
 		}
 
+#if NET7_0_OR_GREATER || (NET6_0_OR_GREATER && ANDROID_33) || ANDROID_34
+		// See: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=25322
+		public T RequireViewById<T> (int id)
+			where T : Android.Views.View
+		{
+			var view = FindViewById<T> (id);
+			if (view == null)
+			{
+				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
+			}
+			return view;
+		}
+#endif //NET7_0_OR_GREATER || (NET6_0_OR_GREATER && ANDROID_33) || ANDROID_34
+
 		public bool Post (Action action)
 		{
 			return Post (new Java.Lang.Thread.RunnableImplementor (action, true));

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -36,7 +36,7 @@ namespace Android.Views {
 		{
 			var view = FindViewById<T> (id);
 			if (view == null) {
-				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
+				throw new Java.Lang.IllegalArgumentException ($"Parameter 'id' of value 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
 			}
 			return view;
 		}

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -35,8 +35,7 @@ namespace Android.Views {
 			where T : Android.Views.View
 		{
 			var view = FindViewById<T> (id);
-			if (view == null)
-			{
+			if (view == null) {
 				throw new Java.Lang.IllegalArgumentException ($"ID 0x{id:X} does not reference a View of type '{typeof (T)}' inside this View");
 			}
 			return view;


### PR DESCRIPTION
Context: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=25322
Context: https://developer.android.com/reference/android/view/View#requireViewById(int)

In porting Xamarin.Android samples to .NET 6, using latest C# 10
features like `Nullable=enable`, you run into a pattern such as:

    var foo = FindViewById<TextView>(Resource.Id.foo);
    ArgumentNullException.ThrowIfNull(foo);
    foo.Text = "bar";

`var` here is a nullable `TextView?`, so you have to null-check. This
is pretty verbose, and actually seems to make NRTs annoying...

API 28 introduced a `requireViewById()`:

https://developer.android.com/reference/android/view/View#requireViewById(int)

Let's introduce a C# version of this, so you can simply do:

    TextView foo = RequireViewById<TextView>(Resource.Id.foo);
    foo.Text = "bar";

Or use `var` if you prefer.

If `foo` was not found, an `ArgumentException` is thrown with a
message containing the target type and hex value of the ID.

I don't think there is a way to easily put the name `foo` in the error
message?