### PR TITLE
Parse cookies on redirect (legacy AndroidClientHandler)

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.Legacy.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.Legacy.cs
@@ -485,12 +485,12 @@ namespace Xamarin.Android.Net
 					}
 				}
 
+				CopyHeaders (httpConnection, ret);
+				ParseCookies (ret, connectionUri);
+
 				if (disposeRet) {
 					ret.Dispose ();
 					ret = null!;
-				} else {
-					CopyHeaders (httpConnection, ret);
-					ParseCookies (ret, connectionUri);
 				}
 
 				// We don't want to pass the authorization header onto the next location


### PR DESCRIPTION
When using the `AllowAutoRedirect` feature of `AndroidClientHandler` to automatically follow 3xx redirects, the cookies that are returned together with the redirection are not processed. If the redirection target requires the cookies returned by the first request, the call will fail.

With this change the cookies are always processes before the redirection takes place. Fixes #3954.

Please note that this change was already merged for `AndroidMessageHandler` (see #6987), but not for the legacy `AndroidClientHandler`.
