### PR TITLE
[tests] update `.apkdesc` files for failing tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -8,46 +8,46 @@
       "Size": 1024
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 58913
+      "Size": 58914
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87163
+      "Size": 87157
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5895
+      "Size": 5867
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Console.dll": {
-      "Size": 6438
+      "Size": 6431
     },
     "assemblies/System.Linq.dll": {
-      "Size": 9122
+      "Size": 9111
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 516811
+      "Size": 517598
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2620
+      "Size": 2613
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3753
+      "Size": 3743
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3219
+      "Size": 3213
     },
     "classes.dex": {
-      "Size": 19020
+      "Size": 19752
     },
     "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
       "Size": 93552
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 379320
+      "Size": 378640
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3090760
+      "Size": 3093016
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -56,10 +56,10 @@
       "Size": 94328
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 155056
+      "Size": 155136
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 16720
+      "Size": 16760
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -11,10 +11,10 @@
       "Size": 58914
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 87157
+      "Size": 87076
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5867
+      "Size": 5798
     },
     "assemblies/rc.bin": {
       "Size": 1182
@@ -35,7 +35,7 @@
       "Size": 3743
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3213
+      "Size": 3211
     },
     "classes.dex": {
       "Size": 19752
@@ -59,7 +59,7 @@
       "Size": 155136
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 16760
+      "Size": 16720
     },
     "META-INF/BNDLTOOL.RSA": {
       "Size": 1213

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -5,136 +5,136 @@
       "Size": 3568
     },
     "assemblies/_Microsoft.Android.Resource.Designer.dll": {
-      "Size": 1942
+      "Size": 1940
     },
     "assemblies/FormsViewGroup.dll": {
       "Size": 7313
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 66786
+      "Size": 66793
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 444703
+      "Size": 444874
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5895
+      "Size": 5867
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3857
+      "Size": 3850
     },
     "assemblies/netstandard.dll": {
-      "Size": 5567
+      "Size": 5562
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 10529
+      "Size": 10520
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15258
+      "Size": 15249
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 7487
+      "Size": 7479
     },
     "assemblies/System.ComponentModel.dll": {
-      "Size": 1964
+      "Size": 1958
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2579
+      "Size": 2573
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6069
+      "Size": 6066
     },
     "assemblies/System.Console.dll": {
-      "Size": 6610
+      "Size": 6601
     },
     "assemblies/System.Core.dll": {
-      "Size": 1982
+      "Size": 1975
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6580
+      "Size": 6576
     },
     "assemblies/System.dll": {
-      "Size": 2338
+      "Size": 2330
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 2023
+      "Size": 2016
     },
     "assemblies/System.Drawing.Primitives.dll": {
-      "Size": 11996
+      "Size": 11990
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 16847
+      "Size": 16839
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 9957
+      "Size": 9952
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19441
+      "Size": 19432
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 164128
+      "Size": 164124
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 65982
+      "Size": 66104
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 22441
+      "Size": 22437
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3620
+      "Size": 3613
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8144
+      "Size": 8139
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 808708
+      "Size": 810557
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 192356
+      "Size": 192352
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42878
+      "Size": 42872
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 216193
+      "Size": 216186
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16662
+      "Size": 16658
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2763
+      "Size": 2756
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 3753
+      "Size": 3743
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1943
+      "Size": 1936
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2509
+      "Size": 2501
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3791
+      "Size": 3785
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 7766
+      "Size": 7767
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 156677
+      "Size": 157070
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1833
+      "Size": 1826
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1856
+      "Size": 1849
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 5294
+      "Size": 5286
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 5870
+      "Size": 5867
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
       "Size": 6117
@@ -146,7 +146,7 @@
       "Size": 6592
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 16404
+      "Size": 16408
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
       "Size": 96738
@@ -158,16 +158,16 @@
       "Size": 39951
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 5923
+      "Size": 5924
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
       "Size": 6391
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6459
+      "Size": 6462
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3067
+      "Size": 3068
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
       "Size": 12473
@@ -176,7 +176,7 @@
       "Size": 84804
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 4866
+      "Size": 4870
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
       "Size": 10389
@@ -188,10 +188,10 @@
       "Size": 528450
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 337828
+      "Size": 337831
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
-      "Size": 11084
+      "Size": 11080
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
       "Size": 60774
@@ -200,16 +200,16 @@
       "Size": 40158
     },
     "classes.dex": {
-      "Size": 3141008
+      "Size": 3127152
     },
     "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
       "Size": 93552
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 379320
+      "Size": 378640
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3090760
+      "Size": 3093016
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
@@ -218,10 +218,10 @@
       "Size": 94328
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 155056
+      "Size": 155136
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 333720
+      "Size": 333760
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -1976,5 +1976,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 7828228
+  "PackageSize": 7807748
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -14,10 +14,10 @@
       "Size": 66793
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 444874
+      "Size": 444804
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5867
+      "Size": 5798
     },
     "assemblies/mscorlib.dll": {
       "Size": 3850
@@ -221,7 +221,7 @@
       "Size": 155136
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 333760
+      "Size": 333720
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7264347&view=ms.vss-test-web.build-test-results-tab&runId=67617676&resultId=100033&paneView=debug

A single test was failing on Windows-only:

    BuildReleaseArm64(True)
    apkdiff regression test failed with exit code: 3
    stdErr: Error: apkdiff: PackageSize decrease 8,192 is 3,072 bytes more than the threshold 5,120. apk1 size: 9,521,310 bytes, apk2 size: 9,513,118 bytes.
    Error: apkdiff: Size regression occured, 1 check(s) failed.

Most notably a single file changed:

    14,556 classes.dex

I believe this started failing in 35db5272, due to a combination of changes:

* [dotnet/runtime#77386][0] introduced `libSystem.Security.Cryptography.Native.Android.jar` in the Mono runtime packs.

* We updated `.apkdesc` files *before* including the new `.jar`.

* We added appropriate logic to include the new `.jar`.

The result was we have `.apkdesc` files that don't match the full set of changes in 35db5272. Then in 8872d04 the app size changed beyond the threshold for a test to fail.

[0]: https://github.com/dotnet/runtime/pull/77386