### PR TITLE
$(AndroidPackVersionSuffix)=rc.1; net7 is 33.0.0.rc.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>33.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/7.0.1xx-preview7
Context: https://github.com/xamarin/xamarin-android/pull/7170

We branched for .NET 7 Preview 7, and there is already a Maestro bump
for .NET 7 RC 1.

Let's update xamarin-android/main's version number.