### PR TITLE
[ci] Do not publish .NET 8 packages

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -58,14 +58,19 @@ variables:
   value: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
 - name: DotNetNUnitCategories
   value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != SystemApplication'
+  #TODO: Remove package var overrides once we are building against a .NET 8 SDK and can push to the dotnet8 feed
+- name: PushXAPackages
+  value: false
+- name: PushXAPackageInfoToMaestro
+  value: false
 - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage
   - name: DotNetFeedCredential
-    value: dotnet8-internal-dnceng-internal-feed
+    value: dotnet7-internal-dnceng-internal-feed
 - ${{ if ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - name: DotNetFeedCredential
-    value: dnceng-dotnet8
+    value: dnceng-dotnet7
 - ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Real


### PR DESCRIPTION
Context: 7723f856

The steps that publish our .NET packages to a dotnet feed and to maestro have been disabled.  We should re-enable these steps when main is building and testing against .NET 8, and when we have a service connection set up for the `dotnet8` feed.