### PR TITLE
Add `_AndroidLibraryProjectImportsCache` to `FileWrites`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -857,6 +857,7 @@ namespace Lib2
 
 				b.BuildLogFile = "build2.log";
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+				FileAssert.Exists (cacheFile);
 				var actual = ReadCache (cacheFile);
 				CollectionAssert.AreEqual (actual.Jars.Select (j => j.ItemSpec),
 					expected.Jars.Select (j => j.ItemSpec));
@@ -871,6 +872,7 @@ namespace Lib2
 
 				b.BuildLogFile = "build3.log";
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
+				FileAssert.Exists (cacheFile);
 				actual = ReadCache (cacheFile);
 				Assert.AreEqual (expected.Jars.Length + 1, actual.Jars.Length,
 					$"{nameof (expected.Jars)} should have one more item");
@@ -885,6 +887,7 @@ namespace Lib2
 				// Build with no changes, checking we are skipping targets appropriately
 				b.BuildLogFile = "build4.log";
 				Assert.IsTrue (b.Build (proj), "fourth build should have succeeded.");
+				FileAssert.Exists (cacheFile);
 				var targets = new List<string> {
 					"_UpdateAndroidResgen",
 					"_CompileJava",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.EmbeddedResource.targets
@@ -46,6 +46,10 @@ This file is used by all project types, including binding projects.
         OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
     />
     <Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidLibraryProjectImportsCache)"
+          Condition="Exists ('$(_AndroidLibraryProjectImportsCache)')"/>
+    </ItemGroup>
   </Target>
 
   <Target Name="_ExtractLibraryProjectImports" DependsOnTargets="_ResolveLibraryProjectImports">


### PR DESCRIPTION
On occasion we see the following error when building a Maui app.

```
MyMauiApp/Platforms/Android/AndroidManifest.xml : error APT2260: resource style/Maui.SplashTheme
(aka com.companyname.mymauiapp:style/Maui.SplashTheme) not found.
```

Looking in detail at te build log we notice that NONE of the resources in the `$(IntermediateOutputPath)\lp` folder 
are being included in the call to `aapt2`. Looking further we see two very important lines

`Skipping target "_ResolveLibraryProjectImports" because all output files are up-to-date with respect to the input files.`

```
Task "ReadLibraryProjectImportsCache" (TaskId:184)
Task Parameter:CacheFile=obj/Debug/net7.0-android/libraryprojectimports.cache (TaskId:184)
Task ReadLibraryProjectImportsCache (TaskId:184)
    CacheFile: obj/Debug/net7.0-android/libraryprojectimports.cache (TaskId:184)
   obj/Debug/net7.0-android/libraryprojectimports.cache does not exist. No Project Library Imports found (TaskId:184)
 Done executing task "ReadLibraryProjectImportsCache". (TaskId:184)
```

So in this case it seems that the `.cache` file which stores the list of resource directories was created, but was then
deleted later on. A search of our build system shows that this case file was never added to the `FileWrites` ItemGroup.
As a result it gets deleted, but the `.stamp` file which controls `_ResolveLibraryProjectImports` is left in place. We end up in a situation where the target which generates the cache will NEVER run again because its stamp file is present. 
Only a full Clean will fix this issue.