### PR TITLE
[ci] Add Android Designer test template

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1318,32 +1318,30 @@ stages:
         jdkTestFolder: $(JAVA_HOME_8_X64)
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-    - template: designer\android-designer-build-win.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)\UITools\Designer
-        uiToolsSourcePath: $(System.DefaultWorkingDirectory)\UITools
-        javaSdkDirectory: $(JAVA_HOME_8_X64)
-
-    - template: designer\android-designer-tests.yaml@yaml
-      parameters:
-        designerSourcePath: $(System.DefaultWorkingDirectory)\UITools\Designer
-
-    - task: CopyFiles@2
-      displayName: 'Copy binlogs'
+    - task: VSBuild@1
+      displayName: Restore Xamarin.AndroidDesigner
       inputs:
-        sourceFolder: $(System.DefaultWorkingDirectory)\UITools\Designer\Xamarin.Designer.Android
-        contents: '**/*.binlog'
-        targetFolder: $(Build.ArtifactStagingDirectory)\designer-binlogs
-        overWrite: true
-        flattenFolders: true
-      condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+        solution: $(System.DefaultWorkingDirectory)\UITools\Designer\Xamarin.Designer.Android\Xamarin.AndroidDesigner.sln
+        vsVersion: 17.0
+        msbuildArgs: >-
+          /t:Restore /p:RestoreDisableParallel=true
+          /p:RestoreConfigFile="$(System.DefaultWorkingDirectory)\UITools\NuGet.Config"
+          /p:JavaSdkDirectory="$(JAVA_HOME_8_X64)"
+        platform: Any CPU
+        configuration: DebugWin32
 
-    - template: yaml-templates/publish-artifact.yaml
+    - task: VSBuild@1
+      displayName: Build Xamarin.AndroidDesigner
+      inputs:
+        solution: $(System.DefaultWorkingDirectory)\UITools\Designer\Xamarin.Designer.Android\Xamarin.AndroidDesigner.sln
+        vsVersion: 17.0
+        msbuildArgs: /t:Build
+        platform: Any CPU
+        configuration: DebugWin32
+
+    - template: yaml-templates/run-designer-tests.yml
       parameters:
-        displayName: upload designer binlogs
-        artifactName: Test Results - Designer - Windows
-        targetPath: $(Build.ArtifactStagingDirectory)\designer-binlogs
-        condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+        designerSourcePath: $(System.DefaultWorkingDirectory)\UITools\Designer
 
 - stage: bcl_tests
   displayName: BCL Emulator Tests

--- a/build-tools/automation/yaml-templates/run-designer-tests.yml
+++ b/build-tools/automation/yaml-templates/run-designer-tests.yml
@@ -1,0 +1,76 @@
+parameters:
+  designerSourcePath: $(System.DefaultWorkingDirectory)
+  nunitConsoleVersion: '3.9.0'
+  runAddinTests: true
+  testResultArtifactName: Test Results - Designer - Windows
+
+steps:
+- task: DeleteFiles@1
+  displayName: Delete Test Outputs
+  inputs:
+    SourceFolder: ${{ parameters.designerSourcePath }}/Xamarin.Designer.Android/Xamarin.AndroidDesigner.Tests
+    Contents: |
+     CustomControlsOutput
+     AndroidCustomControlsClass/obj
+     AndroidCustomControlsBinding/obj
+     AndroidCustomControls/obj
+     AndroidCustomControlsClass/bin
+     AndroidCustomControlsBinding/bin
+     AndroidCustomControls/bin
+
+- task: NuGetCommand@2
+  displayName: Install NUnit.Console ${{ parameters.nunitConsoleVersion }}
+  inputs:
+    command: custom
+    arguments: install NUnit.Console -version ${{ parameters.nunitConsoleVersion }} -OutputDirectory ${{ parameters.designerSourcePath }}/packages
+
+- powershell: |
+    $nunitConsole = [IO.Path]::Combine("${{ parameters.designerSourcePath }}", "packages", "NUnit.ConsoleRunner.${{ parameters.nunitConsoleVersion }}", "tools", "nunit3-console.exe")
+    if ([Environment]::OSVersion.Platform -eq "Unix")
+    {
+        mono64 "$nunitConsole" "-labels=All" "-result=TestResult_AndroidDesignerUnitTests.xml" "Xamarin.AndroidDesigner.UnitTests.dll"
+    }
+    else
+    {
+        ."$nunitConsole" "-labels=All" "-result=TestResult_AndroidDesignerUnitTests.xml" "Xamarin.AndroidDesigner.UnitTests.dll"
+    }
+  displayName: Run Unit Tests
+  workingDirectory: ${{ parameters.designerSourcePath }}/Xamarin.Designer.Android/Xamarin.AndroidDesigner.Tests/bin-tests/Debug
+
+- powershell: |
+    if ([Environment]::OSVersion.Platform -eq "Unix")
+    {
+        mono64 "--debug" "GuiUnit.exe" "-labels=All" "-result=TestResult_AndroidDesigner.xml" "Xamarin.AndroidDesigner.Tests.dll"
+    }
+    else
+    {
+        .\GuiUnit.exe "-labels=All" "-result=TestResult_AndroidDesigner.xml" "Xamarin.AndroidDesigner.Tests.dll"
+    }
+  displayName: Run GUI Tests 
+  workingDirectory: ${{ parameters.designerSourcePath }}/Xamarin.Designer.Android/Xamarin.AndroidDesigner.Tests/bin/Debug
+  condition: false # https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1583237
+
+- task: PublishTestResults@2
+  displayName: Publish Core Unit Test Results
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: ${{ parameters.designerSourcePath }}/Xamarin.Designer.Android/Xamarin.AndroidDesigner.Tests/**/TestResult_*.xml
+    testRunTitle: Xamarin.AndroidDesigner.Tests
+  condition: succeededOrFailed()
+
+- task: CopyFiles@2
+  displayName: 'Copy binlogs'
+  inputs:
+    sourceFolder: ${{ parameters.designerSourcePath }}/Xamarin.Designer.Android
+    contents: '**/*.binlog'
+    targetFolder: $(Build.ArtifactStagingDirectory)/designer-binlogs
+    overWrite: true
+    flattenFolders: true
+  condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+
+- template: publish-artifact.yaml
+  parameters:
+    displayName: upload designer binlogs
+    artifactName: ${{ parameters.testResultArtifactName }}
+    targetPath: $(Build.ArtifactStagingDirectory)/designer-binlogs
+    condition: ne(variables['Agent.JobStatus'], 'Succeeded')


### PR DESCRIPTION
The designer team is no longer using the build and test templates in
[yaml-templates][0], so there is not much value in us maintaining them
externally.

A copy of the test template has been moved into our repo, and the build
and test steps have been updated to reflect the latest changes in the
UITools repo.

[0]: https://github.com/xamarin/yaml-templates/tree/89becd2759512ebd8fe560a53f6916cc684f0b4c/designer