### PR TITLE
Bump to dotnet/runtime/release/7.0-rc1@06aceb70

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,17 +8,17 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>313671b195b1b36d56a8888a9a0e12edaac52c57</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22423.16" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22426.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>430c42acb0eb0481f58d1acb172af346363e2edc</Sha>
+      <Sha>06aceb7015f3bd2ff019ef5920d2354eb2ea2c92</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0-rc.1.22423.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0-rc.1.22424.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>321399ab3ab4853fbf861b2eaed2113447a6d7e4</Sha>
+      <Sha>5ef661392ae7b1595b683df83d63e3a0365fc126</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.1.22423.3" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.1.22424.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>321399ab3ab4853fbf861b2eaed2113447a6d7e4</Sha>
+      <Sha>5ef661392ae7b1595b683df83d63e3a0365fc126</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22425.9</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22423.4</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22423.16</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22426.10</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rc.1.22423.3</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rc.1.22424.1</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,61 +5,58 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 58974
+      "Size": 59098
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88640
+      "Size": 88538
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Console.dll": {
-      "Size": 6404
+      "Size": 6403
     },
     "assemblies/System.Diagnostics.Tracing.dll": {
-      "Size": 2084
+      "Size": 2086
     },
     "assemblies/System.Linq.dll": {
-      "Size": 9088
+      "Size": 9091
     },
     "assemblies/System.Memory.dll": {
-      "Size": 3383
+      "Size": 3381
     },
     "assemblies/System.Private.CoreLib.dll": {
       "Size": 533637
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 3493
+      "Size": 3496
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3741
+      "Size": 3740
     },
     "assemblies/System.Threading.dll": {
-      "Size": 5480
+      "Size": 5481
     },
     "assemblies/System.Threading.Thread.dll": {
-      "Size": 1974
+      "Size": 1975
     },
     "assemblies/System.Threading.ThreadPool.dll": {
-      "Size": 2003
+      "Size": 2005
     },
     "assemblies/System.Transactions.Local.dll": {
-      "Size": 62998
+      "Size": 62991
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3558
+      "Size": 3561
     },
     "classes.dex": {
       "Size": 360744
-    },
-    "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 96832
     },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 425416
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3052824
+      "Size": 3073288
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -71,16 +68,16 @@
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 10528
+      "Size": 10216
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 3459
+      "Size": 3339
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 3332
+      "Size": 3212
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 4762
@@ -107,5 +104,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2820744
+  "PackageSize": 2791978
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,139 +8,139 @@
       "Size": 7114
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 66533
+      "Size": 66672
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 442098
+      "Size": 441995
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3854
+      "Size": 3858
     },
     "assemblies/netstandard.dll": {
-      "Size": 5569
+      "Size": 5574
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 10478
+      "Size": 10479
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15293
+      "Size": 15301
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 7425
+      "Size": 7429
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 1937
+      "Size": 1939
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2549
+      "Size": 2552
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6028
+      "Size": 6030
     },
     "assemblies/System.Console.dll": {
-      "Size": 7264
+      "Size": 7265
     },
     "assemblies/System.Core.dll": {
-      "Size": 1981
+      "Size": 1985
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6545
+      "Size": 6544
     },
     "assemblies/System.Diagnostics.Tracing.dll": {
-      "Size": 2084
+      "Size": 2086
     },
     "assemblies/System.dll": {
-      "Size": 2338
+      "Size": 2340
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2022
+      "Size": 2025
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 11964
+      "Size": 11966
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 16669
+      "Size": 16667
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 9986
+      "Size": 9985
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19130
+      "Size": 19132
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 163888
+      "Size": 163887
     },
     "assemblies/System.Memory.dll": {
-      "Size": 3383
+      "Size": 3381
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 66829
+      "Size": 66832
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 21869
+      "Size": 21876
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3597
+      "Size": 3601
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8099
+      "Size": 8100
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 786584
+      "Size": 786590
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
       "Size": 192243
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42211
+      "Size": 42213
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 215336
+      "Size": 215334
     },
     "assemblies/System.Private.Xml.Linq.dll": {
       "Size": 16625
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 3644
+      "Size": 3645
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3741
+      "Size": 3740
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1946
+      "Size": 1949
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2476
+      "Size": 2477
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3755
+      "Size": 3757
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 7783
+      "Size": 7787
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 154124
+      "Size": 154127
     },
     "assemblies/System.Threading.dll": {
-      "Size": 5480
+      "Size": 5481
     },
     "assemblies/System.Threading.Thread.dll": {
-      "Size": 1974
+      "Size": 1975
     },
     "assemblies/System.Threading.ThreadPool.dll": {
-      "Size": 2003
+      "Size": 2005
     },
     "assemblies/System.Transactions.Local.dll": {
-      "Size": 62998
+      "Size": 62991
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1834
+      "Size": 1837
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1854
+      "Size": 1858
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 117252
@@ -214,14 +214,11 @@
     "classes.dex": {
       "Size": 3473216
     },
-    "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 96832
-    },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 425416
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3052824
+      "Size": 3073288
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -233,7 +230,7 @@
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 99952
+      "Size": 99640
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -347,13 +344,13 @@
       "Size": 1213
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 79748
+      "Size": 79628
     },
     "META-INF/com.google.android.material_material.version": {
       "Size": 10
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 79621
+      "Size": 79501
     },
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
@@ -1988,5 +1985,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8107074
+  "PackageSize": 8078308
 }


### PR DESCRIPTION
Context: https://maestro-prod.westus2.cloudapp.azure.com/3077/https:%2F%2Fgithub.com%2Fdotnet%2Fruntime/latest/graph
Changes: https://github.com/dotnet/runtime/compare/430c42acb0eb0481f58d1acb172af346363e2edc...06aceb7015f3bd2ff019ef5920d2354eb2ea2c92
Changes: https://github.com/dotnet/emsdk/compare/321399ab3ab4853fbf861b2eaed2113447a6d7e4...5ef661392ae7b1595b683df83d63e3a0365fc126

To get this bump sooner, I removed:

    CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal"

Then locally ran:

    darc update-dependencies --id 146680