### PR TITLE
Bump to Android 32.0.485 packs for .NET 6

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.476</AndroidNet6Version>
+    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.485</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -303,12 +303,8 @@ public class JavaSourceTest {
 }",
 					},
 				},
-				ExtraNuGetConfigSources = {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				},
 			};
+			proj.AddNuGetSourcesForOlderTargetFrameworks ();
 			if (IsPreviewFrameworkVersion (targetFramework)) {
 				proj.SetProperty ("EnablePreviewFeatures", "true");
 			}
@@ -841,12 +837,8 @@ public class JavaSourceTest {
 			var proj = new XASdkProject {
 				TargetFramework = targetFramework,
 				IsRelease = isRelease,
-				ExtraNuGetConfigSources = {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				},
 			};
+			proj.AddNuGetSourcesForOlderTargetFrameworks ();
 			proj.SetProperty (KnownProperties.RuntimeIdentifier, runtimeIdentifier);
 
 			var preview = IsPreviewFrameworkVersion (targetFramework);
@@ -935,13 +927,9 @@ public class JavaSourceTest {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,
 					}
-				},
-				ExtraNuGetConfigSources = {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				},
+				}
 			};
+			proj.AddNuGetSourcesForOlderTargetFrameworks (dotnetTargetFramework);
 
 			using var b = new Builder ();
 			var legacyTargetFrameworkVersion = "13.0";
@@ -969,12 +957,8 @@ public class JavaSourceTest {
 			var targetFramework = $"{dotnetVersion}-{platform}";
 			var library = new XASdkProject (outputType: "Library") {
 				TargetFramework = targetFramework,
-				ExtraNuGetConfigSources = {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				},
 			};
+			library.AddNuGetSourcesForOlderTargetFrameworks ();
 
 			var preview = IsPreviewFrameworkVersion (targetFramework);
 			if (preview) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -34,6 +34,21 @@ namespace Xamarin.ProjectTools
 			get { return GetProperty ("TargetFramework"); }
 			set { SetProperty ("TargetFramework", value); }
 		}
+
+		/// <summary>
+		/// Projects targeting net6.0/net7.0 require ref/runtime packs on NuGet.org or dotnet6/dotnet7
+		/// </summary>
+		public void AddNuGetSourcesForOlderTargetFrameworks (string targetFramework = null)
+		{
+			targetFramework ??= TargetFramework;
+			if (targetFramework.IndexOf ("net6.0", StringComparison.OrdinalIgnoreCase) != -1) {
+				ExtraNuGetConfigSources = new List<string> {
+					"https://api.nuget.org/v3/index.json",
+					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
+				};
+			}
+		}
+
 		public string Sdk { get; set; }
 
 		public IList<BuildItem> OtherBuildItems { get; private set; }

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -74,13 +74,7 @@ namespace Xamarin.Android.Build.Tests
 				};
 			}
 			proj.TargetFramework = targetFramework;
-			if (targetFramework.Contains ("net6.0")) {
-				proj.ExtraNuGetConfigSources = new List<string> () {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org or dotnet6
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				};
-			}
+			proj.AddNuGetSourcesForOlderTargetFrameworks ();
 			proj.SetRuntimeIdentifier (DeviceAbi);
 
 			var relativeProjDir = Path.Combine ("temp", TestName);
@@ -160,13 +154,7 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XASdkProject ();
 			proj.TargetFramework = targetFramework;
-			if (targetFramework.Contains ("net6.0")) {
-				proj.ExtraNuGetConfigSources = new List<string> () {
-					// Projects targeting net6.0 require ref/runtime packs on NuGet.org or dotnet6
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-				};
-			}
+			proj.AddNuGetSourcesForOlderTargetFrameworks ();
 			proj.SetRuntimeIdentifier (DeviceAbi);
 			string runtimeId = proj.GetProperty (KnownProperties.RuntimeIdentifier);
 


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-android/pull/7602
Changes: https://github.com/xamarin/xamarin-android/compare/9bf238f0f3eb5436cf9f9236327c3315bfc6689e...619ab7a92a09825ecb274bf87d8086d2dbe63aea

Other changes:

* Partially backport 5b7c5bff
* Update `AddNuGetSourcesForOlderTargetFrameworks`, to fix the `XamarinLegacySdk` test
* This allows the test to use the `dotnet6` feed when needed