### PR TITLE
[DevOps] Rename the yaml-tempaltes resources to match the MAUI repo.

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -11,7 +11,7 @@ pr:
 # External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
-  - repository: yaml
+  - repository: xamarin-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -11,7 +11,7 @@ pr:
 # External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
-  - repository: xamarin-templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1451,7 +1451,7 @@ stages:
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
   - template: nuget-msi-convert/job/v3.yml@xamarin-templates
     parameters:
-      yamlResourceName: yaml
+      yamlResourceName: xamarin-templates
       dependsOn: sign_net_mac_win
       artifactName: nuget-signed
       artifactPatterns: |
@@ -1526,7 +1526,7 @@ stages:
         blobName: $(NupkgCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\nuget-signed
-        yamlResourceName: yaml
+        yamlResourceName: xamarin-templates
 
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
@@ -1535,7 +1535,7 @@ stages:
         blobName: $(VSDropCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-        yamlResourceName: yaml
+        yamlResourceName: xamarin-templates
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:
@@ -1549,7 +1549,7 @@ stages:
         blobName: $(MultiTargetVSDropCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-        yamlResourceName: yaml
+        yamlResourceName: xamarin-templates
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -11,7 +11,7 @@ trigger:
 # External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
-  - repository: yaml
+  - repository: xamarin-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main
@@ -1246,11 +1246,11 @@ stages:
         jdkTestFolder: $(JAVA_HOME_8_X64)
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-    - template: designer/android-designer-build-mac.yaml@yaml
+    - template: designer/android-designer-build-mac.yaml@xamarin-templates
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/UITools/Designer
 
-    - template: designer/android-designer-tests.yaml@yaml
+    - template: designer/android-designer-tests.yaml@xamarin-templates
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/UITools/Designer
         runAddinTests: false
@@ -1428,7 +1428,7 @@ stages:
   condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
   jobs:
   # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
-  - template: sign-artifacts/jobs/v2.yml@yaml
+  - template: sign-artifacts/jobs/v2.yml@xamarin-templates
     parameters:
       name: sign_net_mac_win
       poolName: $(VSEngMicroBuildPool)
@@ -1438,7 +1438,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
-  - template: sign-artifacts/jobs/v2.yml@yaml
+  - template: sign-artifacts/jobs/v2.yml@xamarin-templates
     parameters:
       name: sign_net_linux
       displayName: Sign Linux Archive
@@ -1449,7 +1449,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v3.yml@yaml
+  - template: nuget-msi-convert/job/v3.yml@xamarin-templates
     parameters:
       yamlResourceName: yaml
       dependsOn: sign_net_mac_win
@@ -1584,7 +1584,7 @@ stages:
 # .NET 6 VS Insertion Stage
 # Check - "Xamarin.Android (VS Insertion - Wait For Approval)"
 # Check - "Xamarin.Android (VS Insertion - Create VS Drop and Open PR)"
-- template: vs-insertion/stage/v1.yml@yaml
+- template: vs-insertion/stage/v1.yml@xamarin-templates
   parameters:
     dependsOn: dotnet_prepare_release
     symbolArtifactName: nuget-signed
@@ -1820,7 +1820,7 @@ stages:
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)
       displayName: validate notarized pkg
 
-    - template: upload-to-storage.yml@yaml
+    - template: upload-to-storage.yml@xamarin-templates
       parameters:
         BuildPackages: $(System.DefaultWorkingDirectory)/storage-artifacts
         AzureContainerName: $(Azure.Container.Name)
@@ -1842,7 +1842,7 @@ stages:
   - finalize_installers
   condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   jobs:
-  - template: compliance/sbom/job.v1.yml@yaml
+  - template: compliance/sbom/job.v1.yml@xamarin-templates
     parameters:
       artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
       statusContexts: [ 'vsts-devdiv artifacts' ]
@@ -1865,11 +1865,11 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - template: security\credscan\v2.yml@yaml
+    - template: security\credscan\v2.yml@xamarin-templates
       parameters:
         suppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
 
-    - template: security\policheck\v1.yml@yaml
+    - template: security\policheck\v1.yml@xamarin-templates
       parameters:
         exclusionFile: $(System.DefaultWorkingDirectory)\build-tools\automation\PoliCheckExclusions.xml
         pE: 1|2|3|4

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -11,7 +11,7 @@ trigger:
 # External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
-  - repository: xamarin-templates
+  - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/main
@@ -1246,11 +1246,11 @@ stages:
         jdkTestFolder: $(JAVA_HOME_8_X64)
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
-    - template: designer/android-designer-build-mac.yaml@xamarin-templates
+    - template: designer/android-designer-build-mac.yaml@yaml-templates
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/UITools/Designer
 
-    - template: designer/android-designer-tests.yaml@xamarin-templates
+    - template: designer/android-designer-tests.yaml@yaml-templates
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/UITools/Designer
         runAddinTests: false
@@ -1428,7 +1428,7 @@ stages:
   condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
   jobs:
   # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
-  - template: sign-artifacts/jobs/v2.yml@xamarin-templates
+  - template: sign-artifacts/jobs/v2.yml@yaml-templates
     parameters:
       name: sign_net_mac_win
       poolName: $(VSEngMicroBuildPool)
@@ -1438,7 +1438,7 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
-  - template: sign-artifacts/jobs/v2.yml@xamarin-templates
+  - template: sign-artifacts/jobs/v2.yml@yaml-templates
     parameters:
       name: sign_net_linux
       displayName: Sign Linux Archive
@@ -1449,9 +1449,9 @@ stages:
       usePipelineArtifactTasks: true
 
   # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v3.yml@xamarin-templates
+  - template: nuget-msi-convert/job/v3.yml@yaml-templates
     parameters:
-      yamlResourceName: xamarin-templates
+      yamlResourceName: yaml-templates
       dependsOn: sign_net_mac_win
       artifactName: nuget-signed
       artifactPatterns: |
@@ -1526,7 +1526,7 @@ stages:
         blobName: $(NupkgCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\nuget-signed
-        yamlResourceName: xamarin-templates
+        yamlResourceName: yaml-templates
 
     - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
       parameters:
@@ -1535,7 +1535,7 @@ stages:
         blobName: $(VSDropCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-        yamlResourceName: xamarin-templates
+        yamlResourceName: yaml-templates
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:
@@ -1549,7 +1549,7 @@ stages:
         blobName: $(MultiTargetVSDropCommitStatusName)
         packagePrefix: xamarin-android
         artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-        yamlResourceName: xamarin-templates
+        yamlResourceName: yaml-templates
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           inputs:
@@ -1584,7 +1584,7 @@ stages:
 # .NET 6 VS Insertion Stage
 # Check - "Xamarin.Android (VS Insertion - Wait For Approval)"
 # Check - "Xamarin.Android (VS Insertion - Create VS Drop and Open PR)"
-- template: vs-insertion/stage/v1.yml@xamarin-templates
+- template: vs-insertion/stage/v1.yml@yaml-templates
   parameters:
     dependsOn: dotnet_prepare_release
     symbolArtifactName: nuget-signed
@@ -1820,7 +1820,7 @@ stages:
     - script: xcrun stapler validate $(XA.Unsigned.Pkg)
       displayName: validate notarized pkg
 
-    - template: upload-to-storage.yml@xamarin-templates
+    - template: upload-to-storage.yml@yaml-templates
       parameters:
         BuildPackages: $(System.DefaultWorkingDirectory)/storage-artifacts
         AzureContainerName: $(Azure.Container.Name)
@@ -1842,7 +1842,7 @@ stages:
   - finalize_installers
   condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'), eq(dependencies.finalize_installers.result, 'Succeeded'))
   jobs:
-  - template: compliance/sbom/job.v1.yml@xamarin-templates
+  - template: compliance/sbom/job.v1.yml@yaml-templates
     parameters:
       artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
       statusContexts: [ 'vsts-devdiv artifacts' ]
@@ -1865,11 +1865,11 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - template: security\credscan\v2.yml@xamarin-templates
+    - template: security\credscan\v2.yml@yaml-templates
       parameters:
         suppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
 
-    - template: security\policheck\v1.yml@xamarin-templates
+    - template: security\policheck\v1.yml@yaml-templates
       parameters:
         exclusionFile: $(System.DefaultWorkingDirectory)\build-tools\automation\PoliCheckExclusions.xml
         pE: 1|2|3|4

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -10,7 +10,7 @@ steps:
   condition: ${{ parameters.condition }}
 
 # ESRP signing requires minimum azure client version 2.8.0
-- template: azure-tools/az-client-update.yml@xamarin-templates
+- template: azure-tools/az-client-update.yml@yaml-templates
   parameters:
     version: '2.8.0'
     condition: and(${{ parameters.condition }}, eq(variables['agent.os'], 'Darwin'))

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -10,7 +10,7 @@ steps:
   condition: ${{ parameters.condition }}
 
 # ESRP signing requires minimum azure client version 2.8.0
-- template: azure-tools/az-client-update.yml@yaml
+- template: azure-tools/az-client-update.yml@xamarin-templates
   parameters:
     version: '2.8.0'
     condition: and(${{ parameters.condition }}, eq(variables['agent.os'], 'Darwin'))

--- a/build-tools/automation/yaml-templates/update-vs.yaml
+++ b/build-tools/automation/yaml-templates/update-vs.yaml
@@ -12,6 +12,6 @@ steps:
     provisioning_extra_args: -vv
   condition: ${{ parameters.condition }}
 
-- template: environment/win/vs-msbuild.v1.yml@yaml   # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
+- template: environment/win/vs-msbuild.v1.yml@xamarin-templates # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
   parameters:
     condition: ${{ parameters.condition }}

--- a/build-tools/automation/yaml-templates/update-vs.yaml
+++ b/build-tools/automation/yaml-templates/update-vs.yaml
@@ -12,6 +12,6 @@ steps:
     provisioning_extra_args: -vv
   condition: ${{ parameters.condition }}
 
-- template: environment/win/vs-msbuild.v1.yml@xamarin-templates # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
+- template: environment/win/vs-msbuild.v1.yml@yaml-templates # Display (in log) VS installation(s) including installation status with associated MSBuild location(s)
   parameters:
     condition: ${{ parameters.condition }}


### PR DESCRIPTION
In an attempt to unify the build for all the SDKs we need to rename all the resources to use the same names. This change follows the pattern used by tehe MAUI repo.

Partial fix for https://github.com/xamarin/sdk-insertions/issues/39