### PR TITLE
[Xamarin.Android.Build.Tasks] Honour the AndroidGenerateResourceDesigner setting

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -93,7 +93,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_GenerateResourceDesignerIntermediateClass"
-    Condition=" '$(AndroidUseDesignerAssembly)' == 'True' "
+    Condition=" '$(AndroidUseDesignerAssembly)' == 'True' And '$(AndroidGenerateResourceDesigner)' == 'true' "
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(_GenerateResourceDesignerClassFile)"
   >
@@ -166,11 +166,11 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </ReferencePath>
     <Compile Remove="$(_AndroidResourceDesignerFile)" />
-    <Compile Include="$(_GenerateResourceDesignerClassFile)" Condition=" '$(Language)' != 'F#' "/>
+    <Compile Include="$(_GenerateResourceDesignerClassFile)" Condition=" '$(Language)' != 'F#' And '$(AndroidGenerateResourceDesigner)' == 'true' "/>
     <!-- For F# we need to use the CompileBefore ItemGroup so that our type is processed
           before all the other types in the build. Otherwise we get weird compiler errors.
       -->
-    <CompileBefore Include="$(_GenerateResourceDesignerClassFile)" Condition=" '$(Language)' == 'F#' "/>
+    <CompileBefore Include="$(_GenerateResourceDesignerClassFile)" Condition=" '$(Language)' == 'F#' And '$(AndroidGenerateResourceDesigner)' == 'true' "/>
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -10,9 +10,10 @@
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' == 'true' ">Xamarin.Android.Net.AndroidMessageHandler</AndroidHttpClientHandlerType>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' != 'true' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>
-    <AndroidGenerateResourceDesigner Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidGenerateResourceDesigner>
     <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">true</AndroidGenerateResourceDesigner>
+    <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseDesignerAssembly>
+    <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>
+    <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidUseIntermediateDesignerFile>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseIntermediateDesignerFile>
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -11,7 +11,6 @@
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' == 'true' ">Xamarin.Android.Net.AndroidMessageHandler</AndroidHttpClientHandlerType>
     <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' != 'true' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">true</AndroidGenerateResourceDesigner>
-    <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseDesignerAssembly>
     <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidUseIntermediateDesignerFile>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseIntermediateDesignerFile>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -553,7 +553,7 @@ namespace Xamarin.Android.Build.Tests
 			return GetPathToLatestBuildTools (exe);
 		}
 
-		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project)
+		protected string GetResourceDesignerPath (DotNetCLI builder, XASdkProject project, bool designtime = false)
 		{
 			string path;
 			if (Builder.UseDotNet) {
@@ -561,8 +561,30 @@ namespace Xamarin.Android.Build.Tests
 				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
 					return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
 				}
+				if (designtime)
+					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
 			} else {
 				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
+				if (designtime)
+					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
+			}
+			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
+		}
+
+		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project, bool designtime = false)
+		{
+			string path;
+			if (Builder.UseDotNet) {
+				path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
+				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
+					return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
+				}
+				if (designtime)
+					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
+			} else {
+				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
+				if (designtime)
+					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
 			}
 			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -553,7 +553,7 @@ namespace Xamarin.Android.Build.Tests
 			return GetPathToLatestBuildTools (exe);
 		}
 
-		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project, bool designtime = false)
+		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project)
 		{
 			string path;
 			if (Builder.UseDotNet) {
@@ -561,12 +561,8 @@ namespace Xamarin.Android.Build.Tests
 				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
 					return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
 				}
-				if (designtime)
-					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
 			} else {
 				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
-				if (designtime)
-					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
 			}
 			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -553,24 +553,6 @@ namespace Xamarin.Android.Build.Tests
 			return GetPathToLatestBuildTools (exe);
 		}
 
-		protected string GetResourceDesignerPath (DotNetCLI builder, XASdkProject project, bool designtime = false)
-		{
-			string path;
-			if (Builder.UseDotNet) {
-				path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
-				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
-					return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
-				}
-				if (designtime)
-					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
-			} else {
-				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
-				if (designtime)
-					path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
-			}
-			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
-		}
-
 		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project, bool designtime = false)
 		{
 			string path;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -455,7 +455,7 @@ public class JavaSourceTest {
 		}
 
 		[Test]
-		public void GenerateResourceDesigner_false()
+		public void GenerateResourceDesigner_false([Values (false, true)] bool useDesignerAssembly)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
 				Sources = {
@@ -466,7 +466,8 @@ public class JavaSourceTest {
 			};
 			// Turn off Resource.designer.cs and remove usage of it
 			proj.SetProperty ("AndroidGenerateResourceDesigner", "false");
-			proj.SetProperty ("AndroidUseDesignerAssembly", "false");
+			if (!useDesignerAssembly)
+				proj.SetProperty ("AndroidUseDesignerAssembly", "false");
 			proj.MainActivity = proj.DefaultMainActivity
 				.Replace ("Resource.Layout.Main", "0")
 				.Replace ("Resource.Id.myButton", "0");
@@ -474,12 +475,12 @@ public class JavaSourceTest {
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build(target: "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true" }), "Designtime build should succeed.");
 			var intermediate = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);
-			var resource_designer_cs = Path.Combine (intermediate, "designtime",  "Resource.designer.cs");
+			var resource_designer_cs = GetResourceDesignerPath (dotnet, proj, designtime: true);
 			FileAssert.DoesNotExist (resource_designer_cs);
 
 			Assert.IsTrue (dotnet.Build (), "build should succeed");
 
-			resource_designer_cs = Path.Combine (intermediate, "Resource.designer.cs");
+			resource_designer_cs =  GetResourceDesignerPath (dotnet, proj);
 			FileAssert.DoesNotExist (resource_designer_cs);
 
 			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.dll");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -522,12 +522,16 @@ public class FooA {
 			var dotnet = CreateDotNetBuilder (proj);
 			Assert.IsTrue (dotnet.Build(target: "CoreCompile", parameters: new string[] { "BuildingInsideVisualStudio=true" }), "Designtime build should succeed.");
 			var intermediate = Path.Combine (FullProjectDirectory, proj.IntermediateOutputPath);
-			var resource_designer_cs = GetResourceDesignerPath (dotnet, proj, designtime: true);
+			var resource_designer_cs = Path.Combine (intermediate, "designtime",  "Resource.designer.cs");
+			if (useDesignerAssembly)
+				resource_designer_cs = Path.Combine (intermediate, "__Microsoft.Android.Resource.Designer.cs");
 			FileAssert.DoesNotExist (resource_designer_cs);
 
 			Assert.IsTrue (dotnet.Build (), "build should succeed");
 
-			resource_designer_cs =  GetResourceDesignerPath (dotnet, proj);
+			resource_designer_cs =  Path.Combine (intermediate, "Resource.designer.cs");
+			if (useDesignerAssembly)
+				resource_designer_cs = Path.Combine (intermediate, "__Microsoft.Android.Resource.Designer.cs");
 			FileAssert.DoesNotExist (resource_designer_cs);
 
 			var assemblyPath = Path.Combine (FullProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.dll");


### PR DESCRIPTION
Currently setting `AndroidGenerateResourceDesigner` to `false` does NOT stop the new resource designer assembly
from being generated. 
We should change this so that library projects which want to use this setting (as per the docs) to disable
the resoruce designer then it should work.  So if the `AndroidGenerateResourceDesigner` is set to fail we will NOT generate
the intermediate `__Microsoft.Resource.Designer.Assembly.cs` (or .fs) file. But we will still generate the assembly. 
This means the `Resource` class will not be part of the built assembly and will not be available. 

A unit test has been updated to test this change.