### PR TITLE
Update Apk Size descriptions Script

### DIFF
--- a/Documentation/project-docs/ApkSizeRegressionChecks.md
+++ b/Documentation/project-docs/ApkSizeRegressionChecks.md
@@ -41,7 +41,9 @@ are named like this:
 The new reference files can be obtained from the test results
 archive - artifact of the given CI build (preferred method).
 Or they can be obtained from local build using
-the `build-tools/scripts/UpdateApkSizeReference.ps1` script.
+the `build-tools/scripts/UpdateApkSizeReference.ps1` script
+or the `build-tools/scripts/UpdateApkSizeReference.sh` script
+if you are on MacOS or *nix.
 
 The thresholds for these checks are set
 in `src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs`

--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -8,8 +8,8 @@ if (-not (Test-Path bin/Release)) {
 Write-Output "Building xabuild"
 msbuild /p:Configuration=Release /restore .\tools\xabuild\xabuild.csproj
 Write-Output "Building legacy BuildReleaseArm64 tests"
-msbuild /p:Configuration=Release Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest.BuildReleaseArm64"
+msbuild /p:Configuration=Release Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest2.BuildReleaseArm64"
 Write-Output "Building DotNet BuildReleaseArm64 tests"
-bin\Release\dotnet\dotnet test -p:Configuration=Release --filter BuildTest.BuildReleaseArm64 .\bin\TestRelease\net6.0\Xamarin.Android.Build.Tests.dll
+bin\Release\dotnet\dotnet test -p:Configuration=Release --filter=Name~BuildReleaseArm64 .\bin\TestRelease\net6.0\Xamarin.Android.Build.Tests.dll
 Write-Output "Updating reference files"
 Copy-Item -Verbose bin\TestRelease\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.sh
+++ b/build-tools/scripts/UpdateApkSizeReference.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+./build-tools/scripts/nunit3-console bin/TestRelease/net472/Xamarin.Android.Build.Tests.dll --test=Xamarin.Android.Build.Tests.BuildTest2.BuildReleaseArm64
+./dotnet-local.sh test bin/TestRelease/net6.0/Xamarin.Android.Build.Tests.dll --filter=Name~BuildReleaseArm64
+cp bin/TestRelease/BuildReleaseArm64*.apkdesc src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/


### PR DESCRIPTION
Add a shell script for updating these descriptions locally on MacOS/*nix. Since not everyone wants to install PowerShell. 
Update the PowerShell script to use the correct test names, since the Unit tests was moved to a new class.