### PR TITLE
[Xamarin.Android.Build.Tasks] Fix aapt_rules.txt corruption

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -244,6 +244,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <ItemGroup Condition=" '$(_Aapt2ProguardRules)' != '' And Exists('$(_Aapt2ProguardRules)') ">
     <ProguardConfiguration Include="$(_Aapt2ProguardRules)" />
     <FileWrites Include="$(_Aapt2ProguardRules)" />
+    <FileWrites Include="$(IntermediateOutputPath)android\*\aapt_rules.txt" />
   </ItemGroup>
 </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -122,8 +122,8 @@ namespace Xamarin.Android.Tasks {
 				if (!string.IsNullOrEmpty (ProguardRuleOutput)) {
 					// combine the "proguard" temp files into one file.
 					var sb = new StringBuilder ();
+					sb.AppendLine ("#Auto Generated file. Do not Edit.");
 					HashSet<string> output = new HashSet<string> ();
-					output.Add ("#Auto Generated file. Do not Edit.");
 					lock (rulesFiles) {
 						foreach (var file in rulesFiles) {
 							var lines = File.ReadAllLines (file);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -123,15 +123,13 @@ namespace Xamarin.Android.Tasks {
 					// combine the "proguard" temp files into one file.
 					var sb = new StringBuilder ();
 					sb.AppendLine ("#Auto Generated file. Do not Edit.");
-					HashSet<string> output = new HashSet<string> ();
 					lock (rulesFiles) {
 						foreach (var file in rulesFiles) {
-							var lines = File.ReadAllLines (file);
-							output.UnionWith (lines);
+							sb.AppendLine ($"# Data from {file}");
+							foreach (var line in File.ReadLines (file))
+								sb.AppendLine (line);
 						}
 					}
-					foreach (var line in output)
-						sb.AppendLine (line);
 					Files.CopyIfStringChanged (sb.ToString (), ProguardRuleOutput);
 				}
 			} finally {


### PR DESCRIPTION
Fixes #7447

Users are reporting a error with the aapt_rules file generated by aapt2
```
MSBUILD : java.exe error JAVA0000: Error in obj\Release\110\aapt_rules.txt at line 289, column 1: [C:\Jenkins\workspace\Demo\Demo.Android\Demo.Android.csproj]
MSBUILD : java.exe error JAVA0000: Expected char '-' at obj\Release\110\aapt_rules.txt:289:1 [C:\Jenkins\workspace\Demo\Demo.Android\Demo.Android.csproj]
MSBUILD : java.exe error JAVA0000: nit>(...); } [C:\Jenkins\workspace\Demo\Demo.Android\Demo.Android.csproj]
MSBUILD : java.exe error JAVA0000: Compilation failed
```

This only happens when building with `AndroidCreatePackagePerAbi` set to `true`. After looking at the code, it turns out that we call `aapt2 link` multiple times when building per abi. The temp file used for the `aapt2 link` proguard output was the same file for ALL of the calls. This results in one call to aapt2 overwriting the previous ones results... or worse leaving garbage at the end.

So the fix in this case is to provide a different temp file for each call to `aapt2`. These files are then combined later just in case they contain unique information for that abi. While this does result in duplicate lines in the `aapt_rules` file, this does not impact on the build.