### PR TITLE
[illink] set `$(TrimmerRemoveSymbols)` by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -14,6 +14,7 @@ This file contains the .NET 5-specific targets to customize ILLink
       AfterTargets="ComputeResolvedFilesToPublishList"
       DependsOnTargets="GetReferenceAssemblyPaths;_CreatePropertiesCache">
     <PropertyGroup>
+      <TrimmerRemoveSymbols Condition=" '$(AndroidIncludeDebugSymbols)' != 'true' ">true</TrimmerRemoveSymbols>
       <!--
         Used for the <ILLink DumpDependencies="$(_TrimmerDumpDependencies)" /> value:
         https://github.com/dotnet/sdk/blob/a5393731b5b7b225692fff121f747fbbc9e8b140/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L150


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7302
Context: https://github.com/dotnet/linker/issues/2203
Context: https://github.com/dotnet/runtime/issues/67660
Context: https://github.com/xamarin/xamarin-android/pull/6598

This partially backports 745214d.

Building a `net6.0-android` app in `Release` mode with .NET 7 can fail with many errors like:

    error XA4215: The Java type `androidx.activity.contextaware.OnContextAvailableListener` is generated by more than one managed type. Please change the [Register] attribute so that the same Java type is not emitted.

This happens because we end up with multiple assemblies, such as:

    obj/Release/net6.0-android/android-arm/linked/Xamarin.AndroidX.Activity.dll
    obj/Release/net6.0-android/android-arm64/linked/Xamarin.AndroidX.Activity.dll
    obj/Release/net6.0-android/android-x64/linked/Xamarin.AndroidX.Activity.dll
    obj/Release/net6.0-android/android-x86/linked/Xamarin.AndroidX.Activity.dll

To fix this, in addition to this backport to dotnet/runtime/release/6.0:

https://github.com/dotnet/runtime/pull/75311

In .NET 7 we opt into `$(TrimmerRemoveSymbols)` by default for `Release` builds. This allows the .NET 7 linker to have stable MVIDs for assemblies for each architecture. Somehow when the linker outputs `.pdb` files, it creates different MVIDs per architecture.

There may potentially be a dotnet/linker issue here to look into further. However, this seems to be the best fix for getting .NET 6 projects building under .NET 7 at the moment.