### PR TITLE
[Tests] Replace azurestorage with a github repo.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -30,13 +30,13 @@ namespace Xamarin.Android.Build.Tests
 			Directory.Delete (tempDirectory, recursive: true);
 		}
 
-		Task<string> DownloadFromNuGet (string url) =>
-			Task.Factory.StartNew (() => new DownloadedCache ().GetAsFile (url));
+		Task<string> DownloadFromNuGet (string url, string filename = "") =>
+			Task.Factory.StartNew (() => new DownloadedCache ().GetAsFile (url, filename));
 
-		async Task<string []> GetAssembliesFromNuGet (string url, string path)
+		async Task<string []> GetAssembliesFromNuGet (string url, string filename, string path)
 		{
 			var assemblies = new List<string> ();
-			var nuget = await DownloadFromNuGet (url);
+			var nuget = await DownloadFromNuGet (url, filename);
 			using (var zip = ZipArchive.Open (nuget, FileMode.Open)) {
 				foreach (var entry in zip) {
 					if (entry.FullName.StartsWith (path, StringComparison.OrdinalIgnoreCase) &&
@@ -67,6 +67,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var assemblies = await GetAssembliesFromNuGet (
 				"https://www.nuget.org/api/v2/package/Refractored.Controls.CircleImageView/1.0.1",
+				"Refractored.Controls.CircleImageView.1.0.1.nupkg",
 				"lib/MonoAndroid10/");
 			var actual = Run (assemblies);
 			var expected = new [] { "Refractored.Controls.CircleImageView.dll" };
@@ -78,6 +79,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var assemblies = await GetAssembliesFromNuGet (
 				"https://www.nuget.org/api/v2/package/Xamarin.Forms/3.6.0.220655",
+				"Xamarin.Forms.3.6.0.220655.nupkg",
 				"lib/MonoAndroid90/");
 			var actual = Run (assemblies);
 			var expected = new [] {
@@ -93,6 +95,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var assemblies = await GetAssembliesFromNuGet (
 				"https://www.nuget.org/api/v2/package/Xamarin.Google.Guava.ListenableFuture/1.0.0",
+				"Xamarin.Google.Guava.ListenableFuture.1.0.0.nupkg",
 				"lib/MonoAndroid50/");
 			var actual = Run (assemblies);
 			var expected = new [] { "Xamarin.Google.Guava.ListenableFuture.dll" };

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
@@ -133,11 +133,11 @@ namespace Xamarin.ProjectTools
 		}
 
 		/// <summary>
-		/// NOTE: downloads a file from our https://xamjenkinsartifact.azureedge.net/ Azure Storage Account
+		/// NOTE: downloads a file from our https://github.com/dellis1972/xamarin-android-unittest-files repo
 		/// </summary>
 		public string WebContentFileNameFromAzure {
 			get { throw new NotSupportedException (); }
-			set { WebContent = $"https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/{value}"; }
+			set { WebContent = $"https://github.com/dellis1972/xamarin-android-unittest-files/blob/main/{value}?raw=true"; }
 		}
 
 		public string MetadataValues {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DownloadedCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DownloadedCache.cs
@@ -24,11 +24,11 @@ namespace Xamarin.ProjectTools
 
 		public string CacheDirectory { get; private set; }
 
-		public string GetAsFile (string url)
+		public string GetAsFile (string url, string filename = "")
 		{
 			Directory.CreateDirectory (CacheDirectory);
 
-			var filename = Path.Combine (CacheDirectory, Path.GetFileName (new Uri (url).LocalPath));
+			filename = Path.Combine (CacheDirectory, string.IsNullOrEmpty (filename) ? Path.GetFileName (new Uri (url).LocalPath) : filename);
 			lock (locks.GetOrAdd (filename, _ => new object ())) {
 				if (File.Exists (filename))
 					return filename;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/SevenZipHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/SevenZipHelper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace Xamarin.ProjectTools {
+	public class SevenZipHelper : IDisposable {
+		public string ArchivePath { get; private set; }
+
+		public SevenZipHelper (string archivePath)
+		{
+			ArchivePath = archivePath;
+		}
+
+		public bool ExtractAll (string destinationDir)
+		{
+			using (var p = new Process ()) {
+				p.StartInfo.FileName = Path.Combine ("7z");
+				p.StartInfo.Arguments = $"x {ArchivePath} -o{destinationDir}";
+				p.StartInfo.CreateNoWindow = true;
+				p.StartInfo.UseShellExecute = false;
+				p.StartInfo.RedirectStandardOutput = true;
+				p.StartInfo.RedirectStandardError = true;
+				p.ErrorDataReceived += (sender, e) => {
+					if (e.Data != null) {
+						Console.WriteLine (e.Data);
+					}
+				};
+				p.ErrorDataReceived += (sender, e) => {
+					if (e.Data != null) {
+						Console.WriteLine (e.Data);
+					}
+				};
+
+				p.Start ();
+				p.BeginOutputReadLine ();
+				p.BeginErrorReadLine ();
+				bool completed = p.WaitForExit ((int) new TimeSpan (0, 15, 0).TotalMilliseconds);
+				return completed && p.ExitCode == 0;
+			}
+		}
+
+		public void Dispose ()
+		{
+		}
+
+		public static SevenZipHelper Open (string path, FileMode fileMode)
+		{
+			return new SevenZipHelper (path);
+		}
+	}
+}

--- a/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
@@ -2,7 +2,6 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using Xamarin.ProjectTools;
-using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -10,17 +9,16 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("DotNetIgnore"), Category ("Node-1")] // .csproj files are legacy projects that won't build under dotnet
 	public class DeleteBinObjTest : DeviceTest
 	{
-		const string BaseUrl = "https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/";
+		const string BaseUrl = "https://github.com/dellis1972/xamarin-android-unittest-files/blob/main/";
 		readonly DownloadedCache Cache = new DownloadedCache ();
 
 		string HostOS => IsWindows ? "Windows" : "Darwin";
-
 		void RunTest (string name, string sln, string csproj, string version, string revision, string packageName, string javaPackageName, bool isRelease)
 		{
 			var configuration = isRelease ? "Release" : "Debug";
-			var zipPath = Cache.GetAsFile ($"{BaseUrl}{name}-{version}-{HostOS}-{revision}.zip");
+			var zipPath = Cache.GetAsFile ($"{BaseUrl}{name}-{version}-{HostOS}-{revision}.7z?raw=true");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName)))
-			using (var zip = ZipArchive.Open (zipPath, FileMode.Open)) {
+			using (var zip = SevenZipHelper.Open (zipPath, FileMode.Open)) {
 				builder.AutomaticNuGetRestore = false;
 
 				if (!builder.TargetFrameworkExists ("v9.0")) {


### PR DESCRIPTION
Our `https://xamjenkinsartifact.azureedge.net` site for some of the unit test data seems to have disappeared.

So lets use a github repo to store this data instead. The unit tests can download the raw files directly from github. The repo will be public as well so there won't be any need for authorization.

The new repo can currently be found at https://github.com/dellis1972/xamarin-android-unittest-files. 