### PR TITLE
[tests] disable `$(_FastDeploymentDiagnosticLogging)` in PerformanceTest

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -93,6 +93,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 			};
 			proj.SetAndroidSupportedAbis (DeviceAbi); // Use a single ABI
+			proj.SetProperty ("_FastDeploymentDiagnosticLogging", "False");
 			return proj;
 		}
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6595850&view=ms.vss-test-web.build-test-results-tab&runId=51752272&resultId=100026&paneView=debug

Frequently `Install_CSharp_Change` fails with:

    Exceeded expected time of 4500ms, actual 4671.203ms

Reviewing the `.binlog` the `<FastDeploy/>` task shows up:

    Top 10 most expensive tasks
        GenerateJavaStubs = 1.304 s
            _GenerateJavaStubs = 1.304 s
        FastDeploy = 498 ms
            _Upload = 498 ms

`<FastDeploy/>` is logging "lots of stuff" due to
`$(_FastDeploymentDiagnosticLogging)`:

    FastDeploy
        Parameters
            DiagnosticLogging = True
    ...
    // Hundreds of lines of:
    xamarin.find: Ignoring line 'DEBUG: ./UnnamedProject.dll size:1661286176390 mtime:6144 tv_sec:1661286176 tv_nsec:390000'. Line is incorrectly formatted.

This was added in 7b51fd1b, to help debug other issues.

Let's turn off this setting on `PerformanceTest`, as we're looking to
measure how fast build & deploy is. Less log messages should help.