### PR TITLE
[readme] Be more explicit about support status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
-<img src="Documentation/images/banner.png" alt="Xamarin.Android banner" height="145" >
+<img src="Documentation/images/banner.png" alt="Android for .NET banner" height="145" >
 
 Android for .NET
 ===============
 
 `Android for .NET` provides open-source bindings of the Android SDK and tooling for use with
-.NET managed languages such as C#. This repository is also home to the classic `Xamarin.Android`
-product.
+.NET managed languages such as C#. This ships as an optional [.NET workload][net-workload] for .NET 6+ that can 
+be updated independently from .NET in order to respond to external dependency updates like new Android
+platform and tooling.
+
+While `Android for .NET` is an essential part of [MAUI][maui-intro], it is still fully supported to be 
+used independently for "native" .NET Android development.
+
+This repository is also home to the classic `Xamarin.Android` product.
+
+[net-workload]: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install
+[maui-intro]: https://learn.microsoft.com/en-us/dotnet/maui/what-is-maui
+
+# Support
+
+`Android for .NET` is now part of .NET 6+ and follows the same lifecycle as the [MAUI Support Lifecycle][maui-support-lifecycle].
+
+Classic `Xamarin.Android` support will end on `May 1, 2024` per the [Xamarin Support Policy][xamarin-support-policy]:
+
+> Xamarin support will end on May 1, 2024 for all classic Xamarin SDKs. Android 13 will be the final version classic Xamarin.Android will target.
+
+[maui-support-lifecycle]: https://dotnet.microsoft.com/en-us/platform/support/policy/maui
+[xamarin-support-policy]: https://dotnet.microsoft.com/en-us/platform/support/policy/xamarin
 
 # Build Status
 


### PR DESCRIPTION
Try to be a bit more explicit about the status of XA and Android for .NET to clear up some confusion we've seen from users.  

Particularly:

- Classic Xamarin.Android is deprecated and has an announced end of support date.
- Android for .NET exists and is supported as a standalone product without MAUI.

We can tweak the exact verbiage as needed, but these are the main points we should try to convey.