### PR TITLE
[tests] update times in MSBuildDeviceIntegration.csv

### DIFF
--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -3,8 +3,8 @@
 Test Name,Time in ms (int)
 # Data
 Build_From_Clean_DontIncludeRestore,13000
-Build_No_Changes,2250
-Build_CSharp_Change,3500
+Build_No_Changes,2500
+Build_CSharp_Change,4000
 Build_AndroidResource_Change,3250
 Build_AndroidAsset_Change,10000
 Build_AndroidManifest_Change,4500
@@ -13,5 +13,5 @@ Build_JLO_Change,10000
 Build_CSProj_Change,12500
 Build_XAML_Change,7400
 Build_XAML_Change_RefAssembly,4000
-Install_CSharp_Change,4250
+Install_CSharp_Change,4500
 Install_XAML_Change,5000

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -4,14 +4,14 @@ Test Name,Time in ms (int)
 # Data
 Build_From_Clean_DontIncludeRestore,13000
 Build_No_Changes,2250
-Build_CSharp_Change,3350
+Build_CSharp_Change,3500
 Build_AndroidResource_Change,3250
 Build_AndroidAsset_Change,10000
-Build_AndroidManifest_Change,3750
+Build_AndroidManifest_Change,4500
 Build_Designer_Change,3000
 Build_JLO_Change,10000
 Build_CSProj_Change,12500
 Build_XAML_Change,7400
 Build_XAML_Change_RefAssembly,4000
-Install_CSharp_Change,4000
+Install_CSharp_Change,4250
 Install_XAML_Change,5000


### PR DESCRIPTION
Frequently 3 performance tests fail with times such as:

    Build_CSharp_Change
    Exceeded expected time of 3850ms, actual 3912.98ms
    Build_AndroidManifest_Change
    Exceeded expected time of 4250ms, actual 4873.595ms
    Install_CSharp_Change
    Exceeded expected time of 4500ms, actual 4693.08ms

Let's increase these times to make our CI runs less noisy.

At some point, we could also do some build performance work to get these times lower. Right now these time differences are pretty small, and I believe due to environmental changes in the CI machines, etc.