### PR TITLE
[Xamarin.Android.Build.Tasks] perf improvements for LlvmIrGenerator

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/App.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/App.config
@@ -9,6 +9,12 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.0" />
       </dependentAssembly>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -405,22 +406,22 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		{
 			output = EnsureOutput (output);
 
-			var sb = new StringBuilder (llvmLinkage[options.Linkage]);
+			output.Write ('@');
+			output.Write (symbolName);
+			output.Write (" = ");
+
+			var linkage = llvmLinkage [options.Linkage];
+			if (!string.IsNullOrEmpty (linkage)) {
+				output.Write (linkage);
+				output.Write (' ');
+			}
 			if (options.AddressSignificance != LlvmIrAddressSignificance.Default) {
-				if (sb.Length > 0) {
-					sb.Append (' ');
-				}
-
-				sb.Append (llvmAddressSignificance[options.AddressSignificance]);
+				output.Write (llvmAddressSignificance[options.AddressSignificance]);
+				output.Write (' ');
 			}
 
-			if (sb.Length > 0) {
-				sb.Append (' ');
-			}
-
-			sb.Append (llvmWritability[options.Writability]);
-
-			output.Write ($"@{symbolName} = {sb.ToString ()} ");
+			output.Write (llvmWritability[options.Writability]);
+			output.Write (' ');
 		}
 
 		object? GetTypedMemberValue<T> (StructureInfo<T> info, StructureMemberInfo<T> smi, StructureInstance<T> instance, Type expectedType, object? defaultValue = null)
@@ -476,7 +477,12 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 			WriteGlobalSymbolStart (variableName, preAllocatedBufferVariableOptions, output);
 			ulong size = bufferSize * smi.BaseTypeSize;
-			output.WriteLine ($"[{bufferSize} x {irType}] zeroinitializer, align {GetAggregateAlignment ((int)smi.BaseTypeSize, size)}");
+			output.Write ('[');
+			output.Write (bufferSize);
+			output.Write (" x ");
+			output.Write (irType);
+			output.Write ("] zeroinitializer, align ");
+			output.WriteLine (GetAggregateAlignment ((int) smi.BaseTypeSize, size));
 			instance.AddPointerData (smi, variableName, size);
 			return true;
 		}
@@ -505,7 +511,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			output = EnsureOutput (output);
 
 			int alignment = isArrayOfPointers ? PointerSize : GetAggregateAlignment (info.MaxFieldAlignment, info.Size * count);
-			output.Write ($", align {alignment}");
+			output.Write (", align ");
+			output.Write (alignment);
 			if (named && !skipFinalComment) {
 				WriteEOL ($"end of '{symbolName!}' array", output);
 			} else {
@@ -519,8 +526,15 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public void WriteStructureArray<T> (StructureInfo<T> info, ulong count, LlvmIrVariableOptions options, string? symbolName = null, bool writeFieldComment = true, string? initialComment = null, bool isArrayOfPointers = false)
 		{
 			bool named = WriteStructureArrayStart<T> (info, null, options, symbolName, initialComment);
-			string pointerAsterisk = isArrayOfPointers ? "*" : String.Empty;
-			Output.Write ($"[{count} x %{info.NativeTypeDesignator}.{info.Name}{pointerAsterisk}] zeroinitializer");
+			Output.Write ('[');
+			Output.Write (count);
+			Output.Write (" x %");
+			Output.Write (info.NativeTypeDesignator);
+			Output.Write ('.');
+			Output.Write (info.Name);
+			if (isArrayOfPointers)
+				Output.Write ('*');
+			Output.Write ("] zeroinitializer");
 
 			WriteStructureArrayEnd<T> (info, symbolName, (ulong)count, named, skipFinalComment: true, isArrayOfPointers: isArrayOfPointers);
 		}
@@ -545,7 +559,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			bool named = WriteStructureArrayStart<T> (info, instances, options, symbolName, initialComment, arrayOutput);
 			int count = instances != null ? instances.Count : 0;
 
-			arrayOutput.Write ($"[{count} x %{info.NativeTypeDesignator}.{info.Name}] ");
+			arrayOutput.Write ('[');
+			arrayOutput.Write (count);
+			arrayOutput.Write (" x %");
+			arrayOutput.Write (info.NativeTypeDesignator);
+			arrayOutput.Write ('.');
+			arrayOutput.Write (info.Name);
+			arrayOutput.Write ("] ");
 			if (instances != null) {
 				var bodyWriterOptions = new StructureBodyWriterOptions (
 					writeFieldComment: true,
@@ -556,18 +576,20 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					buffersOutput: info.HasPreAllocatedBuffers ? new StringWriter () : null
 				);
 
-				arrayOutput.WriteLine ("[");
+				arrayOutput.WriteLine ('[');
 				for (int i = 0; i < count; i++) {
 					StructureInstance<T> instance = instances[i];
 
-					arrayOutput.WriteLine ($"{Indent}; {i}");
+					arrayOutput.Write (Indent);
+					arrayOutput.Write ("; ");
+					arrayOutput.WriteLine (i);
 					WriteStructureBody (info, instance, bodyWriterOptions, nestedStructureWriter);
 					if (i < count - 1) {
 						arrayOutput.Write (", ");
 					}
 					WriteEOL (output: arrayOutput);
 				}
-				arrayOutput.Write ("]");
+				arrayOutput.Write (']');
 
 				WriteBufferToOutput (bodyWriterOptions.StringsOutput);
 				WriteBufferToOutput (bodyWriterOptions.BuffersOutput);
@@ -614,14 +636,21 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 			WriteGlobalSymbolStart (symbolName, options);
 			string elementType = MapManagedTypeToIR (typeof (T), out ulong size);
-			Output.WriteLine ($"[{values.Count} x {elementType}] [");
+			Output.Write ('[');
+			Output.Write (values.Count);
+			Output.Write (" x ");
+			Output.Write (elementType);
+			Output.WriteLine ("] [");
 			Output.Write (Indent);
 			for (int i = 0; i < values.Count; i++) {
 				if (i != 0) {
 					if (optimizeOutput) {
 						Output.Write (',');
 						if (i % 8 == 0) {
-							Output.WriteLine ($" ; {i - 8}..{i - 1}");
+							Output.Write (" ; ");
+							Output.Write (i - 8);
+							Output.Write ("..");
+							Output.WriteLine (i - 1);
 							Output.Write (Indent);
 						} else {
 							Output.Write (' ');
@@ -631,7 +660,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					}
 				}
 
-				Output.Write ($"{elementType} {values[i]}");
+				Output.Write (elementType);
+				Output.Write (' ');
+				Output.Write (values [i]);
 
 				if (!optimizeOutput) {
 					bool last = i == values.Count - 1;
@@ -641,7 +672,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 					string? comment = commentProvider (i, values[i]);
 					if (!String.IsNullOrEmpty (comment)) {
-						Output.Write ($" ; {comment}");
+						Output.Write (" ; ");
+						Output.Write (comment);
 					}
 
 					if (!last) {
@@ -651,11 +683,15 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			}
 			if (optimizeOutput && values.Count / 8 != 0) {
 				int idx = values.Count - (values.Count % 8);
-				Output.Write ($" ; {idx}..{values.Count - 1}");
+				Output.Write (" ; ");
+				Output.Write (idx);
+				Output.Write ("..");
+				Output.Write (values.Count - 1);
 			}
 
 			Output.WriteLine ();
-			Output.WriteLine ($"], align {GetAggregateAlignment ((int)size, size * (ulong)values.Count)}");
+			Output.Write ("], align ");
+			Output.WriteLine (GetAggregateAlignment ((int) size, size * (ulong) values.Count));
 		}
 
 		void AssertArraySize<T> (StructureInfo<T> info, StructureMemberInfo<T> smi, ulong length, ulong expectedLength)
@@ -671,7 +707,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		{
 			// Byte arrays are represented in the same way as strings, without the explicit NUL termination byte
 			AssertArraySize (info, smi, expectedArraySize ?? (ulong)bytes.Length, smi.ArrayElements);
-			output.Write ($"c{QuoteString (bytes, out _, nullTerminated: false)}");
+			output.Write ('c');
+			output.Write (QuoteString (bytes, bytes.Length, out _, nullTerminated: false));
 		}
 
 		void MaybeWriteStructureStringsAndBuffers<T> (StructureInfo<T> info, StructureMemberInfo<T> smi, StructureInstance<T> instance, StructureBodyWriterOptions options)
@@ -704,7 +741,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					throw new InvalidOperationException ($"Out of line arrays aren't supported at this time (structure '{info.Name}', field '{smi.Info.Name}')");
 				}
 
-				output.Write ($"{options.FieldIndent}{smi.IRType} ");
+				output.Write (options.FieldIndent);
+				output.Write (smi.IRType);
+				output.Write (" ");
 				value = valueOverride ?? GetTypedMemberValue (info, smi, instance, smi.MemberType);
 
 				if (smi.MemberType == typeof(byte[])) {
@@ -724,10 +763,15 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void WriteStructureBody<T> (StructureInfo<T> info, StructureInstance<T>? instance, StructureBodyWriterOptions options, Action<LlvmIrGenerator, StructureBodyWriterOptions, Type, object>? nestedStructureWriter = null)
 		{
 			TextWriter structureOutput = EnsureOutput (options.StructureOutput);
-			structureOutput.Write ($"{options.StructIndent}%{info.NativeTypeDesignator}.{info.Name} ");
+			structureOutput.Write (options.StructIndent);
+			structureOutput.Write ('%');
+			structureOutput.Write (info.NativeTypeDesignator);
+			structureOutput.Write ('.');
+			structureOutput.Write (info.Name);
+			structureOutput.Write (' ');
 
 			if (instance != null) {
-				structureOutput.WriteLine ("{");
+				structureOutput.WriteLine ('{');
 				for (int i = 0; i < info.Members.Count; i++) {
 					StructureMemberInfo<T> smi = info.Members[i];
 
@@ -735,7 +779,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					WriteStructureField (info, instance, smi, i, options, structureOutput, nestedStructureWriter: nestedStructureWriter);
 				}
 
-				structureOutput.Write ($"{options.StructIndent}}}");
+				structureOutput.Write (options.StructIndent);
+				structureOutput.Write ('}');
 			} else {
 				structureOutput.Write ("zeroinitializer");
 			}
@@ -751,8 +796,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			if (String.IsNullOrEmpty (comment)) {
 				var sb = new StringBuilder (smi.Info.Name);
 				if (value != null && smi.MemberType.IsPrimitive && smi.MemberType != typeof(bool)) {
-					sb.Append (" (");
-					sb.Append ($"0x{value:x})");
+					sb.Append (" (0x");
+					sb.Append ($"{value:x}");
+					sb.Append (')');
 				}
 				comment = sb.ToString ();
 			}
@@ -771,7 +817,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void WritePrimitiveField<T> (StructureInfo<T> info, StructureMemberInfo<T> smi, StructureInstance<T> instance, TextWriter output, object? overrideValue = null)
 		{
 			object? value = overrideValue ?? GetTypedMemberValue (info, smi, instance, smi.MemberType);
-			output.Write ($"{smi.IRType} {value}");
+			output.Write (smi.IRType);
+			output.Write (' ');
+			output.Write (value);
 		}
 
 		void WritePointer<T> (StructureInfo<T> info, StructureMemberInfo<T> smi, StructureInstance<T> instance, TextWriter output, object? overrideValue = null)
@@ -829,7 +877,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void WriteNullPointer<T> (StructureMemberInfo<T> smi, TextWriter output)
 		{
-			output.Write ($"{smi.IRType} null");
+			output.Write (smi.IRType);
+			output.Write (" null");
 		}
 
 		// In theory, functionality implemented here should be folded into WriteStructureArray, but in practice it would slow processing for most of the structures we
@@ -900,7 +949,10 @@ namespace Xamarin.Android.Tasks.LLVMIR
 				bool firstField;
 				instanceType.Clear ();
 				if (!hasPaddedFields) {
-					instanceType.Append ($"\t%{info.NativeTypeDesignator}.{info.Name}");
+					instanceType.Append ("\t%");
+					instanceType.Append (info.NativeTypeDesignator);
+					instanceType.Append ('.');
+					instanceType.Append (info.Name);
 				} else {
 					instanceType.Append ("\t{ ");
 
@@ -917,7 +969,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 							continue;
 						}
 
-						instanceType.Append ($"<{{ {psm.ValueIRType}, {psm.PaddingIRType} }}>");
+						instanceType.Append ("<{ ");
+						instanceType.Append (psm.ValueIRType);
+						instanceType.Append (", ");
+						instanceType.Append (psm.PaddingIRType);
+						instanceType.Append (" }>");
 					}
 
 					instanceType.Append (" }");
@@ -946,12 +1002,24 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					if (!firstField && previousFieldWasPadded) {
 						structureBodyOutput.Write (", ");
 					}
-					structureBodyOutput.Write ($"{bodyWriterOptions.FieldIndent}<{{ {psm.ValueIRType}, {psm.PaddingIRType} }}> <{{ {psm.ValueIRType} c{QuoteString ((byte[])psm.Value)}, {psm.PaddingIRType} zeroinitializer }}> ");
+					structureBodyOutput.Write (bodyWriterOptions.FieldIndent);
+					structureBodyOutput.Write ("<{ ");
+					structureBodyOutput.Write (psm.ValueIRType);
+					structureBodyOutput.Write (", ");
+					structureBodyOutput.Write (psm.PaddingIRType);
+					structureBodyOutput.Write (" }> <{ ");
+					structureBodyOutput.Write (psm.ValueIRType);
+					structureBodyOutput.Write (" c");
+					structureBodyOutput.Write (QuoteString ((byte []) psm.Value));
+					structureBodyOutput.Write (", ");
+					structureBodyOutput.Write (psm.PaddingIRType);
+					structureBodyOutput.Write (" zeroinitializer }> ");
 					MaybeWriteFieldComment (info, psm.MemberInfo, instance, bodyWriterOptions, value: null, output: structureBodyOutput);
 					previousFieldWasPadded = true;
 				}
 				structureBodyOutput.WriteLine ();
-				structureBodyOutput.Write ($"{Indent}}}");
+				structureBodyOutput.Write (Indent);
+				structureBodyOutput.Write ('}');
 			}
 
 			structureOutput.WriteLine ("<{");
@@ -993,7 +1061,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		void FinishStructureWrite<T> (StructureInfo<T> info, StructureBodyWriterOptions bodyWriterOptions)
 		{
-			bodyWriterOptions.StructureOutput.WriteLine ($", align {info.MaxFieldAlignment}");
+			bodyWriterOptions.StructureOutput.Write (", align ");
+			bodyWriterOptions.StructureOutput.WriteLine (info.MaxFieldAlignment);
 
 			WriteBufferToOutput (bodyWriterOptions.StringsOutput);
 			WriteBufferToOutput (bodyWriterOptions.BuffersOutput);
@@ -1064,7 +1133,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			}
 
 			if (String.IsNullOrEmpty (variableName)) {
-				output.Write ($"{irType} null");
+				output.Write (irType);
+				output.Write (" null");
 			} else {
 				string irBaseType;
 				if (irType[irType.Length - 1] == '*') {
@@ -1073,7 +1143,18 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					irBaseType = irType;
 				}
 
-				output.Write ($"{irType} getelementptr inbounds ([{size} x {irBaseType}], [{size} x {irBaseType}]* @{variableName}, i32 0, i32 0)");
+				output.Write (irType);
+				output.Write (" getelementptr inbounds ([");
+				output.Write (size);
+				output.Write (" x ");
+				output.Write (irBaseType);
+				output.Write ("], [");
+				output.Write (size);
+				output.Write (" x ");
+				output.Write (irBaseType);
+				output.Write ("]* @");
+				output.Write (variableName);
+				output.Write (", i32 0, i32 0)");
 			}
 		}
 
@@ -1114,7 +1195,9 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		void WriteStringArray (string symbolName, LlvmIrVariableOptions options, List<StringSymbolInfo> strings)
 		{
 			WriteGlobalSymbolStart (symbolName, options);
-			Output.Write ($"[{strings.Count} x i8*]");
+			Output.Write ('[');
+			Output.Write (strings.Count);
+			Output.Write (" x i8*]");
 
 			if (strings.Count > 0) {
 				Output.WriteLine (" [");
@@ -1134,7 +1217,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					//
 					WriteGetStringPointer (varName, size);
 					if (j < strings.Count - 1) {
-						Output.WriteLine (",");
+						Output.WriteLine (',');
 					}
 				}
 				WriteEOL ();
@@ -1144,9 +1227,10 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 			var arraySize = (ulong)(strings.Count * PointerSize);
 			if (strings.Count > 0) {
-				Output.Write ("]");
+				Output.Write (']');
 			}
-			Output.WriteLine ($", align {GetAggregateAlignment (PointerSize, arraySize)}");
+			Output.Write (", align ");
+			Output.WriteLine (GetAggregateAlignment (PointerSize, arraySize));
 		}
 
 		/// <summary>
@@ -1168,7 +1252,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			string irType = GetIRType<T> (out ulong size, value);
 			WriteGlobalSymbolStart (symbolName, options);
 
-			Output.WriteLine ($"{irType} {GetValue (value)}, align {size}");
+			Output.Write (irType);
+			Output.Write (' ');
+			Output.Write (GetValue (value));
+			Output.Write (", align ");
+			Output.WriteLine (size);
 		}
 
 		/// <summary>
@@ -1236,14 +1324,31 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// It might seem counter-intuitive that when we're requested to write a global string, here we generate a **local** one,
 			// but global strings are actually pointers to local storage.
 			WriteGlobalSymbolStart (strSymbolName, global ? LlvmIrVariableOptions.LocalConstexprString : options);
-			Output.WriteLine ($"[{stringSize} x i8] c{quotedString}, align {GetAggregateAlignment (1, stringSize)}");
+			Output.Write ('[');
+			Output.Write (stringSize);
+			Output.Write (" x i8] c");
+			Output.Write (quotedString);
+			Output.Write (", align ");
+			Output.WriteLine (GetAggregateAlignment (1, stringSize));
+
 			if (!global) {
 				return symbolName;
 			}
 
 			string indexType = Is64Bit ? "i64" : "i32";
 			WriteGlobalSymbolStart (symbolName, LlvmIrVariableOptions.GlobalConstantStringPointer);
-			Output.WriteLine ($"i8* getelementptr inbounds ([{stringSize} x i8], [{stringSize} x i8]* @{strSymbolName}, {indexType} 0, {indexType} 0), align {GetAggregateAlignment (PointerSize, stringSize)}");
+			Output.Write ("i8* getelementptr inbounds ([");
+			Output.Write (stringSize);
+			Output.Write (" x i8], [");
+			Output.Write (stringSize);
+			Output.Write (" x i8]* @");
+			Output.Write (strSymbolName);
+			Output.Write (", ");
+			Output.Write (indexType);
+			Output.Write (" 0, ");
+			Output.Write (indexType);
+			Output.Write (" 0), align ");
+			Output.WriteLine (GetAggregateAlignment (PointerSize, stringSize));
 
 			return symbolName;
 		}
@@ -1317,7 +1422,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public void WriteStructureDeclarationStart (string typeDesignator, string name, bool forOpaqueType = false)
 		{
 			WriteEOL ();
-			Output.Write ($"%{typeDesignator}.{name} = type ");
+			Output.Write ('%');
+			Output.Write (typeDesignator);
+			Output.Write ('.');
+			Output.Write (name);
+			Output.Write (" = type ");
 			if (forOpaqueType) {
 				Output.WriteLine ("opaque");
 			} else {
@@ -1327,12 +1436,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public void WriteStructureDeclarationEnd ()
 		{
-			Output.WriteLine ("}");
+			Output.WriteLine ('}');
 		}
 
 		public void WriteStructureDeclarationField (string typeName, string comment, bool last)
 		{
-			Output.Write ($"{Indent}{typeName}");
+			Output.Write (Indent);
+			Output.Write (typeName);
 			if (!last) {
 				Output.Write (",");
 			}
@@ -1400,7 +1510,8 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			writer.Write (name);
 
 			if (!String.IsNullOrEmpty (value)) {
-				writer.Write ($" = {value}");
+				writer.Write (" = ");
+				writer.Write (value);
 			}
 
 			WriteEOL (writer, comment);
@@ -1433,28 +1544,39 @@ namespace Xamarin.Android.Tasks.LLVMIR
 
 		public static string QuoteString (byte[] bytes)
 		{
-			return QuoteString (bytes, out _, nullTerminated: false);
+			return QuoteString (bytes, bytes.Length, out _, nullTerminated: false);
 		}
 
 		public static string QuoteString (string value, out ulong stringSize, bool nullTerminated = true)
 		{
-			return QuoteString (Encoding.UTF8.GetBytes (value), out stringSize, nullTerminated);
+			var encoding = Encoding.UTF8;
+			int byteCount = encoding.GetByteCount (value);
+			var bytes = ArrayPool<byte>.Shared.Rent (byteCount);
+			try {
+				encoding.GetBytes (value, 0, value.Length, bytes, 0);
+				return QuoteString (bytes, byteCount, out stringSize, nullTerminated);
+			} finally {
+				ArrayPool<byte>.Shared.Return (bytes);
+			}
 		}
 
-		public static string QuoteString (byte[] bytes, out ulong stringSize, bool nullTerminated = true)
+		public static string QuoteString (byte[] bytes, int byteCount, out ulong stringSize, bool nullTerminated = true)
 		{
-			var sb = new StringBuilder ();
+			var sb = new StringBuilder (byteCount * 2); // rough estimate of capacity
 
-			foreach (byte b in bytes) {
+			byte b;
+			for (int i = 0; i < byteCount; i++) {
+				b = bytes [i];
 				if (b != '"' && b != '\\' && b >= 32 && b < 127) {
 					sb.Append ((char)b);
 					continue;
 				}
 
-				sb.Append ($"\\{b:X2}");
+				sb.Append ('\\');
+				sb.Append ($"{b:X2}");
 			}
 
-			stringSize = (ulong)bytes.Length;
+			stringSize = (ulong) byteCount;
 			if (nullTerminated) {
 				stringSize++;
 				sb.Append ("\\00");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -537,7 +537,6 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			Output.Write (info.NativeTypeDesignator);
 			Output.Write ('.');
 			Output.Write (info.Name);
-
 			if (isArrayOfPointers)
 				Output.Write ('*');
 			Output.Write ("] zeroinitializer");


### PR DESCRIPTION
Reviewing `dotnet trace` output for a `dotnet new maui` app:

    dotnet trace collect --format speedscope -- .\bin\Release\dotnet\dotnet.exe build -bl --no-restore foo.csproj

21% of the time in `<GenerateJavaStubs/>` is spent in:

    249.60ms xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.LlvmIrComposer.Write(value class Xamarin.Android.Tools.Andro...

Drilling down, some of the hot spots are:

    68.64ms xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.LlvmIrGenerator.WriteString(class System.String,class System.St
    40.39ms xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.LlvmIrGenerator.WritePointer(class Xamarin.Android.Tasks.LLVMIR

These seem to be places we create intermediate `string` or `byte[]` objects.

The types of things I solved so far:

* I audited every `$""` to see if we could call `TextWriter.Write()` or `StringBuilder.Append()` multiple times to avoid creating a string.

* Use `ArrayPool` in combination with `Encoding.GetBytes()`.

* Use `char` overloads, where we were using a 1-length `string`.

Hopefully, I've changed no behavior at all here, and we've just saved a lot of `string` and `byte[]` allocations.

After these changes go in, we can probably profile and find other areas to improve.

Testing the same `dotnet new maui` app, the overall time is now:

    190.97ms xamarin.android.build.tasks!Xamarin.Android.Tasks.LLVMIR.LlvmIrComposer.Write(value class Xamarin.Android.Tools.AndroidT

I think this will save ~60ms on incremental builds of the .NET MAUI project template. Larger projects with more Java subclasses could save even more.