### PR TITLE
[build] Fix workload install for local dependencies

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -254,15 +254,19 @@
 
   <Target Name="InstallManifestAndDependencies">
     <PropertyGroup>
+      <_EmptyDepsWorkloadName>android.deps.workload</_EmptyDepsWorkloadName>
       <_LocalSdkManifestsFolder>$(BuildOutputDirectory)lib\sdk-manifests\$(DotNetSdkManifestsFolder)\</_LocalSdkManifestsFolder>
       <_LocalAndroidManifestFolder>$(_LocalSdkManifestsFolder)microsoft.net.sdk.android\</_LocalAndroidManifestFolder>
-      <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)android.deps.workload\</_EmptyWorkloadDir>
+      <_EmptyWorkloadDir>$(_LocalSdkManifestsFolder)$(_EmptyDepsWorkloadName)\</_EmptyWorkloadDir>
       <_EmptyWorkloadJsonContent>
 <![CDATA[
 {"version": "0.0.1", "workloads": { "android-deps": { "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ] } } }
 ]]>
       </_EmptyWorkloadJsonContent>
     </PropertyGroup>
+    <ItemGroup>
+      <_WorkloadManifestsTxt Include="$(DotNetPreviewPath)sdk\*\IncludedWorkloadManifests.txt" />
+    </ItemGroup>
     <MakeDir Directories="$(_LocalAndroidManifestFolder)" />
     <MSBuild
         Projects="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj"
@@ -274,6 +278,15 @@
     <WriteLinesToFile
         File="$(_EmptyWorkloadDir)WorkloadManifest.json"
         Lines="$(_EmptyWorkloadJsonContent)"
+        Overwrite="true"
+    />
+    <!-- Add empty workload to list of known workload manifests -->
+    <ReadLinesFromFile File="@(_WorkloadManifestsTxt)" >
+      <Output TaskParameter="Lines" ItemName="_KnownWorkloadManifests"/>
+    </ReadLinesFromFile>
+    <WriteLinesToFile
+        File="@(_WorkloadManifestsTxt)"
+        Lines="@(_KnownWorkloadManifests);$(_EmptyDepsWorkloadName)"
         Overwrite="true"
     />
     <Exec


### PR DESCRIPTION
The `InstallManifestAndDependencies` target is used by local builds to
install the runtime dependencies and WorkloadManifest files required for
building net*-android projects.  This broke after a recent .NET SDK
update, as the empty workload that we only use locally is not known to
the .NET SDK.  Fix this by adding our empty workload to the list of
included workloads when building locally.