### PR TITLE
MAUI project with non-ASCII project name cannot release to my Android phone

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -31,6 +31,7 @@ ms.date: 01/24/2020
 + APT0003: Invalid file name: It must contain only \[^a-zA-Z0-9_.\]+.
 + APT0004: Invalid file name: It must start with either A-Z or a-z or an underscore.
 + [APT2264](apt2264.md): The system cannot find the file specified. (2).
++ [APT2265](apt2265.md): The system cannot find the file specified. (2).
 
 ## JAVAxxxx: Java Tool
 

--- a/Documentation/guides/messages/apt2264.md
+++ b/Documentation/guides/messages/apt2264.md
@@ -9,29 +9,26 @@ ms.date: 12/16/2022
 
 The tool `aapt2` is unable to resolve one of the files it was passed.
 This is generally caused by the path being longer than the Maximum Path
-length allowed on windows. Alternately it might be due to non-ASCII
-characters in the project name or the path to the project.
+length allowed on windows.
 
 ## Solution
 
 The best way to avoid this is to ensure that your project is not located
-deep in the folder structure and does not contain non-ASCII characters.
+deep in the folder structure.
 For example if you create all of your projects in folders such as
 
-`C:\Users\shëlly\Visual Studio\Android\MyProjects\Com.SomeReallyLongCompanyName.MyBrillantApplication\MyBrilliantApplicaiton.Android\`
+`C:\Users\shelly\Visual Studio 2022\Android\MyProjects\Com.SomeReallyLongCompanyName.MyBrillantApplication\MyBrilliantApplicaiton.Android\`
 
 you may well encounter problems with not only `aapt2` but also Ahead of Time
-compilation. Keeping your project names and folder structures short, concise and
-ASCII will help work around these issues. For example instead of the above
-you could use
+compilation. Keeping your project names and folder structures short, concise
+will help work around these issues. For example instead of the above you could use
 
 `C:\Work\Android\MyBrilliantApp`
 
 Which is much shorter and much less likely to encounter path issues.
 
 However this is not always possible. Sometimes a project or a environment requires
-deep folder structures. For non-ASCII paths there is no work around.
-In the long path case, enabling long path support in Windows *might*
+deep folder structures. Enabling long path support in Windows *might*
 be enough to get your project working. Details on how to do this can be found
 [here](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later).
 

--- a/Documentation/guides/messages/apt2264.md
+++ b/Documentation/guides/messages/apt2264.md
@@ -9,27 +9,29 @@ ms.date: 12/16/2022
 
 The tool `aapt2` is unable to resolve one of the files it was passed.
 This is generally caused by the path being longer than the Maximum Path
-length allowed on windows.
+length allowed on windows. Alternately it might be due to non-ASCII
+characters in the project name or the path to the project.
 
 ## Solution
 
 The best way to avoid this is to ensure that your project is not located
-deep in the folder structure. For example if you create all of your
-projects in folders such as
+deep in the folder structure and does not contain non-ASCII characters.
+For example if you create all of your projects in folders such as
 
-`C:\Users\shelly\Visual Studio\Android\MyProjects\Com.SomeReallyLongCompanyName.MyBrillantApplication\MyBrilliantApplicaiton.Android\`
+`C:\Users\shëlly\Visual Studio\Android\MyProjects\Com.SomeReallyLongCompanyName.MyBrillantApplication\MyBrilliantApplicaiton.Android\`
 
 you may well encounter problems with not only `aapt2` but also Ahead of Time
-compilation. Keeping your project names and folder structures short and
-concise will help work around these issues. For example instead of the above
+compilation. Keeping your project names and folder structures short, concise and
+ASCII will help work around these issues. For example instead of the above
 you could use
 
 `C:\Work\Android\MyBrilliantApp`
 
 Which is much shorter and much less likely to encounter path issues.
 
-However this is no always possible. Sometimes a project or a environment requires
-deep folder structures. In this case enabling long path support in Windows *might*
+However this is not always possible. Sometimes a project or a environment requires
+deep folder structures. For non-ASCII paths there is no work around.
+In the long path case, enabling long path support in Windows *might*
 be enough to get your project working. Details on how to do this can be found
 [here](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later).
 

--- a/Documentation/guides/messages/apt2265.md
+++ b/Documentation/guides/messages/apt2265.md
@@ -1,0 +1,29 @@
+---
+title: Xamarin.Android error APT2265
+description: APT2265 error code
+ms.date: 12/16/2022
+---
+# Xamarin.Android error APT2265
+
+## Issue
+
+The tool `aapt2` is unable to resolve one of the files it was passed.
+This is generally caused by non-ASCII characters in the project name
+or the path to the project.
+
+## Solution
+
+The best way to avoid this is to ensure that your project does not contain
+non-ASCII characters.
+For example if you create all of your projects in folders such as
+
+`C:\Users\shëlly\Visual Studio 2022\Android\MyProjects\Com.SomeReallyLongCompanyName.MyBrillantApplication\MyBrilliantApplicaiton.Android\`
+
+you may well encounter problems with not only `aapt2` but also Ahead of Time
+compilation. Keeping your project names and folder structures short, concise and
+ASCII will help work around these issues. For example instead of the above
+you could use
+
+`C:\Work\Android\MyBrilliantApp`
+
+Which is much shorter, contains no non-ASCII characters and much less likely to encounter issues.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -819,6 +819,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to This could be caused by the project having non-ASCII characters in it path.
+        /// </summary>
+        public static string APT2265 {
+            get {
+                return ResourceManager.GetString("APT2265", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Could not AOT the assembly: {0}.
         /// </summary>
         public static string XA3001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -542,7 +542,11 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 {0} - The assembly name</comment>
   </data>
   <data name="APT2264" xml:space="preserve">
-    <value>This could be caused by the project having non-ASCII characters in it path or exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2264 for details.</value>
+    <value>This could be caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2264 for details.</value>
+    <comment>The following are literal names and should not be translated:</comment>
+  </data>
+  <data name="APT2265" xml:space="preserve">
+    <value>This could be caused by the project having non-ASCII characters in its filename or path. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2265 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="XA3001" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -542,7 +542,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 {0} - The assembly name</comment>
   </data>
   <data name="APT2264" xml:space="preserve">
-    <value>This is probably caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2264 for details.</value>
+    <value>This could be caused by the project having non-ASCII characters in it path or exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2264 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="XA3001" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -138,22 +138,8 @@ namespace Xamarin.Android.Tasks {
 					LogCodedError ("APT0001", Properties.Resources.APT0001, message.Substring ("unknown option '".Length).TrimEnd ('.', '\''));
 					return false;
 				}
-				if (message.Contains ("in APK") && message.Contains ("is compressed.")) {
-					LogMessage (singleLine, messageImportance);
+				if (LogNotesOrWarnings (message, singleLine, messageImportance))
 					return true;
-				}
-				if (message.Contains ("fakeLogOpen")) {
-					LogMessage (singleLine, messageImportance);
-					return true;
-				}
-				if (message.Contains ("note:")) {
-					LogMessage (singleLine, messageImportance);
-					return true;
-				}
-				if (message.Contains ("warn:")) {
-					LogCodedWarning (GetErrorCode (singleLine), singleLine);
-					return true;
-				}
 				if (level.Contains ("note")) {
 					LogMessage (message, messageImportance);
 					return true;
@@ -199,12 +185,35 @@ namespace Xamarin.Android.Tasks {
 
 			if (!apptResult) {
 				var message = string.Format ("{0} \"{1}\".", singleLine.Trim (), singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1));
+				if (LogNotesOrWarnings (message, singleLine, messageImportance))
+					return true;
 				var errorCode = GetErrorCode (message);
 				LogCodedError (errorCode, AddAdditionalErrorText (errorCode, message), ToolName);
 			} else {
 				LogCodedWarning (GetErrorCode (singleLine), singleLine);
 			}
 			return true;
+		}
+
+		bool LogNotesOrWarnings (string message, string singleLine, MessageImportance messageImportance)
+		{
+			if (message.Contains ("in APK") && message.Contains ("is compressed.")) {
+				LogMessage (singleLine, messageImportance);
+				return true;
+			}
+			if (message.Contains ("fakeLogOpen")) {
+				LogMessage (singleLine, messageImportance);
+				return true;
+			}
+			if (message.Contains ("note:")) {
+				LogMessage (singleLine, messageImportance);
+				return true;
+			}
+			if (message.Contains ("warn:")) {
+				LogCodedWarning (GetErrorCode (singleLine), singleLine);
+				return true;
+			}
+			return false;
 		}
 
 		static string AddAdditionalErrorText (string errorCode, string message)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.Tasks {
 	public abstract class Aapt2 : AndroidAsyncTask {
 
 		private const int MAX_PATH = 260;
+		private const int ASCII_MAX_CHAR = 127;
 		private static readonly int DefaultMaxAapt2Daemons = 6;
 		protected Dictionary<string, string> _resource_name_case_map;
 
@@ -235,7 +236,7 @@ namespace Xamarin.Android.Tasks {
 				return true;
 
 			foreach (var c in filePath)
-				if (c > 128) // cannot use Char.IsAscii cos we are .netstandard2.0
+				if (c > ASCII_MAX_CHAR) // cannot use Char.IsAscii cos we are .netstandard2.0
 					return false;
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -216,9 +216,6 @@ namespace Xamarin.Android.Tasks {
 				LogCodedWarning (GetErrorCode (singleLine), singleLine);
 				return true;
 			}
-			else {
-				LogMessage (singleLine, messageImportance);
-			}
 			return false;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -136,6 +136,9 @@ namespace Xamarin.Android.Build.Tests
 			using (var builder = CreateApkBuilder (Path.Combine (rootPath, proj.ProjectName))){
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, builder.Build (proj), "Build should have succeeded.");
+				if (!expectedResult) {
+					StringAssert.Contains ("APT2265", builder.LastBuildOutput, "Error APT2265 should be raised.");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -137,7 +137,9 @@ namespace Xamarin.Android.Build.Tests
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, builder.Build (proj), "Build should have succeeded.");
 				if (!expectedResult) {
-					StringAssertEx.Contains ("APT2265", builder.LastBuildOutput, "Error APT2265 should be raised.");
+					var aotFailed = builder.LastBuildOutput.Contains ("Precompiling failed");
+					var aapt2Failed = builder.LastBuildOutput.Contains ("APT2265");
+					Assert.IsTrue (aotFailed | aapt2Failed, "Error APT2265 or an AOT error should have been raised.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -137,9 +137,9 @@ namespace Xamarin.Android.Build.Tests
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, builder.Build (proj), "Build should have succeeded.");
 				if (!expectedResult) {
-					var aotFailed = builder.LastBuildOutput.Contains ("Precompiling failed");
-					var aapt2Failed = builder.LastBuildOutput.Contains ("APT2265");
-					Assert.IsTrue (aotFailed | aapt2Failed, "Error APT2265 or an AOT error should have been raised.");
+					var aotFailed = builder.LastBuildOutput.ContainsText ("Precompiling failed");
+					var aapt2Failed = builder.LastBuildOutput.ContainsText ("APT2265");
+					Assert.IsTrue (aotFailed || aapt2Failed, "Error APT2265 or an AOT error should have been raised.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, builder.Build (proj), "Build should have succeeded.");
 				if (!expectedResult) {
-					StringAssert.Contains ("APT2265", builder.LastBuildOutput, "Error APT2265 should be raised.");
+					StringAssertEx.Contains ("APT2265", builder.LastBuildOutput, "Error APT2265 should be raised.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -112,6 +112,33 @@ namespace Xamarin.Android.Build.Tests
 			StringAssertEx.DoesNotContainRegex (@$"Using profile data file.*{filename}\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile", RegexOptions.IgnoreCase);
 		}
 
+		[Test]
+		[TestCase ("テスト", false, false, true)]
+		[TestCase ("テスト", true, true, false)]
+		[TestCase ("テスト", true, false, true)]
+		[TestCase ("随机生成器", false, false, true)]
+		[TestCase ("随机生成器", true, true, false)]
+		[TestCase ("随机生成器", true, false, true)]
+		[TestCase ("中国", false, false, true)]
+		[TestCase ("中国", true, true, false)]
+		[TestCase ("中国", true, false, true)]
+		public void BuildAotApplicationWithSpecialCharactersInProject (string testName, bool isRelease, bool aot, bool expectedResult)
+		{
+			if (!IsWindows)
+				expectedResult = true;
+			var rootPath = Path.Combine (Root, "temp", TestName);
+			var proj = new XamarinAndroidApplicationProject () {
+				ProjectName = testName,
+				IsRelease = isRelease,
+				AotAssemblies = aot,
+			};
+			proj.SetAndroidSupportedAbis ("armeabi-v7a",  "arm64-v8a", "x86", "x86_64");
+			using (var builder = CreateApkBuilder (Path.Combine (rootPath, proj.ProjectName))){
+				builder.ThrowOnBuildFailure = false;
+				Assert.AreEqual (expectedResult, builder.Build (proj), "Build should have succeeded.");
+			}
+		}
+
 		static object [] AotChecks () => new object [] {
 			new object[] {
 				/* supportedAbis */   "arm64-v8a",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -26,6 +26,11 @@ namespace Xamarin.Android.Build.Tests
 		protected static bool IsDeviceAttached (bool refreshCachedValue = false)
 		{
 			if (string.IsNullOrEmpty (_shellEchoOutput) || refreshCachedValue) {
+				// run this twice as sometimes the first time returns the
+				// device as "offline".
+				RunAdbCommand ("devices");
+				var devices = RunAdbCommand ("devices");
+				TestContext.Out.WriteLine ($"LOG adb devices: {devices}");
 				_shellEchoOutput = RunAdbCommand ("shell echo OK", timeout: 15);
 			}
 			return _shellEchoOutput.Contains ("OK");
@@ -58,11 +63,14 @@ namespace Xamarin.Android.Build.Tests
 							DeviceAbi = RunAdbCommand ("shell getprop ro.product.cpu.abilist64").Trim ();
 
 						if (string.IsNullOrEmpty (DeviceAbi))
-							DeviceAbi = RunAdbCommand ("shell getprop ro.product.cpu.abi") ?? RunAdbCommand ("shell getprop ro.product.cpu.abi2");
+							DeviceAbi = (RunAdbCommand ("shell getprop ro.product.cpu.abi") ?? RunAdbCommand ("shell getprop ro.product.cpu.abi2")) ?? "x86_64";
 
 						if (DeviceAbi.Contains (",")) {
 							DeviceAbi = DeviceAbi.Split (',')[0];
 						}
+					} else {
+						TestContext.Out.WriteLine ($"LOG GetSdkVersion: {DeviceSdkVersion}");
+						DeviceAbi = "x86_64";
 					}
 				} catch (Exception ex) {
 					Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not: " + ex);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -167,10 +167,11 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 
 		[Test]
 		[Category ("UsesDevice")]
-		public void SmokeTestBuildAndRunWithSpecialCharacters ()
+		[TestCase ("テスト")]
+		[TestCase ("随机生成器")]
+		[TestCase ("中国")]
+		public void SmokeTestBuildAndRunWithSpecialCharacters (string testName)
 		{
-			var testName = "テスト";
-
 			var rootPath = Path.Combine (Root, "temp", TestName);
 			var proj = new XamarinFormsAndroidApplicationProject () {
 				ProjectName = testName,


### PR DESCRIPTION
Context https://i.azdo.io/1714603
Context https://issuetracker.google.com/issues/188679588

There is a known issue with `aapt2`, `AndroidAsset` and non-ASCII paths/project names. 
`aapt2` has a bug where it cannot correctly traverse a directory which contains non-ASCII 
characters. We curently have no way to work around this issue. 

So the PR adds some more detail to the specific error message which `aapt2` raises in 
these cases. It suggests the user check their paths to make sure it does not contain 
non-ASCII characters. 

We also add some unit tests to cover this senario. 