### PR TITLE
[build] support for multiple API levels in .NET 7

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -56,32 +56,33 @@
     <RemoveDir Directories="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned" />
   </Target>
 
-  <Target Name="_CreateDefaultRefPack"
-      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidDefaultTargetDotnetApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\Mono.Android.dll') ">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-  </Target>
-
-  <Target Name="_CreatePreviewPacks"
-      Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' and Exists('$(_MonoAndroidNETOutputRoot)$(AndroidLatestUnstableApiLevel)\Mono.Android.dll') ">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=$(AndroidLatestUnstableApiLevel) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-  </Target>
-
   <Target Name="CreateAllPacks"
-      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory;_CreatePreviewPacks;_CreateDefaultRefPack">
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-arm64 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x86   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:AndroidRID=android-x64   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
-    <Exec Command="&quot;$(DotNetPreviewTool)&quot; pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
+      DependsOnTargets="DeleteExtractedWorkloadPacks;_SetGlobalProperties;GetXAVersionInfo;_CleanNuGetDirectory">
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-arm -p:AndroidABI=armeabi-v7a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-arm64 -p:AndroidABI=arm64-v8a-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-x86 -p:AndroidABI=x86-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) -p:AndroidRID=android-x64 -p:AndroidABI=x86_64-net6 &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Runtime.proj&quot;"
+    />
+    <Exec
+        Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+        Command="dotnet pack @(_GlobalProperties, ' ') -p:AndroidApiLevel=%(AndroidApiInfo.Level) &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Ref.proj&quot;"
+    />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Linux   &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Linux' " />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Darwin  &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' == 'Darwin' " />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') -p:HostOS=Windows &quot;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk.proj&quot;" Condition=" '$(HostOS)' != 'Linux' " /> <!-- Windows pack should be built both Windows and macOS -->
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Android.proj&quot;" />
+    <Exec Command="dotnet pack @(_GlobalProperties, ' ') &quot;$(XamarinAndroidSourcePath)src\Microsoft.Android.Templates\Microsoft.Android.Templates.csproj&quot;" />
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
@@ -126,7 +127,7 @@
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <_PreviewPacks Condition=" '$(AndroidLatestStableApiLevel)' != '$(AndroidLatestUnstableApiLevel)' " Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\Microsoft.Android.Ref.$(AndroidLatestUnstableApiLevel).*.nupkg" />
       <_InstallArguments Include="android" />
-      <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
+      <_InstallArguments Include="android-%(AndroidApiInfo.Level)" Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' and '%(AndroidApiInfo.Level)' != '$(AndroidDefaultTargetDotnetApiLevel)' " />
       <_InstallArguments Include="--skip-manifest-update" />
       <_InstallArguments Include="--verbosity diag" />
       <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -42,6 +42,10 @@ core workload SDK packs imported by WorkloadManifest.targets.
     />
 
     <ItemGroup>
+      <_AndroidApiInfo
+          Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' "
+          Include="$(XAInstallPrefix)xbuild-frameworks\Microsoft.Android\net6.0-android%(AndroidApiInfo.Level)\AndroidApiInfo.xml"
+      />
       <_PackageFiles Include="@(AndroidSdkBuildTools)" PackagePath="%(AndroidSdkBuildTools.PackagePath)" />
       <_PackageFiles Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Sdk.ILLink.dll" PackagePath="tools" />
       <_PackageFiles Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Sdk.ILLink.pdb" PackagePath="tools" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -1,43 +1,41 @@
 <Project>
   <PropertyGroup>
-    <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
     <_BinlogDateTime>$([System.DateTime]::Now.ToString("yyyyMMddTHHmmss"))</_BinlogDateTime>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
+
   <Target Name="BuildExternal">
     <MSBuild
-        Projects="$(_Root)\external\monodroid\monodroid.proj"
+        Projects="$(XamarinAndroidSourcePath)\external\monodroid\monodroid.proj"
         Properties="DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir);CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild\Novell"
     />
   </Target>
   <Target Name="PrepareJavaInterop">
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_Root)bin/Build$(Configuration)/msbuild-$(_BinlogDateTime)-prepare-java-interop.binlog"
-        WorkingDirectory="$(_Root)external\Java.Interop"
+        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(XamarinAndroidSourcePath)bin/Build$(Configuration)/msbuild-$(_BinlogDateTime)-prepare-java-interop.binlog"
+        WorkingDirectory="$(XamarinAndroidSourcePath)external\Java.Interop"
     />
   </Target>
   <Target Name="BuildDotNet"
       DependsOnTargets="PrepareJavaInterop">
-    <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
-    <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
-    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ConfigureLocalWorkload" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ConfigureLocalWorkload" />
   </Target>
   <Target Name="PackDotNet">
     <!-- Build extra versions of Mono.Android.dll if necessary -->
     <MSBuild
-         Condition=" '$(AndroidDefaultTargetDotnetApiLevel)' != '$(AndroidLatestStableApiLevel)' "
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=$(DotNetTargetFramework);AndroidApiLevel=$(AndroidDefaultTargetDotnetApiLevel);AndroidPlatformId=$(AndroidDefaultTargetDotnetApiLevel);DisableApiCompatibilityCheck=true"
+         Condition=" '%(AndroidApiInfo.DotNetSupported)' == 'true' and '%(AndroidApiInfo.Level)' != '$(AndroidLatestStableApiLevel)' "
+         Projects="$(XamarinAndroidSourcePath)src\Mono.Android\Mono.Android.csproj"
+         Properties="TargetFramework=net6.0;AndroidApiLevel=%(AndroidApiInfo.Level);AndroidPlatformId=%(AndroidApiInfo.Id);DisableApiCompatibilityCheck=true"
     />
-    <MSBuild
-         Condition=" '$(AndroidLatestUnstableApiLevel)' != '$(AndroidLatestStableApiLevel)' "
-         Projects="$(_Root)src\Mono.Android\Mono.Android.csproj"
-         Properties="TargetFramework=$(DotNetTargetFramework);AndroidApiLevel=$(AndroidLatestUnstableApiLevel);AndroidPlatformId=$(AndroidLatestUnstablePlatformId);DisableApiCompatibilityCheck=true"
-    />
-    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
-    <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="CreateAllPacks" />
+    <MSBuild Projects="$(XamarinAndroidSourcePath)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ExtractWorkloadPacks" />
     <!-- Clean up old, previously restored packages -->
     <ItemGroup>
-      <_OldPackages Include="$(_Root)packages\microsoft.android.*\**\*.nupkg" />
+      <_OldPackages Include="$(XamarinAndroidSourcePath)packages\microsoft.android.*\**\*.nupkg" />
       <_DirectoriesToRemove Include="%(_OldPackages.RootDir)%(_OldPackages.Directory)" />
     </ItemGroup>
     <RemoveDir Directories="@(_DirectoriesToRemove)" />

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedMonoAndroidProjitemsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedMonoAndroidProjitemsFile.cs
@@ -25,23 +25,26 @@ namespace Xamarin.Android.Prepare
 		{
 			using (var fs = File.Open (OutputPath, FileMode.Create)) {
 				using (var sw = new StreamWriter (fs)) {
-					GenerateFile (sw);
+					GenerateFile (context, sw);
 				}
 			}
 		}
 
-		void GenerateFile (StreamWriter sw)
+		void GenerateFile (Context context, StreamWriter sw)
 		{
 			sw.Write (FileTop);
 
+			string apiLevelText = context.Properties.GetRequiredValue (KnownProperties.AndroidDefaultTargetDotnetApiLevel);
+			uint.TryParse (apiLevelText, out var dotnetApiLevel);
+
 			sw.WriteLine ("  <ItemGroup>");
-			BuildAndroidPlatforms.AllPlatforms.ForEach (androidPlatform => WriteGroupApiInfo (sw, androidPlatform));
+			BuildAndroidPlatforms.AllPlatforms.ForEach (androidPlatform => WriteGroupApiInfo (sw, androidPlatform, dotnetApiLevel));
 			sw.WriteLine ("  </ItemGroup>");
 
 			sw.Write (FileBottom);
 		}
 
-		void WriteGroupApiInfo (StreamWriter sw, AndroidPlatform androidPlatform)
+		void WriteGroupApiInfo (StreamWriter sw, AndroidPlatform androidPlatform, uint dotnetApiLevel)
 		{
 			if (string.IsNullOrWhiteSpace (androidPlatform.ApiName)) {
 				return;
@@ -52,6 +55,7 @@ namespace Xamarin.Android.Prepare
 			sw.WriteLine ($"      <Level>{androidPlatform.ApiLevel}</Level>");
 			sw.WriteLine ($"      <Id>{androidPlatform.PlatformID}</Id>");
 			sw.WriteLine ($"      <Stable>{androidPlatform.Stable}</Stable>");
+			sw.WriteLine ($"      <DotNetSupported>{androidPlatform.ApiLevel >= dotnetApiLevel}</DotNetSupported>");
 			sw.WriteLine ($"    </AndroidApiInfo>");
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Prepare
 			Steps.Add (new Step_InstallAdoptOpenJDK8 ());
 			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
 			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));
+			Steps.Add (new Step_GenerateMonoAndroidProfileItems ());
 
 			// disable installation of missing programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BaseGenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BaseGenerateFiles.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	abstract class Step_BaseGenerateFiles : Step
+	{
+		public Step_BaseGenerateFiles () : base ("Generating files required by the build")
+		{
+		}
+
+		public Step_BaseGenerateFiles (string description) : base (description)
+		{
+		}
+
+#pragma warning disable CS1998
+		protected override async Task<bool> Execute (Context context)
+		{
+			List<GeneratedFile>? filesToGenerate = GetFilesToGenerate (context);
+			if (filesToGenerate != null && filesToGenerate.Count > 0) {
+				foreach (GeneratedFile gf in filesToGenerate) {
+					if (gf == null)
+						continue;
+
+					Log.Status ("Generating ");
+					Log.Status (Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.OutputPath), ConsoleColor.White);
+					if (!String.IsNullOrEmpty (gf.InputPath))
+						Log.StatusLine ($" {context.Characters.LeftArrow} ", Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, gf.InputPath), leadColor: ConsoleColor.Cyan, tailColor: ConsoleColor.White);
+					else
+						Log.StatusLine ();
+
+					gf.Generate (context);
+				}
+			}
+
+			return true;
+		}
+#pragma warning restore CS1998
+
+		protected abstract List<GeneratedFile>? GetFilesToGenerate (Context context);
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	partial class Step_GenerateFiles : Step
+	partial class Step_GenerateFiles : Step_BaseGenerateFiles
 	{
 		bool atBuildStart;
 		bool onlyRequired;
@@ -15,7 +15,6 @@ namespace Xamarin.Android.Prepare
 
 
 		public Step_GenerateFiles (bool atBuildStart, bool onlyRequired = false)
-			: base ("Generating files required by the build")
 		{
 			this.atBuildStart = atBuildStart;
 			this.onlyRequired = onlyRequired;
@@ -49,7 +48,7 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		List<GeneratedFile>? GetFilesToGenerate (Context context)
+		protected override List<GeneratedFile>? GetFilesToGenerate (Context context)
 		{
 			if (atBuildStart) {
 				if (onlyRequired) {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateMonoAndroidProfileItems.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateMonoAndroidProfileItems.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	class Step_GenerateMonoAndroidProfileItems : Step_BaseGenerateFiles
+	{
+		protected override List<GeneratedFile>? GetFilesToGenerate (Context context) => new List<GeneratedFile> {
+			new GeneratedMonoAndroidProjitemsFile(),
+		};
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/in/Microsoft.Android.Sdk.BundledVersions.in.targets
@@ -14,7 +14,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <_AndroidTargetingPackId Condition="$(TargetPlatformVersion.EndsWith('.0'))">$(TargetPlatformVersion.Substring(0, $(TargetPlatformVersion.LastIndexOf('.0'))))</_AndroidTargetingPackId>
     <_AndroidTargetingPackId Condition="'$(_AndroidTargetingPackId)' == ''">$(TargetPlatformVersion)</_AndroidTargetingPackId>
-    <_AndroidRuntimePackId Condition=" '$(_AndroidTargetingPackId)' &lt; '@ANDROID_LATEST_STABLE_API_LEVEL@' ">@ANDROID_LATEST_STABLE_API_LEVEL@</_AndroidRuntimePackId>
     <_AndroidRuntimePackId Condition=" '$(_AndroidRuntimePackId)' == '' ">$(_AndroidTargetingPackId)</_AndroidRuntimePackId>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Reflection;
 using System.Text;
@@ -1132,6 +1133,30 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			proj.SetProperty ("RunAOTCompilation", aot.ToString ());
 			var builder = CreateDotNetBuilder (proj);
 			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
+		}
+
+		[Test]
+		public void UseCorrectRuntimePacks([Values (31, 32, 33)] int apiLevel)
+		{
+			var proj = new XASdkProject {
+				TargetFramework = $"net6.0-android{apiLevel}",
+				Sources = {
+					new BuildItem.Source ("MyThread.cs") {
+						TextContent = () => "class MyThread : Java.Lang.Thread { }",
+					},
+				},
+			};
+			var builder = CreateDotNetBuilder (proj);
+			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
+
+			// Assert we get the right runtime pack, find a path such as:
+			// dotnet\packs\Microsoft.Android.Runtime.31.android-arm\*\runtimes\android-arm\lib\net6.0\Mono.Android.dll
+			var regex = new Regex (@$"Microsoft\.Android\.Runtime\.{apiLevel}\.android-.+Mono\.Android\.dll", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+			foreach (var line in builder.LastBuildOutput) {
+				if (regex.IsMatch (line))
+					return;
+			}
+			Assert.Fail ($"Did not find a Mono.Android.dll from the Microsoft.Android.Runtime.{apiLevel} pack.");
 		}
 
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)


### PR DESCRIPTION
This ports 2c63936 to xamarin-android/main.

It uses `%(AndroidApiInfo.DotNetSupported)` for deciding what API levels to build. We will need this support when API 34 is available, and we want to bring it to .NET 7.

Bringing the changes here now shouldn't really have any effect, but the changes should still *build*.

There is one test for `net6.0-android31` through `net6.0-android33`. I left that in, so we can eventually move it to `net7.0-android33` and `net7.0-android34`.