### PR TITLE
Use Environment.SpecialFolder.UserProfile, not SpecialFolder.Personal

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -232,7 +232,7 @@ namespace Xamarin.Android.Prepare
 		public static partial class Paths
 		{
 			// Global, compile-time locations
-			public static readonly string HomeDir                          = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+			public static readonly string HomeDir                          = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 			public static readonly string BootstrapResourcesDir            = Path.Combine (BuildPaths.XAPrepareSourceDir, "Resources");
 			public static readonly string BuildToolsDir                    = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "build-tools");
 			public static readonly string BuildToolsScriptsDir             = Path.Combine (BuildToolsDir, "scripts");

--- a/src-ThirdParty/NUnitLite/Env.cs
+++ b/src-ThirdParty/NUnitLite/Env.cs
@@ -50,7 +50,7 @@ namespace NUnit
 #if SILVERLIGHT || PocketPC || WindowsCE || NETCF
         public static string DocumentFolder = @"\My Documents";
 #else
-        public static string DocumentFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+        public static string DocumentFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 #endif
     }
 }

--- a/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/Bug35195.cs
+++ b/tests/MSBuildDeviceIntegration/Resources/LinkDescTest/Bug35195.cs
@@ -12,7 +12,7 @@ namespace LinkTestLib
 			try {
 				// Initialize the database name.
 				const string sqliteFilename = "TaskDB.db3";
-				string libraryPath = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				string libraryPath = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 				string path = Path.Combine (libraryPath, sqliteFilename);
 				var db = new SQLiteAsyncConnection (path);
 				db.CreateTableAsync<TodoTask> ().GetAwaiter ().GetResult ();

--- a/tests/Mono.Android-Tests/Mono.Data.Sqlite/SqliteTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Data.Sqlite/SqliteTests.cs
@@ -41,7 +41,7 @@ namespace Mono.Data.Sqlite.Tests
 
 			ItemsDb ()
 			{
-				dbPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), fileName);
+				dbPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), fileName);
 			}
 
 			SqliteConnection GetConnection ()


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/pull/68610

In .NET 8, a test using `SpecialFolder.Personal` failed with:

```
   [FAIL] Create table attempt failed!
   SQLite.SQLiteException: Could not open database file: /data/user/0/com.xamarin.customlinkdescriptionpreserve/files/Documents/TaskDB.db3 (CannotOpen)
      at SQLite.SQLiteConnection..ctor(SQLiteConnectionString )
      at SQLite.SQLiteConnectionWithLock..ctor(SQLiteConnectionString )
      at SQLite.SQLiteConnectionPool.Entry..ctor(SQLiteConnectionString )
      at SQLite.SQLiteConnectionPool.GetConnectionAndTransactionLock(SQLiteConnectionString , Object& )
      at SQLite.SQLiteConnectionPool.GetConnection(SQLiteConnectionString )
      at SQLite.SQLiteAsyncConnection.GetConnection()
      at SQLite.SQLiteAsyncConnection.<>c__DisplayClass33_0`1[[SQLite.CreateTableResult, SQLite-net, Version=1.7.335.0, Culture=neutral, PublicKeyToken=null]].<WriteAsync>b__0()
      at System.Threading.Tasks.Task`1[[SQLite.CreateTableResult, SQLite-net, Version=1.7.335.0, Culture=neutral, PublicKeyToken=null]].InnerInvoke()
      at System.Threading.Tasks.Task.<>c.<.cctor>b__273_0(Object )
      at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread , ExecutionContext , ContextCallback , Object )
   --- End of stack trace from previous location ---
      at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread , ExecutionContext , ContextCallback , Object )
      at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& , Thread )
   --- End of stack trace from previous location ---
      at LinkTestLib.Bug35195.AttemptCreateTable()
   All regression tests completed.
```

In .NET 8+, we should use `SpecialFolder.UserProfile` instead.