### PR TITLE
[ci] Fix test categories for emu smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ apk-sizes-*.txt
 *~
 external/monodroid/
 external/mono/
-tests/api-compatibility/reference/*.dll
-tests/api-compatibility/reference/*.cs
+tests/api-compatibility/reference/*/*.dll
+tests/api-compatibility/reference/*/*.cs
 Novell
 *.patch
 *.keystore

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -346,8 +346,7 @@ stages:
     condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], '$(DotNetReleaseBranchPrefix)')))
     pool:
       vmImage: $(HostedMacImage)
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 5
+    timeoutInMinutes: 180
     workspace:
       clean: all
     variables:
@@ -771,8 +770,7 @@ stages:
     displayName: macOS > Tests > MSBuild+Emulator One .NET
     pool:
       vmImage: $(HostedMacImage)
-    timeoutInMinutes: 90
-    cancelTimeoutInMinutes: 5
+    timeoutInMinutes: 180
     workspace:
       clean: all
     steps:
@@ -802,7 +800,7 @@ stages:
         useDotNet: true
         testRunTitle: MSBuildDeviceIntegration Smoke - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-        nunitConsoleExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
+        dotNetTestExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
         testResultsFile: TestResult-MSBuildDeviceIntegrationSmoke-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1


### PR DESCRIPTION
Fixes a timeout in the `MSBuild+Emulator One .NET` job by ensuring that
the correct test categories are passed to `dotnet test`.  All smoke test
job timeouts have been set to 180 minutes for consistency.  A couple of
gitignore entries have also been updated to ignore the files produced
when running API compatibility checks on Mono.Android.