### PR TITLE
[ci] Use nuget-msi-convert/job/v3.yml

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1441,7 +1441,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@yaml
+  - template: nuget-msi-convert/job/v3.yml@yaml
     parameters:
       yamlResourceName: yaml
       dependsOn: sign_net_mac_win
@@ -1450,8 +1450,6 @@ stages:
         !*Darwin*
       propsArtifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
-      runInParallel: false
-      useDateTimeVersion: true
       postConvertSteps:
       - task: DownloadPipelineArtifact@2
         inputs:


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195

Updates the build to the latest MSI generation template.  The `v3`
template uses the latest changes from arcade which include a large
refactoring and support for workload pack group MSIs.

The generation of workload pack group MSIs is enabled by default.  The
tooling will now generate a single MSI for each workload declared in our
WorkloadManifest.json file.  This should improve MSI based installation
scenarios as it dramatically reduces the number of MSIs that we ship.