### PR TITLE
Add Unit Test for testOnly apps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.Tasks
 					UseEmbeddedDex = value;
 				}
 
-				text = app.Attribute (androidNs + "testOnly");
+				text = app.Attribute (androidNs + "testOnly")?.Value;
 				if (bool.TryParse (text, out value)) {
 					IsTestOnly = value;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -35,6 +35,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public bool UseEmbeddedDex { get; set; } = false;
 
+		[Output]
+		public bool IsTestOnly { get; set; } = false;
+
 		public override bool RunTask ()
 		{
 			var androidNs = AndroidAppManifest.AndroidXNamespace;
@@ -50,6 +53,11 @@ namespace Xamarin.Android.Tasks
 				text = app.Attribute (androidNs + "useEmbeddedDex")?.Value;
 				if (bool.TryParse (text, out value)) {
 					UseEmbeddedDex = value;
+				}
+
+				text = app.Attribute (androidNs + "testOnly");
+				if (bool.TryParse (text, out value)) {
+					IsTestOnly = value;
 				}
 
 				var libraries = new List<ITaskItem> ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1641,6 +1641,7 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="EmbeddedDSOsEnabled" PropertyName="_EmbeddedDSOsEnabled" />
     <Output TaskParameter="UsesLibraries"       ItemName="AndroidExternalJavaLibrary" />
     <Output TaskParameter="UseEmbeddedDex"      PropertyName="_UseEmbeddedDex" />
+    <Output TaskParameter="IsTestOnly"          PropertyName="_AndroidIsTestOnlyPackage" />
   </ReadAndroidManifest>
   <PropertyGroup>
     <AndroidStoreUncompressedFileExtensions Condition=" '$(_EmbeddedDSOsEnabled)' == 'True' ">.so;$(AndroidStoreUncompressedFileExtensions)</AndroidStoreUncompressedFileExtensions>

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -764,12 +764,14 @@ using System.Runtime.Serialization.Json;
 		}
 
 		[Test]
-		public void SingleProject_ApplicationId ()
+		public void SingleProject_ApplicationId ([Values (false, true)] bool testOnly)
 		{
 			AssertHasDevices ();
 
 			proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("ApplicationId", "com.i.should.get.overridden.by.the.manifest");
+			if (testOnly)
+				proj.AndroidManifest = proj.AndroidManifest.Replace ("<application", "<application android:testOnly=\"true\"");
 
 			var abis = new string [] { "armeabi-v7a", "arm64-v8a", "x86", "x86_64" };
 			proj.SetAndroidSupportedAbis (abis);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/11345

For context users can mark their package as "testOnly" in the `AndroidManifest.xml`. When they do this `adb` also needs an additonal flag to install the package. 

PR https://github.com/xamarin/monodroid/pull/1279 adds the ability to pass this additional flag to `adb`. 
This PR adds the ability to read the flag from the `AndroidManifest.xml`, so it can be used by other tasks. 
A unit test has also been added to the Device tests to make sure we can install `testOnly` packages.