### PR TITLE
[One .NET] error with XA1030 for AOT and PublishTrimmed=false

### DIFF
--- a/Documentation/guides/messages/xa1030.md
+++ b/Documentation/guides/messages/xa1030.md
@@ -1,0 +1,37 @@
+---
+title: Xamarin.Android error XA1030
+description: XA1030 error code
+ms.date: 09/26/2022
+---
+# Xamarin.Android error XA1030
+
+## Example messages
+
+```
+The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.
+```
+
+## Solution
+
+Instead of using:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <RunAOTCompilation>true</RunAOTCompilation>
+  <!-- Either of these disable the linker/trimmer -->
+  <PublishTrimmed>false</PublishTrimmed>
+  <AndroidLinkMode>None</AndroidLinkMode>
+</PropertyGroup>
+```
+
+Use the default value for `$(PublishTrimmed)` and `$(AndroidLinkMode)`
+instead:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <RunAOTCompilation>true</RunAOTCompilation>
+</PropertyGroup>
+```
+
+Additionally, as mentioned by [`XA0119`](xa0119.md), you should not
+use `$(RunAOTCompilation)` in `Debug` configurations.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -79,6 +79,7 @@
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' and '$(AotAssemblies)' == 'true' ">true</RunAOTCompilation>
     <RunAOTCompilation Condition=" '$(RunAOTCompilation)' == '' ">false</RunAOTCompilation>
     <_AndroidXA1029 Condition=" '$(AotAssemblies)' != '' ">true</_AndroidXA1029>
+    <_AndroidXA1030 Condition=" '$(RunAOTCompilation)' == 'true' and '$(PublishTrimmed)' == 'false' ">true</_AndroidXA1030>
     <AotAssemblies>$(RunAOTCompilation)</AotAssemblies>
     <AndroidEnableProfiledAot Condition=" '$(AndroidEnableProfiledAot)' == '' and '$(RunAOTCompilation)' == 'true' ">true</AndroidEnableProfiledAot>
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -466,6 +466,10 @@ In this message, the term "binding" means a piece of generated code that makes i
     <value>The 'AotAssemblies' MSBuild property is deprecated. Edit the project file in a text editor to remove this property, and use the 'RunAOTCompilation' MSBuild property instead.</value>
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
+  <data name="XA1030" xml:space="preserve">
+    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
+  </data>
   <data name="XA2000" xml:space="preserve">
     <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -1103,6 +1103,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 				/* useInterpreter */ true,
 				/* publishTrimmed */ true,
 				/* aot */            true,
+				/* expected */       true,
 			},
 			// Debug + AOT
 			new object [] {
@@ -1110,6 +1111,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 				/* useInterpreter */ false,
 				/* publishTrimmed */ true,
 				/* aot */            true,
+				/* expected */       true,
 			},
 			// Debug + PublishTrimmed
 			new object [] {
@@ -1117,12 +1119,21 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 				/* useInterpreter */ false,
 				/* publishTrimmed */ true,
 				/* aot */            false,
+				/* expected */       true,
+			},
+			// AOT + PublishTrimmed=false
+			new object [] {
+				/* isRelease */      true,
+				/* useInterpreter */ false,
+				/* publishTrimmed */ false,
+				/* aot */            true,
+				/* expected */       false,
 			},
 		};
 
 		[Test]
 		[TestCaseSource (nameof (SettingCombinationsSource))]
-		public void SettingCombinations (bool isRelease, bool useInterpreter, bool publishTrimmed, bool aot)
+		public void SettingCombinations (bool isRelease, bool useInterpreter, bool publishTrimmed, bool aot, bool expected)
 		{
 			var proj = new XASdkProject {
 				IsRelease = isRelease,
@@ -1131,7 +1142,7 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			proj.SetProperty ("PublishTrimmed", publishTrimmed.ToString ());
 			proj.SetProperty ("RunAOTCompilation", aot.ToString ());
 			var builder = CreateDotNetBuilder (proj);
-			Assert.IsTrue (builder.Build (), $"{proj.ProjectName} should succeed");
+			Assert.AreEqual (expected, builder.Build (), $"{proj.ProjectName} should {(expected ? "succeed" : "fail")}");
 		}
 
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -516,6 +516,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA1029"
       Condition=" $(_AndroidXA1029) == 'true' "
   />
+  <AndroidError Code="XA1030"
+      ResourceName="XA1030"
+      Condition=" $(_AndroidXA1030) == 'true' "
+  />
   <AndroidError Code="XA1011"
       ResourceName="XA1011"
       Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(AndroidDexTool)' == 'd8' "

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -23,44 +23,43 @@ namespace Xamarin.Android.Build.Tests
 			new object[] {
 				/* isRelease */      false,
 				/* xamarinForms */   false,
-				/* publishTrimmed */ default (bool?),
 				/* targetFramework*/ "net7.0-android",
 			},
 			new object[] {
 				/* isRelease */      true,
 				/* xamarinForms */   false,
-				/* publishTrimmed */ default (bool?),
 				/* targetFramework*/ "net7.0-android",
 			},
 			new object[] {
 				/* isRelease */      false,
 				/* xamarinForms */   true,
-				/* publishTrimmed */ default (bool?),
 				/* targetFramework*/ "net7.0-android",
 			},
 			new object[] {
 				/* isRelease */      true,
 				/* xamarinForms */   true,
-				/* publishTrimmed */ default (bool?),
 				/* targetFramework*/ "net7.0-android",
 			},
 			new object[] {
 				/* isRelease */      true,
 				/* xamarinForms */   false,
-				/* publishTrimmed */ false,
 				/* targetFramework*/ "net7.0-android",
+			},
+			new object[] {
+				/* isRelease */      false,
+				/* xamarinForms */   true,
+				/* targetFramework*/ "net6.0-android",
 			},
 			new object[] {
 				/* isRelease */      true,
 				/* xamarinForms */   true,
-				/* publishTrimmed */ true,
 				/* targetFramework*/ "net6.0-android",
 			},
 		};
 
 		[Test]
 		[TestCaseSource (nameof (DotNetInstallAndRunSource))]
-		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, bool? publishTrimmed, string targetFramework)
+		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, string targetFramework)
 		{
 			AssertHasDevices ();
 
@@ -81,9 +80,6 @@ namespace Xamarin.Android.Build.Tests
 					"https://api.nuget.org/v3/index.json",
 					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
 				};
-			}
-			if (publishTrimmed != null) {
-				proj.SetProperty (KnownProperties.PublishTrimmed, publishTrimmed.ToString ());
 			}
 			proj.SetRuntimeIdentifier (DeviceAbi);
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7178

Using this combination:

    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
      <RunAOTCompilation>true</RunAOTCompilation>
      <PublishTrimmed>false</PublishTrimmed>
    </PropertyGroup>

Causes apps to crash at runtime with:

    07-18 11:39:53.613 20269 20269 D Mono    : AOT: module Microsoft.Maui.dll.so is unusable (GUID of dependent assembly Xamarin.AndroidX.AppCompat doesn't match (expected '1FC81757-8A70-4D56-93E6-8A635E2C23DE', got 'FD3821D1-CBF4-4956-B930-EA2A5379E18D')).

AOT runs right after the `<ILLink/>` MSBuild task, and so the combination currently doesn't work when trimming is disabled.

For now, to solve this let's emit a `XA1030` error and fail the build. This way you at least get a reasonable error at build time instead of at runtime.

I do not know of a scenario when it would be useful to disable trimming completely during a `Release` + AOT build. If you are hitting a trimming/linker issue, you would be better off preserving a single assembly, type, etc.