### PR TITLE
[ci] Attach logcat files to apk test failures

### DIFF
--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/xa-internal/xa-remap-members.xml
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/xa-internal/xa-remap-members.xml
@@ -1,0 +1,7 @@
+<replacements>
+  <replace-type from="com/xamarin/interop/RenameClassBase1" to="com/xamarin/interop/RenameClassBase2" />
+  <replace-method source-type="java/lang/Object" source-method-name="remappedToToString" source-method-signature="()Ljava/lang/String;" target-type="java/lang/Object" target-method-name="toString" target-method-instance-to-static="false" />
+  <replace-method source-type="java/lang/Object" source-method-name="remappedToStaticHashCode" target-type="com/xamarin/interop/ObjectHelper" target-method-name="getHashCodeHelper" target-method-instance-to-static="true" />
+  <replace-method source-type="java/lang/Runtime" source-method-name="remappedToGetRuntime" target-type="java/lang/Runtime" target-method-name="getRuntime" target-method-instance-to-static="false" />
+  <replace-method source-type="com/xamarin/interop/RenameClassBase2" source-method-name="hashCode" source-method-signature="()" target-type="com/xamarin/interop/RenameClassBase2" target-method-name="myNewHashCode" target-method-instance-to-static="false" />
+</replacements>

--- a/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
+++ b/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
@@ -26,7 +26,7 @@ namespace System.Drawing {
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (Rectangle));
 			var rect = (Rectangle)typeConverter.ConvertFromString ("10, 20, 30, 40");
-
+			Assert.Fail();
 			Assert.AreEqual (10, rect.X, "X");
 			Assert.AreEqual (20, rect.Y, "Y");
 			Assert.AreEqual (30, rect.Width, "Width");

--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -34,6 +34,7 @@ namespace System.NetTests {
 					Console.WriteLine ("# ServerCertificateValidationCallback");
 					return true;
 			};
+			Assert.Fail();
 
 			TaskStatus status     = 0;
 			Exception  exception  = null;


### PR DESCRIPTION
Attaching the logcat file to the result when a test fails should improve
our ability to quickly review test failures in the APK test suites.