### PR TITLE
[tests] temporarily ignore net6.0 and net7.0 tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -843,6 +843,9 @@ public class JavaSourceTest {
 			var dotnetVersion = (string)data[0];
 			var platform = (string)data[1];
 			var apiLevel = (int)data[2];
+			if (dotnetVersion != "net8.0") {
+				Assert.Ignore ("https://github.com/dotnet/runtime/issues/77385");
+			}
 
 			if (string.IsNullOrEmpty (platform))
 				Assert.Ignore ($"Test for API level {apiLevel} was skipped as it matched the default or latest stable API level.");

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -72,6 +72,9 @@ namespace Xamarin.Android.Build.Tests
 		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, string targetFramework)
 		{
 			AssertHasDevices ();
+			if (!targetFramework.Contains ("net8.0")) {
+				Assert.Ignore ("https://github.com/dotnet/runtime/issues/77385");
+			}
 
 			XASdkProject proj;
 			if (xamarinForms) {
@@ -157,10 +160,13 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("Debugger"), Category ("Node-4")]
-		public void DotNetDebug ([Values("net6.0-android", "net7.0-android")] string targetFramework)
+		public void DotNetDebug ([Values("net6.0-android", "net7.0-android", "net8.0-android")] string targetFramework)
 		{
 			AssertCommercialBuild ();
 			AssertHasDevices ();
+			if (!targetFramework.Contains ("net8.0")) {
+				Assert.Ignore ("https://github.com/dotnet/runtime/issues/77385");
+			}
 
 			var proj = new XASdkProject ();
 			proj.TargetFramework = targetFramework;


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/77385

To get our CI "greener", let's ignore some tests that are currently failing with the .NET 8 SDK, when you build a `net6.0-android` or `net7.0-android` project.