### PR TITLE
[templates] Wear template should be net6.0-android

### DIFF
--- a/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
     <SupportedOSPlatformVersion>SUPPORTED_OS_PLATFORM_VERSION</SupportedOSPlatformVersion>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidApp1</RootNamespace>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
The `DotNetNew("androidwear")` test is failing with:

    (_CheckForUnsupportedNETCoreVersion target) ->
    /Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/6.0.400/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(144,5):
    error NETSDK1045: The current .NET SDK does not support targeting .NET 7.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 7.0.

When I backported 0b375fec, we needed to change the
`$(TargetFramework)` to `net6.0-android`.