### PR TITLE
[One .NET] add XA1029 for $(AotAssemblies)

### DIFF
--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -87,9 +87,9 @@ Overridable MSBuild properties include:
 
   * `$(AndroidSupportedTargetAotAbis)`: The Android ABIs for which to build the
     Mono AOT compilers. The AOT compilers are required in order to set the
-    [`$(AotAssemblies)`][aot-assemblies] app configuration property to True.
+    [`$(RunAOTCompilation)`][runaotcompilation] app configuration property to True.
 
-    [aot-assemblies]: https://developer.xamarin.com/guides/android/under_the_hood/build_process/#AotAssemblies
+    [runaotcompilation]: https://developer.xamarin.com/guides/android/under_the_hood/build_process/#RunAOTCompilation
 
   * `$(AndroidSupportedTargetJitAbis)`: The Android ABIs for which to build the
     the Mono JIT for inclusion within apps. This is a `:`-separated list of

--- a/Documentation/guides/OneDotNet.md
+++ b/Documentation/guides/OneDotNet.md
@@ -172,9 +172,9 @@ AOT. This is the same property used for [Blazor WASM][blazor].
 migration from "legacy" Xamarin.Android to .NET 6.
 
 It is recommended to migrate to the new `$(RunAOTCompilation)`
-property, as `$(AotAssemblies)` will eventually be deprecated.
+property, as `$(AotAssemblies)` is deprecated in .NET 7.
 
-[blazor]: https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-4/#blazor-webassembly-ahead-of-time-aot-compilation
+[blazor]: https://docs.microsoft.com/aspnet/core/blazor/host-and-deploy/webassembly/#ahead-of-time-aot-compilation
 
 We want to choose the optimal settings for startup time and app size.
 By default `Release` builds will default to:

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1517,13 +1517,15 @@ Support for this property was added in Xamarin.Android 11.3.
 
 ## AotAssemblies
 
-A boolean property that determines
-whether or not assemblies will be Ahead-of-Time compiled into
-native code and included in the `.apk`.
+A boolean property that determines whether or not assemblies will be
+Ahead-of-Time compiled into native code and included in applications.
+This property is `False` by default.
 
 Support for this property was added in Xamarin.Android 5.1.
 
-This property is `False` by default.
+Deprecated in .NET 7. Migrate to the new
+[`$(RunAOTCompilation)`](#runaotcompilation) MSBuild property instead,
+as support for `$(AotAssemblies)` will be removed in a future release.
 
 ## AProfUtilExtraOptions
 
@@ -1822,3 +1824,18 @@ debugging symbols enabled:
 is True.
 
 Added in Xamarin.Android 7.1.
+
+## RunAOTCompilation
+
+A boolean property that determines whether or not assemblies will be
+Ahead-of-Time compiled into native code and included in applications.
+This property is `False` by default for `Debug` builds and `True` by
+default for `Release` builds.
+
+This MSBuild property replaces the
+[`$(AotAssemblies)`](#aotassemblies) MSBuild property from
+Xamarin.Android. This is the same property used for [Blazor WASM][blazor].
+
+Added in .NET 6, not supported in Xamarin.Android.
+
+[blazor]: https://docs.microsoft.com/aspnet/core/blazor/host-and-deploy/webassembly/#ahead-of-time-aot-compilation

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -129,6 +129,7 @@ or 'Help->Report a Problem' in Visual Studio for Mac.
 + [XA1025](xa1025.md): The experimental 'Hybrid' value for the 'AndroidAotMode' MSBuild property is not currently compatible with the armeabi-v7a target ABI.
 + [XA1027](xa1027.md): The 'EnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.
 + [XA1028](xa1028.md): The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.
++ [XA1029](xa1029.md): The 'AotAssemblies' MSBuild property is deprecated. Edit the project file in a text editor to remove this property, and use the 'RunAOTCompilation' MSBuild property instead.
 
 ## XA2xxx: Linker
 

--- a/Documentation/guides/messages/xa1029.md
+++ b/Documentation/guides/messages/xa1029.md
@@ -1,0 +1,30 @@
+---
+title: Xamarin.Android warning XA1029
+description: XA1029 warning code
+ms.date: 09/06/2022
+---
+# Xamarin.Android warning XA1029
+
+## Example messages
+
+```
+warning XA1029: The 'AotAssemblies' MSBuild property is deprecated. Edit the project file in a text editor to remove this property, and use the 'RunAOTCompilation' MSBuild property instead.
+```
+
+## Solution
+
+Instead of using:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <AotAssemblies>true</AotAssemblies>
+</PropertyGroup>
+```
+
+Use instead:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <RunAOTCompilation>true</RunAOTCompilation>
+</PropertyGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -78,6 +78,7 @@
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == '' and '$(Configuration)' == 'Release' ">true</RunAOTCompilation>
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == 'true' ">true</RunAOTCompilation>
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' ">false</RunAOTCompilation>
+    <_AndroidXA1029 Condition=" '$(AotAssemblies)' != '' ">true</_AndroidXA1029>
     <AotAssemblies>$(RunAOTCompilation)</AotAssemblies>
     <AndroidEnableProfiledAot Condition=" '$(AndroidEnableProfiledAot)' == '' and '$(RunAOTCompilation)' == 'true' ">true</AndroidEnableProfiledAot>
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -462,6 +462,10 @@ In this message, the term "binding" means a piece of generated code that makes i
     <value>The 'AndroidEnableProguard' MSBuild property is set to 'true' and the 'AndroidLinkTool' MSBuild property is empty, so 'AndroidLinkTool' will default to 'proguard'.</value>
     <comment>The following are literal names and should not be translated: 'AndroidEnableProguard', 'true', 'AndroidLinkTool', 'proguard'</comment>
   </data>
+  <data name="XA1029" xml:space="preserve">
+    <value>The 'AotAssemblies' MSBuild property is deprecated. Edit the project file in a text editor to remove this property, and use the 'RunAOTCompilation' MSBuild property instead.</value>
+    <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1717,9 +1717,9 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
+				AotAssemblies = true,
 			};
 			proj.SetProperty ("UseInterpreter", "true");
-			proj.SetProperty ("AotAssemblies", "true");
 			using (var builder = CreateApkBuilder ()) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -16,6 +16,7 @@ namespace Xamarin.ProjectTools
 		public const string AndroidSupportedAbis = "AndroidSupportedAbis";
 		public const string RuntimeIdentifier = "RuntimeIdentifier";
 		public const string RuntimeIdentifiers = "RuntimeIdentifiers";
+		public const string RunAOTCompilation = "RunAOTCompilation";
 		public const string PublishTrimmed = "PublishTrimmed";
 		public const string SupportedOSPlatformVersion = "SupportedOSPlatformVersion";
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -108,9 +108,11 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.BundleAssemblies, value.ToString ()); }
 		}
 
+		string AotAssembliesPropertyName => Builder.UseDotNet ? KnownProperties.RunAOTCompilation : KnownProperties.AotAssemblies;
+
 		public bool AotAssemblies {
-			get { return string.Equals (GetProperty (KnownProperties.AotAssemblies), "True", StringComparison.OrdinalIgnoreCase); }
-			set { SetProperty (KnownProperties.AotAssemblies, value.ToString ()); }
+			get { return string.Equals (GetProperty (AotAssembliesPropertyName), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (AotAssembliesPropertyName, value.ToString ()); }
 		}
 
 		public bool AndroidEnableProfiledAot {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -507,6 +507,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA1028"
       Condition=" $(_AndroidXA1028) == 'true' "
   />
+  <AndroidWarning Code="XA1029"
+      ResourceName="XA1029"
+      Condition=" $(_AndroidXA1029) == 'true' "
+  />
   <AndroidError Code="XA1011"
       ResourceName="XA1011"
       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7297

The way we support `$(AotAssemblies)` requires us to *know* the names
of packs in the Mono workload.

Let's drop support for `$(AotAssemblies)` and use the new
`$(RunAOTCompilation)` property instead. We can begin by emitting a
warning in .NET 7, to potentially remove/error in .NET 8.