### PR TITLE
[build] fix 8.0.100-alpha.1 version band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->
     <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
-    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-(preview|rc).\d+`))</DotNetSdkManifestsFolder>
+    <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-(preview|rc|alpha).\d+`))</DotNetSdkManifestsFolder>
     <!-- NOTE: sometimes we hardcode these when transitioning to new version bands -->
     <DotNetAndroidManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetAndroidManifestVersionBand>
     <DotNetMonoManifestVersionBand>8.0.100</DotNetMonoManifestVersionBand>


### PR DESCRIPTION
Local builds were failing with:

    make prepare all
    ...
    build-tools/create-packs/Directory.Build.targets(280,5): error MSB3073: The command ""…/xamarin-android/bin/Debug/dotnet/dotnet" workload install android-deps --configfile "…/xamarin-android/NuGet.config" --skip-manifest-update --verbosity diag" exited with code 1.

`android-deps` is our workaround for installing the "abstract" Mono workload that we need to build against.

Since we are "inventing" this workload, there is not a way for the .NET workload system to fall back to older version bands.

And so:

    bin/Debug/lib/sdk-manifests/8.0.100/android.deps.workload/WorkloadManifest.json

Doesn't work because the version band is *actually* 8.0.100-alpha.1.

Update our logic in `eng/Versions.props` to support `alpha` version bands.