### PR TITLE
[Xamarin.Android.Build.Tasks] use `ToJniName (type, cache)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -346,7 +346,7 @@ namespace Xamarin.Android.Tasks
 			regCallsWriter.WriteLine ("\t\t// Application and Instrumentation ACWs must be registered first.");
 			foreach (var type in javaTypes) {
 				if (JavaNativeTypeManager.IsApplication (type, cache) || JavaNativeTypeManager.IsInstrumentation (type, cache)) {
-					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
+					string javaKey = JavaNativeTypeManager.ToJniName (type, cache).Replace ('/', '.');
 					regCallsWriter.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);",
 						type.GetAssemblyQualifiedName (cache), javaKey);
 				}


### PR DESCRIPTION
I noticed there might be a performance regression in .NET 7 when
building a .NET MAUI project, in the `<GenerateJavaStubs/>` MSBuild
task:

    .NET 6:  GenerateJavaStubs = 799 ms
    xa main: GenerateJavaStubs = 912 ms

When reviewing what PerfView shows, I saw:

    54.31ms (5.7%) module java.interop.tools.javacallablewrappers <<java.interop.tools.javacallablewrappers!Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName(class Mono.Cecil.TypeDefinition)>>

This was the overload that did not take in a `TypeDefinitionCache`. I
found one instance of this in `<GenerateJavaStubs/>`.

This doesn't seem like the .NET 7 regression, because it has always
been this way.

However, it seems to help quite a bit:

    GenerateJavaStubs = 825 ms
    GenerateJavaStubs = 867 ms

This probably saves around ~50ms in this task.