### PR TITLE
[xaprepare] Support arm64 emulator components

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -54,6 +54,7 @@
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>
     <HostOS Condition="$([MSBuild]::IsOSPlatform('linux'))">Linux</HostOS>
     <HostOS Condition="$([MSBuild]::IsOSPlatform('osx'))">Darwin</HostOS>
+    <HostOSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString())</HostOSArchitecture>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftAndroidSdkPackName Condition="$([MSBuild]::IsOSPlatform('windows'))">Microsoft.Android.Sdk.Windows</MicrosoftAndroidSdkPackName>
@@ -194,9 +195,9 @@
     <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">7.0</CommandLineToolsFolder>
     <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">8512546_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
-    <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-1.xml -->
-    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">8129060</EmulatorVersion>
-    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">31.3.1</EmulatorPkgRevision>
+    <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-3.xml -->
+    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">9364964</EmulatorVersion>
+    <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">32.1.9</EmulatorPkgRevision>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -18,6 +18,7 @@
 
   <PropertyGroup>
     <TestAvdApiLevel Condition=" '$(TestAvdApiLevel)' == '' ">29</TestAvdApiLevel>
+    <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' and '$(HostOS)' == 'Darwin' and  '$(HostOSArchitecture)' == 'Arm64' ">arm64-v8a</TestAvdAbi>
     <TestAvdAbi Condition=" '$(TestAvdAbi)' == '' ">x86_64</TestAvdAbi>
     <TestAvdType Condition=" '$(TestAvdType)' == '' ">default</TestAvdType>
     <TestDeviceName Condition=" '$(TestDeviceName)' == '' ">pixel_4</TestDeviceName>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Xamarin.Android.Prepare
 {
@@ -30,10 +31,14 @@ namespace Xamarin.Android.Prepare
 			string XABuildTools30PackagePrefix = Context.Instance.Properties [KnownProperties.XABuildTools30PackagePrefix] ?? String.Empty;
 			string XAPlatformToolsVersion  = GetRequiredProperty (KnownProperties.XAPlatformToolsVersion);
 			string XAPlatformToolsPackagePrefix = Context.Instance.Properties [KnownProperties.XAPlatformToolsPackagePrefix] ?? String.Empty;
+			bool isArm64Apple = Context.Instance.OS.Flavor == "macOS" && RuntimeInformation.OSArchitecture == Architecture.Arm64;
+			string emulatorArch = isArm64Apple ? "aarch64" : "x64";
+			string systemImageArch = isArm64Apple ? "arm64-v8a" : "x86_64";
 
 			// Upstream manifests with version information:
 			//
 			//  https://dl-ssl.google.com/android/repository/repository2-1.xml
+			//  https://dl-ssl.google.com/android/repository/repository2-3.xml
 			//    * platform APIs
 			//    * build-tools
 			//    * command-line tools
@@ -87,10 +92,10 @@ namespace Xamarin.Android.Prepare
 					dependencyType: AndroidToolchainComponentType.BuildDependency,
 					buildToolVersion: "47.0.0"
 				),
-				new AndroidToolchainComponent ($"x86_64-29_r07-{osTag}",
-					destDir: Path.Combine ("system-images", "android-29", "default", "x86_64"),
+				new AndroidToolchainComponent (isArm64Apple ? $"{systemImageArch}-29_r08" : $"{systemImageArch}-29_r08-{osTag}",
+					destDir: Path.Combine ("system-images", "android-29", "default", systemImageArch),
 					relativeUrl: new Uri ("sys-img/android/", UriKind.Relative),
-					pkgRevision: "7",
+					pkgRevision: "8",
 					dependencyType: AndroidToolchainComponentType.EmulatorDependency
 				),
 				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}",
@@ -123,7 +128,7 @@ namespace Xamarin.Android.Prepare
 					buildToolName: "android-sdk-platform-tools",
 					buildToolVersion: XAPlatformToolsVersion
 				),
-				new AndroidToolchainComponent ($"emulator-{osTag}_x64-{EmulatorVersion}",
+				new AndroidToolchainComponent ($"emulator-{osTag}_{emulatorArch}-{EmulatorVersion}",
 					destDir: "emulator",
 					pkgRevision: EmulatorPkgRevision,
 					dependencyType: AndroidToolchainComponentType.EmulatorDependency


### PR DESCRIPTION
Updates xaprepare to install arm64 versions of Android emulator
components on Apple devices that support them.  The `emulator` tool
version has also been bumped from `31.3.1` to `32.1.9`.