### PR TITLE
[Xamarin.Android.Build.Tasks] fix NRE in `<GenerateResourceCaseMap/>`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceCaseMap.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tasks
 			ResourceDirectory = Path.GetFullPath (ResourceDirectory);
 
 			// Create our capitalization maps so we can support mixed case resources
-			foreach (var item in Resources) {
+			foreach (var item in Resources ?? Array.Empty<ITaskItem>()) {
 				var path = Path.GetFullPath (item.ItemSpec);
 				if (!path.StartsWith (ResourceDirectory, StringComparison.OrdinalIgnoreCase)) {
 					Log.LogDebugMessage ($"Skipping {item}. Path is not include the '{ResourceDirectory}'");


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/12520
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7209613&view=results

dotnet/maui's build fails with:

    Task GenerateResourceCaseMap
    Parameters
        ResourceDirectory = obj/Debug/net8.0-android/res/
        OutputFile = obj/Debug/net8.0-android/case_map.txt
        AdditionalResourceDirectories
            ...
    Errors
        /Users/builder/azdo/_work/2/s/bin/dotnet/packs/Microsoft.Android.Sdk.Darwin/34.0.0-preview.1.119/tools/Xamarin.Android.Resource.Designer.targets(82,3): error XAGRCM7001: System.NullReferenceException: Object reference not set to an instance of an object.
        at Xamarin.Android.Tasks.GenerateResourceCaseMap.RunTask()
        at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 17 [/Users/builder/azdo/_work/2/s/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj]

Note that the `Resources` parameter is empty. This is apparently a `TestUtils.DeviceTests.Sample.csproj` project with no `@(AndroidResource)` files.

Added a null check.