### PR TITLE
Add local date time offset monovm prop

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -25,7 +25,7 @@
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/api-xml-adjuster/Makefile` -->
     <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v4.4</AndroidFirstFrameworkVersion>
     <AndroidFirstApiLevel Condition="'$(AndroidFirstApiLevel)' == ''">19</AndroidFirstApiLevel>
-    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">21</AndroidJavaRuntimeApiLevel>
+    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">26</AndroidJavaRuntimeApiLevel>
     <!-- The min API level supported by Microsoft.Android.Sdk, should refactor/remove when this value is the same as $(AndroidFirstApiLevel) -->
     <AndroidMinimumDotNetApiLevel Condition="'$(AndroidMinimumDotNetApiLevel)' == ''">21</AndroidMinimumDotNetApiLevel>
     <AndroidFirstPlatformId Condition="'$(AndroidFirstPlatformId)' == ''">$(AndroidFirstApiLevel)</AndroidFirstPlatformId>

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -45,10 +45,13 @@ public class MonoPackageManager {
 				String dataDir      = getNativeLibraryPath (context);
 				ClassLoader loader  = context.getClassLoader ();
 				String runtimeDir = getNativeLibraryPath (runtimePackage);
-				int localDateTimeOffset = (Calendar.getInstance ().get (Calendar.ZONE_OFFSET) + Calendar.getInstance ().get (Calendar.DST_OFFSET)) / 1000;
+				int localDateTimeOffset;
 
 				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
 					localDateTimeOffset = OffsetDateTime.now().getOffset().getTotalSeconds();
+				}
+				else {
+					localDateTimeOffset = (Calendar.getInstance ().get (Calendar.ZONE_OFFSET) + Calendar.getInstance ().get (Calendar.DST_OFFSET)) / 1000;
 				}
 
 				//

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -2,6 +2,9 @@ package mono;
 
 import java.io.*;
 import java.lang.String;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Calendar;
 import java.util.Locale;
 import java.util.HashSet;
 import java.util.zip.*;
@@ -42,6 +45,11 @@ public class MonoPackageManager {
 				String dataDir      = getNativeLibraryPath (context);
 				ClassLoader loader  = context.getClassLoader ();
 				String runtimeDir = getNativeLibraryPath (runtimePackage);
+				int localDateTimeOffset = (Calendar.getInstance ().get (Calendar.ZONE_OFFSET) + Calendar.getInstance ().get (Calendar.DST_OFFSET)) / 1000;
+
+				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+					localDateTimeOffset = OffsetDateTime.now().getOffset().getTotalSeconds();
+				}
 
 				//
 				// Should the order change here, src/monodroid/jni/SharedConstants.hh must be updated accordingly
@@ -106,6 +114,7 @@ public class MonoPackageManager {
 						apks,
 						runtimeDir,
 						appDirs,
+						localDateTimeOffset,
 						loader,
 						MonoPackageManager_Resources.Assemblies,
 						Build.VERSION.SDK_INT,

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -14,12 +14,13 @@ public class Runtime {
 		Thread.setDefaultUncaughtExceptionHandler (new XamarinUncaughtExceptionHandler (Thread.getDefaultUncaughtExceptionHandler ()));
 	}
 
-	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
+	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, int localDateTimeOffset, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
 	public static native void initInternal (
 		String lang,
 		String[] runtimeApks,
 		String runtimeDataDir,
 		String[] appDirs,
+		int localDateTimeOffset,
 		ClassLoader loader,
 		String[] assemblies,
 		int apiLevel,

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -14,7 +14,7 @@ public class Runtime {
 		Thread.setDefaultUncaughtExceptionHandler (new XamarinUncaughtExceptionHandler (Thread.getDefaultUncaughtExceptionHandler ()));
 	}
 
-	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, int localDateTimeOffset, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
+	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
 	public static native void initInternal (
 		String lang,
 		String[] runtimeApks,

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,18 +10,18 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I[Ljava/lang/String;)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I[Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
 
 /*
  * Class:     mono_android_Runtime
  * Method:    initInternal
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;IZZ)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/ClassLoader;[Ljava/lang/String;IZZ)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_initInternal
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jint, jboolean, jboolean);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jint, jboolean, jboolean);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;ILjava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I[Ljava/lang/String;)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I[Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jint, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -174,8 +174,8 @@ namespace xamarin::android::internal
 	public:
 		void Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods);
 		void Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-		                                             jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
+		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset,
+		                                             jobject loader, jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
 		                                             jboolean haveSplitApks);
 #if !defined (ANDROID)
 		jint Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava,

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2441,7 +2441,7 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
 /* !DO NOT REMOVE! Used by the Android Designer */
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset, jobject loader,
+                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
                                 [[maybe_unused]] jobjectArray externalStorageDirs, jobjectArray assembliesJava, [[maybe_unused]] jstring packageName,
                                 jint apiLevel, [[maybe_unused]] jobjectArray environmentVariables)
 {
@@ -2452,7 +2452,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 		runtimeApksJava,
 		runtimeNativeLibDir,
 		appDirs,
-		localDateTimeOffset,
+		0,
 		loader,
 		assembliesJava,
 		apiLevel,

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2152,8 +2152,8 @@ MonodroidRuntime::install_logging_handlers ()
 
 inline void
 MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                                          jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                                          jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
+                                                          jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset,
+                                                          jobject loader, jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
                                                           jboolean haveSplitApks)
 {
 	char *mono_log_mask_raw = nullptr;
@@ -2180,7 +2180,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	mono_opt_aot_lazy_assembly_load = application_config.aot_lazy_load ? TRUE : FALSE;
 
 	{
-		MonoVMProperties monovm_props { home };
+		MonoVMProperties monovm_props { home, localDateTimeOffset };
 
 		// NOTE: the `const_cast` breaks the contract made to MonoVMProperties that the arrays it returns won't be
 		// modified, but it's "ok" since Mono doesn't modify them and by using `const char* const*` in MonoVMProperties
@@ -2441,7 +2441,7 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
 /* !DO NOT REMOVE! Used by the Android Designer */
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+                                jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset, jobject loader,
                                 [[maybe_unused]] jobjectArray externalStorageDirs, jobjectArray assembliesJava, [[maybe_unused]] jstring packageName,
                                 jint apiLevel, [[maybe_unused]] jobjectArray environmentVariables)
 {
@@ -2452,6 +2452,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 		runtimeApksJava,
 		runtimeNativeLibDir,
 		appDirs,
+		localDateTimeOffset,
 		loader,
 		assembliesJava,
 		apiLevel,
@@ -2462,7 +2463,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+                                jstring runtimeNativeLibDir, jobjectArray appDirs, jint localDateTimeOffset, jobject loader,
                                 jobjectArray assembliesJava, jint apiLevel, jboolean isEmulator,
                                 jboolean haveSplitApks)
 {
@@ -2473,6 +2474,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 		runtimeApksJava,
 		runtimeNativeLibDir,
 		appDirs,
+		localDateTimeOffset,
 		loader,
 		assembliesJava,
 		apiLevel,

--- a/src/monodroid/jni/monovm-properties.cc
+++ b/src/monodroid/jni/monovm-properties.cc
@@ -5,9 +5,11 @@ using namespace xamarin::android::internal;
 MonoVMProperties::property_array MonoVMProperties::_property_keys {
 	RUNTIME_IDENTIFIER_KEY,
 	APP_CONTEXT_BASE_DIRECTORY_KEY,
+	LOCAL_DATE_TIME_OFFSET_KEY,
 };
 
 MonoVMProperties::property_array MonoVMProperties::_property_values {
 	SharedConstants::runtime_identifier,
+	nullptr,
 	nullptr,
 };

--- a/src/monodroid/jni/monovm-properties.hh
+++ b/src/monodroid/jni/monovm-properties.hh
@@ -10,7 +10,7 @@ namespace xamarin::android::internal
 {
 	class MonoVMProperties final
 	{
-		constexpr static size_t PROPERTY_COUNT = 2;
+		constexpr static size_t PROPERTY_COUNT = 3;
 
 		constexpr static char RUNTIME_IDENTIFIER_KEY[] = "RUNTIME_IDENTIFIER";
 		constexpr static size_t RUNTIME_IDENTIFIER_INDEX = 0;
@@ -18,15 +18,22 @@ namespace xamarin::android::internal
 		constexpr static char APP_CONTEXT_BASE_DIRECTORY_KEY[] = "APP_CONTEXT_BASE_DIRECTORY";
 		constexpr static size_t APP_CONTEXT_BASE_DIRECTORY_INDEX = 1;
 
+		constexpr static char LOCAL_DATE_TIME_OFFSET_KEY[] = "System.TimeZoneInfo.LocalDateTimeOffset";
+		constexpr static size_t LOCAL_DATE_TIME_OFFSET_INDEX = 2;
+
 		using property_array = const char*[PROPERTY_COUNT];
 
 	public:
-		explicit MonoVMProperties (jstring_wrapper& filesDir)
+		explicit MonoVMProperties (jstring_wrapper& filesDir, jint localDateTimeOffset)
 		{
 			static_assert (PROPERTY_COUNT == N_PROPERTY_KEYS);
 			static_assert (PROPERTY_COUNT == N_PROPERTY_VALUES);
 
 			_property_values[APP_CONTEXT_BASE_DIRECTORY_INDEX] = strdup (filesDir.get_cstr ());
+
+			char localDateTimeOffsetBuffer[32];
+			snprintf (localDateTimeOffsetBuffer, sizeof(localDateTimeOffsetBuffer), "%d", localDateTimeOffset);
+			_property_values[LOCAL_DATE_TIME_OFFSET_INDEX] = strdup (localDateTimeOffsetBuffer);
 		}
 
 		constexpr int property_count () const

--- a/src/monodroid/jni/monovm-properties.hh
+++ b/src/monodroid/jni/monovm-properties.hh
@@ -31,9 +31,9 @@ namespace xamarin::android::internal
 
 			_property_values[APP_CONTEXT_BASE_DIRECTORY_INDEX] = strdup (filesDir.get_cstr ());
 
-			char localDateTimeOffsetBuffer[32];
-			snprintf (localDateTimeOffsetBuffer, sizeof(localDateTimeOffsetBuffer), "%d", localDateTimeOffset);
-			_property_values[LOCAL_DATE_TIME_OFFSET_INDEX] = strdup (localDateTimeOffsetBuffer);
+			static_local_string<32> localDateTimeOffsetBuffer;
+			localDateTimeOffsetBuffer.append (localDateTimeOffset);
+			_property_values[LOCAL_DATE_TIME_OFFSET_INDEX] = strdup (localDateTimeOffsetBuffer.get ());
 		}
 
 		constexpr int property_count () const


### PR DESCRIPTION
Follows up https://github.com/dotnet/runtime/pull/74459 for https://github.com/dotnet/runtime/issues/71004

On dotnet/runtime, `DateTimeOffset.Now` is now updated to leverage an App Context's property as a fast path result if provided. In order to improve startup performance for applications that rely on DateTimeOffset.Now during startup will need to set `System.TimeZoneInfo.LocalDateTimeOffset` as the appropriate value.
The original issue reported a perf timing of 277ms, and after https://github.com/dotnet/runtime/pull/74459, has an average perf timing of 21.818ms.

---------------------------

## Testing

Created an Android app
Added `_ = DateTimeOffset.Now;` to OnCreate

The timing of DateTimeOffset.Now with dotnet-trace was 1.18ms + 17.67ms = 18.85ms
![Screen Shot 2022-09-02 at 11 06 01 AM](https://user-images.githubusercontent.com/16830051/188178864-c7b2c1e1-24ca-4c65-852f-2c5190b25824.png)

----------------------------

This PR does the following:
1) Bump `AndroidJavaRuntimeApiLevel` to 26 to allow for `java.time.OffsetDateTime` and `java.time.ZoneOffset`.
2) Adds the System.TimeZoneInfo.LocalDateTimeOffset property to MonoVMProperties passed into the mono runtime to enable DateTimeOffset.Now fast path.
