### PR TITLE
[One .NET] produce 31, 32, 33 packs

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -56,26 +56,28 @@
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
   </Target>
 
-  <Target Name="_CreateDefaultRefPack"
-      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-  </Target>
-
-  <Target Name="_CreateAPI32Packs">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=32 -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=32 -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=32 -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=32 -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=32 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-  </Target>
-
   <Target Name="CreateAllPacks"
-      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreateAPI32Packs;_CreateDefaultRefPack">
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory">
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;"
+    />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
     <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
@@ -123,7 +125,7 @@
     <ItemGroup>
       <_NuGetSources Include="$(OutputPath.TrimEnd('\'))" />
       <_InstallArguments Include="android" />
-      <_InstallArguments Include="android-33" />
+      <_InstallArguments Include="android-%(AndroidApiInfo.Level)" Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' and '%(AndroidApiInfo.Level)' != '$(AndroidDefaultTargetDotnetApiLevel)' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />
       <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -63,8 +63,10 @@ core workload SDK packs imported by WorkloadManifest.targets.
     />
 
     <ItemGroup>
-      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" />
-      <_AndroidApiInfo Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android32\AndroidApiInfo.xml" Condition="Exists('$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android32\AndroidApiInfo.xml')" />
+      <_AndroidApiInfo
+          Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+          Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android%(AndroidApiInfo.Level)\AndroidApiInfo.xml"
+      />
       <!-- Microsoft.Android.Sdk.ILLink output -->
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.dll" PackagePath="tools" />
       <_PackageFiles Include="$(XAInstallPrefix)xbuild\Xamarin\Android\Microsoft.Android.Sdk.ILLink.pdb" PackagePath="tools" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -1,24 +1,23 @@
 <Project>
   <PropertyGroup>
-    <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
+
   <Target Name="PackDotNet">
-    <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
-    <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
     <MSBuild
-         Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=net6.0;AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel);DisableApiCompatibilityCheck=true"
+         Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' and '%(AndroidApiInfo.Level)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
+         Properties="TargetFramework=net6.0;AndroidApiLevel=%(AndroidApiInfo.Level);AndroidPlatformId=%(AndroidApiInfo.Id);DisableApiCompatibilityCheck=true"
     />
-    <MSBuild
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=net6.0;AndroidApiLevel=32;AndroidPlatformId=32;DisableApiCompatibilityCheck=true"
-    />
-    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
-    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->
     <ItemGroup>
-      <_OldPackages Include="$(_Root)packages\microsoft.android.*\**\*.nupkg" />
+      <_OldPackages Include="$(XamarinAndroidSourcePath)packages\microsoft.android.*\**\*.nupkg" />
       <_DirectoriesToRemove Include="%(_OldPackages.RootDir)%(_OldPackages.Directory)" />
     </ItemGroup>
     <RemoveDir Directories="@(_DirectoriesToRemove)" />
@@ -26,19 +25,19 @@
   <Target Name="CreateWorkloadInstallers">
     <MSBuild
         Targets="ExtractWorkloadPacks"
-        Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj"
+        Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj"
         Properties="Configuration=$(Configuration)"
     />
     <MSBuild
         Condition=" $([MSBuild]::IsOSPlatform('windows')) "
         Targets="Restore;Build"
-        Projects="$(_Root)build-tools\create-dotnet-msi\create-dotnet-msi.csproj"
+        Projects="$(XamarinAndroidSourcePath)build-tools\create-dotnet-msi\create-dotnet-msi.csproj"
         Properties="Configuration=$(Configuration)"
     />
     <MSBuild
         Condition=" $([MSBuild]::IsOSPlatform('osx')) "
         Targets="Restore;Build"
-        Projects="$(_Root)build-tools\create-dotnet-pkg\create-dotnet-pkg.csproj"
+        Projects="$(XamarinAndroidSourcePath)build-tools\create-dotnet-pkg\create-dotnet-pkg.csproj"
         Properties="Configuration=$(Configuration)"
     />
   </Target>

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedMonoAndroidProjitemsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedMonoAndroidProjitemsFile.cs
@@ -25,23 +25,26 @@ namespace Xamarin.Android.Prepare
 		{
 			using (var fs = File.Open (OutputPath, FileMode.Create)) {
 				using (var sw = new StreamWriter (fs)) {
-					GenerateFile (sw);
+					GenerateFile (context, sw);
 				}
 			}
 		}
 
-		void GenerateFile (StreamWriter sw)
+		void GenerateFile (Context context, StreamWriter sw)
 		{
 			sw.Write (FileTop);
 
+			string apiLevelText = context.Properties.GetRequiredValue (KnownProperties.AndroidDefaultTargetDotnetApiLevel);
+			uint.TryParse (apiLevelText, out var dotnetApiLevel);
+
 			sw.WriteLine ("  <ItemGroup>");
-			BuildAndroidPlatforms.AllPlatforms.ForEach (androidPlatform => WriteGroupApiInfo (sw, androidPlatform));
+			BuildAndroidPlatforms.AllPlatforms.ForEach (androidPlatform => WriteGroupApiInfo (sw, androidPlatform, dotnetApiLevel));
 			sw.WriteLine ("  </ItemGroup>");
 
 			sw.Write (FileBottom);
 		}
 
-		void WriteGroupApiInfo (StreamWriter sw, AndroidPlatform androidPlatform)
+		void WriteGroupApiInfo (StreamWriter sw, AndroidPlatform androidPlatform, uint dotnetApiLevel)
 		{
 			if (string.IsNullOrWhiteSpace (androidPlatform.ApiName)) {
 				return;
@@ -52,6 +55,7 @@ namespace Xamarin.Android.Prepare
 			sw.WriteLine ($"      <Level>{androidPlatform.ApiLevel}</Level>");
 			sw.WriteLine ($"      <Id>{androidPlatform.PlatformID}</Id>");
 			sw.WriteLine ($"      <Stable>{androidPlatform.Stable}</Stable>");
+			sw.WriteLine ($"      <DotNetSupported>{androidPlatform.ApiLevel >= dotnetApiLevel}</DotNetSupported>");
 			sw.WriteLine ($"    </AndroidApiInfo>");
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Prepare
 			Steps.Add (new Step_InstallAdoptOpenJDK8 ());
 			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
 			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));
+			Steps.Add (new Step_GenerateMonoAndroidProfileItems ());
 
 			// disable installation of missing programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BaseGenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BaseGenerateFiles.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	abstract class Step_BaseGenerateFiles : Step
+	{
+		public Step_BaseGenerateFiles () : base ("Generating files required by the build")
+		{
+		}
+
+		public Step_BaseGenerateFiles (string description) : base (description)
+		{
+		}
+
+#pragma warning disable CS1998
+		protected override async Task<bool> Execute (Context context)
+		{
+			List<GeneratedFile>? filesToGenerate = GetFilesToGenerate (context);
+			if (filesToGenerate != null && filesToGenerate.Count > 0) {
+				foreach (GeneratedFile gf in filesToGenerate) {
+					if (gf == null)
+						continue;
+
+					Log.Status ("Generating ");
+					Log.Status (Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.OutputPath), ConsoleColor.White);
+					if (!String.IsNullOrEmpty (gf.InputPath))
+						Log.StatusLine ($" {context.Characters.LeftArrow} ", Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.InputPath), leadColor: ConsoleColor.Cyan, tailColor: ConsoleColor.White);
+					else
+						Log.StatusLine ();
+
+					gf.Generate (context);
+				}
+			}
+
+			return true;
+		}
+#pragma warning restore CS1998
+
+		protected abstract List<GeneratedFile>? GetFilesToGenerate (Context context);
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -1,47 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	partial class Step_GenerateFiles : Step
+	partial class Step_GenerateFiles : Step_BaseGenerateFiles
 	{
 		bool atBuildStart;
 		bool onlyRequired;
 
 		public Step_GenerateFiles (bool atBuildStart, bool onlyRequired = false)
-			: base ("Generating files required by the build")
 		{
 			this.atBuildStart = atBuildStart;
 			this.onlyRequired = onlyRequired;
 		}
 
-#pragma warning disable CS1998
-		protected override async Task<bool> Execute (Context context)
-		{
-			List<GeneratedFile>? filesToGenerate = GetFilesToGenerate (context);
-			if (filesToGenerate != null && filesToGenerate.Count > 0) {
-				foreach (GeneratedFile gf in filesToGenerate) {
-					if (gf == null)
-						continue;
-
-					Log.Status ("Generating ");
-					Log.Status (Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.OutputPath), ConsoleColor.White);
-					if (!String.IsNullOrEmpty (gf.InputPath))
-						Log.StatusLine ($" {context.Characters.LeftArrow} ", Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.InputPath), leadColor: ConsoleColor.Cyan, tailColor: ConsoleColor.White);
-					else
-						Log.StatusLine ();
-
-					gf.Generate (context);
-				}
-			}
-
-			return true;
-		}
-#pragma warning restore CS1998
-
-		List<GeneratedFile>? GetFilesToGenerate (Context context)
+		protected override List<GeneratedFile>? GetFilesToGenerate (Context context)
 		{
 			if (atBuildStart) {
 				if (onlyRequired) {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateMonoAndroidProfileItems.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateMonoAndroidProfileItems.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	class Step_GenerateMonoAndroidProfileItems : Step_BaseGenerateFiles
+	{
+		protected override List<GeneratedFile>? GetFilesToGenerate (Context context) => new List<GeneratedFile> {
+			new GeneratedMonoAndroidProjitemsFile(),
+		};
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -14,7 +14,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <_AndroidTargetingPackId Condition="$(TargetPlatformVersion.EndsWith('.0'))">$(TargetPlatformVersion.Substring(0, $(TargetPlatformVersion.LastIndexOf('.0'))))</_AndroidTargetingPackId>
     <_AndroidTargetingPackId Condition="'$(_AndroidTargetingPackId)' == ''">$(TargetPlatformVersion)</_AndroidTargetingPackId>
-    <_AndroidRuntimePackId Condition=" '$(_AndroidTargetingPackId)' &lt; '@ANDROID_LATEST_STABLE_API_LEVEL@' ">@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidRuntimePackId>
     <_AndroidRuntimePackId Condition=" '$(_AndroidRuntimePackId)' == '' ">$(_AndroidTargetingPackId)</_AndroidRuntimePackId>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,19 +6,36 @@
       "packs": [
         "Microsoft.Android.Sdk",
         "Microsoft.Android.Ref.31",
-        "Microsoft.Android.Ref.32",
-        "Microsoft.Android.Ref.33",
-        "Microsoft.Android.Runtime.33.android-arm",
-        "Microsoft.Android.Runtime.33.android-arm64",
-        "Microsoft.Android.Runtime.33.android-x86",
-        "Microsoft.Android.Runtime.33.android-x64",
+        "Microsoft.Android.Runtime.31.android-arm",
+        "Microsoft.Android.Runtime.31.android-arm64",
+        "Microsoft.Android.Runtime.31.android-x86",
+        "Microsoft.Android.Runtime.31.android-x64",
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ]
     },
+    "android-32": {
+      "description": "Support for Android API-32.",
+      "packs": [
+        "Microsoft.Android.Ref.32",
+        "Microsoft.Android.Runtime.32.android-arm",
+        "Microsoft.Android.Runtime.32.android-arm64",
+        "Microsoft.Android.Runtime.32.android-x86",
+        "Microsoft.Android.Runtime.32.android-x64"
+      ],
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
+      "extends" : [ "android" ]
+    },
     "android-33": {
       "description": "Support for Android API-33.",
+      "packs": [
+        "Microsoft.Android.Ref.33",
+        "Microsoft.Android.Runtime.33.android-arm",
+        "Microsoft.Android.Runtime.33.android-arm64",
+        "Microsoft.Android.Runtime.33.android-x86",
+        "Microsoft.Android.Runtime.33.android-x64"
+      ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ "android" ]
     }
@@ -45,6 +62,22 @@
       "version": "@WORKLOAD_VERSION@"
     },
     "Microsoft.Android.Ref.33": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.31.android-arm": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.31.android-arm64": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.31.android-x86": {
+      "kind": "framework",
+      "version": "@WORKLOAD_VERSION@"
+    },
+    "Microsoft.Android.Runtime.31.android-x64": {
       "kind": "framework",
       "version": "@WORKLOAD_VERSION@"
     },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -771,8 +771,7 @@ namespace Xamarin.Android.Build.Tests
 			var expectedMonoAndroidRefPath = Path.Combine (refDirectory, "ref", "net6.0", "Mono.Android.dll");
 			Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRefPath), $"Build should be using {expectedMonoAndroidRefPath}");
 
-			var runtimeApiLevel = (apiLevel == XABuildConfig.AndroidDefaultTargetDotnetApiLevel && apiLevel < XABuildConfig.AndroidLatestStableApiLevel) ? XABuildConfig.AndroidLatestStableApiLevel : apiLevel;
-			var runtimeDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Runtime.{runtimeApiLevel}.{runtimeIdentifier}")).LastOrDefault ();
+			var runtimeDirectory = Directory.GetDirectories (Path.Combine (AndroidSdkResolver.GetDotNetPreviewPath (), "packs", $"Microsoft.Android.Runtime.{apiLevel}.{runtimeIdentifier}")).LastOrDefault ();
 			var expectedMonoAndroidRuntimePath = Path.Combine (runtimeDirectory, "runtimes", runtimeIdentifier, "lib", "net6.0", "Mono.Android.dll");
 			Assert.IsTrue (dotnet.LastBuildOutput.ContainsText (expectedMonoAndroidRuntimePath), $"Build should be using {expectedMonoAndroidRuntimePath}");
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/7183

Adding a class like this to a `dotnet new android` project:

    class MyThread : Java.Lang.Thread { }

Causes the build to fail with:

    obj\Debug\net6.0-android\android\src\crc6474063b540de74d1e\RenderingThread.java(76,3): error JAVAC0000:  error: no suitable constructor found for Thread(ThreadGroup,Runnable,String,long,boolean)
      super (p0, p1, p2, p3, p4);
    constructor Thread.Thread() is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(Runnable) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(ThreadGroup,Runnable) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(String) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(ThreadGroup,String) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(Runnable,String) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(ThreadGroup,Runnable,String) is not applicable
      (actual and formal argument lists differ in length)
    constructor Thread.Thread(ThreadGroup,Runnable,String,long) is not applicable
      (actual and formal argument lists differ in length)

This is a new `Thread` constructor added in API 33:

https://developer.android.com/reference/java/lang/Thread#Thread(java.lang.ThreadGroup,%20java.lang.Runnable,%20java.lang.String,%20long,%20boolean)

What's happening here is a result of our workload authoring...

* `net6.0-android` defaults to `$(TargetPlatformVersion)` 31

* You get a `Microsoft.Android.Ref.31` reference assembly for
  `Mono.Android.dll`

* However, we mistakenly thought a `Microsoft.Android.Runtime.33`
  "runtime" assembly for `Mono.Android.dll` would work!

And so the `<GenerateJavaStubs/>` MSBuild target runs against an API
33 `Mono.Android.dll`, generating a `Thread` constructor that doesn't
compile.

To fix this:

* `Mono.Android.Apis.projitems` now contains metadata for each API
  level, such as:

```xml
<AndroidApiInfo Include="v11.0">
  <Name>R</Name>
  <Level>30</Level>
  <Id>30</Id>
  <Stable>True</Stable>
  <DotNetSupported>False</DotNetSupported>
</AndroidApiInfo>
<AndroidApiInfo Include="v12.0">
  <Name>S</Name>
  <Level>31</Level>
  <Id>31</Id>
  <Stable>True</Stable>
  <DotNetSupported>True</DotNetSupported>
</AndroidApiInfo>
```

* Build API 31, 32, 33 runtime packs based on
  `%(AndroidApiInfo.DotNetSupported)`. We will ship these going forward.

* The workload now installs 31 packs by default. The API 32 & 33 packs
  can be restored from NuGet, or via the `android-32` or `android-33`
  workloads.

I added a test for this scenario that validates the runtime pack used
during a build.

I will port these changes to xamarin-android/main in a future PR.