### PR TITLE
[xapreapre] Generate omnisharp.json for the current branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tests/api-compatibility/reference/*.cs
 Novell
 *.patch
 *.keystore
+/omnisharp.json

--- a/build-tools/scripts/omnisharp.json.in
+++ b/build-tools/scripts/omnisharp.json.in
@@ -1,0 +1,20 @@
+{
+    "msbuild": {
+        "loadProjectsOnDemand": true,
+    },
+
+    "RenameOptions": {
+        "RenameInComments": false,
+        "RenameOverloads": true,
+        "RenameInStrings": false
+    },
+
+    "sdk": {
+        "IncludePreleases": true,
+        "Path": "@DOTNET_SDK_PATH@",
+    },
+
+	"msbuild": {
+        "Configuration": "@CONFIGURATION@"
+    }
+}

--- a/build-tools/scripts/omnisharp.json.in
+++ b/build-tools/scripts/omnisharp.json.in
@@ -1,6 +1,6 @@
 {
     "msbuild": {
-        "loadProjectsOnDemand": true,
+        "loadProjectsOnDemand": true
     },
 
     "RenameOptions": {
@@ -11,7 +11,7 @@
 
     "sdk": {
         "IncludePreleases": true,
-        "Path": "@DOTNET_SDK_PATH@",
+        "Path": "@DOTNET_SDK_PATH@"
     },
 
 	"msbuild": {

--- a/build-tools/scripts/omnisharp.json.in
+++ b/build-tools/scripts/omnisharp.json.in
@@ -1,7 +1,7 @@
 {
     "msbuild": {
         "loadProjectsOnDemand": true,
-		"Configuration": "@CONFIGURATION@"
+        "Configuration": "@CONFIGURATION@"
     },
 
     "RenameOptions": {

--- a/build-tools/scripts/omnisharp.json.in
+++ b/build-tools/scripts/omnisharp.json.in
@@ -1,6 +1,7 @@
 {
     "msbuild": {
-        "loadProjectsOnDemand": true
+        "loadProjectsOnDemand": true,
+		"Configuration": "@CONFIGURATION@"
     },
 
     "RenameOptions": {
@@ -12,9 +13,5 @@
     "sdk": {
         "IncludePreleases": true,
         "Path": "@DOTNET_SDK_PATH@"
-    },
-
-	"msbuild": {
-        "Configuration": "@CONFIGURATION@"
     }
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Android.Prepare
 						Get_mingw_32_cmake (context),
 						Get_mingw_64_cmake (context),
 						Get_MonoGitHash_props (context),
+						Get_Omnisharp_Json (context),
 					};
 				}
 			}
@@ -235,6 +236,22 @@ namespace Xamarin.Android.Prepare
 				replacements,
 				Path.Combine (Configurables.Paths.BootstrapResourcesDir, $"{OutputFileName}.in"),
 				Path.Combine (Configurables.Paths.BuildBinDir, OutputFileName)
+			);
+		}
+
+		public GeneratedFile Get_Omnisharp_Json (Context context)
+		{
+			const string OutputFileName = "omnisharp.json";
+
+			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
+				{ "@CONFIGURATION@", context.Configuration },
+				{ "@DOTNET_SDK_PATH@", Path.Combine (Configurables.Paths.DotNetPreviewPath, "sdk", context.Properties.GetRequiredValue (KnownProperties.MicrosoftDotnetSdkInternalPackageVersion)) },
+			};
+
+			return new GeneratedPlaceholdersFile (
+				replacements,
+				Path.Combine (Configurables.Paths.BuildToolsScriptsDir, $"{OutputFileName}.in"),
+				Path.Combine (BuildPaths.XamarinAndroidSourceRoot, OutputFileName)
 			);
 		}
 	}


### PR DESCRIPTION
Context: https://github.com/OmniSharp/omnisharp-roslyn/wiki/Configuration-Options

The generated file should allow any editor using OmniSharp to open
samples, solutions, projects, tests in the XA tree which use .NET7
and get full code completion etc.

Note that the generated file will affect only the Xamarin.Android
repository.  If you want to be able to open projects outside the
Xamarin.Android source tree, the generated file needs to be copied
(or symlinked) to `~/.omnisharp/` or to the root of the project being 
opened.