### PR TITLE
Maybe fix the `unable to open file as zip archive` error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -183,6 +183,7 @@ namespace Xamarin.Android.Tasks
 					string apkName = dex.GetMetadata ("ApkName");
 					string dexPath = string.IsNullOrWhiteSpace (apkName) ? Path.GetFileName (dex.ItemSpec) : apkName;
 					AddFileToArchiveIfNewer (apk, dex.ItemSpec, DalvikPath + dexPath, compressionMethod: dexCompressionMethod);
+					apk.Flush ();
 				}
 
 				if (EmbedAssemblies && !BundleAssemblies) {


### PR DESCRIPTION
Context: https://gist.github.com/grendello/55b9a74c80c611dd48b726ee6f16d3c9

Sometimes in our tests we see an error from LibZipSharp which claims an file 
cannot be opened as a valid ZIP archive.  The reason for this is ZIP format 
corruption happening sometimes in the `BuildApk` task.

The way the process works is that we first run `aapt2` to produce an APK archive 
named `packaged_resources`, which we then copy to the destination APK (using 
standard `File.Copy`) and open it to append our content.  The first item we 
always append is the `classes.dex` file which is also the **only** corrupted e
ntry in the broken APK files.

ZIP files contain two records describing each entry in the archive:

  1. in the Central Directory (which is located at the end of the file)
  2. local header in the ZIP data stream, offset of whose is contained 
     in the above Central Directory record.

After close examination, it appears that the broken APK files contain `1` above 
for `classes.dex` but not `2`.  Instead of `2` we see a copy of `packaged_resource` 
package's Central Directory record.

The corruption may be caused by invalid stream position after we open the 
`packaged_resources` copy and append `classes.dex` entry to it.

Calling `Flush ()` after adding `classex.dex` **may** fix the problem.

If it doesn't, we should consider copying data from `packaged_resources` to the 
final APK entry by entry by decompressing them from the original archive and 
adding them to the destination one.