### PR TITLE
[tests] Switch to `httpbin.org`

### DIFF
--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -246,7 +246,7 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_Without_Protocol_Works()
 		{
-			var requestURI = new Uri ("https://httpbingo.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
+			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
 			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var tr = ConnectIgnoreFailure (() => c.GetAsync (requestURI), out bool connectionFailed);
@@ -265,7 +265,7 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Redirect_POST_With_Content_Works ()
 		{
-			var requestURI = new Uri ("https://httpbingo.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
+			var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://github.com/xamarin/xamarin-android");
 			var redirectedURI = new Uri ("https://github.com/xamarin/xamarin-android");
 			using (var c = new HttpClient (CreateHandler ())) {
 				var request = new HttpRequestMessage (HttpMethod.Post, requestURI);


### PR DESCRIPTION
`httpbingo.org` is returning the following error when we try to redirect.

```
Forbidden redirect URL. Be careful with this link.
```

To lets try to use `httpbin.org` directly instead.