### PR TITLE
[Mono.Android] Fix WindowManagerLayoutParams.SystemUiVisibility enumification

### DIFF
--- a/src/Mono.Android/Android.Telecom/InCallService.cs
+++ b/src/Mono.Android/Android.Telecom/InCallService.cs
@@ -6,7 +6,7 @@ namespace Android.Telecom
 	public abstract partial class InCallService : Android.App.Service
 	{
 #if ANDROID_23
-		[Obsolete ("Incorrect enum parameter, use the overload that takes a CallAudioRoute paramter instead.")]
+		[Obsolete ("Incorrect enum parameter, use the overload that takes a CallAudioRoute parameter instead.")]
 		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android23.0")]
 		public void SetAudioRoute ([global::Android.Runtime.GeneratedEnum] Android.Telecom.VideoQuality route)
 		{

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -90,5 +90,13 @@ namespace Android.Views {
 			return InvokeFitsSystemWindows ();
 		}
 #endif
+
+#if NET && ANDROID_34
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0", "These flags are deprecated. Use WindowInsetsController instead.")]
+		public SystemUiFlags SystemUiFlags {
+			get => (SystemUiFlags) SystemUiVisibility;
+			set => SystemUiVisibility = (Android.Views.StatusBarVisibility) value;
+		}
+#endif
 	}
 }

--- a/src/Mono.Android/Android.Views/WindowManagerLayoutParams.cs
+++ b/src/Mono.Android/Android.Views/WindowManagerLayoutParams.cs
@@ -4,7 +4,7 @@ namespace Android.Views
 {
 	partial class WindowManagerLayoutParams
 	{
-#if NET
+#if NET && ANDROID_34
 		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0", "These flags are deprecated. Use WindowInsetsController instead.")]
 		public SystemUiFlags SystemUiFlags {
 			get => (SystemUiFlags) SystemUiVisibility;

--- a/src/Mono.Android/Android.Views/WindowManagerLayoutParams.cs
+++ b/src/Mono.Android/Android.Views/WindowManagerLayoutParams.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Android.Views
+{
+	partial class WindowManagerLayoutParams
+	{
+#if NET
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0", "These flags are deprecated. Use WindowInsetsController instead.")]
+		public SystemUiFlags SystemUiFlags {
+			get => (SystemUiFlags) SystemUiVisibility;
+			set => SystemUiVisibility = (Android.Views.StatusBarVisibility) value;
+		}
+#endif
+	}
+}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Android.Runtime\DynamicMethodNameCounter.cs" />
     <Compile Include="Android.Runtime\IJavaObjectValueMarshaler.cs" />
     <Compile Include="Android.Telecom\InCallService.cs" />
+    <Compile Include="Android.Views\WindowManagerLayoutParams.cs" />
   </ItemGroup>
 
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1717,6 +1717,10 @@
 
   <attr api-since="34" path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
   <attr api-since="34" path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated-since">0</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='View']/method[@name='getSystemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='View']/method[@name='getSystemUiVisibility']" name="deprecated-since">0</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='View']/method[@name='setSystemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='View']/method[@name='setSystemUiVisibility']" name="deprecated-since">0</attr>
 
   <!--
     ***********************************************************************

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1715,6 +1715,9 @@
   <remove-node api-since="33" path="/api/package[@name='java.util.concurrent']/class[@name='TimeUnit']/method[@name='of' and count(parameter)=1 and parameter[1][@type='java.time.temporal.ChronoUnit']]" />
   <remove-node api-since="33" path="/api/package[@name='java.util.concurrent']/class[@name='TimeUnit']/method[@name='toChronoUnit' and count(parameter)=0]" />
 
+  <attr path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
+  <attr path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated-since">0</attr>
+
   <!--
     ***********************************************************************
     THE FOLLOWING LINES MUST BE CREATED FOR ANY NEW PLATFORM THAT IS ADDED.

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1715,8 +1715,8 @@
   <remove-node api-since="33" path="/api/package[@name='java.util.concurrent']/class[@name='TimeUnit']/method[@name='of' and count(parameter)=1 and parameter[1][@type='java.time.temporal.ChronoUnit']]" />
   <remove-node api-since="33" path="/api/package[@name='java.util.concurrent']/class[@name='TimeUnit']/method[@name='toChronoUnit' and count(parameter)=0]" />
 
-  <attr path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
-  <attr path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated-since">0</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated">This property has an incorrect enumeration type. Use the SystemUiFlags property instead.</attr>
+  <attr api-since="34" path="/api/package[@name='android.view']/class[@name='WindowManager.LayoutParams']/field[@name='systemUiVisibility']" name="deprecated-since">0</attr>
 
   <!--
     ***********************************************************************


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/4290

The following API were incorrectly enumified as `StatusBarVisibility` instead of `SystemUiFlags`:
- `android.views.View.[get|set]SystemUiVisibility (int)` ([source](https://developer.android.com/reference/android/view/View#setSystemUiVisibility(int)))
- `android.views.WindowManager.LayoutParams.SystemUiVisibility` ([source](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#systemUiVisibility))

As these are properties, we cannot create an overload.  Instead create a new property called `SystemUiFlags` and obsolete the incorrect property.  Additionally, this whole thing was deprecated in API-30, so make sure we reflect that on the new method.  It's still worth fixing this, as people will be using this for pre-API-30 device support for years to come.

## API Reference Results:
**WindowManagerLayoutParams**
![image](https://user-images.githubusercontent.com/179295/214159458-a00eeab7-613a-46f2-b0c1-ea4d59c87d70.png)

**View**
![image](https://user-images.githubusercontent.com/179295/214945408-a1fa5237-0e96-4ae9-9cf4-51c647cba381.png)
