### PR TITLE
[Xamarin.Android.Build.Tasks] Fix issue where app will not install

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidAdb.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidAdb.cs
@@ -1,0 +1,57 @@
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using System.Text;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks {
+
+	public class AndroidAdb : AndroidToolTask
+	{
+		public override string TaskPrefix => "AADB";
+
+		public string AdbTarget { get; set; }
+		public string Command { get; set; }
+		public string Arguments { get; set; }
+
+		public bool IgnoreErrors { get; set; } = false;
+
+		[Output]
+		public bool Result { get; set; } = true;
+
+		protected override string ToolName => OS.IsWindows ? "adb.exe" : "adb";
+
+		protected override string GenerateFullPathToTool ()
+		{
+			return Path.Combine (ToolPath, ToolExe);
+		}
+
+		//adb $(AdbTarget) uninstall -k &quot;$(_AndroidPackage)&quot;
+		//adb $(AdbTarget) uninstall $(_AndroidPackage)
+		//adb $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;
+		//adb $(AdbTarget) shell cmd package uninstall -k $(_AndroidPackage)
+		protected override string GenerateCommandLineCommands ()
+		{
+			var sb = new StringBuilder ();
+			if (!string.IsNullOrEmpty (AdbTarget))
+				sb.Append ($" {AdbTarget} ");
+			sb.AppendFormat ("{0} {1}", Command, Arguments);
+			return sb.ToString ();
+		}
+
+		protected override bool HandleTaskExecutionErrors ()
+		{
+			if (!Result)
+				return true;
+			return base.HandleTaskExecutionErrors ();
+		}
+
+		protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+		{
+			if (singleLine.Contains ("adb shell cmd package uninstall"))
+				Result = false;
+			base.LogEventsFromTextOutput (singleLine, messageImportance);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Tasks
 			return cmd;
 		}
 
-		const string InstallErrorRegExString = @"(?<exception>com.android.tools.build.bundletool.model.exceptions.CommandExecutionException+):(?<error>.+)";
+		const string InstallErrorRegExString = @"(?<exception>com.android.tools.build.bundletool.model.exceptions.CommandExecutionException):(?<error>.+)";
 		static readonly Regex installErrorRegEx = new Regex (InstallErrorRegExString, RegexOptions.Compiled);
 
 		protected override IEnumerable<Regex> GetCustomExpressions ()

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -17,6 +17,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="_WriteLockFile">
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveUnknownFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidAdb" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidComputeResPaths" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidSignPackage" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidCreateDebugKey" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -2658,21 +2659,12 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <_DeployCommand>&quot;$(AdbToolPath)adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
   </PropertyGroup>
-  <Exec
-      ContinueOnError="True"
-      Command="$(_DeployCommand)"
-      ConsoleToMSBuild="True">
-    <Output TaskParameter="ExitCode"      PropertyName="_DeployExitCode" />
-    <Output TaskParameter="ConsoleOutput" ItemName="_DeployConsoleOutput" />
-  </Exec>
-  <ItemGroup>
-    <_AdbError Include="The command `$(_DeployCommand)` exited with code $(_DeployExitCode):" />
-    <_AdbError Include="@(_DeployConsoleOutput->'  %(Identity)')" />
-  </ItemGroup>
-  <Error
-      Condition=" '$(_DeployExitCode)' != '0' "
-      Code="ADB0000"
-      Text="@(_AdbError, '%0a')"
+  <AndroidAdb
+      ToolExe="$(AdbToolExe)"
+      ToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Command="install"
+      Arguments="-r &quot;$(ApkFileSigned)&quot;"
   />
 </Target>
 
@@ -2704,11 +2696,25 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <_UninstallCommand>&quot;$(AdbToolPath)adb&quot; $(AdbTarget) uninstall -k &quot;$(_AndroidPackage)&quot;</_UninstallCommand>
   </PropertyGroup>
-  <Exec
-      ContinueOnError="True"
-      Command="$(_UninstallCommand)"
-      ConsoleToMSBuild="True"
+  <AndroidAdb
       Condition=" '$(EmbedAssembliesIntoApk)' == 'true' "
+      ContinueOnError="True"
+      ToolExe="$(AdbToolExe)"
+      ToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Command="uninstall"
+      Arguments="-k $(_AndroidPackage)"
+  >
+    <Output TaskParameter="Result" PropertyName="_UninstallResult" />
+  </AndroidAdb>
+   <AndroidAdb
+      Condition=" '$(EmbedAssembliesIntoApk)' == 'true' And '$(_UninstallResult)' == 'false' "
+      ContinueOnError="True"
+      ToolExe="$(AdbToolExe)"
+      ToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Command="shell cmd package uninstall"
+      Arguments="$(_AndroidPackage)"
   />
   <InstallApkSet
       ToolPath="$(JavaToolPath)"
@@ -2728,7 +2734,13 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_Uninstall">
-  <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) uninstall $(_AndroidPackage)" />
+  <AndroidAdb
+      ToolExe="$(AdbToolExe)"
+      ToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
+      Command="uninstall"
+      Arguments="$(_AndroidPackage)"
+  />
 </Target>
 
 <Target Name="Uninstall"


### PR DESCRIPTION
Fixes https://i.azdo.io/1398544

It is quite common for users to switch from Debug to Release mode in
order to test the app. However if the `Release` build is using a custom
signing keystore you will generally see this warning and error.

```
warning MSB6006: "adb" exited with code 1.
[BT : 1.8.1] error : Installation of the app failed.
```

This is not entirely helpful. Since you need to dig into the log to
figure out what the actual issue is.
The warning is produced when we try to run `adb uninstall -k <package>`.

```
adb uninstall -k com.xamarin.foo  (TaskId:361)
The -k option uninstalls the application while retaining the data/cache. (TaskId:361)
At the moment, there is no way to remove the remaining data. (TaskId:361)
You will have to reinstall the application with the same signature, and fully uninstall it. (TaskId:361)
If you truly wish to continue, execute 'adb shell cmd package uninstall -k'.
```

We are not entirely sure why the application gets into this state. But
once it does you have to completely uninstall it. We currently ignore
this error but that then results in the following.

```
Error: INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package com.xamarin.toggledebugreleasewithsigning signatures do not match newer version; ignoring!
```

This is because the apps have different signing keystores. As a result
they are incompatible. The only option once you get this issue is to
uninstall the app manually and try again. However the error messaging
is not obvious so users generally have no idea what to do.

So lets fix a few things wrong in this area. Firstly lets introduce a
new task `AndroidAdb` which is responsible for making the calls to `adb`.
We currently use `Exec` which means its hard to make any customizations
around error messaging. We will check the result of `AndroidAdb` when
calling `adb uninstall -k <package>` and if we get message we will
automatically fall back on calling `adb shell cmd package uninstall`.
This will completely remove the app from the device and will allow the
later `bundletool` call to work.

We have also updated `InstallApkSet` to look for error messages from
`bundletool` and report them, so users will get better information. So
we now get error messages like

```
[BT : 1.8.1] error : Installation of the app failed. [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: The APKs have been extracted in the directory: /var/folders/5p/10yqy2kx6r9dnmnxh_nt6s0r0000gn/T/1389125984700138671 [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 01:54:24 E/SplitApkInstallerBase: Failed to commit install session 1426763565 with command cmd package install-commit 1426763565. Error: INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package com.xamarin.toggledebugreleasewithsigning signatures do not match newer version; ignoring! [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: [BT:1.8.1] Error: Installation of the app failed. [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: com.android.tools.build.bundletool.model.exceptions.CommandExecutionException [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000:  Installation of the app failed. [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.model.exceptions.InternalExceptionBuilder.build(InternalExceptionBuilder.java:57) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.device.DdmlibDevice.installApks(DdmlibDevice.java:192) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.commands.InstallApksCommand.lambda$execute$2(InstallApksCommand.java:214) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.device.AdbRunner.run(AdbRunner.java:81) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.device.AdbRunner.run(AdbRunner.java:43) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.commands.InstallApksCommand.execute(InstallApksCommand.java:214) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.BundleToolMain.main(BundleToolMain.java:91) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.BundleToolMain.main(BundleToolMain.java:49) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: Caused by: com.android.ddmlib.InstallException: Failed to commit install session 1426763565 with command cmd package install-commit 1426763565. Error: INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package com.xamarin.toggledebugreleasewithsigning signatures do not match newer version; ignoring! [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.ddmlib.SplitApkInstallerBase.installCommit(SplitApkInstallerBase.java:99) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.ddmlib.SplitApkInstaller.install(SplitApkInstaller.java:85) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.ddmlib.internal.DeviceImpl.installPackages(DeviceImpl.java:1166) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	at com.android.tools.build.bundletool.device.DdmlibDevice.installApks(DdmlibDevice.java:176) [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000: 	... 6 more [ToggleDebugReleaseWithSigning/UnnamedProject.csproj]
obj/Release/android/bin/com.xamarin.toggledebugreleasewithsigning.apks : java error BT0000:
```

Unit Test also added.