### PR TITLE
Bump to xamarin/monodroid/main@8c54ea6d

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@8f925e3346c8aea63f3481a26c811374915b8d18
+xamarin/monodroid:main@8c54ea6df5dfdbe4a0db61445e5b7f2faf9810dd
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d


### PR DESCRIPTION
Changes: http://github.com/xamarin/monodroid/compare/8f925e3346c8aea63f3481a26c811374915b8d18...8c54ea6df5dfdbe4a0db61445e5b7f2faf9810dd

  * xamarin/monodroid@8c54ea6df: Bump to xamarin/androidtools/main@df37cc76 (xamarin/monodroid#1275)
  * xamarin/monodroid@cd1e08ced: Enable CodeQL on Windows build job (xamarin/monodroid#1274)
  * xamarin/monodroid@1ff225b8d: Merge pull request xamarin/monodroid#1271 from xamarin/dev/msylvia/update-provisionator-bootstrap
  * xamarin/monodroid@fce261626: Update provisionator bootstrap
  * xamarin/monodroid@56cb29f17: Use .NET 7.0.x; Bump to xamarin/xamarin-android/main@ca2c6292 (xamarin/monodroid#1273)

Of particular note is xamarin/monodroid@8c54ea6df, which fixes a `FormatException` from `AndroidDevice.RunShellCommandAsync()`:

	System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
	   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
	   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
	   at System.String.Format(String format, Object[] args)
	   at Mono.AndroidTools.AndroidLogger.LogError(String task, String format, Object[] args) in D:\a\_work\1\s\External\androidtools\Mono.AndroidTools\AndroidLogger.cs:line 63
	   at Mono.AndroidTools.AndroidDevice.<>c__DisplayClass118_0.<RunShellCommandAsync>b__0() in D:\a\_work\1\s\External\androidtools\Mono.AndroidTools\AndroidDevice.cs:line 1012

The IDE will need to be separately updated to fully fix this.