### PR TITLE
[One .NET] remove Microsoft.NETCore.App.Host.linux-*

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -14,6 +14,15 @@ _ResolveAssemblies MSBuild target.
   <UsingTask TaskName="Xamarin.Android.Tasks.ProcessNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.StripNativeLibraries" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
+  <!-- HACK: workaround for: https://github.com/dotnet/sdk/issues/25679 -->
+  <Target Name="_RemoveLinuxFrameworkReferences"
+      AfterTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <_ProblematicRIDs Include="linux-arm;linux-arm64;linux-x86;linux-x64" />
+      <PackageDownload Remove="Microsoft.NETCore.App.Host.%(_ProblematicRIDs.Identity)" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup Condition=" '$(_ComputeFilesToPublishForRuntimeIdentifiers)' == 'true' ">
     <OutputPath Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutputPath>
     <OutDir     Condition=" '$(_OuterOutputPath)' != '' ">$(_OuterOutputPath)</OutDir>


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-android/pull/7043

Backporting this to help dogfooding MAUI. 

Folks are hitting errors such as:

    Unable to find package Microsoft.NETCore.App.Host.linux-arm with version (= 6.0.8)

## Original PR Description ##

Context: 3f052b5f
Context: https://github.com/dotnet/sdk/issues/25679

If you use our .NET 7 workload, and do:

	dotnet new android
	dotnet restore

It fails with:

	C:\src\foo\foo.csproj error NU1102: Unable to find package Microsoft.NETCore.App.Host.linux-arm with version (= 7.0.0-preview.5.22271.4)
	- Found 88 version(s) in nuget.org [ Nearest version: 7.0.0-preview.4.22229.4 ]
	- Found 0 version(s) in Microsoft Visual Studio Offline Packages [C:\src\foo\foo.csproj]
	C:\src\foo\foo.csproj error NU1102: Unable to find package Microsoft.NETCore.App.Host.linux-arm64 with version (= 7.0.0-preview.5.22271.4)
	- Found 88 version(s) in nuget.org [ Nearest version: 7.0.0-preview.4.22229.4 ]
	- Found 0 version(s) in Microsoft Visual Studio Offline Packages [C:\src\foo\foo.csproj]
	C:\src\foo\foo.csproj error NU1102: Unable to find package Microsoft.NETCore.App.Host.linux-x64 with version (= 7.0.0-preview.5.22271.4)
	- Found 88 version(s) in nuget.org [ Nearest version: 7.0.0-preview.4.22229.4 ]
	- Found 0 version(s) in Microsoft Visual Studio Offline Packages [C:\src\foo\foo.csproj]

You have to add a `nuget.config` to solve the issue:

	<?xml version="1.0" encoding="utf-8"?>
	<configuration>
	  <packageSources>
	    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
	  </packageSources>
	</configuration>

In 3f052b5f, we had a workaround for early .NET 6 previews to prevent
this issue.  At some point the problem *seemed* fixed because the
dotnet/runtime we were using was always on NuGet.org.  I tested a
.NET 6 Android app with the 6.0.300 SDK, and it always downloads
these packages.

For now, let's put 3f052b5f back in.  This should also allow us to
remove the `dotnet7` feed in our MSBuild tests.