### PR TITLE
[Mono.Android] Fix Android.Telecom.InCallService.SetAudioRoute enumification.

### DIFF
--- a/src/Mono.Android/Android.Telecom/InCallService.cs
+++ b/src/Mono.Android/Android.Telecom/InCallService.cs
@@ -1,0 +1,19 @@
+using System;
+using Android.Content;
+
+namespace Android.Telecom
+{
+	public abstract partial class InCallService : Android.App.Service
+	{
+#if ANDROID_23
+		[Obsolete ("Incorrect enum parameter, use the overload that takes a CallAudioRoute paramter instead.")]
+		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android23.0")]
+		public void SetAudioRoute ([global::Android.Runtime.GeneratedEnum] Android.Telecom.VideoQuality route)
+		{
+			SetAudioRoute ((CallAudioRoute) route);
+		}
+#endif
+	}
+}
+
+

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Android.Icu\DateIntervalFormat.cs" />
     <Compile Include="Android.Runtime\DynamicMethodNameCounter.cs" />
     <Compile Include="Android.Runtime\IJavaObjectValueMarshaler.cs" />
+    <Compile Include="Android.Telecom\InCallService.cs" />
   </ItemGroup>
 
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -1879,7 +1879,7 @@
 23, android.telecom, InCallService.VideoCall.Callback, onCallSessionEvent, event, Android.Telecom.VideoSessionEvent
 23, android.telecom, InCallService.VideoCall.Callback, onSessionModifyResponseReceived, status, Android.Telecom.ModifyRequestResult
 23, android.telecom, InCallService.VideoCall.Callback, onVideoQualityChanged, videoQuality, Android.Telecom.VideoQuality
-23, android.telecom, InCallService, setAudioRoute, route, Android.Telecom.VideoQuality
+23, android.telecom, InCallService, setAudioRoute, route, Android.Telecom.CallAudioRoute
 23, android.telecom, PhoneAccount, hasCapabilities, capability, Android.Telecom.ConnectionCapability
 23, android.telecom, PhoneAccount, getCapabilities, return, Android.Telecom.ConnectionCapability
 23, android.telecom, RemoteConference, getConnectionCapabilities, return, Android.Telecom.ConnectionCapability

--- a/tests/api-compatibility/acceptable-breakages-vReference-net8.0.txt
+++ b/tests/api-compatibility/acceptable-breakages-vReference-net8.0.txt
@@ -3079,3 +3079,4 @@ CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'Org.Apac
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'Org.Apache.Http.Conn.Ssl.SSLSocketFactory..ctor(Java.Security.KeyStore, System.String)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'Org.Apache.Http.Conn.Ssl.SSLSocketFactory..ctor(Java.Security.KeyStore, System.String, Java.Security.KeyStore)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ObsoleteAttribute' exists on 'Org.Apache.Http.Conn.Ssl.SSLSocketFactory.CreateSocket(Java.Net.Socket, System.String, System.Int32, System.Boolean)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'Android.Runtime.RegisterAttribute' exists on 'Android.Telecom.InCallService.SetAudioRoute(Android.Telecom.VideoQuality)' in the contract but not the implementation.

--- a/tests/api-compatibility/acceptable-breakages-vReference.txt
+++ b/tests/api-compatibility/acceptable-breakages-vReference.txt
@@ -1,1 +1,2 @@
 Compat issues with assembly Mono.Android:
+CannotRemoveAttribute : Attribute 'Android.Runtime.RegisterAttribute' exists on 'Android.Telecom.InCallService.SetAudioRoute(Android.Telecom.VideoQuality)' in the contract but not the implementation.


### PR DESCRIPTION
Fixes #2472 

`Android.Telecom.InCallService.SetAudioRoute (int)` was incorrectly enumified as `Android.Telecom.VideoQuality` instead of `Android.Telecom.CallAudioRoute`.

To fix, we need to change the enum map to generate the correct method:
```csharp
[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android23.0")]
[Register ("setAudioRoute", "(I)V", "", ApiSince = 23)]
public unsafe void SetAudioRoute ([global::Android.Runtime.GeneratedEnum] Android.Telecom.CallAudioRoute route)
{ ... }
```

For backwards compatibility, we need to add an `[Obsolete]` overload containing the incorrect enumification:
```csharp
[Obsolete ("Incorrect enum parameter, use the overload that takes a CallAudioRoute paramter instead.")]
[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android23.0")]
public void SetAudioRoute ([global::Android.Runtime.GeneratedEnum] Android.Telecom.VideoQuality route)
{ ... }
```

The `acceptable-breakages` is due to the `[Register]` attribute being moved from the old overload to the corrected overload.