### PR TITLE
[dependabot] Fix automatic submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,15 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "gitsubmodule"
-    directory: "/external/android-api-docs"
+    directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/external/Java.Interop"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/external/xamarin-android-tools"
-    schedule:
-      interval: "daily"
+    ignore:
+      - dependency-name: "apksig"
+      - dependency-name: "debugger-libs"
+      - dependency-name: "lz4"
+      - dependency-name: "mman-win32"
+      - dependency-name: "nrefactory"
+      - dependency-name: "opentk"
+      - dependency-name: "robin-map"
+      - dependency-name: "sqlite"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/network/updates/488916011

Commit 619420ae attempted to add submodule dependency updating to our dependabot configuration, however it was not configured correctly:

    Dependabot couldn't find a .gitmodules.
    Dependabot requires a .gitmodules to evaluate your Git dependencies. It had expected to find one at the path: /external/android-api-docs/.gitmodules.

The directory for the `gitsubmodule` dependency has been updated to fix this, and the repos that we may not want automatic updates for have been added to the ignore list.