### PR TITLE
[tests] fix `WearOS On Device - macOS` tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1122,7 +1122,7 @@ stages:
       parameters:
         useDotNet: true
         testRunTitle: WearOS On Device - macOS
-        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/net6.0/MSBuildDeviceIntegration.dll
         dotNetTestExtraArgs: --filter "TestCategory = WearOS"
         testResultsFile: TestResult-WearOS--$(XA.Build.Configuration).xml
 


### PR DESCRIPTION
These tests fail with:

    DotNetStableTargetFramework: /Users/runner/work/_temp/9afef9fa-d376-4c50-9d87-8a9a6a9fee17.ps1:7
    Line |
    7 |  … elease/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuil …
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | The term 'DotNetStableTargetFramework' is not recognized as a
      | name of a cmdlet, function, script file, or executable
      | program. Check the spelling of the name, or if a path was
      | included, verify that the path is correct and try again.

When we backported 0b375fec, it used the `$(DotNetStableTargetFramework)`
variable, which isn't defined on `release/6.0.4xx`.

We can use `net6.0` instead on this branch.