### PR TITLE
[Xamarin.Android.Build.Tasks] use %(TrimmerRootAssembly.RootMode) All

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -99,7 +99,7 @@ This file contains the .NET 5-specific targets to customize ILLink
 
   <Target Name="_FixRootAssembly" AfterTargets="PrepareForILLink">
     <ItemGroup>
-      <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Condition=" '%(RootMode)' == 'EntryPoint' " RootMode="Library" />
+      <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Condition=" '%(RootMode)' == 'EntryPoint' " RootMode="All" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/linker/issues/3165#issuecomment-1358680001

In 2a10e969, I added a workaround for new linker behavior.

It turns out I should have used `All` instead of `Library` for now.

The original issue is still under discussion.