### PR TITLE
Don't use Dictionary<K,V> to avoid duplicate value exception (#7340)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tasks
 			public byte[] MvidBytes;
 			public AssemblyDefinition Assembly;
 			public TypeMapReleaseEntry[] Types;
-			public Dictionary<uint, TypeMapReleaseEntry> DuplicateTypes;
+			public List<TypeMapReleaseEntry> DuplicateTypes;
 			public string AssemblyName;
 			public string AssemblyNameLabel;
 			public string OutputFilePath;
@@ -382,7 +382,7 @@ namespace Xamarin.Android.Tasks
 						Assembly = td.Module.Assembly,
 						AssemblyName = td.Module.Assembly.Name.Name,
 						TypesScratch = new Dictionary<string, TypeMapReleaseEntry> (StringComparer.Ordinal),
-						DuplicateTypes = new Dictionary<uint, TypeMapReleaseEntry> (),
+						DuplicateTypes = new List<TypeMapReleaseEntry> (),
 					};
 					tempModules.Add (moduleUUID, moduleData);
 				}
@@ -410,7 +410,7 @@ namespace Xamarin.Android.Tasks
 					// build) and has no value for the end user. The message is left here because it may be useful to us
 					// in our devloop at some point.
 					//logger ($"Warning: duplicate Java type name '{entry.JavaName}' in assembly '{moduleData.AssemblyName}' (new token: {entry.Token}).");
-					moduleData.DuplicateTypes.Add (entry.Token, entry);
+					moduleData.DuplicateTypes.Add (entry);
 				} else
 					moduleData.TypesScratch.Add (entry.JavaName, entry);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
@@ -237,7 +237,7 @@ namespace Xamarin.Android.Tasks
 				if (mapOutput != null) {
 					WriteManagedMaps (generator, mapOutput, mapName, data.Types);
 					if (data.DuplicateTypes.Count > 0) {
-						WriteManagedMaps (generator, mapOutput, duplicateMapName, data.DuplicateTypes.Values);
+						WriteManagedMaps (generator, mapOutput, duplicateMapName, data.DuplicateTypes);
 					}
 				}
 			}


### PR DESCRIPTION
Backport of #7340
(There were some minor merge conflicts)

Fixes: https://github.com/xamarin/xamarin-android/issues/7302
Context: https://github.com/xamarin/xamarin-android/commit/7117414ca27d88a71b4a272705a0207f772423bd

When building .NET6 app on .NET7, sometimes the build fails with:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\32.0.451\tools\Xamarin.Android.Common.targets(1438,3): error XAGJS7004: System.ArgumentException: An item with the same key has already been added.
     at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
     at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
     at Xamarin.Android.Tasks.TypeMapGenerator.GenerateRelease(Boolean skipJniAddNativeMethodRegistrationAttributeScan, List`1 javaTypes, String outputDirectory, ApplicationConfigTaskState appConfState)
     at Xamarin.Android.Tasks.GenerateJavaStubs.WriteTypeMappings(List`1 types, TypeDefinitionCache cache)
     at Xamarin.Android.Tasks.GenerateJavaStubs.Run(DirectoryAssemblyResolver res)
     at Xamarin.Android.Tasks.GenerateJavaStubs.RunTask()
     at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17

Avoid that by switching the data structure to `List<T>`, since we no longer use the Dictionary key for anything.