### PR TITLE
Bump to xamarin/monodroid/d17-5@9b69cb11

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:d17-5@c0c933b7a5286c0babecb165c0676c32f5e44092
+xamarin/monodroid:d17-5@9b69cb11ce5dafed7126baafad28ac8dff22a5d2
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/Unable-to-debug-XamarinAndroid-system-a/10247269 Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1714340

Changes: https://github.com/xamarin/monodroid/compare/c0c933b7a5286c0babecb165c0676c32f5e44092...9b69cb11ce5dafed7126baafad28ac8dff22a5d2

  * xamarin/monodroid@9b69cb11c: [tools/msbuild] Fix System App detection (xamarin/monodroid#1284)