### PR TITLE
[build] Add `rc.*` to $(DotNetSdkManifestsFolder)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
-    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-preview.\d+`))</DotNetSdkManifestsFolder>
+    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-(preview|rc).\d+`))</DotNetSdkManifestsFolder>
     <!-- NOTE: sometimes we hardcode these when transitioning to new version bands -->
     <DotNetAndroidManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetAndroidManifestVersionBand>
     <DotNetMonoManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetMonoManifestVersionBand>


### PR DESCRIPTION
Continue to append pre-release version information to our manifest pack
name and `sdk-manifests` subfolder name (e.g. 7.0.100-rc.1).  We likely
wont want to drop this pre-release string until we move to `-rtm`
branded builds.