### PR TITLE
Nullability for AndroidMessageHandler.RequestNeedsAuthorization

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -233,6 +234,7 @@ namespace Xamarin.Android.Net
 		/// If <c>true</c> then the server requested authorization and the application must use information
 		/// found in <see cref="RequestedAuthentication"/> to set the value of <see cref="PreAuthenticationData"/>
 		/// </summary>
+		[MemberNotNullWhen(true, nameof(RequestedAuthentication))]
 		public bool RequestNeedsAuthorization {
 			get { return RequestedAuthentication?.Count > 0; }
 		}

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -234,7 +234,9 @@ namespace Xamarin.Android.Net
 		/// If <c>true</c> then the server requested authorization and the application must use information
 		/// found in <see cref="RequestedAuthentication"/> to set the value of <see cref="PreAuthenticationData"/>
 		/// </summary>
+#if NETCOREAPP
 		[MemberNotNullWhen(true, nameof(RequestedAuthentication))]
+#endif
 		public bool RequestNeedsAuthorization {
 			get { return RequestedAuthentication?.Count > 0; }
 		}


### PR DESCRIPTION
My project uses AndroidMessageHandler.  Currently, idiomatic code like this produces a nullability warning:

```cs
if (handler.RequestNeedsAuthorization)
    handler.PreAuthenticationData = handler.RequestedAuthentication[0];
```

This PR adds a [MemberNotNullWhen attribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.membernotnullwhenattribute?view=net-6.0) that allows RequestedAuthentication to be used without a null-check after testing RequestNeedsAuthorization.