### PR TITLE
[Xamarin.Android.Build.Tasks] Feature for excluding Kotlin-related files from apps

### DIFF
--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -222,7 +222,7 @@ This is so MSBuild does not try to interpret them as actual file wildcards.
 NOTE: `*`, `?` and `.` will be replaced in the `BuildApk` task with the
 appropriate RegEx expressions.
 
-Added in Xamarin.Android 13.0.
+Added in Xamarin.Android 13.1 and .NET 7.
 
 ## AndroidResource
 

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -206,7 +206,7 @@ used to specify the ABI that the library targets. Thus, if you add
 
 ## AndroidPackagingOptionsExclude
 
-A set if RegEx compatible items which will allow for items to be
+A set of file glob compatible items which will allow for items to be
 excluded from the final package. The default values are as follows
 
 ```

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -204,6 +204,26 @@ used to specify the ABI that the library targets. Thus, if you add
 </ItemGroup>
 ```
 
+## AndroidPackagingOptionsExclude
+
+A set if RegEx compatible items which will allow for items to be
+excluded from the final package. The default values are as follows
+
+```
+<ItemGroup>
+	<AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
+	<AndroidPackagingOptionsExclude Include="%2A.kotlin_%2A" />
+</ItemGroup>
+```
+
+NOTE: The Items MUST use URL encoding for characters like `*`. This
+is so MSBuild does not try to interpret them as file wildcards.
+
+NOTE: `*` will be replaced in the `BuildApk` task with the RegEx
+`(.)` to match all characters.
+
+Added in Xamarin.Android XX.X.
+
 ## AndroidResource
 
 All files with an *AndroidResource* build action are compiled into

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -212,7 +212,7 @@ excluded from the final package. The default values are as follows
 ```
 <ItemGroup>
 	<AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
-	<AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin_*'))" />
+	<AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin_*')" />
 </ItemGroup>
 ```
 Items can use file blob characters for wildcards such as `*` and `?`.

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -212,15 +212,15 @@ excluded from the final package. The default values are as follows
 ```
 <ItemGroup>
 	<AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
-	<AndroidPackagingOptionsExclude Include="%2A.kotlin_%2A" />
+	<AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin_*'))" />
 </ItemGroup>
 ```
+Items can use file blob characters for wildcards such as `*` and `?`.
+However these Items MUST use URL encoding or '$([MSBuild]::Escape(''))'.
+This is so MSBuild does not try to interpret them as actual file wildcards.
 
-NOTE: The Items MUST use URL encoding for characters like `*`. This
-is so MSBuild does not try to interpret them as file wildcards.
-
-NOTE: `*` will be replaced in the `BuildApk` task with the RegEx
-`(.)` to match all characters.
+NOTE: `*`, `?` and `.` will be replaced in the `BuildApk` task with the
+appropriate RegEx expressions.
 
 Added in Xamarin.Android XX.X.
 

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -222,7 +222,7 @@ This is so MSBuild does not try to interpret them as actual file wildcards.
 NOTE: `*`, `?` and `.` will be replaced in the `BuildApk` task with the
 appropriate RegEx expressions.
 
-Added in Xamarin.Android XX.X.
+Added in Xamarin.Android 13.0.
 
 ## AndroidResource
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -304,7 +304,7 @@ namespace Xamarin.Android.Tasks
 
 			existingEntries.Clear ();
 
-			foreach (var pattern in ExcludeFiles) {
+			foreach (var pattern in ExcludeFiles ?? Array.Empty<string> ()) {
 				excludePatterns.Add (new Regex (pattern.Replace ("*", "(.)"), RegexOptions.IgnoreCase | RegexOptions.Compiled));
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -341,7 +341,8 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		static Regex FileGlobToRegEx (string fileGlob, RegexOptions options) {
+		static Regex FileGlobToRegEx (string fileGlob, RegexOptions options)
+		{
 			StringBuilder sb = new StringBuilder ();
 			foreach (char c in fileGlob) {
 				switch (c) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -305,7 +305,7 @@ namespace Xamarin.Android.Tasks
 			existingEntries.Clear ();
 
 			foreach (var pattern in ExcludeFiles ?? Array.Empty<string> ()) {
-				excludePatterns.Add (new Regex (pattern.Replace ("*", "(.)"), RegexOptions.IgnoreCase | RegexOptions.Compiled));
+				excludePatterns.Add (FileGlobToRegEx (pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled));
 			}
 
 			bool debug = _Debug;
@@ -339,6 +339,23 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  [Output] OutputFiles :", OutputFiles);
 
 			return !Log.HasLoggedErrors;
+		}
+
+		static Regex FileGlobToRegEx (string fileGlob, RegexOptions options) {
+			StringBuilder sb = new StringBuilder ();
+			foreach (char c in fileGlob) {
+				switch (c) {
+					case '*': sb.Append (".*");
+						break;
+					case '?': sb.Append (".");
+						break;
+					case '.': sb.Append (@"\.");
+						break;
+					default: sb.Append (c);
+						break;
+				}
+			}
+			return new Regex (sb.ToString (), options);
 		}
 
 		void AddAssemblies (ZipArchiveEx apk, bool debug, bool compress, IDictionary<string, CompressedAssemblyInfo> compressedAssembliesInfo, string assemblyStoreApkName)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -916,6 +916,26 @@ public class Test
 		}
 
 		[Test]
+		public void CheckExcludedFilesAreMissing ()
+		{
+
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			proj.PackageReferences.Add (KnownPackages.Xamarin_Kotlin_StdLib_Common);
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.OutputPath, $"{proj.PackageName}-Signed.apk");
+				string expected = $"Ignoring jar entry 'kotlin/Error.kotlin_metadata'";
+				Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"Error.kotlin_metadata should have been ignored.");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+					Assert.IsFalse (zip.ContainsEntry ("Error.kotlin_metadata"), "Error.kotlin_metadata should have been ignored.");
+				}
+			}
+		}
+
+		[Test]
 		public void ExtractNativeLibsTrue ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -499,6 +499,10 @@ namespace Xamarin.ProjectTools
 			Id = "Xamarin.GooglePlayServices.Maps",
 			Version = "117.0.1.2",
 		};
+		public static Package Xamarin_Kotlin_StdLib_Common = new Package {
+			Id = "Xamarin.Kotlin.Stdlib.Common",
+			Version = "1.6.20.1"
+		};
 		public static Package Acr_UserDialogs = new Package {
 			Id = "Acr.UserDialogs",
 			Version = "6.5.1",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2038,6 +2038,10 @@ because xbuild doesn't support framework reference assemblies.
   Outputs="$(_BuildApkEmbedOutputs)"
   Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
   <!-- Put the assemblies and native libraries in the apk -->
+  <!--
+    NOTE: Adding Arguments to BuildApk or BuildBaseAppBundle
+    also need to have the args added in monodroid.
+  -->
   <BuildApk
     Condition=" '$(AndroidPackageFormat)' != 'aab' "
     AndroidNdkDirectory="$(_AndroidNdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -353,7 +353,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <ItemGroup>
 	<AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
-	<AndroidPackagingOptionsExclude Include="%2A.kotlin_%2A" />
+	<AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin_*'))" />
 </ItemGroup>
 
 <!--

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2040,7 +2040,8 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Put the assemblies and native libraries in the apk -->
   <!--
     NOTE: Adding Arguments to BuildApk or BuildBaseAppBundle
-    also need to have the args added in monodroid.
+    also need to have the args added to Xamarin.Android.Common.Debugging.targets
+    in monodroid.
   -->
   <BuildApk
     Condition=" '$(AndroidPackageFormat)' != 'aab' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -351,6 +351,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</AllowedReferenceRelatedFileExtensions>
 </PropertyGroup>
 
+<ItemGroup>
+	<AndroidPackagingOptionsExclude Include="DebugProbesKt.bin" />
+	<AndroidPackagingOptionsExclude Include="%2A.kotlin_%2A" />
+</ItemGroup>
+
 <!--
 *******************************************
           Imports
@@ -2063,6 +2068,7 @@ because xbuild doesn't support framework reference assemblies.
     IncludeWrapSh="$(AndroidIncludeWrapSh)"
     CheckedBuild="$(_AndroidCheckedBuild)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
+    ExcludeFiles="@(AndroidPackagingOptionsExclude)"
     UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
@@ -2096,6 +2102,7 @@ because xbuild doesn't support framework reference assemblies.
       IncludeWrapSh="$(AndroidIncludeWrapSh)"
       CheckedBuild="$(_AndroidCheckedBuild)"
       RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
+      ExcludeFiles="@(AndroidPackagingOptionsExclude)"
       UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>


### PR DESCRIPTION
Fixes #6920

Add a new ItemGroup `AndroidPackagingOptionsExclude` to the common targets. This ItemGroup will contain a set of RegEx compatible patterns which will be used to exclude certain files from the final apk/aab.

The patterns will need to be Url encoded so that MSBuild does not try to interpret them.

The main purpose of this is to allow us to exclude certain Kotlin meta-data files from the final package. These files seem to be excluded by gradle so we should do the same.