### PR TITLE
[FabricBot] Apply 'needs-triage' label to new issues.

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,246 +1,201 @@
-[
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssuesOnlyResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "need-info"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add comment when 'need-info' is applied to issue",
+        "actions": [
           {
-            "name": "labelAdded",
+            "name": "addReply",
             "parameters": {
-              "label": "need-info"
+              "comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
             }
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Add comment when 'need-info' is applied to issue",
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Hi @${issueAuthor}. We have added the \"need-info\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 1,
-          "hours": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23
-          ],
-          "timezoneOffset": -5
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isIssue",
-          "parameters": {}
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "hasLabel",
-          "parameters": {
-            "label": "need-info"
-          }
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 7
-          }
-        }
-      ],
-      "taskName": "[Idle Issue Management] Close stale 'need-info' issues",
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
-          }
-        },
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
-            }
+            "weekDay": 1,
+            "hours": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23
+            ],
+            "timezoneOffset": -5
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
           },
           {
             "name": "isOpen",
@@ -253,296 +208,345 @@
             }
           },
           {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "admin"
-                }
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "write"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "[Idle Issue Management] Replace 'need-info' with 'need-attention' label when the customer comments on an issue",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "need-info"
-          }
-        },
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "need-attention"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
-            }
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "noActivitySince",
-                "parameters": {
-                  "days": 7
-                }
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isCloseAndComment",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
-              }
-            }
-          },
-          {
-            "name": "activitySenderHasPermissions",
-            "parameters": {
-              "permissions": "none"
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "need-info"
-            }
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
-      "actions": [
-        {
-          "name": "reopenIssue",
-          "parameters": {}
-        },
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "need-info"
-          }
-        },
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "need-attention"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
-            }
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "name": "activitySenderHasPermissions",
-            "parameters": {
-              "permissions": "none"
-            }
-          },
-          {
             "name": "noActivitySince",
             "parameters": {
               "days": 7
             }
+          }
+        ],
+        "taskName": "[Idle Issue Management] Close stale 'need-info' issues",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}. Due to inactivity, we will be closing this issue. Please feel free to re-open this issue if the issue persists. For enhanced visibility, if over 7 days have passed, please open a new issue and link this issue there. Thank you."
+            }
           },
           {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isCloseAndComment",
-                "parameters": {}
-              }
-            ]
+            "name": "closeIssue",
+            "parameters": {}
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "need-info"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Idle Issue Management] Replace 'need-info' with 'need-attention' label when the customer comments on an issue",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "need-info"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "need-attention"
+            }
           }
-        }
-      ]
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "noActivitySince",
+                  "parameters": {
+                    "days": 7
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "need-info"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+        "actions": [
+          {
+            "name": "reopenIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "need-info"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "need-attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 7
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              10,
+              22
+            ],
+            "timezoneOffset": -5
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isClosed",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          },
+          {
+            "name": "isUnlocked",
+            "parameters": {}
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          }
+        ],
+        "taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
+        "actions": [
+          {
+            "name": "lockIssue",
+            "parameters": {
+              "reason": "resolved"
+            }
+          }
+        ]
+      }
     }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            10,
-            22
-          ],
-          "timezoneOffset": -5
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isClosed",
-          "parameters": {}
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 30
-          }
-        },
-        {
-          "name": "isUnlocked",
-          "parameters": {}
-        },
-        {
-          "name": "isIssue",
-          "parameters": {}
-        }
-      ],
-      "taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
-      "actions": [
-        {
-          "name": "lockIssue",
-          "parameters": {
-            "reason": "resolved"
-          }
-        }
-      ]
-    }
-  }
-]
+  ],
+  "userGroups": []
+}

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -546,6 +546,39 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-triage"
+            }
+          }
+        ],
+        "taskName": "[New Issues] Apply 'needs-triage' to new issues"
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
Today we rely on our templates to apply the `needs-triage` label to new issues.  However, there are several ways issues can be added to our repo that bypasses our templates:

- Using the "blank" template
- Moved from another repository
- Moved from `vsfeedback`

FabricBot can ensure *every* new issue is tagged with `needs-triage`.

Note that the first commit simply allows the FabricBot UI to reformat our existing config file to its desired format.  It does not make any changes.

To see what is actually being added, look at the second commit.