### PR TITLE
[build] bump `$(AndroidNet7Version)`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -47,7 +47,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.1</AndroidNet7Version>
+    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.26</AndroidNet7Version>
     <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.485</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">


### PR DESCRIPTION
Context: https://www.nuget.org/packages/Microsoft.NET.Sdk.Android.Manifest-7.0.100/33.0.26

33.0.26 is the version of the latest `android` workload in .NET 7.

Bump to this version, so we will rely on those packs in .NET 8. Previously we were using an older build, I noticed the issue when trying to dogfood .NET 8 builds on macOS:

    Workload installation failed: microsoft.android.sdk.darwin::33.0.1 is not found in NuGet feeds