### PR TITLE
$(AndroidPackVersionSuffix)=preview.1; net8 is 34.0.0.preview.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,8 +38,8 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>33.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>34.0.0</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -62,10 +62,10 @@ variables:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage
   - name: DotNetFeedCredential
-    value: dotnet7-internal-dnceng-internal-feed
+    value: dotnet8-internal-dnceng-internal-feed
 - ${{ if ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - name: DotNetFeedCredential
-    value: dnceng-dotnet7
+    value: dnceng-dotnet8
 - ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Real


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/7.0.1xx

We branched for .NET 7 into release/7.0.1xx, main is now .NET 8.

Let's update xamarin-android/main's version number to 34.0.0-preview.1.

We should also only push packages from main to the `dotnet8` feed.