### PR TITLE
[tests] export $DOTNET_gcServer as 0

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -38,5 +38,8 @@ variables:
 # Workaround: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1585820
 - name: _WriteTelemetryProperties
   value: false
+# Workaround: https://github.com/dotnet/linker/issues/3012
+- name: DOTNET_gcServer
+  value: 0
 - name: DotNetReleaseBranchPrefix
   value: refs/heads/release/


### PR DESCRIPTION
Context: https://github.com/dotnet/linker/issues/3012#issuecomment-1239958027

See if disabling the "server GC" in favor of the "workstation GC" helps a failing test.