### PR TITLE
Bump to xamarin/monodroid/main@8f925e33

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@135be73fdb3aa6ecbc9f9d078097521ab028e620
+xamarin/monodroid:main@8f925e3346c8aea63f3481a26c811374915b8d18
 mono/mono:2020-02@a96bde9730e4c2244536ce5f4250e5e4f4e6780a


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/135be73fdb3aa6ecbc9f9d078097521ab028e620...8f925e3346c8aea63f3481a26c811374915b8d18

  * xamarin/monodroid@8f925e334: Bump to xamarin/android-sdk-installer/main@0fb3646a (xamarin/monodroid#1270)
  * xamarin/monodroid@51ed9b12d: Bump to xamarin/androidtools/main@c95015cb (xamarin/monodroid#1269)