### PR TITLE
AndroidLinkResources and Styleables

### DIFF
--- a/samples/HelloWorld/HelloLibrary/HelloLibrary.csproj
+++ b/samples/HelloWorld/HelloLibrary/HelloLibrary.csproj
@@ -14,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>false</AndroidApplication>
     <DebugType>portable</DebugType>
+    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
   </PropertyGroup>
   <Import
       Condition="Exists('..\..\..\Configuration.props')"
@@ -71,5 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\Case_Check.png" />
+    <AndroidResource Include="Resources\values\Attr.xml" />
   </ItemGroup>
 </Project>

--- a/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
+++ b/samples/HelloWorld/HelloLibrary/LibraryActivity.cs
@@ -16,7 +16,7 @@ using Android.Util;
 using Android.Views;
 using Android.Widget;
 
-namespace Mono.Samples.Hello
+namespace HelloLibrary
 {
     [Activity(Label = "Library Activity", Name="mono.samples.hello.LibraryActivity")]
     public class LibraryActivity : Activity

--- a/samples/HelloWorld/HelloLibrary/Resources/values/Attr.xml
+++ b/samples/HelloWorld/HelloLibrary/Resources/values/Attr.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="MyLibraryWidget">
+        <attr name="library_bool_attr" format="boolean" />
+        <attr name="library_int_attr" format="integer" />
+    </declare-styleable>
+</resources>

--- a/samples/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Main.axml" />
     <AndroidResource Include="Resources\values\Strings.xml" />
+    <AndroidResource Include="Resources\values\Attr.xml" />
     <AndroidResource Include="Resources\mipmap-hdpi\Icon.png" />
     <AndroidResource Include="Resources\mipmap-mdpi\Icon.png" />
     <AndroidResource Include="Resources\mipmap-xhdpi\Icon.png" />

--- a/samples/HelloWorld/HelloWorld/Resources/values/Attr.xml
+++ b/samples/HelloWorld/HelloWorld/Resources/values/Attr.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="MyWidget">
+        <attr name="bool_attr" format="boolean" />
+        <attr name="int_attr" format="integer" />
+    </declare-styleable>
+</resources>

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveResourceDesignerStep.cs
@@ -55,14 +55,19 @@ namespace MonoDroid.Tuner
 			Dictionary<Instruction, int> instructions = new Dictionary<Instruction, int>();
 			var processor = body.GetILProcessor ();
 			string designerFullName = $"{designer.FullName}/";
+			bool isDesignerMethod = designerFullName.Contains (body.Method.DeclaringType.FullName);
+			string declaringTypeName = body.Method.DeclaringType.Name;
 			foreach (var i in body.Instructions)
 			{
 				string line = i.ToString ();
-				if (line.Contains (designerFullName) && !instructions.ContainsKey (i))
+				if ((line.Contains (designerFullName) || (isDesignerMethod && i.OpCode == OpCodes.Stsfld)) && !instructions.ContainsKey (i))
 				{
 					var match = opCodeRegex.Match (line);
 					if (match.Success && match.Groups.Count == 5) {
 						string key = match.Groups[4].Value.Replace (designerFullName, string.Empty);
+						if (isDesignerMethod) {
+							key = declaringTypeName +"::" + key;
+						}
 						if (designerConstants.ContainsKey (key) && !instructions.ContainsKey (i))
 							instructions.Add(i, designerConstants [key]);
 					}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -712,5 +712,65 @@ using System.Runtime.Serialization.Json;
 				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"));
 			Assert.IsTrue (didStart, "Activity should have started.");
 		}
+
+		[Test]
+		public void AppWithStyleableUsageRuns ([Values (true, false)] bool isRelease, [Values (true, false)] bool linkResources)
+		{
+			AssertHasDevices ();
+			proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\styleables.xml") {
+				TextContent = () => @"<?xml version='1.0' encoding='utf-8'?>
+<resources>
+	<declare-styleable name='MyView'>
+		<attr name='MyBool' format='boolean' />
+		<attr name='MyInt' format='integer' />
+	</declare-styleable>
+</resources>",
+			});
+			proj.SetProperty ("AndroidLinkResources", linkResources ? "False" : "True");
+			proj.LayoutMain = proj.LayoutMain.Replace ("<LinearLayout", "<UnnamedProject.MyLayout xmlns:app='http://schemas.android.com/apk/res-auto' app:MyBool='true' app:MyInt='128'")
+				.Replace ("</LinearLayout>", "</UnnamedProject.MyLayout>");
+
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_MAINACTIVITY}",
+@"public class MyLayout : Android.Widget.LinearLayout
+	{
+
+	public MyLayout (Android.Content.Context context, Android.Util.IAttributeSet attrs) : base (context, attrs)
+	{
+		Android.Content.Res.TypedArray a = context.Theme.ObtainStyledAttributes (attrs, Resource.Styleable.MyView, 0,0);
+		try {
+				bool b = a.GetBoolean (Resource.Styleable.MyView_MyBool, defValue: false);
+				if (!b)
+					throw new Exception (""MyBool was not true."");
+				int i = a.GetInteger (Resource.Styleable.MyView_MyInt, defValue: -1);
+				if (i != 128)
+					throw new Exception (""MyInt was not 128."");
+		}
+		finally {
+			a.Recycle();
+		}
+	}
+    }
+");
+
+			var abis = new string [] { "armeabi-v7a", "arm64-v8a", "x86", "x86_64" };
+			proj.SetAndroidSupportedAbis (abis);
+			builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+
+			if (Builder.UseDotNet)
+				Assert.True (builder.RunTarget (proj, "Run"), "Project should have run.");
+			else if (CommercialBuildAvailable)
+				Assert.True (builder.RunTarget (proj, "_Run"), "Project should have run.");
+			else
+				AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+
+			var didStart = WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"));
+			Assert.IsTrue (didStart, "Activity should have started.");
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/7194
Context https://github.com/dotnet/maui/pull/7038

The initial version of `AndroidLinkResources` commited in 9e6ce03c was to broad in its removal of Fields. 
Certain field usage like `Styleable` arrays were not called using the IL`stsfld` op code. As a result they could
not be easily replaced with constant usage. However the linker removed ALL the fields from the `Resource` 
sub classes. This would result in the following error

`System.BadImageFormatException: 'Could not resolve field token 0x0400000b'`.

This was because the `int[]` fields were removed as part of the linking process. 

So to fix this we need to leave the `int[]` fields in the `Resource` subclasses and not remove them. We can 
still remove all the other `int` fields though. We now also need to fix up the `Resource` subclass constructors 
to replace the `int` field access with the constant values like we do for the rest of the app. 
This was not required because because these constructors were removed. But now we have to keep them because
the static array initialisation takes place in these constructors. 