### PR TITLE
[templates] add `ide.host.json` files

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/.template.config/ide.host.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json.schemastore.org/ide.host",
+    "appliesTo": "Android",
+    "defaultItemExtension": "cs",
+    "itemHierarchyPaths": [ "Android" ]
+}

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/ide.host.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/ide.host.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json.schemastore.org/ide.host",
+    "appliesTo": "Android",
+    "defaultItemExtension": "xml",
+    "itemHierarchyPaths": [ "Android" ]
+}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7315
Fixes: https://github.com/xamarin/xamarin-android/issues/7231

This makes our item templates useable from inside Visual Studio, as it should allow them to show up in a new `Android` category in the "Add New Item" dialog.