### PR TITLE
Bump to dotnet/installer/main@dd355bb 7.0.100-rc.2.22457.6

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,9 @@
     <!-- This is needed (currently) for the Xamarin.Android.Deploy.Installer dependency, getting the installer -->
     <!-- Android binary, to support delta APK install -->
     <add key="xamarin.android util" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 6.0.9 -->
+    <add key="darc-pub-dotnet-emsdk-3f6c45a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-531f715" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-531f715f/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -329,7 +329,7 @@ namespace Xamarin.Android.Prepare
 
 			public static string MicrosoftNETWorkloadMonoPackageDir => Path.Combine (
 				XAPackagesDir,
-				$"microsoft.net.workload.mono.toolchain.manifest-{ctx.Properties.GetRequiredValue (KnownProperties.DotNetMonoManifestVersionBand)}",
+				$"microsoft.net.workload.mono.toolchain.{{0}}.manifest-{ctx.Properties.GetRequiredValue (KnownProperties.DotNetMonoManifestVersionBand)}",
 				ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNETCoreAppRefPackageVersion)
 			);
 
@@ -337,7 +337,7 @@ namespace Xamarin.Android.Prepare
 
 			public static string MicrosoftNETWorkloadEmscriptenPackageDir => Path.Combine (
 				XAPackagesDir,
-				$"microsoft.net.workload.emscripten.manifest-{ctx.Properties.GetRequiredValue (KnownProperties.DotNetEmscriptenManifestVersionBand)}",
+				$"microsoft.net.workload.emscripten.{{0}}.manifest-{ctx.Properties.GetRequiredValue (KnownProperties.DotNetEmscriptenManifestVersionBand)}",
 				ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNETWorkloadEmscriptenPackageVersion)
 			);
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -49,13 +49,16 @@ namespace Xamarin.Android.Prepare
 			var sdk_manifests = Path.Combine (dotnetPath, "sdk-manifests", context.Properties.GetRequiredValue (KnownProperties.DotNetSdkManifestsFolder));
 
 			// Copy the WorkloadManifest.* files from the latest Microsoft.NET.Workload.* listed in package-download.proj
-			var destination = Path.Combine (sdk_manifests, "microsoft.net.workload.mono.toolchain");
-			foreach (var file in Directory.GetFiles (Configurables.Paths.MicrosoftNETWorkloadMonoToolChainDir, "WorkloadManifest.*")) {
-				Utilities.CopyFileToDir (file, destination);
-			}
-			destination = Path.Combine (sdk_manifests, "microsoft.net.workload.emscripten");
-			foreach (var file in Directory.GetFiles (Configurables.Paths.MicrosoftNETWorkloadEmscriptenDir, "WorkloadManifest.*")) {
-				Utilities.CopyFileToDir (file, destination);
+			var dotnets = new [] { "net6", "net7" };
+			foreach (var dotnet in dotnets) {
+				var destination = Path.Combine (sdk_manifests, $"microsoft.net.workload.mono.toolchain.{dotnet}");
+				foreach (var file in Directory.GetFiles (string.Format (Configurables.Paths.MicrosoftNETWorkloadMonoToolChainDir, dotnet), "WorkloadManifest.*")) {
+					Utilities.CopyFileToDir (file, destination);
+				}
+				destination = Path.Combine (sdk_manifests, $"microsoft.net.workload.emscripten.{dotnet}");
+				foreach (var file in Directory.GetFiles (string.Format (Configurables.Paths.MicrosoftNETWorkloadEmscriptenDir, dotnet), "WorkloadManifest.*")) {
+					Utilities.CopyFileToDir (file, destination);
+				}
 			}
 
 			return true;

--- a/build-tools/xaprepare/xaprepare/package-download.proj
+++ b/build-tools/xaprepare/xaprepare/package-download.proj
@@ -20,8 +20,10 @@ Otherwise, $(MicrosoftNETCoreAppRefPackageVersion) from eng/Versions.props will 
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-arm64" Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x86" Version="[$(DotNetRuntimePacksVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.App.Runtime.Mono.android-x64" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(DotNetMonoManifestVersionBand)" Version="[$(DotNetRuntimePacksVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-$(DotNetEmscriptenManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptenPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(DotNetMonoManifestVersionBand)" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(DotNetMonoManifestVersionBand)" Version="[$(DotNetRuntimePacksVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net6.Manifest-$(DotNetEmscriptenManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptenPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(DotNetEmscriptenManifestVersionBand)" Version="[$(MicrosoftNETWorkloadEmscriptenPackageVersion)]" />
   </ItemGroup>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,20 +1,24 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.2.22454.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.2.22457.6">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>330dee39e5e4dcf765f4c41c76b94c8e4497e91c</Sha>
+      <Sha>dd355bb777249689beba30978ac26e15c96da642</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.22423.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.22452.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/linker</Uri>
-      <Sha>313671b195b1b36d56a8888a9a0e12edaac52c57</Sha>
+      <Sha>5f9bfd94d9c687207872ae03f751ea19704381c0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22422.12" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.2.22451.11" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>ef077d0b58ffddcf54fa73bd85dace6b999b8992</Sha>
+      <Sha>6d10e4c8bcd9f96ccd73748ff827561afa09af57</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-rc.1.22411.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0-rc.2.22430.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>216093204c415b6e37dfadfcbcf183881b443636</Sha>
+      <Sha>8d8d2122b16c81df4b158fe43995f958e8fe115e</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.2.22430.5" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>8d8d2122b16c81df4b158fe43995f958e8fe115e</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,13 +1,13 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.2.22454.1</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22423.4</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22422.12</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.2.22457.6</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22452.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.2.22451.11</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-rc.1.22411.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
-    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rc.2.22430.5</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Aot.targets
@@ -23,11 +23,11 @@ They run in a context of an inner build with a single $(RuntimeIdentifier).
     https://github.com/dotnet/runtime/blob/69711860262e44458bbe276393ea3eb9f7a2192a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in#L20-L25
   -->
   <ImportGroup Condition=" '$(MonoAOTCompilerTasksAssemblyPath)' == '' and '$(AotAssemblies)' == 'true' ">
-    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
-    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86" />
-    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64" />
-    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm" />
-    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task.net7" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.net7.android-x86" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.net7.android-x64" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.net7.android-arm" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.net7.android-arm64" />
   </ImportGroup>
 
   <UsingTask TaskName="Xamarin.Android.Tasks.GetAotAssemblies" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -14,7 +14,12 @@
         "Microsoft.Android.Templates"
       ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
-      "extends" : [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ]
+      "extends" : [ 
+        "microsoft-net-runtime-android-net6",
+        "microsoft-net-runtime-android-aot-net6",
+        "microsoft-net-runtime-android",
+        "microsoft-net-runtime-android-aot"
+      ]
     }
   },
   "packs": {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,46 +5,46 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 59092
+      "Size": 59188
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88614
+      "Size": 88549
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Console.dll": {
-      "Size": 6404
+      "Size": 6408
     },
     "assemblies/System.Diagnostics.Tracing.dll": {
-      "Size": 2085
+      "Size": 2089
     },
     "assemblies/System.Linq.dll": {
-      "Size": 9092
+      "Size": 9096
     },
     "assemblies/System.Memory.dll": {
-      "Size": 3384
+      "Size": 3388
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 533637
+      "Size": 533485
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 3496
+      "Size": 3498
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3738
+      "Size": 3770
     },
     "assemblies/System.Threading.dll": {
-      "Size": 5482
+      "Size": 5486
     },
     "assemblies/System.Threading.Thread.dll": {
-      "Size": 1977
+      "Size": 1978
     },
     "assemblies/System.Threading.ThreadPool.dll": {
-      "Size": 2007
+      "Size": 2008
     },
     "assemblies/System.Transactions.Local.dll": {
-      "Size": 62995
+      "Size": 62998
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 3560
@@ -52,14 +52,11 @@
     "classes.dex": {
       "Size": 360720
     },
-    "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 96832
-    },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 425416
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3052824
+      "Size": 3073392
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -71,16 +68,16 @@
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 10512
+      "Size": 10216
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 3459
+      "Size": 3339
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 3332
+      "Size": 3212
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 4762
@@ -107,5 +104,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2820744
+  "PackageSize": 2791978
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,139 +8,139 @@
       "Size": 7114
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 66665
+      "Size": 66767
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 442077
+      "Size": 442556
     },
     "assemblies/mscorlib.dll": {
       "Size": 3859
     },
     "assemblies/netstandard.dll": {
-      "Size": 5569
+      "Size": 5573
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 10480
+      "Size": 10484
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15300
+      "Size": 15299
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 7427
+      "Size": 7434
     },
     "assemblies/System.ComponentModel.dll": {
       "Size": 1940
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2552
+      "Size": 2554
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6031
+      "Size": 6032
     },
     "assemblies/System.Console.dll": {
-      "Size": 7265
+      "Size": 7268
     },
     "assemblies/System.Core.dll": {
-      "Size": 1985
+      "Size": 1986
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6542
+      "Size": 6551
     },
     "assemblies/System.Diagnostics.Tracing.dll": {
-      "Size": 2085
+      "Size": 2089
     },
     "assemblies/System.dll": {
       "Size": 2341
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2025
+      "Size": 2026
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 11967
+      "Size": 11973
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 16669
+      "Size": 16675
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 9989
+      "Size": 9988
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19137
+      "Size": 19139
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 163885
+      "Size": 163894
     },
     "assemblies/System.Memory.dll": {
-      "Size": 3384
+      "Size": 3388
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 66833
+      "Size": 66840
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 21877
+      "Size": 21879
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3601
+      "Size": 3602
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8101
+      "Size": 8106
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 786590
+      "Size": 786299
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
       "Size": 192243
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42215
+      "Size": 42217
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 215337
+      "Size": 215338
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16628
+      "Size": 16635
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 3645
+      "Size": 3647
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3738
+      "Size": 3770
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1949
+      "Size": 1950
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2479
+      "Size": 2480
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3758
+      "Size": 3759
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 7786
+      "Size": 7783
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 154123
+      "Size": 154181
     },
     "assemblies/System.Threading.dll": {
-      "Size": 5482
+      "Size": 5486
     },
     "assemblies/System.Threading.Thread.dll": {
-      "Size": 1977
+      "Size": 1978
     },
     "assemblies/System.Threading.ThreadPool.dll": {
-      "Size": 2007
+      "Size": 2008
     },
     "assemblies/System.Transactions.Local.dll": {
-      "Size": 62995
+      "Size": 62998
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1837
+      "Size": 1838
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1858
+      "Size": 1860
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 117252
@@ -214,14 +214,11 @@
     "classes.dex": {
       "Size": 3473196
     },
-    "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 96832
-    },
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 425416
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3052824
+      "Size": 3073392
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -233,7 +230,7 @@
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 99936
+      "Size": 99640
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -347,13 +344,13 @@
       "Size": 1213
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 79748
+      "Size": 79628
     },
     "META-INF/com.google.android.material_material.version": {
       "Size": 10
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 79621
+      "Size": 79501
     },
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
@@ -1988,5 +1985,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 8107074
+  "PackageSize": 8078308
 }


### PR DESCRIPTION
Changes: https://github.com/dotnet/installer/compare/330dee39e5e4dcf765f4c41c76b94c8e4497e91c...dd355bb777249689beba30978ac26e15c96da642
Changes: https://github.com/dotnet/linker/compare/313671b195b1b36d56a8888a9a0e12edaac52c57...5f9bfd94d9c687207872ae03f751ea19704381c0
Changes: https://github.com/dotnet/runtime/compare/ef077d0b58ffddcf54fa73bd85dace6b999b8992...6d10e4c8bcd9f96ccd73748ff827561afa09af57
Changes: https://github.com/dotnet/emsdk/compare/216093204c415b6e37dfadfcbcf183881b443636...8d8d2122b16c81df4b158fe43995f958e8fe115e

Updates:

* Microsoft.Dotnet.Sdk.Internal: from 7.0.100-rc.2.22454.1 to 7.0.100-rc.2.22457.6
* Microsoft.NET.ILLink.Tasks: from 7.0.100-1.22423.4 to 7.0.100-1.22452.1
* Microsoft.NETCore.App.Ref: from 7.0.0-rc.1.22422.12 to 7.0.0-rc.2.22451.11
* Microsoft.NET.Workload.Emscripten.Manifest-7.0.100: from 7.0.0-rc.1.22411.1 to 7.0.0-rc.2.22430.5

This is bringing required changes from 2bf5153 to `main`.

## Other Changes ##

* `darc update-dependencies --id 148018` to manually update the dotnet/installer version
* Add feeds in `NuGet.config` from our .NET 6 release branch
* Install both net6 & net7 workload manifests for Mono and Emscripten
* Extend both net6 & net7 Mono workloads from the `android` workload
* Support for `$(AotAssemblies)` property (directly uses Mono workload pack names)