### PR TITLE
Fix ServerCertificateValidationCallback after redirect

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -425,6 +425,7 @@ namespace Xamarin.Android.Net
 					if (redirectState.NewUrl == null)
 						throw new InvalidOperationException ("Request redirected but no new URI specified");
 					request.Method = redirectState.Method;
+					request.RequestUri = redirectState.NewUrl;
 				} catch (Java.Net.SocketTimeoutException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {
 					throw new WebException (ex.Message, ex, WebExceptionStatus.Timeout, null);
 				} catch (Java.Net.UnknownServiceException ex) when (JNIEnv.ShouldWrapJavaException (ex)) {

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -119,7 +119,6 @@ namespace Xamarin.Android.NetTests
 			var handler = new AndroidMessageHandler {
 				ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => {
 					callbackCounter++;
-					Assert.Contains (request.RequestUri.Host, cert.SubjectName.Name);
 					return errors == SslPolicyErrors.None;
 				}
 			};

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -27,9 +27,9 @@ namespace Xamarin.Android.NetTests
 			var handler = new AndroidMessageHandler {
 				ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => {
 					Assert.NotNull (request, "request");
-					Assert.AreEqual ("microsoft.com", request.RequestUri.Host);
+					Assert.AreEqual ("www.microsoft.com", request.RequestUri.Host);
 					Assert.NotNull (cert, "cert");
-					Assert.True (cert!.Subject.Contains ("microsoft.com"), $"Unexpected certificate subject {cert!.Subject}");
+					Assert.True (cert!.Subject.Contains ("www.microsoft.com"), $"Unexpected certificate subject {cert!.Subject}");
 					Assert.True (cert!.Issuer.Contains ("Microsoft"), $"Unexpected certificate issuer {cert!.Issuer}");
 					Assert.NotNull (chain, "chain");
 					Assert.AreEqual (SslPolicyErrors.None, errors);
@@ -40,7 +40,7 @@ namespace Xamarin.Android.NetTests
 			};
 
 			var client = new HttpClient (handler);
-			await client.GetStringAsync ("https://microsoft.com/");
+			await client.GetStringAsync ("https://www.microsoft.com/");
 
 			Assert.IsTrue (callbackHasBeenCalled, "custom validation callback hasn't been called");
 		}
@@ -58,7 +58,7 @@ namespace Xamarin.Android.NetTests
 			};
 			var client = new HttpClient (handler);
 
-			await AssertRejectsRemoteCertificate (() => client.GetStringAsync ("https://microsoft.com/"));
+			await AssertRejectsRemoteCertificate (() => client.GetStringAsync ("https://www.microsoft.com/"));
 
 			Assert.IsTrue (callbackHasBeenCalled, "custom validation callback hasn't been called");
 		}
@@ -124,9 +124,9 @@ namespace Xamarin.Android.NetTests
 			};
 
 			var client = new HttpClient (handler);
-			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://microsoft.com/");
+			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/");
 
-			Assert.AreEqual (3, callbackCounter); // httpbin.org, microsoft.com, www.microsoft.com
+			Assert.AreEqual (2, callbackCounter);
 			Assert.IsTrue (result.IsSuccessStatusCode);
 		}
 


### PR DESCRIPTION
Fixes #7650 

We check if the server certificate hostname matches the  request's RequestUri. When the request is redirected to a different host, the verification failed because we tested the next server's hostname against the original request URI. This PR keeps the RequestUri in sync with the redirect status to avoid this problem.