### PR TITLE
[Mono.Android] Fix some incorrect enums.

### DIFF
--- a/src/Mono.Android/Android.Hardware.Camera2/CameraAccessException.cs
+++ b/src/Mono.Android/Android.Hardware.Camera2/CameraAccessException.cs
@@ -1,0 +1,15 @@
+using System;
+using Android.Runtime;
+
+#if ANDROID_23
+namespace Android.Hardware.Camera2 
+{
+    // This was converted to an enum in .NET 8
+    partial class CameraAccessException
+    {
+        [Obsolete ("This constant will be removed in the future version. Use Android.Hardware.Camera2.CameraAccessErrorType enum directly instead of this field.")]
+        [Register ("MAX_CAMERAS_IN_USE", ApiSince=23)]
+        public const int MaxCamerasInUse = 5;
+    }
+}
+#endif // ANDROID_23

--- a/src/Mono.Android/Android.Media/AudioManager.cs
+++ b/src/Mono.Android/Android.Media/AudioManager.cs
@@ -1,6 +1,6 @@
 using System;
-
 using Android.Content;
+using Android.Runtime;
 
 namespace Android.Media {
 
@@ -10,6 +10,13 @@ namespace Android.Media {
 		{
 			return context.GetSystemService (Context.AudioService!) as AudioManager;
 		}
+		
+#if ANDROID_26
+		// This was converted to an enum in .NET 8
+		[Obsolete ("This constant will be removed in the future version. Use Android.Media.Stream enum directly instead of this field.")]
+		[Register ("STREAM_ACCESSIBILITY", ApiSince=26)]
+		public const int StreamAccessibility = 10;
+#endif // ANDROID_26
 	}
 }
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Android.Graphics.Drawables\RotateDrawable.cs" />
     <Compile Include="Android.Graphics.Drawables\ScaleDrawable.cs" />
     <Compile Include="Android.Hardware\SensorManager.cs" />
+    <Compile Include="Android.Hardware.Camera2\CameraAccessException.cs" />
     <Compile Include="Android.Hardware.Camera2.Params\LensShadingMap.cs" />
     <Compile Include="Android.Hardware.Camera2.Params\RggbChannelVector.cs" />
     <Compile Include="Android.Hardware.Camera2.Params\TonemapCurve.cs" />

--- a/src/Mono.Android/map.csv
+++ b/src/Mono.Android/map.csv
@@ -739,7 +739,8 @@ E,21,android/app/usage/UsageStatsManager.INTERVAL_YEARLY,3,Android.App.Usage.Usa
 E,28,android/app/usage/UsageStatsManager.STANDBY_BUCKET_ACTIVE,10,Android.App.Usage.StandbyBucket,Active,remove,
 E,28,android/app/usage/UsageStatsManager.STANDBY_BUCKET_FREQUENT,30,Android.App.Usage.StandbyBucket,Frequent,remove,
 E,28,android/app/usage/UsageStatsManager.STANDBY_BUCKET_RARE,40,Android.App.Usage.StandbyBucket,Rare,remove,
-E,30,android/app/usage/UsageStatsManager.STANDBY_BUCKET_RESTRICTED,45,Android.App.Usage.UsageStatsInterval,Restricted,remove,
+E,30,android/app/usage/UsageStatsManager.STANDBY_BUCKET_RESTRICTED,45,Android.App.Usage.UsageStatsInterval,Restricted,remove,,-1
+A,30,,45,Android.App.Usage.StandbyBucket,Restricted,remove,,
 E,28,android/app/usage/UsageStatsManager.STANDBY_BUCKET_WORKING_SET,20,Android.App.Usage.StandbyBucket,WorkingSet,remove,
 E,31,android/app/WallpaperColors.HINT_SUPPORTS_DARK_TEXT,1,Android.App.WallpaperColorsHint,SupportsDarkText,remove,flags
 E,31,android/app/WallpaperColors.HINT_SUPPORTS_DARK_THEME,2,Android.App.WallpaperColorsHint,SupportsDarkTheme,remove,flags
@@ -1885,7 +1886,7 @@ E,10,android/database/sqlite/SQLiteDatabase.CONFLICT_NONE,0,Android.Database.Sql
 E,10,android/database/sqlite/SQLiteDatabase.CONFLICT_REPLACE,5,Android.Database.Sqlite.Conflict,Replace,remove,
 E,10,android/database/sqlite/SQLiteDatabase.CONFLICT_ROLLBACK,1,Android.Database.Sqlite.Conflict,Rollback,remove,
 E,10,android/database/sqlite/SQLiteDatabase.CREATE_IF_NECESSARY,268435456,Android.Database.Sqlite.DatabaseOpenFlags,CreateIfNecessary,keep,flags
-I,16,android/database/sqlite/SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,536870912,,,,
+E,16,android/database/sqlite/SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,536870912,Android.Database.Sqlite.DatabaseOpenFlags,EnableWriteAheadLogging,keep,flags
 I,15,android/database/sqlite/SQLiteDatabase.MAX_SQL_CACHE_SIZE,100,,,,
 E,10,android/database/sqlite/SQLiteDatabase.NO_LOCALIZED_COLLATORS,16,Android.Database.Sqlite.DatabaseOpenFlags,NoLocalizedCollators,keep,flags
 E,10,android/database/sqlite/SQLiteDatabase.OPEN_READONLY,1,Android.Database.Sqlite.DatabaseOpenFlags,OpenReadonly,keep,flags
@@ -2166,7 +2167,7 @@ E,21,android/hardware/camera2/CameraAccessException.CAMERA_DISABLED,1,Android.Ha
 E,21,android/hardware/camera2/CameraAccessException.CAMERA_DISCONNECTED,2,Android.Hardware.Camera2.CameraAccessErrorType,Disconnected,keep,
 E,21,android/hardware/camera2/CameraAccessException.CAMERA_ERROR,3,Android.Hardware.Camera2.CameraAccessErrorType,Error,keep,
 E,23,android/hardware/camera2/CameraAccessException.CAMERA_IN_USE,4,Android.Hardware.Camera2.CameraAccessErrorType,InUse,keep,
-I,23,android/hardware/camera2/CameraAccessException.MAX_CAMERAS_IN_USE,5,,,,
+E,23,android/hardware/camera2/CameraAccessException.MAX_CAMERAS_IN_USE,5,Android.Hardware.Camera2.CameraAccessErrorType,MaxCamerasInUse,keep,
 E,30,android/hardware/camera2/CameraDevice.AUDIO_RESTRICTION_NONE,0,Android.Hardware.Camera2.CameraDeviceAudioRestrictionType,None,remove,
 E,30,android/hardware/camera2/CameraDevice.AUDIO_RESTRICTION_VIBRATION,1,Android.Hardware.Camera2.CameraDeviceAudioRestrictionType,Vibration,remove,
 E,30,android/hardware/camera2/CameraDevice.AUDIO_RESTRICTION_VIBRATION_SOUND,3,Android.Hardware.Camera2.CameraDeviceAudioRestrictionType,VibrationSound,remove,
@@ -3696,9 +3697,12 @@ E,24,android/location/GnssNavigationMessage.TYPE_GPS_CNAV2,260,Android.Locations
 E,24,android/location/GnssNavigationMessage.TYPE_GPS_L1CA,257,Android.Locations.GnssNavigationType,GpsL1ca,remove,
 E,24,android/location/GnssNavigationMessage.TYPE_GPS_L2CNAV,258,Android.Locations.GnssNavigationType,GpsL2cnav,remove,
 E,24,android/location/GnssNavigationMessage.TYPE_GPS_L5CNAV,259,Android.Locations.GnssNavigationType,GpsL5cnav,remove,
-E,30,android/location/GnssNavigationMessage.TYPE_IRN_L5CA,1793,Android.Locations.GnssNavigationStatus,IrnL5ca,remove,
-E,30,android/location/GnssNavigationMessage.TYPE_QZS_L1CA,1025,Android.Locations.GnssNavigationStatus,QzsL1ca,remove,
-E,30,android/location/GnssNavigationMessage.TYPE_SBS,513,Android.Locations.GnssNavigationStatus,Sbs,remove,
+A,30,,1793,Android.Locations.GnssNavigationType,IrnL5ca,remove,,
+A,30,,1025,Android.Locations.GnssNavigationType,QzsL1ca,remove,,
+A,30,,513,Android.Locations.GnssNavigationType,Sbs,remove,,
+E,30,android/location/GnssNavigationMessage.TYPE_IRN_L5CA,1793,Android.Locations.GnssNavigationStatus,IrnL5ca,remove,,-1
+E,30,android/location/GnssNavigationMessage.TYPE_QZS_L1CA,1025,Android.Locations.GnssNavigationStatus,QzsL1ca,remove,,-1
+E,30,android/location/GnssNavigationMessage.TYPE_SBS,513,Android.Locations.GnssNavigationStatus,Sbs,remove,,-1
 E,24,android/location/GnssNavigationMessage.TYPE_UNKNOWN,0,Android.Locations.GnssNavigationType,Unknown,remove,
 E,24,android/location/GnssNavigationMessage$Callback.STATUS_LOCATION_DISABLED,2,Android.Locations.GnssNavigationCallbackStatus,LocationDisabled,remove,
 E,24,android/location/GnssNavigationMessage$Callback.STATUS_NOT_SUPPORTED,0,Android.Locations.GnssNavigationCallbackStatus,NotSupported,remove,
@@ -4019,7 +4023,7 @@ E,10,android/media/AudioManager.SCO_AUDIO_STATE_CONNECTED,1,Android.Media.ScoAud
 E,15,android/media/AudioManager.SCO_AUDIO_STATE_CONNECTING,2,Android.Media.ScoAudioState,Connecting,remove,
 E,10,android/media/AudioManager.SCO_AUDIO_STATE_DISCONNECTED,0,Android.Media.ScoAudioState,Disconnected,remove,
 E,10,android/media/AudioManager.SCO_AUDIO_STATE_ERROR,-1,Android.Media.ScoAudioState,Error,remove,
-I,26,android/media/AudioManager.STREAM_ACCESSIBILITY,10,,,,
+E,26,android/media/AudioManager.STREAM_ACCESSIBILITY,10,Android.Media.Stream,Accessibility,keep,
 E,1,android/media/AudioManager.STREAM_ALARM,4,Android.Media.Stream,Alarm,keep,
 E,5,android/media/AudioManager.STREAM_DTMF,8,Android.Media.Stream,Dtmf,keep,
 E,1,android/media/AudioManager.STREAM_MUSIC,3,Android.Media.Stream,Music,keep,


### PR DESCRIPTION
Using Android's API-33 `annotations.zip`, some missing and incorrect enum mappings were found.

### Missed Enumeration

Enums that were previously left as constants have been enumified and have had the old members added back to the API with manual additions code marked with `[Obsolete]`.

```csv
I,23,android/hardware/camera2/CameraAccessException.MAX_CAMERAS_IN_USE,5,,,,
```
to
```csharp
E,23,android/hardware/camera2/CameraAccessException.MAX_CAMERAS_IN_USE,5,Android.Hardware.Camera2.CameraAccessErrorType,MaxCameraInUse,keep,

[Obsolete ("This constant will be removed in the future version. Use Android.Hardware.Camera2.CameraAccessErrorType enum directly instead of this field.")]
[Register ("MAX_CAMERAS_IN_USE", ApiSince=23)]
public const int MaxCamerasInUse = 5;
```

### Incorrect Enumeration

Other constants were assigned to the wrong enumeration.  These have been marked as `[Obsolete]` and new values have been added to the correct enumeration.

Example:
```csv
E,30,android/app/usage/UsageStatsManager.STANDBY_BUCKET_RESTRICTED,45,Android.App.Usage.UsageStatsInterval,Restricted,remove,
```
to:
```csv
E,30,android/app/usage/UsageStatsManager.STANDBY_BUCKET_RESTRICTED,45,Android.App.Usage.UsageStatsInterval,Restricted,remove,,-1
A,30,,45,Android.App.Usage.StandbyBucket,Restricted,remove,,
```