### PR TITLE
[AOT] Pass the `hybrid` option to AOT compiler, if enabled

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -173,6 +173,19 @@ namespace Xamarin.Android.Tasks
 						aotOptions.Add ($"ld-flags={LdFlags}");
 					}
 
+					// We don't check whether any mode option was added via `AotAdditionalArguments`, the `AndroidAotMode` property should always win here.
+					// Modes not supported by us directly can be set by setting `AndroidAotMode` to "normal" and adding the desired mode name to the
+					// `AotAdditionalArguments` property.
+					switch (AotMode) {
+						case AotMode.Full:
+							aotOptions.Add ("full");
+							break;
+
+						case AotMode.Hybrid:
+							aotOptions.Add ("hybrid");
+							break;
+					}
+
 					// we need to quote the entire --aot arguments here to make sure it is parsed
 					// on windows as one argument. Otherwise it will be split up into multiple
 					// values, which wont work.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7088

When the AOT hybrid mode is enabled via the
`<AndroidAotMode>Hybrid</AndroidAotMode>` MSBuild property, we failed to
inform the AOT compiler about its desired mode by omitting the `hybrid`
argument from the list of options passed to the compiler via `--aot`

The same would apply to the full AOT mode.

Add `hybrid` and `full` options to the AOT compiler command line, if
enabled via the `AndroidAotMode` MSBuild property.

Mode is set after processing the `AotAdditionalArguments` MSBuild
property.  The `AndroidAotMode` property should always be the definitive
source of AOT compiler mode, as it specifies the options directly
supported by us.

Note that the AOT compiler doesn't appear to validate options passed to
it too rigorously, so setting multiple modes in some way, may have
weird/invalid effects.  I don't think it's our place to verify the
modes, thus I'm not adding any code to that effect.