### PR TITLE
[tests] ignore InstallAndroidDependenciesTest

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Build.Tests
 	public class AndroidDependenciesTests : BaseTest
 	{
 		[Test]
+		[Ignore ("Fixed in main via: https://github.com/xamarin/android-sdk-installer/pull/685")]
 		[NonParallelizable] // Do not run environment modifying tests in parallel.
 		public void InstallAndroidDependenciesTest ()
 		{


### PR DESCRIPTION
Context: https://github.com/xamarin/android-sdk-installer/pull/685

Our `InstallAndroidDependenciesTest` started failing with:

    Xamarin.Installer.Common.targets(12,3): error : Element 'type-details' with parser TypeDetailsSourceParser has a child element 'extension-level' but this version of the library does not support it (https://dl.google.com/android/repository/repository2-3.xml)

Since the fix is going into main / .NET 7, we think we should just
ignore this test for now in .NET 6.