### PR TITLE
[build-tools] Update UpdateApkSizeReference scripts to use the right path

### DIFF
--- a/build-tools/scripts/UpdateApkSizeReference.ps1
+++ b/build-tools/scripts/UpdateApkSizeReference.ps1
@@ -10,6 +10,6 @@ msbuild /p:Configuration=Release /restore .\tools\xabuild\xabuild.csproj
 Write-Output "Building legacy BuildReleaseArm64 tests"
 msbuild /p:Configuration=Release Xamarin.Android.sln /t:RunNunitTests /p:TEST="Xamarin.Android.Build.Tests.BuildTest2.BuildReleaseArm64"
 Write-Output "Building DotNet BuildReleaseArm64 tests"
-bin\Release\dotnet\dotnet test -p:Configuration=Release --filter=Name~BuildReleaseArm64 .\bin\TestRelease\net6.0\Xamarin.Android.Build.Tests.dll
+bin\Release\dotnet\dotnet test -p:Configuration=Release --filter=Name~BuildReleaseArm64 .\bin\TestRelease\net7.0\Xamarin.Android.Build.Tests.dll
 Write-Output "Updating reference files"
 Copy-Item -Verbose bin\TestRelease\BuildReleaseArm64*.apkdesc -Destination src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\

--- a/build-tools/scripts/UpdateApkSizeReference.sh
+++ b/build-tools/scripts/UpdateApkSizeReference.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 ./build-tools/scripts/nunit3-console bin/TestRelease/net472/Xamarin.Android.Build.Tests.dll --test=Xamarin.Android.Build.Tests.BuildTest2.BuildReleaseArm64
-./dotnet-local.sh test bin/TestRelease/net6.0/Xamarin.Android.Build.Tests.dll --filter=Name~BuildReleaseArm64
+./dotnet-local.sh test bin/TestRelease/net7.0/Xamarin.Android.Build.Tests.dll --filter=Name~BuildReleaseArm64
 cp bin/TestRelease/BuildReleaseArm64*.apkdesc src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/


### PR DESCRIPTION
The `UpdateApkSizeReference` scripts were using `net6.0` in their paths. This is wrong as we now produce `net7.0` assemblies. So the scripts were failing. So lets update them!