### PR TITLE
[build] disable classic tests on .NET 6 release branches

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1003,8 +1003,6 @@ stages:
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - Legacy)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
-      # Disabled on .NET 6 release branches
-      condition: false
       node_id: 1
       job_name: mac_msbuilddevice_tests_1
       job_suffix: Legacy
@@ -1013,8 +1011,6 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
-      # Disabled on .NET 6 release branches
-      condition: false
       node_id: 2
       job_name: mac_msbuilddevice_tests_2
       job_suffix: Legacy
@@ -1023,8 +1019,6 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
-      # Disabled on .NET 6 release branches
-      condition: false
       node_id: 3
       job_name: mac_msbuilddevice_tests_3
       job_suffix: Legacy
@@ -1033,8 +1027,6 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
-      # Disabled on .NET 6 release branches
-      condition: false
       node_id: 4
       job_name: mac_msbuilddevice_tests_with_debugger
       job_suffix: Legacy

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -341,6 +341,8 @@ stages:
   jobs:
   # Check - "Xamarin.Android (Smoke Tests APKs Legacy - macOS)"
   - job: mac_apk_tests_legacy
+    # Disabled on .NET 6 release branches
+    condition: false
     displayName: APKs Legacy - macOS
     pool:
       vmImage: $(HostedMacImage)
@@ -820,7 +822,8 @@ stages:
 - stage: msbuild_legacy
   displayName: Legacy Tests
   dependsOn: mac_build
-  condition: and(succeeded(), or(eq(variables['RunAllTests'], true), contains(dependencies.mac_build.outputs['mac_build_create_installers.TestConditions.TestAreas'], 'MSBuild')))
+  # Disabled on .NET 6 release branches
+  condition: false
   jobs:
   # Xamarin.Android (Test MSBuild Legacy - macOS)
   - template: yaml-templates\run-msbuild-mac-tests.yaml
@@ -1000,6 +1003,8 @@ stages:
   # Check - "Xamarin.Android (MSBuild Emulator Tests macOS - Legacy)"
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
+      # Disabled on .NET 6 release branches
+      condition: false
       node_id: 1
       job_name: mac_msbuilddevice_tests_1
       job_suffix: Legacy
@@ -1008,6 +1013,8 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
+      # Disabled on .NET 6 release branches
+      condition: false
       node_id: 2
       job_name: mac_msbuilddevice_tests_2
       job_suffix: Legacy
@@ -1016,6 +1023,8 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
+      # Disabled on .NET 6 release branches
+      condition: false
       node_id: 3
       job_name: mac_msbuilddevice_tests_3
       job_suffix: Legacy
@@ -1024,6 +1033,8 @@ stages:
 
   - template: yaml-templates/run-msbuild-device-tests.yaml
     parameters:
+      # Disabled on .NET 6 release branches
+      condition: false
       node_id: 4
       job_name: mac_msbuilddevice_tests_with_debugger
       job_suffix: Legacy

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1318,6 +1318,8 @@ stages:
   jobs:
   # Check - "Xamarin.Android (BCL Emulator Tests macOS)"
   - job: mac_bcl_tests
+    # Disabled on .NET 6 release branches
+    condition: false
     displayName: macOS
     pool:
       vmImage: $(HostedMacImage)

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -8,8 +8,7 @@ steps:
     artifactName: $(InstallerArtifactName)
     downloadPath: $(System.DefaultWorkingDirectory)
     patterns: xamarin.android*.pkg
-  # Disabled on .NET 6 release branches
-  condition: false
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - task: DownloadPipelineArtifact@2
   inputs:
@@ -31,8 +30,8 @@ steps:
     }
     Write-Host "##vso[task.setvariable variable=XA.Provisionator.Args]$installer"
   displayName: find installer and set provisionator variable
-  # Disabled on .NET 6 release branches
-  condition: false
+  # Disabled Windows on .NET 6 release branches
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - task: provisionator@2
   inputs:
@@ -40,7 +39,7 @@ steps:
     github_token: $(GitHub.Token)
     provisioning_script: $(XA.Provisionator.Args)
     provisioning_extra_args: ${{ parameters.provisionExtraArgs }}
-  # Disabled on .NET 6 release branches
-  condition: false
+  # Disabled Windows on .NET 6 release branches
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
   env:
     PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -8,14 +8,16 @@ steps:
     artifactName: $(InstallerArtifactName)
     downloadPath: $(System.DefaultWorkingDirectory)
     patterns: xamarin.android*.pkg
-  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+  # Disabled on .NET 6 release branches
+  condition: false
 
 - task: DownloadPipelineArtifact@2
   inputs:
     artifactName: $(InstallerArtifactName)
     downloadPath: $(System.DefaultWorkingDirectory)
     patterns: Xamarin.Android*.vsix
-  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+  # Disabled on .NET 6 release branches
+  condition: false
 
 - powershell: |
     $itemPattern = "*.vsix"
@@ -29,7 +31,8 @@ steps:
     }
     Write-Host "##vso[task.setvariable variable=XA.Provisionator.Args]$installer"
   displayName: find installer and set provisionator variable
-  condition: and(succeeded(), ne(variables['agent.os'], 'Linux'))
+  # Disabled on .NET 6 release branches
+  condition: false
 
 - task: provisionator@2
   inputs:
@@ -37,6 +40,7 @@ steps:
     github_token: $(GitHub.Token)
     provisioning_script: $(XA.Provisionator.Args)
     provisioning_extra_args: ${{ parameters.provisionExtraArgs }}
-  condition: and(succeeded(), ne(variables['agent.os'], 'Linux'))
+  # Disabled on .NET 6 release branches
+  condition: false
   env:
     PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -11,6 +11,8 @@ parameters:
 jobs:
   - job: ${{ parameters.job_name }}
     displayName: MSBuild With Emulator - macOS-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
+    # Disabled on .NET 6 release branches
+    condition: ne(${{ parameters.job_suffix }}, 'Legacy')
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 90

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -12,7 +12,7 @@ jobs:
   - job: ${{ parameters.job_name }}
     displayName: MSBuild With Emulator - macOS-${{ parameters.node_id }} - ${{ parameters.job_suffix }}
     # Disabled on .NET 6 release branches
-    condition: ne(${{ parameters.job_suffix }}, 'Legacy')
+    condition: ne('${{ parameters.job_suffix }}', 'Legacy')
     pool:
       vmImage: $(HostedMacImage)
     timeoutInMinutes: 90

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -21,8 +21,6 @@ steps:
 
 - template: run-installer.yaml
   parameters:
-    # Disabled on .NET 6 release branches
-    condition: false
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
 

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -21,6 +21,8 @@ steps:
 
 - template: run-installer.yaml
   parameters:
+    # Disabled on .NET 6 release branches
+    condition: false
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
 


### PR DESCRIPTION
Many of our Windows lanes on `release/6.0.4xx` are failing with:

    Xamarin.Provisioning.ProvisioningException: Failed to provision
    ---> Xamarin.Provisioning.ProvisioningException: Only extension versions greater than that in the instance catalog version (13.0.0.0) can be installed.

This is because the CI machines have VS 17.3 now, and the classic
Xamarin.Android we're building is too old.

For now, let's just disable all these classic tests on this branch. We
can come up with a better idea for this later.