### PR TITLE
[Actions] Add action that will bump the hash used for the unified pipeline.

### DIFF
--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -4,7 +4,8 @@ on:
   # trigger for main and release branches.
   push:
     branches:
-      - '*'
+      - main
+      - 'release/**'
 
 jobs:
   pingRemote:

--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -1,0 +1,34 @@
+name: Notify release branch change
+
+on:
+  # trigger for main and release branches.
+  push:
+    branches:
+      - '*'
+
+jobs:
+  pingRemote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse commit
+        shell: pwsh
+        id: commit_title
+        run: |
+          Write-Host "Commit message is $Env:COMMIT_MESSAGE"
+          $title = ($Env:COMMIT_MESSAGE -split '\n')[0]
+          "COMMIT_TITLE=$title" >> $env:GITHUB_OUTPUT
+        env:
+          COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
+
+      - name: 'Update remote repository'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.SERVICEACCOUNT_PAT }}
+          event-type: 'sdk_insertion' 
+          repository: 'xamarin/sdk-insertions'
+          client-payload: '{"repository": "xamarin/xamarin-android", "branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}", "commit_message": "${{ steps.commit_title.outputs.COMMIT_TITLE }}"}'
+
+


### PR DESCRIPTION
tldr; The action will send an event to the sdk-insertions repository that will do the correct steps to bump the version of the android project to be used in the unified pipeline.

## Details

The idea is as follows:

The action will get the information of an update branch, that is sent to the sdk-insertions repo using a client payload via a repository dispatch (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch). That event with the payload is the parsed by a second action in the sdk-insertions repo and the needed yaml files are updated. This allow to have the unified pipeline build the latest commits of the SDKs without a manual trigger.

More details can be found here: https://github.com/xamarin/sdk-insertions/wiki/Unified-pipeline#github-actions

Because there is no way to run an action without a merge, please refer to the exact same one in the xamarin-macios repo: https://github.com/xamarin/xamarin-macios/actions/runs/3941098858