### PR TITLE
Disable loading of libLLVM at runtime

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1843,12 +1843,19 @@ a nice and smart library installs a ton of signal handlers and don't chain at al
 
 This is a hack to set llvm::DisablePrettyStackTrace to true and avoid this source of signal handlers.
 
+As of Android 5.0 (API 21) the symbol no longer exists in libLLVM.so and stack pretty printing is an opt-in
+instead of an opt-out feature. LLVM change which removed the symbol is at
+
+https://github.com/llvm/llvm-project/commit/c10ca903243f97cbc8014f20c64f1318a57a2936
+
 */
 void
 MonodroidRuntime::disable_external_signal_handlers (void)
 {
-	if (!androidSystem.is_mono_llvm_enabled ())
+#if !defined (NET)
+	if (android_api_level >= 21) {
 		return;
+	}
 
 	void *llvm  = androidSystem.load_dso ("libLLVM.so", JAVA_INTEROP_LIB_LOAD_GLOBALLY, TRUE);
 	if (llvm) {
@@ -1859,6 +1866,7 @@ MonodroidRuntime::disable_external_signal_handlers (void)
 		}
 		//MUST NOT dlclose to ensure we don't lose the hack
 	}
+#endif // ndef NET
 }
 
 #if defined (NET)


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/commit/d887d87d8f 
Context: https://github.com/llvm/llvm-project/commit/c10ca903243f97cbc8014f20c64f1318a57a2936

Disable loading of `libLLVM.so` on Android API 21 and newer, because the symbol we're looking for is no longer present in the library on those Android versions.

The hack was implemented on April 8, 2014:

    Disable LLVM signal handlers. Fixes #18016.

    This happens when RenderScript needs to be compiled. See https://bugzilla.xamarin.com/show_bug.cgi?id=18016

    This happens only on first run of the app. LLVM is used to compiled the RenderScript scripts. LLVM, been
    a nice and smart library installs a ton of signal handlers and don't chain at all, completely breaking us.

    This is a hack to set llvm::DisablePrettyStackTrace to true and avoid this source of signal handlers.

LLVM commit referenced above made the stack pretty print feature opt-in instead of opt-out, removing the `DisablePrettyStackTrace` symbol. Thus, LLVM no longer installs the signal handlers mentioned above and, in effect, doesn't break us anymore.

Consequently, the code is completely disabled for .NET builds, since they build against API 21.

For classic builds we now check the API level and load the library only if running on API < 21.