### PR TITLE
[Mono.Android] Improve generated API docs diff

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -292,7 +292,7 @@
     <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">31</DocsApiLevel>
     <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">31</DocsPlatformId>
     <DocsFxVersion Condition=" '$(DocsFxVersion)' == '' ">v12.0</DocsFxVersion>
-    <_Binlog>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss")).binlog</_Binlog>
+    <_LogPrefix>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))</_LogPrefix>
   </PropertyGroup>
 
   <!-- Generate documentation using MDoc -->
@@ -312,7 +312,7 @@
       <_BuildProps Include="-p:AndroidFrameworkVersion=$(DocsFxVersion)" />
     </ItemGroup>
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build -v:n -c $(Configuration) -bl:$(_Binlog) @(_BuildProps, ' ')"
+        Command="&quot;$(DotNetPreviewTool)&quot; build -v:n -c $(Configuration) -bl:$(_LogPrefix).binlog @(_BuildProps, ' ')"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
@@ -365,14 +365,20 @@
         Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_Lang)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
+    <!-- Ensure updated docs can also be exported to msxdoc format -->
+    <Exec
+        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug export-msxdoc -o &quot;$(_LogPrefix)-Export.xml&quot; &quot;$(XamarinAndroidSourcePath)external/android-api-docs/docs/Mono.Android/en/&quot;"
+        WorkingDirectory="$(MSBuildThisFileDirectory)"
+    />
   </Target>
 
   <Target Name="_GenerateApiDocsDiff">
-    <PropertyGroup>
-      <_DiffFile>$(XamarinAndroidSourcePath)bin/Build$(Configuration)/UpdateApiDocs$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss")).diff</_DiffFile>
-    </PropertyGroup>
     <Exec
-        Command="git diff --output=&quot;$(_DiffFile)&quot;"
+        Command="git add ."
+        WorkingDirectory="$(XamarinAndroidSourcePath)external/android-api-docs"
+    />
+    <Exec
+        Command="git diff --cached --output=&quot;$(_LogPrefix).diff&quot;"
         WorkingDirectory="$(XamarinAndroidSourcePath)external/android-api-docs"
     />
   </Target>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+  <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.Git" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckApiCompatibility" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
   <Import Project="..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems" Condition="Exists('..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems')"/>
@@ -373,13 +374,17 @@
   </Target>
 
   <Target Name="_GenerateApiDocsDiff">
-    <Exec
-        Command="git add ."
+    <Git
+        Arguments="add ."
         WorkingDirectory="$(XamarinAndroidSourcePath)external/android-api-docs"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)"
     />
-    <Exec
-        Command="git diff --cached --output=&quot;$(_LogPrefix).diff&quot;"
+    <Git
+        Arguments="diff --cached --output=&quot;$(_LogPrefix).diff&quot;"
         WorkingDirectory="$(XamarinAndroidSourcePath)external/android-api-docs"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)"
     />
   </Target>
 


### PR DESCRIPTION
Updates the `<UpdateExternalDocumentation/>` target to run the mdoc `export-msxdoc` command for validation, and to include new files in the diff that it produces.