### PR TITLE
$(AndroidPackVersionSuffix)=rtm; net7 is 33.0.0.rtm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>33.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/7.0.1xx-rc2

We branched for .NET 7 RC 2 into release/7.0.1xx-rc2. release/7.0.1xx is branded rtm.

Let's update xamarin-android/release/7.0.1xx's version number to 33.0.0-rtm.