### PR TITLE
Get more verbose debug output for a Designer test

### DIFF
--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -151,7 +151,7 @@ init_logging_categories (char*& mono_log_mask, char*& mono_log_level)
 	mono_log_level = nullptr;
 
 #if !ANDROID
-	log_categories = LOG_DEFAULT;
+	log_categories = LOG_DEFAULT | LOG_ASSEMBLY;
 #endif
 	log_timing_categories = LOG_TIMING_DEFAULT;
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2259,6 +2259,9 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 #if defined (NET)
 	install_logging_handlers ();
 #endif // def NET
+#else
+	mono_trace_set_level_string ("debug");
+	mono_trace_set_mask_string ("all");
 #endif
 
 	if (runtimeNativeLibDir != nullptr) {


### PR DESCRIPTION
This PR is just to help with figuring out what's wrong with https://github.com/xamarin/xamarin-android/pull/7468 and a designer test that fails there (`DisableCustomControls_OutOfSyncCorlib`).

The goal is to get a more verbose Mono output to compare against the failing one.