### PR TITLE
[Xamarin.Android.Build.Tasks] fix @(LibraryProjectZip) and NuGets

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -66,6 +66,9 @@ This item group populates the Build Action drop-down in IDEs.
       <Bind>true</Bind>
       <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
     </AndroidLibrary>
+    <LibraryProjectZip>
+      <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
+    </LibraryProjectZip>
     <AndroidAarLibrary>
       <!-- NOTE: .aar items should skip %(AndroidSkipResourceProcessing) by default -->
       <AndroidSkipResourceProcessing>true</AndroidSkipResourceProcessing>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -266,6 +266,10 @@ namespace Xamarin.Android.Build.Tests
 				MetadataValues = "Link=x86\\libfoo.so",
 				BinaryContent = () => Array.Empty<byte> (),
 			});
+			proj.OtherBuildItems.Add (new AndroidItem.LibraryProjectZip ("..\\baz.aar") {
+				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
+				MetadataValues = "Bind=false",
+			});
 			proj.OtherBuildItems.Add (new AndroidItem.AndroidLibrary (default (Func<string>)) {
 				Update = () => "nopack.aar",
 				WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
@@ -281,7 +285,6 @@ namespace Xamarin.Android.Build.Tests
 			using var nupkg = ZipHelper.OpenZip (nupkgPath);
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/{proj.ProjectName}.dll");
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/{proj.ProjectName}.aar");
-
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/bar.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/bar.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/sub/directory/bar.aar");
@@ -289,6 +292,7 @@ namespace Xamarin.Android.Build.Tests
 			nupkg.AssertDoesNotContainEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/nopack.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
+			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/baz.aar");
 		}
 
 		[Test]


### PR DESCRIPTION
Backport of #7151 

Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/652

In .NET 6, `@(AndroidLibrary.Pack)` defaults to true (97190b6c), while
`%(LibraryProjectZip.Pack)` was never set, and thus was false.  This
would be an issue if you migrated a project using `@(LibraryProjectZip)` and were
not relying on the default wildcards used by:

	<AndroidLibrary Include="**/*.aar" />

The result is that `.aar` files weren't included into the `.nupkg`,
which would result in subsequent build & packaging errors when
using the `.nupkg`, as the `.aar` was missing.

Set `%(LibraryProjectZip.Pack)`=True by default in .NET 6+, to ease
project migration from Classic Xamarin.Android to .NET 6.

I updated a test for this scenario and fixed some assertions that are
working since 2ca2a103 was merged.