### PR TITLE
[Mono.Android] Remove System.Linq usage

### DIFF
--- a/src/Mono.Android/Android.Graphics/Color.cs
+++ b/src/Mono.Android/Android.Graphics/Color.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net.Security;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;

--- a/src/Mono.Android/Android.Runtime/CharSequence.cs
+++ b/src/Mono.Android/Android.Runtime/CharSequence.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Mono.Android/Android.Runtime/IJavaObjectValueMarshaler.cs
+++ b/src/Mono.Android/Android.Runtime/IJavaObjectValueMarshaler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;

--- a/src/Mono.Android/Android.Runtime/JavaArray.cs
+++ b/src/Mono.Android/Android.Runtime/JavaArray.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 
 namespace Android.Runtime {
@@ -108,7 +107,9 @@ namespace Android.Runtime {
 			if (c != null)
 				return JNIEnv.ToLocalJniHandle (c);
 
-			var a = value.ToArray ();
+			var a = new T [value.Count];
+			value.CopyTo (a, 0);
+
 			return  JNIEnv.NewArray (a, typeof (T));
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5442

Remove all `using System.Linq` statements and all use of LINQ
extension methods from `Mono.Android.dll`.

Primary motivation was to reduce `.apk` size (09baa52e), and we don't
want to inadvertently allow LINQ usage back in…