### PR TITLE
[build] Make external build targets more consistent

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -20,7 +20,7 @@ else
 endif
 ifneq ("$(wildcard $(topdir)/external/monodroid/Makefile)","")
 	cd $(topdir)/external/monodroid && ./configure --with-xamarin-android='$(topdir)'
-	$(call SYSTEM_DOTNET_BINLOG,build-commercial) $(SOLUTION) -t:BuildExternal --no-restore
+	$(call DOTNET_BINLOG,build-commercial) $(SOLUTION) -t:BuildExternal
 endif
 	$(MAKE) leeroy
 

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -1,17 +1,17 @@
 <Project>
   <PropertyGroup>
     <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
-    <_BinlogDateTime>$([System.DateTime]::Now.ToString("yyyyMMddTHHmmss"))</_BinlogDateTime>
+    <_BinlogPathPrefix>$(_Root)bin/Build$(Configuration)/msbuild-$([System.DateTime]::Now.ToString("yyyyMMddTHHmmss"))</_BinlogPathPrefix>
   </PropertyGroup>
   <Target Name="BuildExternal">
-    <MSBuild
-        Projects="$(_Root)\external\monodroid\monodroid.proj"
-        Properties="DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir);CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild\Novell"
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; build monodroid.proj -c $(Configuration) -p:DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir) -p:CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild/Novell -bl:$(_BinlogPathPrefix)-build-monodroid.binlog"
+        WorkingDirectory="$(_Root)external\monodroid"
     />
   </Target>
   <Target Name="PrepareJavaInterop">
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_Root)bin/Build$(Configuration)/msbuild-$(_BinlogDateTime)-prepare-java-interop.binlog"
+        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_BinlogPathPrefix)-prepare-java-interop.binlog"
         WorkingDirectory="$(_Root)external\Java.Interop"
     />
   </Target>


### PR DESCRIPTION
The external builds of monodroid and java.interop prep have been made
more consistent.  They will both use an `<Exec/>` task to build with the
preview dotnet SDK that is installed into `bin/$(Configuration)/dotnet`.