### PR TITLE
[build-tools] fix InstallMaui target for .NET 7

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -46,7 +46,7 @@
     <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' " />
     <PropertyGroup>
       <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
-      <MauiVersionBand>$([System.Text.RegularExpressions.Regex]::Match($(MauiVersion), `^\d+\.\d+\.\d`))00</MauiVersionBand>
+      <MauiVersionBand Condition=" '$(MauiVersionBand)' == '' ">$(DotNetSdkManifestsFolder)</MauiVersionBand>
     </PropertyGroup>
     <MakeDir Directories="$(_TempDirectory)" />
     <Exec
@@ -61,11 +61,19 @@
     </ItemGroup>
     <Copy SourceFiles="@(_WLManifest)" DestinationFolder="$(DotNetPreviewPath)sdk-manifests\$(DotNetSdkManifestsFolder)\microsoft.net.sdk.maui" />
 
+    <!-- Parse NuGet.config -->
+    <XmlPeek
+        XmlInputPath="$(XamarinAndroidSourcePath)NuGet.config"
+        Query="/configuration/packageSources/add/@value">
+      <Output TaskParameter="Result" ItemName="_NuGetSources" />
+    </XmlPeek>
+
     <!-- dotnet workload install maui-android -->
     <ItemGroup>
+      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />
-      <_InstallArguments Include="--configfile &quot;$(XamarinAndroidSourcePath)NuGet.config&quot;" />
+      <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
     </ItemGroup>
     <Exec


### PR DESCRIPTION
This addresses several problems with the `InstallMaui` target:

1. There was not a way to override `$(MauiVersionBand)`. You can now
   pass this value in such as `-p:MauiVersionBand=7.0.100`.

2. The logic for computing `$(MauiVersionBand)` was wrong:

    error NU1101: Unable to find package Microsoft.NET.Sdk.Maui.Manifest-7.0.000.

This should default to `$(DotNetSdkManifestsFolder)` now, which will
work by default when this lands: https://github.com/dotnet/maui/pull/8737

Until dotnet/maui#8737 is merged, `-p:MauiVersionBand=7.0.100` can be
used.

3. The `dotnet6` feed is now required:

```
Workload installation failed: microsoft.maui.sdk::6.0.408 is not found in NuGet feeds https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json".
```

This is a .NET 6 package on NuGet.org, but not in dotnet-public. It is
necessary when building `net6.0-*` MAUI projects with a .NET 7 SDK. I
added logic to parse the `NuGet.config` file and add an extra source
for the `dotnet6` feed. This should be the most reliable method going
forward.