### PR TITLE
[ci] Pass token when building Designer tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1343,7 +1343,7 @@ stages:
       inputs:
         solution: $(System.DefaultWorkingDirectory)\UITools\src\Xamarin.Designer.Android\Xamarin.AndroidDesigner.sln
         vsVersion: 17.0
-        msbuildArgs: /t:Build
+        msbuildArgs: /t:Build /p:GitHubToken=$(GitHub.Token)
         platform: Any CPU
         configuration: DebugWin32
 


### PR DESCRIPTION
Context: https://github.com/xamarin/UITools/commit/9559b43b8e897daacb605d2a9ab74427a1541264

A resource used by the Designer tests now requires authentication.