### PR TITLE
Bump `$(AndroidNet6Version)` to 32.0.447

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.415</AndroidNet6Version>
+    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.447</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -12,12 +12,6 @@
         LatestRuntimeFrameworkVersion="@NET6_VERSION@"
         TargetingPackVersion="@NET6_VERSION@"
     />
-    <!--
-      HACK:
-      The .NET 7 SDK specifies 6.0.3 for .NET 6, but our .NET 6 libmonodroid.so depends on 6.0.5.
-      We should be able to remove this when we get a newer .NET 7 SDK.
-     -->
-    <KnownRuntimePack Update="Microsoft.NETCore.App" LatestRuntimeFrameworkVersion="6.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">


### PR DESCRIPTION
Context: https://www.nuget.org/packages/Microsoft.NET.Sdk.Android.Manifest-6.0.400/32.0.447

We shipped newer .NET 6 packs, so we can use them in our .NET 7 workload.

We can also remove the workaround for `Microsoft.NETCore.App`, because the .NET 7 SDK now ships dotnet/runtime 6.0.7.