### PR TITLE
[build] skip provisioning of Xamarin.Android on .NET lanes

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -613,6 +613,7 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
+        provisionClassic: false
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml
@@ -779,6 +780,7 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
+        provisionClassic: false
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: yaml-templates/run-xaprepare.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-device-tests.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
       parameters:
+        provisionClassic: ${{ ne(parameters.target_framework, parameters.dotnet_targetframework) }}
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - template: run-xaprepare.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-mac-tests.yaml
@@ -22,6 +22,7 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
       parameters:
+        provisionClassic: ${{ ne(parameters.target_framework, parameters.dotnet_targetframework) }}
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
     - task: DownloadPipelineArtifact@1

--- a/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-win-tests.yaml
@@ -28,6 +28,7 @@ jobs:
 
     - template: setup-test-environment.yaml
       parameters:
+        provisionClassic: ${{ ne(parameters.target_framework, parameters.dotnet_targetframework) }}
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         remove_dotnet: true
 

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,5 +1,6 @@
 parameters:
   configuration: $(XA.Build.Configuration)
+  provisionClassic: true
   provisionExtraArgs: -vv -f
   provisionatorChannel: latest
   xaSourcePath: $(System.DefaultWorkingDirectory)
@@ -19,10 +20,11 @@ steps:
     parameters: 
       xasourcePath: ${{ parameters.xaSourcePath }}
 
-- template: run-installer.yaml
-  parameters:
-    provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+- ${{ if eq(parameters.provisionClassic, true) }}:
+  - template: run-installer.yaml
+    parameters:
+      provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7102687&view=logs&j=270ba80a-9de5-5c73-abb9-bb787532a07c&s=25cdcba1-3ecb-5490-0002-daf27c697525&t=306f7057-edf0-58b5-5004-8b3b311950d4&l=449

`provisionator` is a source of random failures like:

    [21:41:23 ERR] Error Xamarin.Provisioning.ProvisioningException: Failed to provision C:\a\_work\1\s\xamarin-android\Xamarin.Android.Sdk-13.1.99.88.vsix

In this case, we were downloading a classic Xamarin.Android build for use on a test lane for `One .NET` tests?

To make things better, let's skip this step completely for `One .NET` tests. We shouldn't need to provision classic Xamarin.Android on these test lanes.

This also has the added benefit of faster test runs, just spot-checking the time spent on the above build:

* Saves 1-2 min of time for `provisionator` on macOS lanes.
* Saves up to ~24 min of time for  `provisionator` on Windows lanes.