### PR TITLE
Revert "[Xamarin.Android.Build.Tasks] fix cases of missing `@(Reference)` (#7642)"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -44,7 +44,7 @@ _ResolveAssemblies MSBuild target.
   </PropertyGroup>
 
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
-      DependsOnTargets="BuildOnlySettings;_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
+      DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
       Returns="@(ResolvedFileToPublish)">
       <ItemGroup>
         <ResolvedFileToPublish Remove="@(_SourceItemsToCopyToPublishDirectory)" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -1080,67 +1080,6 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 		}
 
 		[Test]
-		public void ProjectDependencies ([Values(true, false)] bool projectReference)
-		{
-			// Setup dependencies App A -> Lib B -> Lib C
-			var path = Path.Combine ("temp", TestName);
-
-			var libB = new XASdkProject (outputType: "Library") {
-				ProjectName = "LibraryB",
-				IsRelease = true,
-			};
-			libB.Sources.Clear ();
-			libB.Sources.Add (new BuildItem.Source ("Foo.cs") {
-				TextContent = () => @"public class Foo {
-					public Foo () {
-						var bar = new Bar();
-					}
-				}",
-			});
-
-			var libC = new XASdkProject (outputType: "Library") {
-				ProjectName = "LibraryC",
-				IsRelease = true,
-			};
-			libC.Sources.Clear ();
-			libC.Sources.Add (new BuildItem.Source ("Bar.cs") {
-				TextContent = () => "public class Bar { }",
-			});
-
-			// Add a @(Reference) or @(ProjectReference)
-			if (projectReference) {
-				libB.AddReference (libC);
-			} else {
-				libB.OtherBuildItems.Add (new BuildItem.Reference ($@"..\{libC.ProjectName}\bin\Release\{libC.TargetFramework}\{libC.ProjectName}.dll"));
-			}
-
-			// Build libraries
-			var libCBuilder = CreateDotNetBuilder (libC, Path.Combine (path, libC.ProjectName));
-			Assert.IsTrue (libCBuilder.Build (), $"{libC.ProjectName} should succeed");
-			var libBBuilder = CreateDotNetBuilder (libB, Path.Combine (path, libB.ProjectName));
-			Assert.IsTrue (libBBuilder.Build (), $"{libB.ProjectName} should succeed");
-
-			var appA = new XASdkProject {
-				ProjectName = "AppA",
-				IsRelease = true,
-				Sources = {
-					new BuildItem.Source ("Bar.cs") {
-						TextContent = () => "public class Bar : Foo { }",
-					}
-				}
-			};
-			appA.AddReference (libB);
-			var appBuilder = CreateDotNetBuilder (appA, Path.Combine (path, appA.ProjectName));
-			Assert.IsTrue (appBuilder.Build (), $"{appA.ProjectName} should succeed");
-
-			var apkPath = Path.Combine (FullProjectDirectory, appA.OutputPath, $"{appA.PackageName}-Signed.apk");
-			FileAssert.Exists (apkPath);
-			var helper = new ArchiveAssemblyHelper (apkPath);
-			helper.AssertContainsEntry ($"assemblies/{libB.ProjectName}.dll");
-			helper.AssertContainsEntry ($"assemblies/{libC.ProjectName}.dll");
-		}
-
-		[Test]
 		public void DotNetDesignTimeBuild ()
 		{
 			var proj = new XASdkProject ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2006,8 +2006,7 @@ because xbuild doesn't support framework reference assemblies.
     DependsOnTargets="_ResolveAssemblies"
 >
   <ItemGroup>
-    <!-- In .NET 6+, the .NET SDK locates these files -->
-    <_AndroidResolvedSatellitePaths Condition=" '$(UsingAndroidNETSdk)' != 'true' " Include="@(ReferenceSatellitePaths)" />
+    <_AndroidResolvedSatellitePaths Include="@(ReferenceSatellitePaths)" />
     <!-- Satellites from the current project, see: https://github.com/microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4283-L4299 -->
     <_AndroidResolvedSatellitePaths Include="@(IntermediateSatelliteAssembliesWithTargetPath->'$(OutDir)%(Culture)\$(TargetName).resources.dll')" />
   </ItemGroup>


### PR DESCRIPTION
This reverts commit 22f2001.

.NET MAUI is hitting a build failure such as:

    Unable to open file 'obj\Release\net8.0-android\android-x64\aot\x86_64\Microsoft.Maui.Controls.resources\temp.s': Permission denied

In 22f2001, we began passing satellite assemblies to the AOT compiler, on accident? I am unsure how a test in xamarin-android didn't catch this, but it may be something that only happens via a `@(ProjectReference)` as occurred in .NET MAUI.

For now, let's revert the change and revisit later.

We should reopen https://github.com/dotnet/maui/issues/10154 after this is merged.