### PR TITLE
[Xamarin.Android.Build.Tasks] run a Clean if the project path changes.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -981,6 +981,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
 		<_PropertyCacheItems Include="AndroidSupportedAbis=$(AndroidSupportedAbis)" />
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
+		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"


### PR DESCRIPTION
Fixes #6924

If the user moves the project to another location on the hard drive the build will fail with errors such as.

```
APT2126	file not found.	Foo.Foo	C:\Foo.Foo\obj\Debug\net6.0-android\lp\122\jl\res\values\attr.xml	1
```

To work around this we should place the `$(MSBuildProjectFullPath)` value in the `_PropertyCacheItems` ItemGroup. This will trigger a Clean if it changes.