### PR TITLE
[Mono.Android] add "built-in" delegate for MAUI+non-Shell

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -367,6 +367,17 @@ namespace Android.Runtime
 			}
 		}
 
+		internal static IntPtr Wrap_JniMarshal_PPIZI_L (this _JniMarshal_PPIZI_L callback, IntPtr jnienv, IntPtr klazz, int p0, bool p1, int p2)
+		{
+			JNIEnv.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1, p2);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
+			}
+		}
+
 		internal static void Wrap_JniMarshal_PPIIII_V (this _JniMarshal_PPIIII_V callback, IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2, int p3)
 		{
 			JNIEnv.WaitForBridgeProcessing ();
@@ -500,6 +511,8 @@ namespace Android.Runtime
 					return new _JniMarshal_PPLLL_L (Unsafe.As<_JniMarshal_PPLLL_L> (dlg).Wrap_JniMarshal_PPLLL_L);
 				case nameof (_JniMarshal_PPLLL_Z):
 					return new _JniMarshal_PPLLL_Z (Unsafe.As<_JniMarshal_PPLLL_Z> (dlg).Wrap_JniMarshal_PPLLL_Z);
+				case nameof (_JniMarshal_PPIZI_L):
+					return new _JniMarshal_PPIZI_L (Unsafe.As<_JniMarshal_PPIZI_L> (dlg).Wrap_JniMarshal_PPIZI_L);
 				case nameof (_JniMarshal_PPIIII_V):
 					return new _JniMarshal_PPIIII_V (Unsafe.As<_JniMarshal_PPIIII_V> (dlg).Wrap_JniMarshal_PPIIII_V);
 				case nameof (_JniMarshal_PPLLLL_V):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -197,6 +197,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1, p2",
 	},
 	new {
+		Type = "_JniMarshal_PPIZI_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, bool p1, int p2",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0, p1, p2",
+	},
+	new {
 		Type = "_JniMarshal_PPIIII_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1, int p2, int p3",
 		Return = "void",


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/15df4ed8fc8a8f84b090b1afae08303d847c481f
Fixes: https://github.com/xamarin/xamarin-android/issues/7212

In the app we're recording AOT profiles for .NET MAUI, we added a
`FlyoutPage` and navigated to it. This was good because it added
common scenarios to the profile:

* Navigation from one page to another
* A non-Shell API, `FlyoutPage`
* `FlyoutPage` also implicitly uses `NavigationPage`?

This caused the app to start using System.Reflection.Emit and logging:

```
08-16 09:46:24.687 31517 31517 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPIZI_L': IntPtr n_OnCreateAnimation_IZI(IntPtr, IntPtr, Int32, Boolean, Int32)
```

I added a case for `_JniMarshal_PPIZI_L`, this log message is now gone
when I build and run this app.

I think this should be the last one of these we add, unless one
appears from either:

* `dotnet new maui` or `dotnet new maui-blazor`
* [.NET Podcast app][0]

[0]: https://github.com/microsoft/dotnet-podcasts