### PR TITLE
[build] disable `<XamarinTelemetry/>` task

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -38,3 +38,6 @@ variables:
 # Workaround: https://github.com/dotnet/sdk/issues/26965
 - name: DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER
   value: true
+# Workaround: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1585820
+- name: _WriteTelemetryProperties
+  value: false


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1585820
Context: https://github.com/xamarin/XamarinVS/pull/13271

Many of our MSBuild tests fail with:

    error MSB4018: The "XamarinTelemetry" task failed unexpectedly.
    error MSB4018: System.IO.FileNotFoundException: Could not load file or assembly 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed' or one of its dependencies. The system cannot find the file specified.
    error MSB4018: File name: 'Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'
    error MSB4018:    at Microsoft.VisualStudio.Telemetry.TelemetrySessionSettings.GetFaultEventBucketFilterJson(List`1 bucketFilters)
    error MSB4018:    at Microsoft.VisualStudio.Telemetry.TelemetrySessionSettings.ToString()
    error MSB4018:    at Microsoft.VisualStudio.Telemetry.TelemetrySession.SerializeSettings()
    error MSB4018:    at Xamarin.Common.Tasks.Telemetry.GetSession(IBuildEngine4 buildEngine, String vsTelemetrySession) in D:\a\_work\1\s\src\MSBuild\Xamarin.Common.Tasks\Telemetry.cs:line 62
    error MSB4018:    at Xamarin.Common.Tasks.XamarinTelemetry.Execute() in D:\a\_work\1\s\src\MSBuild\Xamarin.Common.Tasks\XamarinTelemetry.cs:line 31
    error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
    error MSB4018: WRN: Assembly binding logging is turned OFF.
    error MSB4018: To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
    error MSB4018: Note: There is some performance penalty associated with assembly bind failure logging.
    error MSB4018: To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].

It appears there is a fix in XamarinVS for this.

In order to get our CI working, it appears we can set
`%_WriteTelemetryProperties%` to `false` for now to workaround it:

https://github.com/xamarin/XamarinVS/blob/d31703e0163cd3db24e874146c41988f64fac737/src/MSBuild/Xamarin/Xamarin.Sdk.targets#L82