### PR TITLE
[xaprepare] use 8.0.100 version band for Mono workloads

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -46,18 +46,18 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			var sdk_manifests = Path.Combine (dotnetPath, "sdk-manifests", context.Properties.GetRequiredValue (KnownProperties.DotNetSdkManifestsFolder));
+			var sdk_manifests = Path.Combine (dotnetPath, "sdk-manifests");
 
 			// Copy the WorkloadManifest.* files from the latest Microsoft.NET.Workload.* listed in package-download.proj
 			// NOTE: the packages that actually *exist* in .NET 8 are mismatched right now...
 			var dotnets = new [] { ".net6", ".net7", "" };
 			foreach (var dotnet in dotnets) {
-				var destination = Path.Combine (sdk_manifests, $"microsoft.net.workload.mono.toolchain{dotnet}");
+				var destination = Path.Combine (sdk_manifests, context.Properties.GetRequiredValue (KnownProperties.DotNetMonoManifestVersionBand), $"microsoft.net.workload.mono.toolchain{dotnet}");
 				foreach (var file in Directory.GetFiles (string.Format (Configurables.Paths.MicrosoftNETWorkloadMonoToolChainDir, dotnet), "WorkloadManifest.*")) {
 					Utilities.CopyFileToDir (file, destination);
 				}
 				if (dotnet != "") {
-					destination = Path.Combine (sdk_manifests, $"microsoft.net.workload.emscripten{dotnet}");
+					destination = Path.Combine (sdk_manifests, context.Properties.GetRequiredValue (KnownProperties.DotNetEmscriptenManifestVersionBand), $"microsoft.net.workload.emscripten{dotnet}");
 					foreach (var file in Directory.GetFiles (string.Format (Configurables.Paths.MicrosoftNETWorkloadEmscriptenDir, dotnet), "WorkloadManifest.*")) {
 						Utilities.CopyFileToDir (file, destination);
 					}


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/77385

Building `net6.0-android` and `net7.0-android` apps with .NET 8 is failing with:

    Microsoft.Android.Sdk.RuntimeConfig.targets(46,5): error MSB4036: The "RuntimeConfigParserTask" task was not found.
    Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with <UsingTask> in the project file, or in the *.tasks files located in the "/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-alpha.1.22553.2" directory.

The problem appears to be due to the import ordering:

    8.0.100-alpha.1/microsoft.net.workload.mono.toolchain.net6/WorkloadManifest.targets
    8.0.100-alpha.1/microsoft.net.workload.mono.toolchain.net7/WorkloadManifest.targets
    8.0.100-alpha.1/microsoft.net.workload.mono.toolchain/WorkloadManifest.targets

Where the third one should be imported first for this to work.

I believe this broke in 5f3deea2, which inadvertently put these files in the `8.0.100-alpha.1` directory instead of `8.0.100`.

The "baseline" version is always imported first, which is `8.0.100`:

https://github.com/dotnet/installer/blob/c09cc8aada26be846359961fe160b5eff528d9df/src/redist/targets/BundledManifests.targets#L9-L13

Move the location of these files to hopefully fix this issue.