### PR TITLE
[ci] Upload test assemblies after signing

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -92,7 +92,7 @@ stages:
       vmImage: $(MacBuildPoolImage)
       ${{ if eq(variables['MacBuildPoolName'], 'VSEng-Xamarin-RedmondMac-Android-Untrusted') }}:
         demands: macOS.Name -equals Monterey
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -49,28 +49,10 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
 
-- task: PublishPipelineArtifact@1
-  displayName: upload build tools inventory
-  inputs:
-    artifactName: BuildToolsInventory
-    targetPath:  ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/buildtoolsinventory.csv
-
-# Build and package test assemblies
+# Build test assemblies
 - script: make all-tests CONFIGURATION=$(XA.Build.Configuration)
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make all-tests
-
-- script: >
-    cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
-    cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
-  workingDirectory: ${{ parameters.xaSourcePath }}
-  displayName: copy bcl-tests assemblies
-
-- task: PublishPipelineArtifact@1
-  displayName: upload test assemblies
-  inputs:
-    artifactName: $(TestAssembliesArtifactName)
-    targetPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
 
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
 - task: MSBuild@1
@@ -119,3 +101,22 @@ steps:
   inputs:
     artifactName: $(InstallerArtifactName)
     targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+
+# Upload test assemblies
+- script: >
+    cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests &&
+    cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: copy bcl-tests assemblies
+
+- task: PublishPipelineArtifact@1
+  displayName: upload test assemblies
+  inputs:
+    artifactName: $(TestAssembliesArtifactName)
+    targetPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
+
+- task: PublishPipelineArtifact@1
+  displayName: upload build tools inventory
+  inputs:
+    artifactName: BuildToolsInventory
+    targetPath:  ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/buildtoolsinventory.csv


### PR DESCRIPTION
We've recently seen a handful of build timeouts and/or failures during
signing.  The ESRP signing service seems to be much less performant and
more error prone on macOS.  In these failure cases, rebuild attempts
would also fail when they got to the "upload test assembly" step:

    [error]Artifact test-assemblies already exists for build 6522654.

Improve this by uploading test assemblies and build inventory data at
the end of the build, and by increasing the overall timeout of the job.