### PR TITLE
[ci] Add EXE files to windows-toolchain-pdb artifact

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -115,10 +115,10 @@ stages:
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&
-        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/$(XA.Build.Configuration)/lib/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/bin/*.pdb
-        $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb/
+        cd $(System.DefaultWorkingDirectory)/xamarin-android/bin/$(XA.Build.Configuration)/lib/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/windows-toolchain-pdb &&
+        zip -r $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb/windows-toolchain-pdb.zip .
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: copy Windows toolchain pdb files
+      displayName: zip Windows toolchain pdb files
 
     - task: PublishPipelineArtifact@1
       displayName: upload Windows toolchain pdb files
@@ -1497,6 +1497,11 @@ stages:
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vs-msi-nugets
+        downloadPath: $(Build.StagingDirectory)\nuget-signed
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(WindowsToolchainPdbArtifactName)
         downloadPath: $(Build.StagingDirectory)\nuget-signed
 
     - task: NuGetCommand@2

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallGNUBinutils.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Android.Prepare
 
 			string osSourcePath = Path.Combine (sourceDir, osName);
 			string sourcePath = Path.Combine (osSourcePath, "bin");
+			string symbolArchiveDir = Path.Combine (destinationDir, "windows-toolchain-pdb");
 			foreach (var kvp in Configurables.Defaults.AndroidToolchainPrefixes) {
 				string prefix = kvp.Value;
 				CopyTools (prefix);
@@ -108,18 +109,18 @@ namespace Xamarin.Android.Prepare
 						continue;
 					}
 
-					toolSourcePath = Path.ChangeExtension (toolSourcePath, ".pdb");
-					if (!File.Exists (toolSourcePath)) {
+					// Copy PDBs and corresponding EXEs to a folder to be zipped up for symbol archiving
+					string toolSourcePdbPath = Path.ChangeExtension (toolSourcePath, ".pdb");
+					if (!File.Exists (toolSourcePdbPath)) {
 						continue;
 					}
 
-					toolDestinationPath = Path.ChangeExtension (toolDestinationPath, ".pdb");
+					toolDestinationPath = Path.Combine (symbolArchiveDir, toolName);
+					string toolDestinationPdbPath = Path.ChangeExtension (toolDestinationPath, ".pdb");
 
-					Log.StatusLine ($"  {context.Characters.Bullet} Installing ", toolName, tailColor: ConsoleColor.White);
+					Log.StatusLine ($"  {context.Characters.Bullet} Copying symbols for ", toolName, tailColor: ConsoleColor.White);
 					Utilities.CopyFile (toolSourcePath, toolDestinationPath);
-
-					versionMarkerPath = GetVersionMarker (toolDestinationPath);
-					File.WriteAllText (versionMarkerPath, DateTime.UtcNow.ToString ());
+					Utilities.CopyFile (toolSourcePdbPath, toolDestinationPdbPath);
 				}
 			}
 		}


### PR DESCRIPTION
The `windows-toolchain-pdb` artifact has been updated to include a ZIP
containing both PDB and EXE files.  This artifact will now be uploaded
to blob storage and included in the `nuget-artifacts` GitHub status.

These changes will allow the .NET Visual Studio insertion pipeline to
archive the symbols in this zip file, as its symbol archiving step
already [has support for processing ZIP files][0] listed in the
`nuget-artifacts` GitHub status.

[0]: https://github.com/xamarin/sdk-insertions/blob/15cc361f17d8c34f208ab8d8be024ba39307b295/templates/common/archive-symbols.yml#L40-L72