### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 11410: Build ID 6765281

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>Die MSBuild-Eigenschaft „RunAOTCompilation“ wird nur unterstützt, wenn die Kürzung aktiviert ist. Bearbeiten Sie die Projektdatei in einem Text-Editor, um „PublishTrimmed“ für diese Buildkonfiguration auf „wahr“ festzulegen.</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>La proprietà MSBuild 'RunAOTCompilation' è supportata solo quando è abilitato il troncamento. Modifica il file di progetto in un editor di testo per impostare 'PublishTrimmed' su 'true' per questa configurazione di compilazione.</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>'RunAOTCompilation' MSBuild プロパティは、トリミングが有効な場合にのみサポートされます。テキスト エディターでプロジェクト ファイルを編集して、このビルド構成の 'PublishTrimmed' を 'true' に設定します。</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>'RunAOTCompilation' MSBuild 속성은 트리밍이 활성화된 경우에만 지원됩니다. 텍스트 편집기에서 프로젝트 파일을 편집하여 이 빌드 구성에 대해 'PublishTrimmed'를 'true'로 설정합니다.</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>Właściwość „RunAOTCompilation” programu MSBuild jest obsługiwana tylko wtedy, gdy jest włączone przycinanie. Edytuj plik projektu w edytorze tekstu, aby ustawić właściwość „PublishTrimmed” na wartość „true” dla tej konfiguracji kompilacji.</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>仅当启用剪裁时，才支持 “RunAOTCompilation” MSBuild 属性。在文本编辑器中编辑项目文件，以将此生成配置的 “PublishTrimmed” 设置为 “true”。</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
@@ -467,7 +467,7 @@ In this message, the term "binding" means a piece of generated code that makes i
     <comment>The following are literal names and should not be translated: 'AotAssemblies', 'RunAOTCompilation'</comment>
   </data>
   <data name="XA1030" xml:space="preserve">
-    <value>The 'RunAOTCompilation' MSBuild property is only supported when trimming is enabled. Edit the project file in a text editor to set 'PublishTrimmed' to 'true' for this build configuration.</value>
+    <value>只有在啟用 [修剪] 時，才支援 'RunAOTCompilation' MSBuild 屬性。在文字編輯器中編輯專案檔案，以將此組建組態的 'PublishTrimmed' 設為 'true'。</value>
     <comment>The following are literal names and should not be translated: 'RunAOTCompilation', 'PublishTrimmed'</comment>
   </data>
   <data name="XA2000" xml:space="preserve">


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.