### PR TITLE
[NuGet] Add back the `dotnet7` feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <!-- This is needed (currently) for the Xamarin.Android.Deploy.Installer dependency, getting the installer -->
     <!-- Android binary, to support delta APK install -->


### PR DESCRIPTION
Without it, it's impossible to install MAUI:

    dotnet msbuild Xamarin.Android.sln -t:InstallMaui -p:MauiVersion=7.0.49 -p:MauiVersionBand=7.0.100 -p:Configuration=Release
    build-tools/scripts/maui.proj : error NU1101: Unable to find package Microsoft.NET.Sdk.Maui.Manifest-7.0.100.