### PR TITLE
[ci] Add support to net7.0 for multi-targeting in VS

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.461</AndroidNet6Version>
+    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.465</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.447</AndroidNet6Version>
+    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.461</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1441,7 +1441,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v2.yml@yaml
+  - template: nuget-msi-convert/job/v3.yml@yaml
     parameters:
       yamlResourceName: yaml
       dependsOn: sign_net_mac_win
@@ -1450,8 +1450,6 @@ stages:
         !*Darwin*
       propsArtifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
-      runInParallel: false
-      useDateTimeVersion: true
       postConvertSteps:
       - task: DownloadPipelineArtifact@2
         inputs:
@@ -1535,6 +1533,20 @@ stages:
           inputs:
             artifactName: vsdrop-signed
             downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+
+    - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+      parameters:
+        githubToken: $(GitHub.Token)
+        githubContext: $(MultiTargetVSDropCommitStatusName)
+        blobName: $(MultiTargetVSDropCommitStatusName)
+        packagePrefix: xamarin-android
+        artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        yamlResourceName: yaml
+        downloadSteps:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: vsdrop-multitarget-signed
+            downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
     - powershell: >-
         & dotnet build -v:n -c $(XA.Build.Configuration)

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -9,7 +9,11 @@
     <ShortNames Include="@PACK_VERSION_LONG@">
       <Replacement>@PACK_VERSION_SHORT@</Replacement>
     </ShortNames>
+    <ShortNames Include="Microsoft.NET.Sdk.Android.Manifest">
+      <Replacement>Android.Manifest</Replacement>
+    </ShortNames>
     <ComponentResources Include="android" Version="@WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Android" Description=".NET SDK Workload for building Android applications."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Android.Manifest*.nupkg" Version="@WORKLOAD_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.Android.Sdk" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -4,8 +4,8 @@
     "android": {
       "description": ".NET SDK Workload for building Android applications.",
       "packs": [
-        "Microsoft.Android.Sdk",
-        "Microsoft.Android.Sdk.NET6",
+        "Microsoft.Android.Sdk.net7",
+        "Microsoft.Android.Sdk.net6",
         "Microsoft.Android.Ref.33",
         "Microsoft.Android.Runtime.33.android-arm",
         "Microsoft.Android.Runtime.33.android-arm64",
@@ -18,7 +18,7 @@
     }
   },
   "packs": {
-    "Microsoft.Android.Sdk": {
+    "Microsoft.Android.Sdk.net7": {
       "kind": "sdk",
       "version": "@WORKLOAD_VERSION@",
       "alias-to": {
@@ -30,7 +30,7 @@
         "linux-x64": "Microsoft.Android.Sdk.Linux"
       }
     },
-    "Microsoft.Android.Sdk.NET6": {
+    "Microsoft.Android.Sdk.net6": {
       "kind": "sdk",
       "version": "@NET6_VERSION@",
       "alias-to": {

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -1,8 +1,8 @@
 <Project>
   <ImportGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
-    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk"
+    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net7"
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) " />
-    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.NET6"
+    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net6"
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) " />
   </ImportGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -306,6 +306,7 @@ public class JavaSourceTest {
 				ExtraNuGetConfigSources = {
 					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
 					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				},
 			};
 			if (IsPreviewFrameworkVersion (targetFramework)) {
@@ -843,6 +844,7 @@ public class JavaSourceTest {
 				ExtraNuGetConfigSources = {
 					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
 					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				},
 			};
 			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
@@ -928,7 +930,7 @@ public class JavaSourceTest {
 		public void XamarinLegacySdk ([Values ("net6.0-android32.0", "net7.0-android33.0")] string dotnetTargetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha1",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha2",
 				Sources = {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,
@@ -937,6 +939,7 @@ public class JavaSourceTest {
 				ExtraNuGetConfigSources = {
 					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
 					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				},
 			};
 
@@ -969,6 +972,7 @@ public class JavaSourceTest {
 				ExtraNuGetConfigSources = {
 					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
 					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				},
 			};
 

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -74,6 +75,13 @@ namespace Xamarin.Android.Build.Tests
 				};
 			}
 			proj.TargetFramework = targetFramework;
+			if (targetFramework.Contains ("net6.0")) {
+				proj.ExtraNuGetConfigSources = new List<string> () {
+					// Projects targeting net6.0 require ref/runtime packs on NuGet.org or dotnet6
+					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
+				};
+			}
 			if (publishTrimmed != null) {
 				proj.SetProperty (KnownProperties.PublishTrimmed, publishTrimmed.ToString ());
 			}
@@ -156,6 +164,13 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XASdkProject ();
 			proj.TargetFramework = targetFramework;
+			if (targetFramework.Contains ("net6.0")) {
+				proj.ExtraNuGetConfigSources = new List<string> () {
+					// Projects targeting net6.0 require ref/runtime packs on NuGet.org or dotnet6
+					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
+				};
+			}
 			proj.SetRuntimeIdentifier (DeviceAbi);
 			string runtimeId = proj.GetProperty (KnownProperties.RuntimeIdentifier);
 


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.

The `Microsoft.Android.Sdk` pack has been renamed to
`Microsoft.Android.Sdk.net7` to allow it to be imported by the .NET 8
workload manifest when the time comes.