### PR TITLE
[maestro] consume dotnet/runtime/release/7.0 directly

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,17 @@
 <configuration>
   <packageSources>
     <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-73eb134-6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-73eb1344-6/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-73eb134-4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-73eb1344-4/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-73eb134-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-73eb1344-2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-73eb134-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-73eb1344-1/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-emsdk -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-pub-dotnet-runtime-de84cf9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-de84cf9f/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,17 +8,17 @@
       <Uri>https://github.com/dotnet/linker</Uri>
       <Sha>219e84c88def8276179f66282b2f7cb5f1d0d126</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>de84cf9f723f5d4342e95c692d088ed2af63fdbe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>6b7d1f47eaaa3f64c95e6f825c9e57debd4c0f31</Sha>
+      <Sha>73eb13444bdee019ec91191f96fd866661acbc78</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>6b7d1f47eaaa3f64c95e6f825c9e57debd4c0f31</Sha>
+      <Sha>73eb13444bdee019ec91191f96fd866661acbc78</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>7.0.101-servicing.22571.1</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>7.0.100-1.22471.3</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.1</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.1</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,52 +5,52 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 58888
+      "Size": 58991
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88068
+      "Size": 88024
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Console.dll": {
-      "Size": 6591
+      "Size": 6527
     },
     "assemblies/System.Linq.dll": {
-      "Size": 9250
+      "Size": 9223
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 462205
+      "Size": 464288
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2373
+      "Size": 2346
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 2262
+      "Size": 2234
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3561
+      "Size": 3631
     },
     "classes.dex": {
-      "Size": 368288
+      "Size": 368636
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 425432
+      "Size": 427328
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3073360
+      "Size": 3074520
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 93032
+      "Size": 93704
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 9640
+      "Size": 9680
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,124 +8,124 @@
       "Size": 7114
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 66836
+      "Size": 66845
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 445435
+      "Size": 445336
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3856
+      "Size": 3829
     },
     "assemblies/netstandard.dll": {
-      "Size": 5570
+      "Size": 5546
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 10637
+      "Size": 10612
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15473
+      "Size": 15447
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 7628
+      "Size": 7597
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 2145
+      "Size": 2118
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2642
+      "Size": 2614
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6194
+      "Size": 6168
     },
     "assemblies/System.Console.dll": {
-      "Size": 7432
+      "Size": 6693
     },
     "assemblies/System.Core.dll": {
-      "Size": 1979
+      "Size": 1953
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6736
+      "Size": 6712
     },
     "assemblies/System.dll": {
-      "Size": 2336
+      "Size": 2309
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2022
+      "Size": 1991
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 12153
+      "Size": 12129
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 16790
+      "Size": 16760
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10150
+      "Size": 10114
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19317
+      "Size": 19286
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 164040
+      "Size": 164020
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 67002
+      "Size": 66971
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 22009
+      "Size": 21981
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3733
+      "Size": 3716
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8158
+      "Size": 8137
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 772575
+      "Size": 772506
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 192490
+      "Size": 192495
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42369
+      "Size": 42378
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 215534
+      "Size": 215549
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16794
+      "Size": 16806
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2577
+      "Size": 2545
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 2262
+      "Size": 2234
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1946
+      "Size": 1917
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2678
+      "Size": 2647
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3847
+      "Size": 3819
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 7948
+      "Size": 7913
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 154203
+      "Size": 154174
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1834
+      "Size": 1805
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1853
+      "Size": 1827
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117375
+      "Size": 117372
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 5872
@@ -197,10 +197,10 @@
       "Size": 3480884
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 427336
+      "Size": 427328
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3073392
+      "Size": 3074520
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -212,7 +212,7 @@
       "Size": 148696
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 99320
+      "Size": 99272
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12


### PR DESCRIPTION
Changes: https://github.com/dotnet/runtime/compare/d099f075e45d2aa6007a22b71b45a08758559f80...de84cf9f723f5d4342e95c692d088ed2af63fdbe
Changes: https://github.com/dotnet/emsdk/compare/6b7d1f47eaaa3f64c95e6f825c9e57debd4c0f31...73eb13444bdee019ec91191f96fd866661acbc78

As .NET goes into servicing mode, much of the Maestro code flow goes through internal Azure DevOps repos. In the past, we made a direct subscription to dotnet/runtime as a way to test the latest changes there (which won't even flow to dotnet/installer).

Let's do the same for `release/7.0.1xx` & .NET 7.

Removed from `Microsoft.NETCore.App.Ref`:

    CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal"

Then ran:

    darc update-dependencies --id 157927

I found this build number via a combination of:

* Maestro site: https://maestro-prod.westus2.cloudapp.azure.com/2236/https:%2F%2Fgithub.com%2Fdotnet%2Fruntime/latest/graph
* .NET runtime builds: https://dev.azure.com/dnceng/internal/_build?definitionId=679&_a=summary&repositoryFilter=315&branchFilter=239278%2C239278

This allowed me to find the latest dotnet/runtime 7.0.1 build and reviewing the build log on the `Publish Using Darc` phase.

After this is merged, we can add a subscription for dotnet/runtime.