### PR TITLE
[ci] Rename job names

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -31,7 +31,7 @@ stages:
   dependsOn: []
   jobs:
   - job: mac_build_create_installers
-    displayName: macOS
+    displayName: macOS > Create Installers
     pool:
       name: VSEng-Xamarin-RedmondMac-Android-Untrusted
       demands: macOS.Name -equals Monterey
@@ -65,7 +65,7 @@ stages:
     - group: xamops-azdev-secrets
   jobs:
   - job: emulator_tests
-    displayName: Emulator
+    displayName: macOS > Tests > APKs (Emulator)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
     strategy:

--- a/build-tools/automation/azure-pipelines-oss.yaml
+++ b/build-tools/automation/azure-pipelines-oss.yaml
@@ -31,7 +31,7 @@ stages:
   condition: eq(variables['EnableMacStage'], 'true')  # The variable is defined on the pipeline definition
   jobs:
   - job: mac_build
-    displayName: Mac Build
+    displayName: macOS > Build
     pool:
       name: VSEng-Xamarin-RedmondMac-Android-OSS
       demands:
@@ -148,7 +148,7 @@ stages:
   dependsOn: []                 # Run stage in parallel
   jobs:
   - job: linux_build_package
-    displayName: Linux Build
+    displayName: Linux > Build
     pool: android-public-ubuntu-vmss
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -81,10 +81,10 @@ variables:
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
 - stage: mac_build
-  displayName: macOS Build
+  displayName: Mac
   dependsOn: []
   jobs:
-  # Check - "Xamarin.Android (Mac Build)"
+  # Check - "Xamarin.Android (macOS > Build)"
   - job: mac_build_create_installers
     displayName: macOS > Build
     pool:
@@ -142,10 +142,10 @@ stages:
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 - stage: win_build_test
-  displayName: Windows Build & Smoke Test
+  displayName: Windows
   dependsOn: []
   jobs:
-  # Check - "Xamarin.Android (Windows Build and Smoke Test)"
+  # Check - "Xamarin.Android (Windows > Build & Smoke Test)"
   - job: win_build_test
     displayName: Windows > Build & Smoke Test
     pool: $(1ESWindowsPool)
@@ -257,9 +257,9 @@ stages:
 
     - template: yaml-templates\fail-on-issue.yaml
 
-# Check - "Xamarin.Android (Linux Build)"
+# Check - "Xamarin.Android (Linux > Build)"
 - stage: linux_build
-  displayName: Linux Build
+  displayName: Linux
   dependsOn: []
   jobs:
   - job: linux_build_create_sdk_pack
@@ -332,10 +332,10 @@ stages:
     - template: yaml-templates/fail-on-issue.yaml
 
 - stage: smoke_tests
-  displayName: macOS > Smoke Tests
+  displayName: Smoke Tests
   dependsOn: mac_build
   jobs:
-  # Check - "Xamarin.Android (Smoke Tests APKs Legacy - macOS)"
+  # Check - "Xamarin.Android (macOS > Tests > APKs Classic)"
   - job: mac_apk_tests_legacy
     displayName: macOS > Tests > APKs Classic
     pool:
@@ -594,7 +594,7 @@ stages:
 
     - template: yaml-templates/fail-on-issue.yaml
 
- # Check - "Xamarin.Android (Smoke Tests APKs .NET - macOS)"
+ # Check - "Xamarin.Android (macOS > Tests > APKs .NET)"
   - job: mac_apk_tests_net
     displayName: macOS > Tests > APKs .NET
     pool:
@@ -758,7 +758,7 @@ stages:
       nunit_categories: '|| cat == SmokeTests'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-  # Check - "Xamarin.Android (Smoke Tests MSBuild Emulator - macOS)"
+  # Check - "Xamarin.Android (macOS > Tests > MSBuild+Emulator)"
   - job: mac_msbuilddevice_tests
     displayName: macOS > Tests > MSBuild+Emulator
     pool:
@@ -818,7 +818,7 @@ stages:
   - mac_build
   - linux_build
   jobs:
-  # Check - "Xamarin.Android (Linux Tests MSBuild Smoke)"
+  # Check - "Xamarin.Android (Linux > Tests > MSBuild)"
   - job: linux_tests_smoke
     displayName: Linux > Tests > MSBuild
     pool: android-devdiv-ubuntu-vmss
@@ -1032,7 +1032,7 @@ stages:
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'MSBuildDevice')))
   jobs:
-  # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - Legacy)"
+  # Check - "Xamarin.Android (macOS > Tests > MSBuild+Emulator Legacy #N)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
       node_id: 1
@@ -1066,7 +1066,7 @@ stages:
       nunit_categories: '&& cat == Debugger'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-  # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - One .NET)"
+  # Check - "Xamarin.Android (macOS > Tests > MSBuild+Emulator One .NET #N)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
       node_id: 1
@@ -1179,11 +1179,11 @@ stages:
 
 
 - stage: designer_tests
-  displayName: Designer Integration Tests
+  displayName: Designer Tests
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'Designer')))
   jobs:
-  # Check - "Xamarin.Android (Designer Tests macOS)"
+  # Check - "Xamarin.Android (macOS > Tests > Designer Integration)"
   - job: designer_integration_mac
     condition: false #TODO: Enable once test issues are fixed.
     displayName: macOS > Tests > Designer Integration
@@ -1263,7 +1263,7 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
         condition: ne(variables['Agent.JobStatus'], 'Succeeded')
 
-  # Check - "Xamarin.Android (Designer Tests Windows)"
+  # Check - "Xamarin.Android (Windows > Tests > Designer Integration)"
   - job: designer_integration_win
     displayName: Windows > Tests > Designer Integration
     pool:
@@ -1350,7 +1350,7 @@ stages:
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'BCL')))
   jobs:
-  # Check - "Xamarin.Android (BCL Emulator Tests macOS)"
+  # Check - "Xamarin.Android (macOS > Tests > BCL (Emulator))"
   - job: mac_bcl_tests
     displayName: macOS > Tests > BCL (Emulator)
     pool:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -81,12 +81,12 @@ variables:
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
 - stage: mac_build
-  displayName: Mac
+  displayName: macOS Build
   dependsOn: []
   jobs:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
-    displayName: Build
+    displayName: macOS > Build
     pool:
       name: $(MacBuildPoolName)
       vmImage: $(MacBuildPoolImage)
@@ -142,12 +142,12 @@ stages:
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
 - stage: win_build_test
-  displayName: Windows
+  displayName: Windows Build & Smoke Test
   dependsOn: []
   jobs:
   # Check - "Xamarin.Android (Windows Build and Smoke Test)"
   - job: win_build_test
-    displayName: Build and Smoke Test
+    displayName: Windows > Build & Smoke Test
     pool: $(1ESWindowsPool)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
@@ -259,11 +259,11 @@ stages:
 
 # Check - "Xamarin.Android (Linux Build)"
 - stage: linux_build
-  displayName: Linux
+  displayName: Linux Build
   dependsOn: []
   jobs:
   - job: linux_build_create_sdk_pack
-    displayName: Build
+    displayName: Linux > Build
     pool: android-devdiv-ubuntu-vmss
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
@@ -332,12 +332,12 @@ stages:
     - template: yaml-templates/fail-on-issue.yaml
 
 - stage: smoke_tests
-  displayName: Smoke Tests
+  displayName: macOS > Smoke Tests
   dependsOn: mac_build
   jobs:
   # Check - "Xamarin.Android (Smoke Tests APKs Legacy - macOS)"
   - job: mac_apk_tests_legacy
-    displayName: APKs Legacy - macOS
+    displayName: macOS > Tests > APKs Classic
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 240
@@ -596,7 +596,7 @@ stages:
 
  # Check - "Xamarin.Android (Smoke Tests APKs .NET - macOS)"
   - job: mac_apk_tests_net
-    displayName: APKs .NET - macOS
+    displayName: macOS > Tests > APKs .NET
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 180
@@ -760,7 +760,7 @@ stages:
 
   # Check - "Xamarin.Android (Smoke Tests MSBuild Emulator - macOS)"
   - job: mac_msbuilddevice_tests
-    displayName: MSBuild Emulator - macOS
+    displayName: macOS > Tests > MSBuild+Emulator
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 90
@@ -820,7 +820,7 @@ stages:
   jobs:
   # Check - "Xamarin.Android (Linux Tests MSBuild Smoke)"
   - job: linux_tests_smoke
-    displayName: MSBuild Smoke
+    displayName: Linux > Tests > MSBuild
     pool: android-devdiv-ubuntu-vmss
     timeoutInMinutes: 180
     workspace:
@@ -1109,7 +1109,7 @@ stages:
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'MSBuildDevice')))
   jobs:
   - job: wear_tests
-    displayName: wear_tests
+    displayName: macOS > Tests > WearOS 
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 2
     strategy:
@@ -1179,14 +1179,14 @@ stages:
 
 
 - stage: designer_tests
-  displayName: Designer Tests
+  displayName: Designer Integration Tests
   dependsOn: mac_build
   condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'Designer')))
   jobs:
   # Check - "Xamarin.Android (Designer Tests macOS)"
   - job: designer_integration_mac
     condition: false #TODO: Enable once test issues are fixed.
-    displayName: macOS
+    displayName: macOS > Tests > Designer Integration
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 120
@@ -1265,7 +1265,7 @@ stages:
 
   # Check - "Xamarin.Android (Designer Tests Windows)"
   - job: designer_integration_win
-    displayName: Windows
+    displayName: Windows > Tests > Designer Integration
     pool:
       vmImage: $(HostedWinImage)
     timeoutInMinutes: 120
@@ -1352,7 +1352,7 @@ stages:
   jobs:
   # Check - "Xamarin.Android (BCL Emulator Tests macOS)"
   - job: mac_bcl_tests
-    displayName: macOS
+    displayName: macOS > Tests > BCL (Emulator)
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 180

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -11,7 +11,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: MSBuild With Emulator - macOS-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
+    displayName: macOS > Tests > MSBuild+Emulator ${{ parameters.job_suffix }} \#${{ parameters.node_id }}
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 90

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -11,7 +11,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: macOS > Tests > MSBuild+Emulator ${{ parameters.job_suffix }} \#${{ parameters.node_id }}
+    displayName: "macOS > Tests > MSBuild+Emulator ${{ parameters.job_suffix }} #${{ parameters.node_id }}"
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 90

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -12,7 +12,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: macOS > Tests > MSBuild ${{ parameters.job_suffix }} \#${{ parameters.node_id }}
+    displayName: "macOS > Tests > MSBuild ${{ parameters.job_suffix }} #${{ parameters.node_id }}"
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 180

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -12,7 +12,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: MSBuild ${{ parameters.job_suffix }} - macOS-${{ parameters.node_id }}
+    displayName: macOS > Tests > MSBuild ${{ parameters.job_suffix }} \#${{ parameters.node_id }}
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 180

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: Windows > Tests > MSBuild ${{ parameters.job_suffix }} \#${{ parameters.node_id }}/${{ parameters.additional_node_id }}
+    displayName: "Windows > Tests > MSBuild ${{ parameters.job_suffix }} #${{ parameters.node_id }}/${{ parameters.additional_node_id }}"
     pool: $(1ESWindowsPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job_name }}
-    displayName: MSBuild ${{ parameters.job_suffix }} - Windows-${{ parameters.node_id }}/${{ parameters.additional_node_id }}
+    displayName: Windows > Tests > MSBuild ${{ parameters.job_suffix }} \#${{ parameters.node_id }}/${{ parameters.additional_node_id }}
     pool: $(1ESWindowsPool)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5


### PR DESCRIPTION
Certain tools such as [Component Governance][0] only use the Pipeline
name -- as defined somewhere in Azure DevOps -- and the `displayName`
property on the [`job` definition][1].  The `displayName` property on
the containing [`stage`][2] is *not* displayed.

This can result in "wonderful" alerts which state that the affected
pipeline is e.g. "Xamarin.Android (macOS)", which isn't particularly
helpful when there are *three* jobs with a `displayName` of `macOS`:

  * `designer_integration_mac`
  * `mac_bcl_tests`
  * `mac_build_create_installers`

Fully understanding these alerts is irksome.

Improve this situation by introducing "redundancy" into the job
`displayName` values, and updating them to follow a pattern:

 1. Host Platform
 2. Category
 3. (Optional) Description

Each part is separated from the others by a ` > `.

Examples:

  * Replace `Mac Build` with `macOS > Build`.
  * For the previous `macOS` displayName:
    * The `designer_integration_mac` job is `macOS > Tests > Designer Integration`
    * The `mac_bcl_tests` job is `macOS > Tests > BCL (Emulator)`
    * The `mac_build_create_installers` job is `macOS > Create Installers`
  * Replace `Build and Smoke Test` with `Windows > Build & Smoke Test`

[0]: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112013?_a=alerts&typeId=6317076&alerts-view-option=active
[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-job?view=azure-pipelines
[2]: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/stages-stage?view=azure-pipelines
