### PR TITLE
[Xamarin.Android.Build.Tasks] Don't report duplicate type if the AssemblyName  is the same.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Android.Tasks
 					TypeDefinition conflict;
 					bool hasConflict = false;
 					if (managed.TryGetValue (managedKey, out conflict)) {
-						if (!conflict.Module.Name.Equals(type.Module.Name)) {
+						if (!conflict.Module.Name.Equals (type.Module.Name)) {
 							if (!managedConflicts.TryGetValue (managedKey, out var list))
 								managedConflicts.Add (managedKey, list = new List<string> { conflict.GetPartialAssemblyName (cache) });
 							list.Add (type.GetPartialAssemblyName (cache));
@@ -290,7 +290,7 @@ namespace Xamarin.Android.Tasks
 						hasConflict = true;
 					}
 					if (java.TryGetValue (javaKey, out conflict)) {
-						if (!conflict.Module.Name.Equals(type.Module.Name)) {
+						if (!conflict.Module.Name.Equals (type.Module.Name)) {
 							if (!javaConflicts.TryGetValue (javaKey, out var list))
 								javaConflicts.Add (javaKey, list = new List<string> { conflict.GetAssemblyQualifiedName (cache) });
 							list.Add (type.GetAssemblyQualifiedName (cache));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -271,7 +271,6 @@ namespace Xamarin.Android.Tasks
 
 			using (var acw_map = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				foreach (TypeDefinition type in javaTypes) {
-					string mvid = type.Module.Mvid.ToString ();
 					string managedKey = type.FullName.Replace ('/', '.');
 					string javaKey = JavaNativeTypeManager.ToJniName (type, cache).Replace ('/', '.');
 
@@ -283,7 +282,7 @@ namespace Xamarin.Android.Tasks
 					TypeDefinition conflict;
 					bool hasConflict = false;
 					if (managed.TryGetValue (managedKey, out conflict)) {
-						if (!conflict.Module.Mvid.Equals(mvid)) {
+						if (!conflict.Module.Mvid.Equals(type.Module.Mvid)) {
 							if (!managedConflicts.TryGetValue (managedKey, out var list))
 								managedConflicts.Add (managedKey, list = new List<string> { conflict.GetPartialAssemblyName (cache) });
 							list.Add (type.GetPartialAssemblyName (cache));
@@ -291,7 +290,7 @@ namespace Xamarin.Android.Tasks
 						hasConflict = true;
 					}
 					if (java.TryGetValue (javaKey, out conflict)) {
-						if (!conflict.Module.Mvid.Equals(mvid)) {
+						if (!conflict.Module.Mvid.Equals(type.Module.Mvid)) {
 							if (!javaConflicts.TryGetValue (javaKey, out var list))
 								javaConflicts.Add (javaKey, list = new List<string> { conflict.GetAssemblyQualifiedName (cache) });
 							list.Add (type.GetAssemblyQualifiedName (cache));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Android.Tasks
 					TypeDefinition conflict;
 					bool hasConflict = false;
 					if (managed.TryGetValue (managedKey, out conflict)) {
-						if (!conflict.Module.Mvid.Equals(type.Module.Mvid)) {
+						if (!conflict.Module.Name.Equals(type.Module.Name)) {
 							if (!managedConflicts.TryGetValue (managedKey, out var list))
 								managedConflicts.Add (managedKey, list = new List<string> { conflict.GetPartialAssemblyName (cache) });
 							list.Add (type.GetPartialAssemblyName (cache));
@@ -290,7 +290,7 @@ namespace Xamarin.Android.Tasks
 						hasConflict = true;
 					}
 					if (java.TryGetValue (javaKey, out conflict)) {
-						if (!conflict.Module.Mvid.Equals(type.Module.Mvid)) {
+						if (!conflict.Module.Name.Equals(type.Module.Name)) {
 							if (!javaConflicts.TryGetValue (javaKey, out var list))
 								javaConflicts.Add (javaKey, list = new List<string> { conflict.GetAssemblyQualifiedName (cache) });
 							list.Add (type.GetAssemblyQualifiedName (cache));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -509,5 +509,41 @@ namespace UnnamedProject {
 				}
 			}
 		}
+
+		[Test]
+		public void DoNotErrorOnPerArchJavaTypeDuplicates ()
+		{
+			if (!Builder.UseDotNet)
+				Assert.Ignore ("Test only valid on .NET");
+
+			var path = Path.Combine (Root, "temp", TestName);
+			var lib = new XamarinAndroidLibraryProject { IsRelease = true, ProjectName = "Lib1" };
+			lib.SetProperty ("IsTrimmable", "true");
+			lib.Sources.Add (new BuildItem.Source ("Library1.cs") {
+				TextContent = () => @"
+namespace Lib1;
+public class Library1 : Java.Lang.Object {
+	private static bool Is64Bits = IntPtr.Size >= 8;
+
+	public static bool Is64 () {
+		return Is64Bits;
+	}
+}",
+			});
+			var proj = new XamarinAndroidApplicationProject { IsRelease = true, ProjectName = "App1" };
+			proj.References.Add(new BuildItem.ProjectReference (Path.Combine ("..", "Lib1", "Lib1.csproj"), "Lib1"));
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"base.OnCreate (bundle);",
+				"base.OnCreate (bundle);\n" +
+				"if (Lib1.Library1.Is64 ()) Console.WriteLine (\"Hello World!\");");
+
+
+			using (var lb = CreateDllBuilder (Path.Combine (path, "Lib1"))) {
+				using (var b = CreateApkBuilder (Path.Combine (path, "App1"))) {
+					Assert.IsTrue (lb.Build (lib), "build should have succeeded.");
+					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -538,12 +538,10 @@ public class Library1 : Java.Lang.Object {
 				"if (Lib1.Library1.Is64 ()) Console.WriteLine (\"Hello World!\");");
 
 
-			using (var lb = CreateDllBuilder (Path.Combine (path, "Lib1"))) {
-				using (var b = CreateApkBuilder (Path.Combine (path, "App1"))) {
-					Assert.IsTrue (lb.Build (lib), "build should have succeeded.");
-					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
-				}
-			}
+			using var lb = CreateDllBuilder (Path.Combine (path, "Lib1"));
+			using var b = CreateApkBuilder (Path.Combine (path, "App1"));
+			Assert.IsTrue (lb.Build (lib), "build should have succeeded.");
+			Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 		}
 	}
 }


### PR DESCRIPTION
Fixes #7473

With the new build system under `dotnet` we can end up with duplicate assemblies for different `RuntimeIdentifiers`. This can cause the `GenerateJavaStubs` task to mistakenly report duplicate types.

```
warning XA4214: The managed type `Microsoft.UI.Xaml.Controls.AnimatedIcon` exists in multiple assemblies: Uno.UI, Uno.UI, Uno.UI, Uno.UI. Please refactor the managed type names in these assemblies so that they are not identical. [C:\a\1\s\UnoAppAll\UnoAppAll.Mobile\UnoAppAll.Mobile.csproj::TargetFramework=net6.0-android]
error XA4215: The Java type `crc64a5a37c43dff01024.GridViewHeaderItem` is generated by more than one managed type. Please change the [Register] attribute so that the same Java type is not emitted. [C:\a\1\s\UnoAppAll\UnoAppAll.Mobile\UnoAppAll.Mobile.csproj::TargetFramework=net6.0-android]
```

We should ignore these duplicates if the name of the the type module is the same. If it is then they will be from the same assembly. We cannot use the `mvid` since that also changes.