### PR TITLE
[ci] Add support to net6.0 for multi-targeting in VS

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -715,14 +715,18 @@ stages:
   - template: yaml-templates/run-msbuild-mac-tests.yaml
     parameters:
       job_name: mac_msbuild_tests_0
-      nunit_categories: '|| cat == SmokeTests'
+      job_suffix: One .NET
+      nunit_categories: '| (TestCategory = SmokeTests $(DotNetNUnitCategories))'
+      target_framework: 'net6.0'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Xamarin.Android (Smoke Tests MSBuild - Win-0)
   - template: yaml-templates\run-msbuild-win-tests.yaml
     parameters:
-      job_name: win_msbuild_tests_0
-      nunit_categories: '|| cat == SmokeTests'
+      job_name: win_dotnet_tests_0
+      job_suffix: One .NET
+      nunit_categories: '| (TestCategory = SmokeTests $(DotNetNUnitCategories))'
+      target_framework: 'net6.0'
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   # Check - "Xamarin.Android (Smoke Tests MSBuild Emulator - macOS)"

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1409,7 +1409,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@yaml
+  - template: nuget-msi-convert/job/v3.yml@yaml
     parameters:
       yamlResourceName: yaml
       dependsOn: sign_net_mac_win
@@ -1418,7 +1418,6 @@ stages:
         !*Darwin*
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
-      runInParallel: false
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets
@@ -1483,6 +1482,20 @@ stages:
           inputs:
             artifactName: vsdrop-signed
             downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+
+    - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: $(MultiTargetVSDropCommitStatusName)
+        blobName: $(MultiTargetVSDropCommitStatusName)
+        packagePrefix: xamarin-android
+        artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        yamlResourceName: yaml
+        downloadSteps:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: vsdrop-multitarget-signed
+            downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
     - powershell: >-
         & dotnet build -v:n -c $(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1422,6 +1422,7 @@ stages:
         !*Darwin*
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
+      useDateTimeVersion: false
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -11,5 +11,6 @@
     </ShortNames>
     <ComponentResources Include="android" Version="@WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Android" Description=".NET SDK Workload for building Android applications."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Android.Manifest*.nupkg" Version="@WORKLOAD_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.Android.Sdk" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -4,7 +4,7 @@
     "android": {
       "description": ".NET SDK Workload for building Android applications.",
       "packs": [
-        "Microsoft.Android.Sdk",
+        "Microsoft.Android.Sdk.net6",
         "Microsoft.Android.Ref.31",
         "Microsoft.Android.Runtime.31.android-arm",
         "Microsoft.Android.Runtime.31.android-arm64",
@@ -41,7 +41,7 @@
     }
   },
   "packs": {
-    "Microsoft.Android.Sdk": {
+    "Microsoft.Android.Sdk.net6": {
       "kind": "sdk",
       "version": "@WORKLOAD_VERSION@",
       "alias-to": {

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk"
+  <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net6"
       Condition=" '$(TargetPlatformIdentifier)' == 'android' " />
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -837,7 +837,7 @@ namespace Xamarin.Android.Build.Tests
 		public void XamarinLegacySdk ([Values ("net6.0-android32.0", "net6.0-android33.0")] string dotnetTargetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha1",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha2",
 				Sources = {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.

The `Microsoft.Android.Sdk` pack has been renamed to
`Microsoft.Android.Sdk.net6` to match the pack alias that is referenced
in the .NET 7 manifest.
