### PR TITLE
[One .NET] transition to 6.0.400 version band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <!-- Match the first three version numbers and append 00 -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
     <!-- NOTE: sometimes we hardcode these when transitioning to new version bands -->
-    <DotNetAndroidManifestVersionBand>6.0.300</DotNetAndroidManifestVersionBand>
+    <DotNetAndroidManifestVersionBand>6.0.400</DotNetAndroidManifestVersionBand>
     <DotNetMonoManifestVersionBand>6.0.300</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>6.0.300</DotNetEmscriptenManifestVersionBand>
   </PropertyGroup>


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1576444

There is a known issue with the VS Mac updater & the 6.0.400 preview
.NET SDK.

The resolution (for now) is to move from:

    Microsoft.NET.Sdk.Android.Manifest-6.0.300

To:

    Microsoft.NET.Sdk.Android.Manifest-6.0.400

Likely further changes would also be needed in the next VS insertion.