### PR TITLE
[OneLoc] Localize Microsoft.Android.Templates

### DIFF
--- a/Documentation/workflow/Localization.md
+++ b/Documentation/workflow/Localization.md
@@ -39,6 +39,13 @@ so when adding a new message, follow these steps:
 
  6. The [OneLocBuild][oneloc] task will manage handoff and handback for string translations.
 
+### Templates
+
+All updates to `src/Microsoft.Android.Templates` should be built locally to update the
+`templatestrings.*.json` used for localization.  The [OneLocBuild][oneloc] task
+will manage handoff and handback for string translations after the
+`templatestrings.*.json` changes are committed.
+
 ## Guidelines
 
   * When an error or warning code is used with more than one output string, use

--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -12,7 +12,7 @@
           "CopyOption": "LangIDOnName",
           "SourceFile": ".\\src\\Xamarin.Android.Build.Tasks\\Properties\\Resources.resx",
           "OutputPath": ".\\src\\Xamarin.Android.Build.Tasks\\Properties\\"
-        },
+        }
       ]
     }
   ]

--- a/Localize/update-locproject.ps1
+++ b/Localize/update-locproject.ps1
@@ -1,0 +1,28 @@
+param ($SourcesDirectory, $LocProjectPath)
+
+$jsonFiles = @()
+$jsonTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\.template\.config\\localize\\.+\.en\.json" } # .NET templating pattern
+$jsonTemplateFiles | ForEach-Object {
+    $null = $_.Name -Match "(.+)\.[\w-]+\.json" # matches '[filename].[langcode].json
+
+    $destinationFile = "$($_.Directory.FullName)\$($Matches.1).json"
+    $jsonFiles += Copy-Item "$($_.FullName)" -Destination $destinationFile -PassThru
+    Write-Host "Template loc file generated: $destinationFile"
+}
+
+Push-Location "$SourcesDirectory"
+$projectObject = Get-Content $LocProjectPath | ConvertFrom-Json
+$jsonFiles | ForEach-Object {
+    $sourceFile = ($_.FullName | Resolve-Path -Relative)
+    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")"
+    $projectObject.Projects[0].LocItems += (@{
+        SourceFile = $sourceFile
+        CopyOption = "LangIDOnName"
+        OutputPath = $outputPath
+    })
+}
+Pop-Location
+
+$locProjectJson = ConvertTo-Json $projectObject -Depth 5
+Set-Content $LocProjectPath $locProjectJson
+Write-Host "LocProject.json was updated to contain template localizations:`n`n$locProjectJson`n`n" 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1880,7 +1880,7 @@ stages:
   # Check - "Xamarin.Android (Tenets OneLocBuild)"
   - job: OneLocBuild
     displayName: OneLocBuild
-    condition: eq(variables['MicroBuildSignType'], 'Real')
+    condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(variables['Build.SourceBranch'], 'refs/heads/loc-net7-templates'))
     pool: VSEngSS-MicroBuild2022-1ES
     timeoutInMinutes: 30
     variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1880,7 +1880,7 @@ stages:
   # Check - "Xamarin.Android (Tenets OneLocBuild)"
   - job: OneLocBuild
     displayName: OneLocBuild
-    condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(variables['Build.SourceBranch'], 'refs/heads/loc-net7-templates'))
+    condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     pool: VSEngSS-MicroBuild2022-1ES
     timeoutInMinutes: 30
     variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1891,6 +1891,13 @@ stages:
     - checkout: self
       clean: true
 
+    - task: PowerShell@2
+      displayName: Update LocProject.json
+      inputs:
+        targetType: filePath
+        filePath: $(Build.SourcesDirectory)\Localize\update-locproject.ps1
+        arguments: -SourcesDirectory "$(Build.SourcesDirectory)" -LocProjectPath "$(Build.SourcesDirectory)\Localize\LocProject.json"
+
     - task: OneLocBuild@2
       displayName: OneLocBuild
       env:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,6 +16,10 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>7b2cd1ee7169143248a7da9fd749caf22affa624</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22409.14">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>efd5e59cbe2751b14f5331d122ccba27dd788cf4</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,10 +16,6 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>7b2cd1ee7169143248a7da9fd749caf22affa624</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22409.14">
-      <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>efd5e59cbe2751b14f5331d122ccba27dd788cf4</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">
@@ -29,6 +25,10 @@
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="7.0.0-beta.22103.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22410.7">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>66ccf71bc4f0ba64f66b1674803e9999cd8111c8</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,7 @@
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-rc.1.22368.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22409.14</MicrosoftTemplateEngineTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-rc.1.22368.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
-    <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22409.14</MicrosoftTemplateEngineTasksPackageVersion>
+    <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/src/Microsoft.Android.Templates/.gitignore
+++ b/src/Microsoft.Android.Templates/.gitignore
@@ -1,0 +1,1 @@
+templatestrings.json

--- a/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
+++ b/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
@@ -8,6 +8,7 @@
     <Description>Templates for Android platforms.</Description>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <LocalizeTemplates Condition=" '$(RunningOnCI)' != 'true' ">true</LocalizeTemplates>
     <ContentTargetFolders>content</ContentTargetFolders>
     <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
     <!-- Remove the `<group targetFramework=".NETStandard2.0" />` entry from the .nuspec. -->
@@ -20,6 +21,10 @@
   <ItemGroup>
     <Content Include="**\*" Exclude="**\bin\**;**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(RunningOnCI)' != 'true' ">
+    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksPackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Activity template",
+  "description": "An Android Activity class",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android-bindinglib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Java Library Binding",
+  "description": "A project for creating a .NET Android class library that binds to a native Java library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "author": "Microsoft",
+  "name": "Android Layout template",
+  "description": "An Android layout (XML) file"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Wear Application",
+  "description": "A project for creating a .NET Android Wear application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "Android Application",
+  "description": "A project for creating a .NET Android application",
+  "symbols/packageName/description": "Overrides the package name in the AndroidManifest.xml",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}

--- a/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/androidlib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": "Android Class Library",
+  "description": "A project for creating a .NET Android class library",
+  "symbols/supportedOSVersion/description": "Overrides $(SupportedOSPlatformVersion) in the project"
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6677

The `Microsoft.Android.Templates` project has been onboarded to the new
template localization system.  Local template builds will now use
`Microsoft.TemplateEngine.Tasks` to generate `templatestrings.*.json`
files used for localization.

The new `update-locproject.ps1` script runs as part of the `OneLocBuild`
job in CI.  This script will copy each english `templatestrings.en.json`
file to `templatestrings.json`, and add it as a new translation source
file entry to `LocProject.json`.  This update to `LocProject.json` will
tell the `OneLocBuild` task to process our templates.

This script borrows heavily from the [generate-locproject.ps1][0] script
found in dotnet/arcade.

-----

Description from PR 6677:

Template engine (dotnet new) added support for template localizations in
.NET 6.0. This new system replaces the old way of localizing templates
that only worked on Visual Studio and works on both .NET CLI as well as
Visual Studio.

This PR introduces changes to switch to the new template localization system.

Summary of the changes:

 * Adds `<LocalizeTemplates>true</>` to project containing templates.
 * Include PackageReference for `Microsoft.TemplateEngine.Tasks` to project containing templates.
 * Generates localization files to be translated by loc team

Every time there is a change to one of the templates:

 * The dev making the change should build the modified template project. This will update the loc files on the local working copy,
 * Push the loc files together with the template modifications. Review & merge.
 * OneLocBuild integration will automatically pick up the changes and will send them for translation.
 * You will receive a PR containing the translated template loc files when they are ready. Review & merge.

[0]: https://github.com/dotnet/arcade/blob/e771d68edea1cfcd4a49e160093a4f32df8a6288/eng/common/generate-locproject.ps1