### PR TITLE
[build] Pass NuGet.config when restoring

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -41,7 +41,12 @@ namespace Xamarin.Android.Prepare
 			// Install runtime packs associated with the SDK previously installed.
 			var packageDownloadProj = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "build-tools", "xaprepare", "xaprepare", "package-download.proj");
 			var logPath = Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{context.BuildTimeStamp}-download-runtime-packs.binlog");
-			if (!Utilities.RunCommand (Configurables.Paths.DotNetPreviewTool, new string [] { "restore", ProcessRunner.QuoteArgument (packageDownloadProj), ProcessRunner.QuoteArgument ($"-bl:{logPath}") })) {
+			var restoreArgs = new string [] { "restore",
+				ProcessRunner.QuoteArgument (packageDownloadProj),
+				"--configfile", Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "NuGet.config"),
+				ProcessRunner.QuoteArgument ($"-bl:{logPath}"),
+			};
+			if (!Utilities.RunCommand (Configurables.Paths.DotNetPreviewTool, restoreArgs)) {
 				Log.ErrorLine ($"dotnet restore {packageDownloadProj} failed.");
 				return false;
 			}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.cs
@@ -25,8 +25,9 @@ namespace Xamarin.Android.Prepare
 				return false;
 
 			return await msbuild.Restore (
-				projectPath: Path.Combine (Configurables.Paths.ExternalXamarinAndroidToolsSln),
+				projectPath: Configurables.Paths.ExternalXamarinAndroidToolsSln,
 				logTag: "xat-restore",
+				arguments: new List<string> () { "--configfile", Path.Combine (Configurables.Paths.ExternalDir, "xamarin-android-tools", "NuGet.config") },
 				binlogName: "prepare-xat-restore"
 			);
 		}


### PR DESCRIPTION
Local builds have been occassionally failing for me:

    Determining projects to restore...
    C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.Mono.android-arm. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, xamarin.android util [C:\Users\Peter\source\xamarin-android\Xamarin.Android.sln]
    C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.Mono.android-arm64. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, xamarin.android util [C:\Users\Peter\source\xamarin-android\Xamarin.Android.sln]
    C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.Mono.android-x86. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, xamarin.android util [C:\Users\Peter\source\xamarin-android\Xamarin.Android.sln]
    C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.Mono.android-x64. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, xamarin.android util [C:\Users\Peter\source\xamarin-android\Xamarin.Android.sln]
        Failed to restore C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj (in 1.79 sec).
    EXEC : error : dotnet restore C:\Users\Peter\source\xamarin-android\build-tools\xaprepare\xaprepare\package-download.proj failed. [C:\Users\Peter\source\xamarin-android\Xamarin.Android.sln]

Fix this by explicitly passing NuGet.config files to various restores
performed by xaprepare.