### PR TITLE
[Xamarin.Android.Build.Tasks] downgrade d8/r8 `warning` messages to `info`

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1110,6 +1110,14 @@ or use `-p:AndroidCreateProguardMappingFile=False` on the command line.
 
 This property was added in Xamarin.Android 11.2.
 
+## AndroidD8IgnoreWarnings
+
+Specifies `--map-diagnostics warning info` to be passed to `d8`. The
+default value is `True`, but can be set to `False` to enforce more
+strict behavior. See the [D8 and R8 readme][r8-source] for details.
+
+Added in .NET 8.
+
 ## AndroidR8IgnoreWarnings
 
 Specifies
@@ -1118,7 +1126,12 @@ to continue with dex compilation even if certain warnings are
 encountered. The default value is `True`, but can be set to `False` to
 enforce more strict behavior. See the [ProGuard manual](https://www.guardsquare.com/manual/configuration/usage) for details.
 
+Starting in .NET 8, specifies `--map-diagnostics warning info`. See
+the [D8 and R8 readme][r8-source] for details.
+
 Added in Xamarin.Android 10.3.
+
+[r8-source]: https://r8.googlesource.com/r8/
 
 ## AndroidR8JarPath
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1114,7 +1114,7 @@ This property was added in Xamarin.Android 11.2.
 
 Specifies `--map-diagnostics warning info` to be passed to `d8`. The
 default value is `True`, but can be set to `False` to enforce more
-strict behavior. See the [D8 and R8 readme][r8-source] for details.
+strict behavior. See the [D8 and R8 source code][r8-source] for details.
 
 Added in .NET 8.
 
@@ -1127,11 +1127,11 @@ encountered. The default value is `True`, but can be set to `False` to
 enforce more strict behavior. See the [ProGuard manual](https://www.guardsquare.com/manual/configuration/usage) for details.
 
 Starting in .NET 8, specifies `--map-diagnostics warning info`. See
-the [D8 and R8 readme][r8-source] for details.
+the [D8 and R8 source code][r8-source] for details.
 
 Added in Xamarin.Android 10.3.
 
-[r8-source]: https://r8.googlesource.com/r8/
+[r8-source]: https://r8.googlesource.com/r8/+/refs/tags/3.3.75/src/main/java/com/android/tools/r8/BaseCompilerCommandParser.java#246
 
 ## AndroidR8JarPath
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -261,6 +261,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
+	<AndroidD8IgnoreWarnings    Condition=" '$(AndroidD8IgnoreWarnings)' == '' ">True</AndroidD8IgnoreWarnings>
 	<AndroidR8IgnoreWarnings    Condition=" '$(AndroidR8IgnoreWarnings)' == '' ">True</AndroidR8IgnoreWarnings>
 	<AndroidCreateProguardMappingFile Condition="'$(AndroidCreateProguardMappingFile)' == '' And '$(AndroidLinkTool)' == 'r8'">True</AndroidCreateProguardMappingFile>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -48,6 +48,11 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         Condition=" '$(AndroidLinkTool)' != '' "
     />
 
+    <ItemGroup>
+      <_AndroidD8MapDiagnostics Condition=" '$(AndroidD8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
+      <_AndroidR8MapDiagnostics Condition=" '$(AndroidR8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
+    </ItemGroup>
+
     <R8
         Condition=" '$(_UseR8)' == 'True' "
         ToolPath="$(JavaToolPath)"
@@ -77,6 +82,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ExtraArguments="$(AndroidR8ExtraArguments)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
         AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+        MapDiagnostics="@(_AndroidR8MapDiagnostics)"
     />
     <D8
         Condition=" '$(_UseR8)' != 'True' "
@@ -96,6 +102,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ExtraArguments="$(AndroidD8ExtraArguments)"
         IntermediateOutputPath="$(IntermediateOutputPath)"
         AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+        MapDiagnostics="@(_AndroidD8MapDiagnostics)"
     />
 
     <Touch Files="$(_AndroidStampDirectory)_CompileToDalvik.stamp" AlwaysCreate="true" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/10901

Building a .NET MAUI project such as:

    dotnet new maui
    dotnet build -c Release -f net6.0-android -p:AndroidLinkMode=r8

Results in build warnings from R8 such as:

    R8 : warning : Missing class androidx.window.extensions.WindowExtensions

In 92bc7050, we already had attempted to silence warnings from R8 such as:

    R8 : warning : Resource 'META-INF/MANIFEST.MF' already exists.

At the time, there was no option to hide warnings, now there is!

    --map-diagnostics[:<type>] <from-level> <to-level>
        # Map diagnostics of <type> (default any) reported as
        # <from-level> to <to-level> where <from-level> and
        # <to-level> are one of 'info', 'warning', or 'error' and the
        # optional <type> is either the simple or fully qualified
        # Java type name of a diagnostic. If <type> is unspecified,
        # all diagnostics at <from-level> will be mapped.
        # Note that fatal compiler errors cannot be mapped.

We can pass:

    --map-diagnostics warning info

Which can be done in existing apps via:

    <AndroidD8ExtraArguments>--map-diagnostics warning info</AndroidD8ExtraArguments>
    <AndroidR8ExtraArguments>--map-diagnostics warning info</AndroidR8ExtraArguments>

To solve this problem, let's create a new `$(AndroidD8IgnoreWarnings)` MSBuild property and make use of one we already have `$(AndroidR8IgnoreWarnings)`:

    <ItemGroup>
      <_AndroidD8MapDiagnostics Condition=" '$(AndroidD8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
      <_AndroidR8MapDiagnostics Condition=" '$(AndroidR8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
    </ItemGroup>

We can then use these item groups to pass `--map-diagnostics` as appropriate. Developers can turn off either property to disable this behavior.

We can then remove the weird `Regex` code added in 92bc7050. The existing tests from 92bc7050 should also be sufficient for testing this change.

Now r8 emits:

    Info: Missing class androidx.window.extensions.WindowExtensions (referenced from: androidx.window.extensions.layout.WindowLayoutComponent androidx.window.layout.SafeWindowLayoutComponentProvider$windowLayoutComponent$2.invoke())
    Info: Resource 'META-INF/MANIFEST.MF' already exists.
    
And you don't get an MSBuild warning anymore.