### PR TITLE
Bump NDK to r25b

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "25";
-		public const string AndroidNdkPkgRevision = "25.0.8775105";
+		public const string AndroidNdkVersion = "25b";
+		public const string AndroidNdkPkgRevision = "25.1.8937393";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 19;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r25#r25b

There are no interesting changes in this version, from our point
of view.  Bumping merely to track the current supported version
of the NDK.