### PR TITLE
[build] Hush a couple of code analyzer warnings for Mono.Android

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -43,6 +43,10 @@
     <NoWarn>$(NoWarn);CS1572;CS1573;CS1574;CS1584;CS1587;CS1591;CS1658;</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(_EnableCodeAnalyzerPlatformWarnings)' == '' ">
+    <NoWarn>$(NoWarn);CA1422;CA1416</NoWarn>
+  </PropertyGroup>
+
   <PropertyGroup>
     <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Building our repo generates around 3400 warnings per single .NET build, similar to:

    warning CA1416: This call site is reachable on: 'Android' 21.0 and later. 'Double' is only supported on: .
    warning CA1422: This call site is reachable on: 'Android' 21.0 and later. 'Double' is obsoleted on: 'Android' 33.0 and later.

Since printing each message to the console needs to be synchronized, that means the build might be slower than necessary, since we generate over 10k of these messages per CI build.

Disable the warnings by default. They can be enabled by setting the `$(_EnableCodeAnalyzerPlatformWarnings)` MSBuild property to any value.