### PR TITLE
[README] Add links to XA 13.0 release installers.

### DIFF
--- a/Documentation/previous-releases.md
+++ b/Documentation/previous-releases.md
@@ -1,0 +1,64 @@
+Xamarin.Android Previous Releases
+===============
+
+| Platform        | Link   |
+|-----------------|--------|
+| **Commercial Xamarin.Android 12.3 (d17-2)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-2-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.3 (d17-2)** for macOS                                       | [Download][commercial-d17-2-macOS-x86_64]   |
+| **Commercial Xamarin.Android 12.2 (d17-1)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-1-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.2 (d17-1)** for macOS                                       | No Stable VSMac 2022 17.1 Release   |
+| **Commercial Xamarin.Android 12.1 (d17-0)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-0-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.1 (d17-0)** for macOS                                       | No Stable VSMac 2022 17.0 Release   |
+| **Commercial Xamarin.Android 12.0 (d16-11)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-11-Windows-x86_64] |
+| **Commercial Xamarin.Android 12.0 (d16-11)** for macOS                                      | [Download][commercial-d16-11-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.3 (d16-10)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-10-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.3 (d16-10)** for macOS                                      | [Download][commercial-d16-10-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.2 (d16-9)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-9-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.2 (d16-9)** for macOS                                       | [Download][commercial-d16-9-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.1 (d16-8)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-8-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.1 (d16-8)** for macOS                                       | [Download][commercial-d16-8-macOS-x86_64]   |
+| **Commercial Xamarin.Android 11.0 (d16-7)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-7-Windows-x86_64] |
+| **Commercial Xamarin.Android 11.0 (d16-7)** for macOS                                       | [Download][commercial-d16-7-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.3 (d16-6)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-6-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.3 (d16-6)** for macOS                                       | [Download][commercial-d16-6-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.2 (d16-5)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-5-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.2 (d16-5)** for macOS                                       | [Download][commercial-d16-5-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.1 (d16-4)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-4-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.1 (d16-4)** for macOS                                       | [Download][commercial-d16-4-macOS-x86_64]   |
+| **Commercial Xamarin.Android 10.0 (d16-3)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-3-Windows-x86_64] |
+| **Commercial Xamarin.Android 10.0 (d16-3)** for macOS                                       | [Download][commercial-d16-3-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.4 (d16-2)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-2-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.4 (d16-2)** for macOS                                        | [Download][commercial-d16-2-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-1-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for macOS                                        | [Download][commercial-d16-1-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-0-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                                        | [Download][commercial-d16-0-macOS-x86_64]   |
+
+[commercial-d16-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-0-windows
+[commercial-d16-0-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-0-macos
+[commercial-d16-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-1-windows
+[commercial-d16-1-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-1-macos
+[commercial-d16-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-2-windows
+[commercial-d16-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-2-macos
+[commercial-d16-3-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-3-windows
+[commercial-d16-3-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-3-macos
+[commercial-d16-4-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-4-windows
+[commercial-d16-4-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-4-macos
+[commercial-d16-5-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-5-windows
+[commercial-d16-5-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-5-macos
+[commercial-d16-6-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-6-windows
+[commercial-d16-6-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-6-macos
+[commercial-d16-7-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-7-windows
+[commercial-d16-7-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-7-macos
+[commercial-d16-8-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-8-windows
+[commercial-d16-8-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-8-macos
+[commercial-d16-9-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-9-windows
+[commercial-d16-9-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-9-macos
+[commercial-d16-10-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-10-windows
+[commercial-d16-10-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-10-macos
+[commercial-d16-11-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-11-windows
+[commercial-d16-11-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-11-macos
+[commercial-d17-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-0-windows
+[commercial-d17-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-1-windows
+[commercial-d17-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-2-windows
+[commercial-d17-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d17-2-macos

--- a/README.md
+++ b/README.md
@@ -24,73 +24,16 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Link   |
 |-----------------|--------|
-| **Commercial Xamarin.Android 12.3 (d17-2)** for Windows+Visual Studio 2022                 | [Download][commercial-d17-2-Windows-x86_64] |
-| **Commercial Xamarin.Android 12.3 (d17-2)** for macOS                                      | [Download][commercial-d17-2-macOS-x86_64]   |
-| **OSS Xamarin.Android (main)** for Ubuntu\*                                                | [![OSS Linux/Ubuntu x86_64][oss-ubuntu-x86_64-icon]][oss-ubuntu-x86_64-status] |
+| **Commercial Xamarin.Android 13.0 (d17-3)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-3-Windows-x86_64] |
+| **Commercial Xamarin.Android 13.0 (d17-3)** for macOS                                       | [Download][commercial-d17-3-macOS-x86_64]   |
+| **OSS Xamarin.Android (main)** for Ubuntu\*                                                 | [![OSS Linux/Ubuntu x86_64][oss-ubuntu-x86_64-icon]][oss-ubuntu-x86_64-status] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
 
-## Previous
+[Previous Releases](Documentation/previous-releases.md) are also available for download.
 
-| Platform        | Link   |
-|-----------------|--------|
-| **Commercial Xamarin.Android 12.2 (d17-1)** for Windows+Visual Studio 2022                 | [Download][commercial-d17-1-Windows-x86_64] |
-| **Commercial Xamarin.Android 12.2 (d17-1)** for macOS                                      | No Stable VSMac 2022 17.1 Release   |
-| **Commercial Xamarin.Android 12.1 (d17-0)** for Windows+Visual Studio 2022                  | [Download][commercial-d17-0-Windows-x86_64] |
-| **Commercial Xamarin.Android 12.1 (d17-0)** for macOS                                       | No Stable VSMac 2022 17.0 Release   |
-| **Commercial Xamarin.Android 12.0 (d16-11)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-11-Windows-x86_64] |
-| **Commercial Xamarin.Android 12.0 (d16-11)** for macOS                                      | [Download][commercial-d16-11-macOS-x86_64]   |
-| **Commercial Xamarin.Android 11.3 (d16-10)** for Windows+Visual Studio 2019                 | [Download][commercial-d16-10-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.3 (d16-10)** for macOS                                      | [Download][commercial-d16-10-macOS-x86_64]   |
-| **Commercial Xamarin.Android 11.2 (d16-9)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-9-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.2 (d16-9)** for macOS                                       | [Download][commercial-d16-9-macOS-x86_64]   |
-| **Commercial Xamarin.Android 11.1 (d16-8)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-8-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.1 (d16-8)** for macOS                                       | [Download][commercial-d16-8-macOS-x86_64]   |
-| **Commercial Xamarin.Android 11.0 (d16-7)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-7-Windows-x86_64] |
-| **Commercial Xamarin.Android 11.0 (d16-7)** for macOS                                       | [Download][commercial-d16-7-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.3 (d16-6)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-6-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.3 (d16-6)** for macOS                                       | [Download][commercial-d16-6-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.2 (d16-5)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-5-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.2 (d16-5)** for macOS                                       | [Download][commercial-d16-5-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.1 (d16-4)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-4-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.1 (d16-4)** for macOS                                       | [Download][commercial-d16-4-macOS-x86_64]   |
-| **Commercial Xamarin.Android 10.0 (d16-3)** for Windows+Visual Studio 2019                  | [Download][commercial-d16-3-Windows-x86_64] |
-| **Commercial Xamarin.Android 10.0 (d16-3)** for macOS                                       | [Download][commercial-d16-3-macOS-x86_64]   |
-| **Commercial Xamarin.Android 9.4 (d16-2)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-2-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.4 (d16-2)** for macOS                                        | [Download][commercial-d16-2-macOS-x86_64]   |
-| **Commercial Xamarin.Android 9.3 (d16-1)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-1-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.3 (d16-1)** for macOS                                        | [Download][commercial-d16-1-macOS-x86_64]   |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-0-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                                        | [Download][commercial-d16-0-macOS-x86_64]   |
-
-[commercial-d16-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-0-windows
-[commercial-d16-0-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-0-macos
-[commercial-d16-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-1-windows
-[commercial-d16-1-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-1-macos
-[commercial-d16-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-2-windows
-[commercial-d16-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-2-macos
-[commercial-d16-3-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-3-windows
-[commercial-d16-3-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-3-macos
-[commercial-d16-4-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-4-windows
-[commercial-d16-4-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-4-macos
-[commercial-d16-5-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-5-windows
-[commercial-d16-5-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-5-macos
-[commercial-d16-6-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-6-windows
-[commercial-d16-6-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-6-macos
-[commercial-d16-7-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-7-windows
-[commercial-d16-7-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-7-macos
-[commercial-d16-8-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-8-windows
-[commercial-d16-8-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-8-macos
-[commercial-d16-9-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-9-windows
-[commercial-d16-9-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-9-macos
-[commercial-d16-10-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-10-windows
-[commercial-d16-10-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-10-macos
-[commercial-d16-11-Windows-x86_64]:       https://aka.ms/xamarin-android-commercial-d16-11-windows
-[commercial-d16-11-macOS-x86_64]:         https://aka.ms/xamarin-android-commercial-d16-11-macos
-[commercial-d17-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-0-windows
-[commercial-d17-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-1-windows
-[commercial-d17-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-2-windows
-[commercial-d17-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d17-2-macos
+[commercial-d17-3-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d17-3-windows
+[commercial-d17-3-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d17-3-macos
 
 # Contributing
 


### PR DESCRIPTION
- Add links to XA 13.0 release installers.
- Move previous release downloads to its own page, as it is starting to take over the entire readme.