### PR TITLE
[One .NET] fix `dotnet run -c Release`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -13,7 +13,7 @@ This file contains targets specific for Android application projects.
     <!-- see: https://github.com/xamarin/xamarin-macios/blob/a6eb528197854c074d9dd5847328c096890337be/dotnet/targets/Xamarin.Shared.Sdk.props#L38-L52 -->
     <_RuntimeIdentifierUsesAppHost>false</_RuntimeIdentifierUsesAppHost>
     <RunCommand>dotnet</RunCommand>
-    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>
+    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run --configuration &quot;$(Configuration)&quot;</RunArguments>
 
     <!-- If Xamarin.Android.Common.Debugging.targets exists, we can rely on _Run for debugging. -->
     <_RunDependsOn Condition=" '$(_XASupportsFastDev)' == 'true' ">


### PR DESCRIPTION
Context: https://github.com/dotnet/xamarin/issues/26

The following does not work as expected:

    dotnet new android
    dotnet run -c Release

You end up with a `Debug` app in this case.

The way we implemented `dotnet run` was to make `$(RunCommand)` and
`$(RunArguments)` invoke `dotnet build -t:Run`.

We were losing the `$(Configuration)` value in this example.