### PR TITLE
[Mono.Android] fix crash on startup with EnableLLVM

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -379,7 +379,7 @@ stages:
         testName: Mono.Android_Tests-Aot
         project: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Aot.xml
-        extraBuildArgs: /p:AotAssemblies=True /p:EnableLlvm=True
+        extraBuildArgs: /p:AotAssemblies=True /p:EnableLLVM=True
         artifactSource: bin/Test$(ApkTestConfiguration)/Mono.Android_Tests-Signed.apk
         artifactFolder: AotLlvm
 
@@ -691,13 +691,15 @@ stages:
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
-        # TODO: disable LLVM test, see: https://github.com/dotnet/runtime/issues/68914
+        # TODO: disable LLVM test, see:
+        # https://github.com/dotnet/runtime/issues/68914
+        # https://github.com/dotnet/runtime/issues/73304
         condition: false
         configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-AotLlvm
         project: tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)AotLlvm.xml
-        extraBuildArgs: -p:TestsFlavor=AotLlvm -p:EnableLlvm=true
+        extraBuildArgs: -p:TestsFlavor=AotLlvm -p:EnableLLVM=true -p:AndroidEnableProfiledAot=false
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-AotLlvm
         useDotNet: true

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -196,9 +196,16 @@ namespace Android.Runtime {
 			}
 
 #if !MONOANDROID1_0
-			SynchronizationContext.SetSynchronizationContext (Android.App.Application.SynchronizationContext);
+			SetSynchronizationContext ();
 #endif
 		}
+
+#if !MONOANDROID1_0
+		// NOTE: prevents Android.App.Application static ctor from running
+		[MethodImpl (MethodImplOptions.NoInlining)]
+		static void SetSynchronizationContext () =>
+			SynchronizationContext.SetSynchronizationContext (Android.App.Application.SynchronizationContext);
+#endif
 
 		internal static void Exit ()
 		{

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -22,10 +22,10 @@
     <AndroidUseNegotiateAuthentication>true</AndroidUseNegotiateAuthentication>
     <!--
       TODO: Fix excluded tests
-      For AOT, InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
+      For $(EnableLLVM), InetAccess excluded due to: https://github.com/dotnet/runtime/issues/56315
     -->
     <ExcludeCategories>DotNetIgnore</ExcludeCategories>
-    <ExcludeCategories Condition=" '$(RunAOTCompilation)' == 'true' ">$(ExcludeCategories):InetAccess</ExcludeCategories>
+    <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):InetAccess</ExcludeCategories>
     <ExcludeCategories Condition=" '$(UseInterpreter)' == 'true' ">$(ExcludeCategories):IgnoreInterpreter</ExcludeCategories>
   </PropertyGroup>
 


### PR DESCRIPTION
`dotnet new android` apps would crash on startup when built with
`-c Release -p:EnableLLVM=true`:

    07-20 08:55:44.642  2983  2983 F monodroid-assembly: Internal p/invoke symbol 'java-interop @ java_interop_jvm_list' (hash: 0x58c48fc8b89cb484) not found in compile-time map.
    ...
    07-20 08:55:44.834  3004  3004 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
    07-20 08:55:44.834  3004  3004 F DEBUG   : Abort message: 'Internal p/invoke symbol 'java-interop @ java_interop_jvm_list' (hash: 0x58c48fc8b89cb484) not found in compile-time map.'

`java_interop_jvm_list` should *never* be called on Android, it is the
result of `new AndroidRuntime()` having not been called yet?

The problem being that the static `Android.App.Application.cctor` was
somehow running *before* `JNIEnv.Initialize()` was complete? And this
only happens with LLVM?

Reviewing the code:

    [UnmanagedCallersOnly]
    internal static unsafe void Initialize (JnienvInitializeArgs* args)
    {
        //...
        SynchronizationContext.SetSynchronizationContext (Android.App.Application.SynchronizationContext);
    }

We do indeed access `Android.App.Application`...

To fix this, we can move this to a new method decorated with
`MethodImplOptions.NoInlining`. Apps built with LLVM now launch for
me.

We can also enable the LLVM `Mono.Android-Tests` again.