### PR TITLE
[Xamarin.Android.Build.Tasks] fast path for `<CheckClientHandlerType/>`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
@@ -20,9 +20,19 @@ namespace Xamarin.Android.Tasks
 		public string ValidHandlerType { get; set; }
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
+		public bool UsingAndroidNETSdk { get; set; }
 
 		public override bool RunTask ()
 		{
+			// Fast path for known types
+			if (UsingAndroidNETSdk) {
+				if (ClientHandlerType == "Xamarin.Android.Net.AndroidMessageHandler")
+					return !Log.HasLoggedErrors;
+			} else {
+				if (ClientHandlerType == "Xamarin.Android.Net.AndroidClientHandler")
+					return !Log.HasLoggedErrors;
+			}
+
 			string[] types = ClientHandlerType.Split (',');
 			string type = types[0].Trim ();
 			string assembly = "Mono.Android";

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -498,6 +498,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <CheckClientHandlerType
     ClientHandlerType="$(AndroidHttpClientHandlerType)"
     ValidHandlerType="$(ValidAndroidHttpClientHandlerBaseType)"
+    UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
     ResolvedAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
   />
 </Target>


### PR DESCRIPTION
`dotnet trace` of a `dotnet new maui` project, I noticed this was
happening on *any* build:

    65.94ms xamarin.android.build.tasks!Xamarin.Android.Tasks.CheckClientHandlerType.RunTask()

Checking outside of a profiler, a `.binlog` says:

    CheckClientHandlerType = 55 ms

This was added in 311b41e8, so it is only in main & .NET 8. Maybe when
we timed this before, it wasn't a MAUI app?

Looking at the stack trace, most of the time is spent loading
assemblies with Mono.Cecil.

Let's add a check at the beginning for the two most common values:

* .NET 6+: `Xamarin.Android.Net.AndroidMessageHandler`
* Classic: `Xamarin.Android.Net.AndroidClientHandler`

And we can return early in these cases.

After these changes, I get:

    CheckClientHandlerType = 2 ms

This should save ~53ms on any build w/ common settings for
`$(AndroidHttpClientHandlerType)`.