### PR TITLE
Bump to xamarin/monodroid/main@135be73

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@43583d026ff4663fa8165b7c8085189f6210b13e
+xamarin/monodroid:main@135be73fdb3aa6ecbc9f9d078097521ab028e620
 mono/mono:2020-02@a96bde9730e4c2244536ce5f4250e5e4f4e6780a


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/43583d0...135be73

This brings fixes for Fast Deployment.

* [tools/msbuild] use full paths & additional logging
* Bump to xamarin/androidtools@f7e9b92