### PR TITLE
Add Nightly Tests for Humanizer 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,6 +50,7 @@
     <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <ELFSharpVersion>2.13.1</ELFSharpVersion>
+    <HumanizerVersion>2.14.1</HumanizerVersion>
     <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.8.9.2</MdocPackageVersion>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ArchiveAssemblyHelper.cs
@@ -239,8 +239,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			using (var zip = ZipHelper.OpenZip (archivePath)) {
 				existingFiles = zip.Where (a => a.FullName.StartsWith (assembliesRootDir, StringComparison.InvariantCultureIgnoreCase)).Select (a => a.FullName).ToList ();
-				missingFiles = fileNames.Where (x => !zip.ContainsEntry (assembliesRootDir + Path.GetFileName (x))).ToList ();
-				additionalFiles = existingFiles.Where (x => !fileNames.Contains (Path.GetFileName (x))).ToList ();
+				missingFiles = fileNames.Where (x => !zip.ContainsEntry (assembliesRootDir + x)).ToList ();
+				additionalFiles = existingFiles.Where (x => !fileNames.Contains (x.Replace (assembliesRootDir, string.Empty))).ToList ();
 			}
 		}
 
@@ -258,7 +258,7 @@ namespace Xamarin.Android.Build.Tests
 			if (otherFiles.Count > 0) {
 				using (var zip = ZipHelper.OpenZip (archivePath)) {
 					foreach (string file in otherFiles) {
-						string fullPath = assembliesRootDir + Path.GetFileName (file);
+						string fullPath = assembliesRootDir + file;
 						if (zip.ContainsEntry (fullPath)) {
 							existingFiles.Add (file);
 						}
@@ -266,7 +266,13 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 
-			var explorer = new AssemblyStoreExplorer (archivePath);
+			var explorer = new AssemblyStoreExplorer (archivePath, customLogger: (a, s) => {
+				Console.WriteLine ($"DEBUG! {s}");
+			});
+
+			foreach (var f in explorer.AssembliesByName) {
+				Console.WriteLine ($"DEBUG!\tKey:{f.Key}");
+			}
 
 			// Assembly stores don't store the assembly extension
 			var storeAssemblies = explorer.AssembliesByName.Keys.Select (x => $"{x}.dll");
@@ -298,7 +304,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			foreach (string file in fileNames) {
-				if (existingFiles.Contains (Path.GetFileName (file))) {
+				if (existingFiles.Contains (file)) {
 					continue;
 				}
 				missingFiles.Add (file);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <PackageReference Include="ELFSharp" Version="$(ELFSharpVersion)" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
+    <PackageReference Include="Humanizer" Version="$(HumanizerVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/MainActivity.cs
@@ -6,6 +6,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+//${USINGS}
 
 namespace ${ROOT_NAMESPACE}
 {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/DotNet/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/DotNet/MainActivity.cs
@@ -1,3 +1,4 @@
+//${USINGS}
 namespace ${ROOT_NAMESPACE}
 {
 	[Android.Runtime.Register ("${JAVA_PACKAGENAME}.MainActivity"), Activity (Label = "${PROJECT_NAME}", MainLauncher = true, Icon = "@drawable/icon")]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
@@ -6,6 +6,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+//${USINGS}
 
 namespace ${ROOT_NAMESPACE}
 {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Wear/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Wear/MainActivity.cs
@@ -8,6 +8,7 @@ using Android.Support.V4.App;
 using Android.Support.Wearable.Views;
 using Android.Views;
 using Android.Widget;
+//${USINGS}
 
 namespace ${ROOT_NAMESPACE}
 {

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="NodaTime" Version="2.4.5" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
+    <PackageReference Include="Humanizer" Version="$(HumanizerVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tests https://github.com/xamarin/xamarin-android/issues/7622

Localisation assemblies were not being fast deployed. Commit https://github.com/xamarin/monodroid/commit/1f52d5873960cf72685b9b08dbe262fc1ad4ca13
fixed that. However we need to add a unit test to make sure that these files are deployed and 
actually produce the required results. 

So lets use Humanizer to handle the localisation. This PR adds a test which checks that the 
app on the device outputs the expected text which Humanizer is supposed to generate. 
It also updates existing packaging tests to make sure that the required satellite assemblies are
 packaged.