### PR TITLE
[xabuild] update binding redirects for MSBuild 17.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,7 +49,8 @@
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
     <LZ4PackageVersion>1.1.11</LZ4PackageVersion>
     <MonoOptionsVersion>6.12.0.148</MonoOptionsVersion>
-    <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <ELFSharpVersion>2.13.1</ELFSharpVersion>
     <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.8.9.2</MdocPackageVersion>
   </PropertyGroup>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DetermineAzurePipelinesTestJobs.cs
@@ -149,6 +149,10 @@ namespace Xamarin.Android.Prepare
 					testAreas.Add ("MSBuildDevice");
 				}
 
+				if (file.Contains ("tools/xabuild")) {
+					testAreas.Add ("MSBuild");
+					testAreas.Add ("MSBuildDevice");
+				}
 			}
 
 			Log.MessageLine ($"##vso[task.setvariable variable=TestAreas;isOutput=true]{string.Join (",", testAreas)}");

--- a/tools/decompress-assemblies/decompress-assemblies.csproj
+++ b/tools/decompress-assemblies/decompress-assemblies.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="$(LZ4PackageVersion)" />
   </ItemGroup>

--- a/tools/xabuild/App.config
+++ b/tools/xabuild/App.config
@@ -39,7 +39,13 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="1.2.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.1.2" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -51,7 +57,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -15,9 +15,10 @@
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildToolsPath)\MSBuild.$(_MSBuildExtension)</HintPath>


### PR DESCRIPTION
`xabuild Xamarin.Android-Tests.sln` was failing with:

    MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
    System.IO.FileLoadException: Could not load file or assembly 'System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
    File name: 'System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
    at Microsoft.Build.Shared.FileUtilities.LooksLikeUnixFilePath(String value, String baseDirectory)
    at Microsoft.Build.CommandLine.MSBuildApp.GatherCommandLineSwitches(List`1 commandLineArgs, CommandLineSwitches commandLineSwitches, String commandLine)
    at Microsoft.Build.CommandLine.MSBuildApp.GatherAllSwitches(String commandLine, CommandLineSwitches& switchesFromAutoResponseFile, CommandLineSwitches& switchesNotFromAutoResponseFile)
    at Microsoft.Build.CommandLine.MSBuildApp.Execute(String commandLine)

This appears to be happening on Windows build machines running VS 2022
17.3 and MSBuild 17.3.

I did an audit comparing xabuild's `App.config` file with:

    C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe.config

We needed to update specifically to:

* System.Memory 4.5.5
* System.Collections.Immutable 6.0.0
* System.Runtime.CompilerServices.Unsafe 6.0.0

Note that in some cases the NuGet package version doesn't match the
assembly version.

After these changes, I can build `xabuild` locally with MSBuild 17.3,
and then also build Xamarin.Android projects.