### PR TITLE
[tests] Use `$(AndroidSdkPlatformToolsVersion)`=33.0.3

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsTrue (b.Build (proj, parameters: new string [] {
 						"AcceptAndroidSDKLicenses=true",
 						"AndroidManifestType=GoogleV2",     // Need GoogleV2 so we can install API-32
+						"AndroidSdkPlatformToolsVersion=33.0.3",
 					}), "InstallAndroidDependencies should have succeeded.");
 					b.Target = defaultTarget;
 					b.BuildLogFile = "build.log";


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297837953679412/1012790775945371698
Context: https://discord.com/channels/732297728826277939/732297837953679412/1012806908224229418
Context: https://discord.com/channels/732297728826277939/732297837953679412/1012874553288048653
Context: https://dl.google.com/android/repository/repository2-3.xml

Ever since 2022-Aug-22, PR and CI builds of xamarin-android have had
a unit test failure in
`AndroidDependenciesTests.InstallAndroidDependenciesTest()`:

	_AndroidSdkDirectory was not set to new SDK path.
	Expected: True
	But was:  False

`install-deps.log` contains:

	Task "InstallAndroidDependencies"
	  Task Parameter:TimeoutInMinutes=7
	  Task Parameter:AcceptAndroidSDKLicenses=True
	  Task Parameter:ManifestType=GoogleV2
	  Task Parameter:
	      Dependencies=
	          platforms/android-33
	          build-tools/32.0.0
	                  Version=32.0.0
	          platform-tools
	                  Version=33.0.2
	          cmdline-tools/7.0
	                  Version=7.0
	   Task Parameter:AndroidSdkPath=/Users/runner/work/1/a/TestRelease/08-22_23.03.40/temp/InstallAndroidDependenciesTest/android-sdk
	  …
	  Component Android SDK Platform-Tools r33.0.3 not present on the system
	  …
	  Dependency found: Android SDK Platform 33
	  Dependency found: Android SDK Build-Tools 32
	  Dependency found: Android SDK Command-line Tools
	  Adding component 'Android SDK Platform 33 r2 [Platform: API 33]'
	  Adding component 'Android SDK Build-Tools 32 r32.0.0'
	  Adding component 'Android SDK Command-line Tools r7.0'
	  Dependency to be installed: Android SDK Platform 33
	  Dependency to be installed: Android SDK Build-Tools 32
	  Dependency to be installed: Android SDK Command-line Tools
	  …
	  Downloading archive from 'https://dl.google.com/android/repository/platform-33_r02.zip'
	  Downloading archive from 'https://dl.google.com/android/repository/5219cc671e844de73762e969ace287c29d2e14cd.build-tools_r32-macosx.zip'
	  Downloading archive from 'https://dl.google.com/android/repository/commandlinetools-mac-8512546_latest.zip'
	  …
	…/Xamarin.Installer.Common.targets(12,3): warning :
	  Dependency `platform-tools` should have been installed but could not be resolved. You can attempt to install it with:
	  `/Users/runner/work/1/a/TestRelease/08-22_23.03.40/temp/InstallAndroidDependenciesTest/android-sdk/cmdline-tools/7.0/bin/sdkmanager --install "platform-tools"`

Reminder: what `InstallAndroidDependenciesTest()` tests is that given:

	dotnet build -t:InstallAndroidDependencies -p:AcceptAndroidSDKLicenses=True \
	  -p:AndroidSdkDirectory=/Users/runner/work/1/a/TestRelease/08-22_23.03.40/temp/InstallAndroidDependenciesTest/android-sdk

that a "new"/"complete" Android SDK is provisioned into
`$(AndroidSdkDirectory)`, such that a subsequent:

	dotnet build -p:AndroidSdkDirectory=…/InstallAndroidDependenciesTest/android-sdk

will build using the specified `$(AndroidSdkDirectory)` value.

The test fails if the *actually used* `$(AndroidSdkDirectory)` value
isn't the one that was provided to
`dotnet build -t:InstallAndroidDependencies`.

Here, as per `install-deps.log`, we request that the following
components get installed:

	platforms/android-33
	build-tools/32.0.0
	        Version=32.0.0
	platform-tools
	        Version=33.0.2
	cmdline-tools/7.0
	        Version=7.0

However, what we see is *actually* installed are everything except
the `platform-tools` package:

	Downloading archive from 'https://dl.google.com/android/repository/platform-33_r02.zip'
	Downloading archive from 'https://dl.google.com/android/repository/5219cc671e844de73762e969ace287c29d2e14cd.build-tools_r32-macosx.zip'
	Downloading archive from 'https://dl.google.com/android/repository/commandlinetools-mac-8512546_latest.zip'

When we run the final `dotnet build`, the specified
`$(AndroidSdkDirectory)` value is *ignored*, as it isn't valid;
from `build.log`:

	Task "ResolveSdks"
	  Task Parameter:AndroidSdkPath=C:\a\_work\2\a\TestRelease\08-24_20.26.42\temp\InstallAndroidDependenciesTest\android-sdk
	  Task Parameter:LatestSupportedJavaVersion=11.0.99
	  Task Parameter:ReferenceAssemblyPaths=C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\data\net7.0-android33\
	  Task Parameter:JavaSdkPath=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64
	  Task Parameter:CommandLineToolsVersion=7.0
	  Task Parameter:MinimumSupportedJavaVersion=11.0
	  ValidateAndroidSdkLocation: for locator=constructor param, path=`C:\a\_work\2\a\TestRelease\08-24_20.26.42\temp\InstallAndroidDependenciesTest\android-sdk`, result=False
	  ValidateAndroidSdkLocation: for locator=preferred path, path=``, result=False
	  Looking for Android SDK...
	  ValidateAndroidSdkLocation: for locator=all paths, path=`C:\Program Files (x86)\Android\android-sdk`, found adb `C:\Program Files (x86)\Android\android-sdk\platform-tools\adb.EXE`
	  ValidateAndroidSdkLocation: for locator=all paths, path=`C:\Program Files (x86)\Android\android-sdk`, result=True
	  ValidateJavaSdkLocation: for locator=constructor param, path=`C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64`, found jarsigner `C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64\bin\jarsigner.EXE`
	  ValidateJavaSdkLocation: for locator=constructor param, path=`C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64`, found jarsigner `C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64\bin\jarsigner.exe`
	  ValidateJavaSdkLocation: locator=constructor param, path=`C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64`, result=True
	  ValidateAndroidNdkLocation: for locator=constructor param, path=``, result=False
	  Skipping NDK in 'C:\Program Files (x86)\Android\android-sdk\ndk\25.0.8775105': version 25.0.8775105 is out of the accepted range (major version must be between 16 and 24
	  Best NDK selected: v24.0.8215888 in C:\Program Files (x86)\Android\android-sdk\ndk\24.0.8215888
	  ValidateAndroidNdkLocation: for locator=within Android SDK, path=`C:\Program Files (x86)\Android\android-sdk\ndk\24.0.8215888`, result=True
	  ResolveSdks Outputs:
	    AndroidSdkPath: C:\Program Files (x86)\Android\android-sdk
	    AndroidNdkPath: C:\Program Files (x86)\Android\android-sdk\ndk\24.0.8215888
	    JavaSdkPath: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64
	    MonoAndroidBinPath: C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools\
	    MonoAndroidToolsPath: C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools
	    AndroidBinUtilsPath: C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools\binutils\bin\
	  Output Property: _AndroidToolsDirectory=C:\Program Files %28x86%29\Android\android-sdk\cmdline-tools\7.0
	  Output Property: AndroidNdkDirectory=C:\Program Files %28x86%29\Android\android-sdk\ndk\24.0.8215888
	  Output Property: _AndroidNdkDirectory=C:\Program Files %28x86%29\Android\android-sdk\ndk\24.0.8215888
	  Output Property: _AndroidSdkDirectory=C:\Program Files %28x86%29\Android\android-sdk
	  Output Property: _JavaSdkDirectory=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.16-101\x64
	  Output Property: MonoAndroidToolsDirectory=C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools
	  Output Property: MonoAndroidBinDirectory=C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools\
	  Output Property: MonoAndroidLibDirectory=C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools\lib\host-\
	  Output Property: AndroidBinUtilsDirectory=C:\a\_work\2\s\xamarin-android\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.0-rc.2.148\tools\binutils\bin\
	Done executing task "ResolveSdks".

In particular:

	ValidateAndroidSdkLocation: for locator=constructor param, path=`C:\a\_work\2\a\TestRelease\08-24_20.26.42\temp\InstallAndroidDependenciesTest\android-sdk`, result=False
	…
	Output Property: _AndroidSdkDirectory=C:\Program Files %28x86%29\Android\android-sdk

That background in mind, *why did it start failing*?

It started failing because [`repository2-3.xml`][0] changed!

	<remotePackage path="platform-tools">
	  <!--Generated from:ab bid:8952118 branch:aosp-sdk-release-->
	  <type-details xsi:type="generic:genericDetailsType"/>
	  <revision>
	    <major>33</major>
	    <minor>0</minor>
	    <micro>3</micro>
	  </revision>
	  <display-name>Android SDK Platform-Tools</display-name>
	  <uses-license ref="android-sdk-license"/>
	  <channelRef ref="channel-0"/>
	  <archives>
	    <archive>
	      <!--Built on: Tue Aug 16 14:04:06 2022.-->
	      <complete>
	        <size>12767128</size>
	        <checksum type="sha1">250da3216e4c93ccd2612dcec0b64c2668354b09</checksum>
	        <url>platform-tools_r33.0.3-darwin.zip</url>
	      </complete>
	      <host-os>macosx</host-os>
	    </archive>
	    <!-- … -->
	  </archives>
	</remotePackage>

Note in particular the "Built on" date: 2022-Aug-16, just a handful
of days before things started failing for us on CI.

*Also* note that the `//remotePackage/revision` value differs;
we request 33.0.2, but the *only* `platform-tools` package listed in
`repository2-3.xml` is for *33.0.3*.

Consequently, we cannot resolve 33.0.2, and thus don't install 33.0.2,
which means that the Android SDK directory that we provision is
incomplete and unusable.  This is why the test fails.

There are two plausible fixes:

 1. Don't use the `$(AndroidManifestType)`=GoogleV2, and instead use
    the default `Xamarin` value.  This uses an Repository Manifest
    that *we* control, and thus won't break "randomly", or

 2. Override `$(AndroidSdkPlatformToolsVersion)`=33.0.3, so that we
    attempt to provision a platform-tools version which is listed
    in the Repository Manifest.

We go with (2) "just in case" we need to use the GoogleV2 manifest
for future API-*X* updates which have package versions which won't
be in the Xamarin Repository Manifest.

[0]: https://dl.google.com/android/repository/repository2-3.xml