### PR TITLE
Address breaking changes in Java.Interop

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -33,6 +33,7 @@ namespace MonoDroid.Tuner
 #if ILLINK
 		public override void Initialize (LinkContext context, MarkContext markContext)
 		{
+			this.cache = context;
 			base.Initialize (context, markContext);
 			markContext.RegisterMarkTypeAction (type => ProcessType (type));
 		}

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -347,9 +347,9 @@ namespace Android.App {
 			return self;
 		}
 
-		internal XElement ToElement (IAssemblyResolver resolver, string packageName, int targetSdkVersion)
+		internal XElement ToElement (IAssemblyResolver resolver, string packageName, TypeDefinitionCache cache, int targetSdkVersion)
 		{
-			return mapping.ToElement (this, specified, packageName, type, resolver, targetSdkVersion);
+			return mapping.ToElement (this, specified, packageName, cache, type, resolver, targetSdkVersion);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -59,15 +59,15 @@ namespace Android.App {
 			  "BackupAgent",
 			  "backupAgent",
 			  (self, value) => self._BackupAgent  = (string) value,
-				(self, p, r)  => {
+				(self, p, r, cache)  => {
 					var typeDef = ManifestDocumentElement.ResolveType (self._BackupAgent, p, r);
 
-					if (!typeDef.IsSubclassOf ("Android.App.Backup.BackupAgent"))
+					if (!typeDef.IsSubclassOf ("Android.App.Backup.BackupAgent", cache))
 						throw new InvalidOperationException (
 								string.Format ("The Type '{0}', referenced by the Android.App.ApplicationAttribute.BackupAgent property, must be a subclass of the type Android.App.Backup.BackupAgent.",
 									typeDef.FullName));
 
-					return ManifestDocumentElement.ToString (typeDef);
+					return ManifestDocumentElement.ToString (typeDef, cache);
 			  }
 			}, {
 			  "BackupInForeground",
@@ -256,16 +256,16 @@ namespace Android.App {
 			return self;
 		}
 
-		internal XElement ToElement (IAssemblyResolver resolver, string packageName)
+		internal XElement ToElement (IAssemblyResolver resolver, string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName, provider, resolver);
+			return mapping.ToElement (this, specified, packageName, cache, provider, resolver);
 		}
 
-		static string ToNameAttribute (ApplicationAttribute self)
+		static string ToNameAttribute (ApplicationAttribute self, ICustomAttributeProvider provider, IAssemblyResolver resolver, TypeDefinitionCache cache)
 		{
 			var type = self.provider as TypeDefinition;
 			if (string.IsNullOrEmpty (self.Name) && type != null)
-				return JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
+				return JavaNativeTypeManager.ToJniName (type, cache).Replace ('/', '.');
 
 			return self.Name;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/BroadcastReceiverAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/BroadcastReceiverAttribute.Partial.cs
@@ -82,9 +82,9 @@ namespace Android.Content {
 			return self;
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ContentProviderAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ContentProviderAttribute.Partial.cs
@@ -118,9 +118,9 @@ namespace Android.Content {
 			return self;
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/GrantUriPermissionAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/GrantUriPermissionAttribute.Partial.cs
@@ -45,9 +45,9 @@ namespace Android.Content {
 			}
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/InstrumentationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/InstrumentationAttribute.Partial.cs
@@ -76,9 +76,9 @@ namespace Android.App {
 			specified.Add ("TargetPackage");
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/LayoutAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/LayoutAttribute.Partial.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
@@ -62,9 +62,9 @@ namespace Android.App
 			return self;
 		}
 
-		internal XElement ToElement (IAssemblyResolver resolver, string packageName)
+		internal XElement ToElement (IAssemblyResolver resolver, string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName, type, resolver);
+			return mapping.ToElement (this, specified, packageName, cache, type, resolver);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/MetaDataAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/MetaDataAttribute.Partial.cs
@@ -46,9 +46,9 @@ namespace Android.App {
 			}
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionAttribute.Partial.cs
@@ -72,9 +72,9 @@ namespace Android.App {
 			}
 		}
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		internal class PermissionAttributeComparer : IEqualityComparer<PermissionAttribute>

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionGroupAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionGroupAttribute.Partial.cs
@@ -62,9 +62,9 @@ namespace Android.App {
 			}
 		}
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		internal class PermissionGroupAttributeComparer : IEqualityComparer<PermissionGroupAttribute>

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionTreeAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/PermissionTreeAttribute.Partial.cs
@@ -57,9 +57,9 @@ namespace Android.App {
 			}
 		}
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		internal class PermissionTreeAttributeComparer : IEqualityComparer<PermissionTreeAttribute>

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ServiceAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ServiceAttribute.Partial.cs
@@ -90,9 +90,9 @@ namespace Android.App {
 			return self;
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/SupportsGLTextureAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/SupportsGLTextureAttribute.Partial.cs
@@ -20,9 +20,9 @@ namespace Android.App
 		};
 
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		ICollection<string> specified;

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesConfigurationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesConfigurationAttribute.Partial.cs
@@ -42,9 +42,9 @@ namespace Android.App {
 			}
 		};
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		ICollection<string> specified;

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesFeatureAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesFeatureAttribute.Partial.cs
@@ -43,9 +43,9 @@ namespace Android.App {
 			return String.Format("0x{0}", GLESVersion.ToString("X8"));
 		}
 
-		internal XElement ToElement (string packageName)
+		internal XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		ICollection<string> specified;

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesLibraryAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesLibraryAttribute.Partial.cs
@@ -58,9 +58,9 @@ namespace Android.App {
 			}
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesPermissionAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesPermissionAttribute.Partial.cs
@@ -54,9 +54,9 @@ namespace Android.App {
 			}
 		}
 
-		public XElement ToElement (string packageName)
+		public XElement ToElement (string packageName, TypeDefinitionCache cache)
 		{
-			return mapping.ToElement (this, specified, packageName);
+			return mapping.ToElement (this, specified, packageName, cache);
 		}
 
 		internal class UsesPermissionComparer : IEqualityComparer<UsesPermissionAttribute>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -483,7 +483,7 @@ namespace Xamarin.Android.Tasks
 						jti.Generate (writer);
 						if (useMarshalMethods) {
 							if (classifier.FoundDynamicallyRegisteredMethods (t)) {
-								Log.LogWarning ($"Type '{t.GetAssemblyQualifiedName ()}' will register some of its Java override methods dynamically. This may adversely affect runtime performance. See preceding warnings for names of dynamically registered methods.");
+								Log.LogWarning ($"Type '{t.GetAssemblyQualifiedName (cache)}' will register some of its Java override methods dynamically. This may adversely affect runtime performance. See preceding warnings for names of dynamically registered methods.");
 							}
 						}
 						writer.Flush ();


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1069

Any place we had:

    TypeDefinitionCache?
    IMetadataResolver?

These no longer allow nulls, and so overloads that use `Obsolete` now emit errors instead of warnings:

    [Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
    public static MethodDefinition GetBaseDefinition (this MethodDefinition method) => throw new NotSupportedException ();

This results in 3 compiler errors in xamarin-android:

    src\Xamarin.Android.Build.Tasks\Mono.Android\ApplicationAttribute.Partial.cs(65,11): error CS0619: 'TypeDefinitionRocks.IsSubclassOf(TypeDefinition, string)' is obsolete: 'Use the TypeDefinitionCache overload for better performance.'
    src\Xamarin.Android.Build.Tasks\Mono.Android\ApplicationAttribute.Partial.cs(268,12): error CS0619: 'JavaNativeTypeManager.ToJniName(TypeDefinition)' is obsolete: 'Use the TypeDefinitionCache overload for better performance.'
    src\Xamarin.Android.Build.Tasks\Utilities\ManifestDocumentElement.cs(28,11): error CS0619: 'JavaNativeTypeManager.ToJniName(TypeDefinition)' is obsolete: 'Use the TypeDefinitionCache overload for better performance.'

After these changes, it appears we will improve the performance further of apps that use:

* `ApplicationAttribute.BackupAgent`
* `ApplicationAttribute.Name`
* `AndroidManifest.xml` attributes that take a `System.Type` values