### PR TITLE
[Xamarin.Android.Build.Tasks] skip MSBuild targets when project file changes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -90,7 +90,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_ConvertResourcesCases"
-    Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource);@(_LibraryResourceDirectories->'%(StampFile)')"
+    Inputs="$(_AndroidBuildPropertiesCache);@(AndroidResource);@(_LibraryResourceDirectories->'%(StampFile)')"
     Outputs="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
     DependsOnTargets="_CollectLibraryResourceDirectories;$(_BeforeConvertResourcesCases)"
   >

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -90,7 +90,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_ConvertResourcesCases"
-    Inputs="$(_AndroidBuildPropertiesCache);@(AndroidResource);@(_LibraryResourceDirectories->'%(StampFile)')"
+    Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource);@(_LibraryResourceDirectories->'%(StampFile)')"
     Outputs="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
     DependsOnTargets="_CollectLibraryResourceDirectories;$(_BeforeConvertResourcesCases)"
   >

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -85,7 +85,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
   <Target Name="_CompileBindingJava"
       Condition=" '@(_JavaBindingSource->Count())' != '0' "
       DependsOnTargets="$(_CompileBindingJavaDependsOnTargets)"
-      Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaBindingSource)"
+      Inputs="$(_AndroidBuildPropertiesCache);@(_JavaBindingSource);@(_BindingJavaLibrariesToCompile);@(_ReferenceJavaLibs)"
       Outputs="$(_AndroidCompileBindingJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
@@ -132,7 +132,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
 
   <Target Name="_CompileJava"
     DependsOnTargets="$(_CompileJavaDependsOnTargets);_CollectJavaSource"
-    Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(_JavaSource)"
+    Inputs="$(_AndroidBuildPropertiesCache);@(_JavaStubFiles);@(_JavaSource);@(_JavaLibrariesToCompile);@(_InstantRunJavaReference);@(_ReferenceJavaLibs)"
     Outputs="$(_AndroidCompileJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -22,6 +22,8 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <_AndroidIntermediateBindingClassesDocs>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName)-docs.xml</_AndroidIntermediateBindingClassesDocs>
     <_AndroidCompileJavaStampFile>$(_AndroidStampDirectory)_CompileJava.stamp</_AndroidCompileJavaStampFile>
     <_AndroidCompileBindingJavaStampFile>$(_AndroidStampDirectory)_CompileBindingJava.stamp</_AndroidCompileBindingJavaStampFile>
+    <_JavaSourceHashFile>$(IntermediateOutputPath)javasource.hash</_JavaSourceHashFile>
+    <_JavaBindingSourceHashFile>$(IntermediateOutputPath)javabindingsource.hash</_JavaBindingSourceHashFile>
   </PropertyGroup>
 
   <Target Name="_AdjustJavacVersionArguments">
@@ -74,18 +76,42 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <ItemGroup>
       <_JavaBindingSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' == 'True' " />
     </ItemGroup>
+    <Hash ItemsToHash="@(_JavaBindingSource)">
+      <Output TaskParameter="HashResult" PropertyName="_JavaBindingSourceHash" />
+    </Hash>
+    <WriteLinesToFile
+        File="$(_JavaBindingSourceHashFile)"
+        Lines="$(_JavaBindingSourceHash)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_JavaBindingSourceHashFile)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CollectJavaSource">
     <ItemGroup>
       <_JavaSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' != 'True' " />
     </ItemGroup>
+    <Hash ItemsToHash="@(_JavaSource)">
+      <Output TaskParameter="HashResult" PropertyName="_JavaSourceHash" />
+    </Hash>
+    <WriteLinesToFile
+        File="$(_JavaSourceHashFile)"
+        Lines="$(_JavaSourceHash)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_JavaSourceHashFile)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CompileBindingJava"
       Condition=" '@(_JavaBindingSource->Count())' != '0' "
       DependsOnTargets="$(_CompileBindingJavaDependsOnTargets)"
-      Inputs="$(_AndroidBuildPropertiesCache);@(_JavaBindingSource);@(_BindingJavaLibrariesToCompile);@(_ReferenceJavaLibs)"
+      Inputs="$(_AndroidBuildPropertiesCache);$(_JavaBindingSourceHashFile);@(_JavaBindingSource);@(_BindingJavaLibrariesToCompile);@(_ReferenceJavaLibs)"
       Outputs="$(_AndroidCompileBindingJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
@@ -132,7 +158,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
 
   <Target Name="_CompileJava"
     DependsOnTargets="$(_CompileJavaDependsOnTargets);_CollectJavaSource"
-    Inputs="$(_AndroidBuildPropertiesCache);@(_JavaStubFiles);@(_JavaSource);@(_JavaLibrariesToCompile);@(_InstantRunJavaReference);@(_ReferenceJavaLibs)"
+    Inputs="$(_AndroidBuildPropertiesCache);$(_JavaSourceHashFile);@(_JavaStubFiles);@(_JavaSource);@(_JavaLibrariesToCompile);@(_InstantRunJavaReference);@(_ReferenceJavaLibs)"
     Outputs="$(_AndroidCompileJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -706,7 +706,6 @@ namespace Lib2
 			var targets = new [] {
 				"_CompileJava",
 				"_CompileToDalvik",
-				"_GeneratePackageManagerJava",
 				"_ManifestMerger",
 			};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -706,9 +706,6 @@ namespace Lib2
 			var targets = new [] {
 				"_CompileJava",
 				"_CompileToDalvik",
-				"_ConvertResourcesCases",
-				"_GenerateAndroidAssetsDir",
-				"_GenerateAndroidResourceDir",
 				"_GeneratePackageManagerJava",
 				"_ManifestMerger",
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -531,8 +531,8 @@ namespace Lib2
 				Assert.IsTrue (b.Build (proj), "first build should succeed");
 				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");
 
-				// Change .csproj & build again
-				proj.SetProperty ("Foo", "Bar");
+				// Change $(AndroidManifestMerger) & build again
+				proj.ManifestMerger = "legacy";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should succeed");
 				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -994,9 +994,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 		<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 		<_PropertyCacheItems Include="AndroidGenerateJniMarshalMethods=$(AndroidGenerateJniMarshalMethods)" />
-		<_PropertyCacheItems Include="AndroidEnableMarshalMethods=$(AndroidEnableMarshalMethods)" />
-		<_PropertyCacheItems Include="AndroidUseAssemblyStore=$(AndroidUseAssemblyStore)" />
-		<_PropertyCacheItems Include="AndroidEnableAssemblyCompression=$(AndroidEnableAssemblyCompression)" />
 		<_PropertyCacheItems Include="AndroidManifestMerger=$(AndroidManifestMerger)" />
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
@@ -1763,7 +1760,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
-  Inputs="$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+  Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -914,7 +914,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateAndroidAssetsDir"
-	Inputs="@(_AndroidResolvedAssets);$(_AndroidBuildPropertiesCache)"
+	Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
 	Outputs="@(_AndroidAssetsDest)">
 	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate)" />
 	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
@@ -1030,6 +1030,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_BeforeManagedUpdateAndroidResgen">
   <PropertyGroup>
     <_ManagedUpdateAndroidResgenInputs>
+      @(_AndroidMSBuildAllProjects);
       @(AndroidResource);
       @(AndroidBoundLayout);
       @(_MonoAndroidReferencePath);
@@ -1114,7 +1115,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
+	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
 	Outputs="$(_AndroidResFlagFile)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CheckForInvalidResourceFileNames

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -914,7 +914,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateAndroidAssetsDir"
-	Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
+	Inputs="@(_AndroidResolvedAssets);$(_AndroidBuildPropertiesCache)"
 	Outputs="@(_AndroidAssetsDest)">
 	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate)" />
 	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
@@ -994,6 +994,10 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 		<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 		<_PropertyCacheItems Include="AndroidGenerateJniMarshalMethods=$(AndroidGenerateJniMarshalMethods)" />
+		<_PropertyCacheItems Include="AndroidEnableMarshalMethods=$(AndroidEnableMarshalMethods)" />
+		<_PropertyCacheItems Include="AndroidUseAssemblyStore=$(AndroidUseAssemblyStore)" />
+		<_PropertyCacheItems Include="AndroidEnableAssemblyCompression=$(AndroidEnableAssemblyCompression)" />
+		<_PropertyCacheItems Include="AndroidManifestMerger=$(AndroidManifestMerger)" />
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
@@ -1026,7 +1030,6 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_BeforeManagedUpdateAndroidResgen">
   <PropertyGroup>
     <_ManagedUpdateAndroidResgenInputs>
-      @(_AndroidMSBuildAllProjects);
       @(AndroidResource);
       @(AndroidBoundLayout);
       @(_MonoAndroidReferencePath);
@@ -1111,7 +1114,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="$(MSBuildProjectFullPath);@(_AndroidMSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
+	Inputs="@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
 	Outputs="$(_AndroidResFlagFile)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CheckForInvalidResourceFileNames
@@ -1525,7 +1528,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
     DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-    Inputs="@(_AndroidMSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+    Inputs="@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
     Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
   <PropertyGroup>
@@ -1591,7 +1594,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_ManifestMerger"
     Condition=" '$(AndroidManifestMerger)' == 'manifestmerger.jar' "
-    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
+    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);$(_AndroidBuildPropertiesCache)"
     Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml"
   >
   <ItemGroup>
@@ -1759,7 +1762,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
-  Inputs="@(_AndroidMSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+  Inputs="$(_ResolvedUserAssembliesHashFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
@@ -1813,7 +1816,6 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <_CreateBaseApkInputs>
       $(_CreateBaseApkInputs);
-      @(_AndroidMSBuildAllProjects);
       $(IntermediateOutputPath)android\AndroidManifest.xml;
       @(_ModifiedResources);
       @(_AndroidAssetsDest);
@@ -1934,8 +1936,7 @@ because xbuild doesn't support framework reference assemblies.
 		_CalculateProguardConfigurationFiles;
 	</_CompileToDalvikDependsOnTargets>
 	<_CompileToDalvikInputs>
-		@(_AndroidMSBuildAllProjects)
-		;@(_JavaLibrariesToCompileForApp)
+		@(_JavaLibrariesToCompileForApp)
 		;@(AndroidExternalJavaLibrary)
 		;$(_AndroidIntermediateClassesZip)
 		;@(ProguardConfiguration)
@@ -2114,8 +2115,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <PropertyGroup>
 	<_BuildApkEmbedInputs>
-		@(_AndroidMSBuildAllProjects)
-		;$(_PackagedResources)
+		$(_PackagedResources)
 		;@(_ShrunkAssemblies)
 		;@(AndroidNativeLibrary)
 		;@(_DexFile)
@@ -2371,7 +2371,6 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_PrepareForSign">
   <PropertyGroup Condition=" '$(AndroidPackageFormat)' == 'aab' ">
     <_SignInputs>
-      @(_AndroidMSBuildAllProjects);
       $(_AndroidBuildPropertiesCache);
       $(_AppBundleIntermediate);
     </_SignInputs>
@@ -2381,7 +2380,6 @@ because xbuild doesn't support framework reference assemblies.
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AndroidPackageFormat)' != 'aab' ">
     <_SignInputs>
-      @(_AndroidMSBuildAllProjects);
       $(_AndroidBuildPropertiesCache);
       $(ApkFileIntermediate);
     </_SignInputs>


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/7808

There is currently a bug in VS where adding new MAUI pages edits the `.csproj` file:

    <ItemGroup>
      <MauiXaml Update="NewPage1.xaml">
        <Generator>MSBuild:Compile</Generator>
      </MauiXaml>
    </ItemGroup>

Unfortunately, this triggers many of the Android MSBuild targets to run again -- when they really don't need to.

Various targets have different forms of:

    Inputs="@(_AndroidMSBuildAllProjects)"
    Inputs="$(MSBuildProjectFullPath)"

Understandably, this reduces the chance of bin/obj bugs such as:

1. I build my project.

2. I change some setting my my project file.

3. I expect the MSBuild targets interested in this setting to rebuild.

So I don't think we can blindly delete all instances of `@(_AndroidMSBuildAllProjects)`, but try a few at a time. We can replace this value with `$(_AndroidBuildPropertiesCache)` (which is `build.props`) making sure important properties are stored in this file.

Interestingly, even `CoreCompile` reruns if the project file changes:

    Building target "CoreCompile" completely.
    Input file "UnnamedProject.csproj" is newer than output file "obj\Debug\UnnamedProject.pdb".

Meaning that any of our targets that depend on the current project's build output is going to run anyway. But we can focus on slow parts of the build like `javac` and `d8`/`r8`.

So far, I updated the following targets:

* `_ConvertResourcesCases`
  * Not related to project file at all?
* `_CompileBindingJava` and `_CompileJava`
  * Runs when `.java` source file change, adjusted some `Inputs`
* `_GenerateAndroidAssetsDir` and `_GenerateAndroidResourceDir`
  * Not related to project file at all?
* `_BeforeManagedUpdateAndroidResgen`
  * Runs when `@(AndroidResource)` files change
* `_GenerateJavaStubs`
  * actually runs when .NET assemblies change anyway
* `_ManifestMerger`
  * `$(AndroidManifestMerger)` added to `build.props`
* `_GeneratePackageManagerJava`
  * `$(AndroidEnableMarshalMethods)`, `$(AndroidUseAssemblyStore)`, and `$(AndroidEnableAssemblyCompression)` added to `build.props`.
* `_CompileToDalvik`
  * runs when `.jar` files change
* `_BuildApkEmbed`
  * runs when .NET assemblies change
* `_PrepareForSign`
  * without Fast Dev, runs when .NET assemblies change
  * runs when `.apk`/`.aab` files change

There are still more MSBuild targets that use `@(_AndroidMSBuildAllProjects)`, but this is a start.

I added a new test for this scenario.