### PR TITLE
Use .jar files from the .NET runtime pack

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1341,6 +1341,12 @@ because xbuild doesn't support framework reference assemblies.
   <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)" Condition=" !Exists ('$(MonoAndroidIntermediateAssemblyDir)') " />
 </Target>
 
+<Target Name="_CollectRuntimePackJarFiles" DependsOnTargets="ComputeResolvedFilesToPublishList">
+  <ItemGroup>
+    <AndroidJavaLibrary Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.jar' " />
+  </ItemGroup>
+</Target>
+
 <Target Name="_CollectRuntimeJarFilenames">
   <PropertyGroup>
     <_RuntimeJar Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(MSBuildThisFileDirectory)\java_runtime.jar</_RuntimeJar>
@@ -1861,6 +1867,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <PropertyGroup>
     <_CompileJavaDependsOnTargets>
+		_CollectRuntimePackJarFiles;
 		_AdjustJavacVersionArguments;
 		_GeneratePackageManagerJava;
 		_FindJavaStubFiles;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1341,7 +1341,7 @@ because xbuild doesn't support framework reference assemblies.
   <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)" Condition=" !Exists ('$(MonoAndroidIntermediateAssemblyDir)') " />
 </Target>
 
-<Target Name="_CollectRuntimePackJarFiles" DependsOnTargets="ComputeResolvedFilesToPublishList">
+<Target Name="_CollectRuntimePackJarFiles">
   <ItemGroup>
     <AndroidJavaLibrary Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.jar' " />
   </ItemGroup>


### PR DESCRIPTION
Since https://github.com/dotnet/runtime/pull/77386 has been merged, .NET will require a certain class from  `libSystem.Security.Cryptography.Native.Android.jar` that will be located in the runtime pack files.

I'm not sure if this is the best way to pull the .jar from the runtimepack so feedback is welcome.