### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Android Version Code for Release builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -527,6 +527,8 @@ namespace Bug12935
 		[TestCase ("1", true, "x86_64=500001;arm64-v8a=400001")]
 		[TestCase ("2", false, "manifest=2")]
 		[TestCase ("2", true, "x86_64=500002;arm64-v8a=400002")]
+		[TestCase ("999", false, "manifest=999")]
+		[TestCase ("999", true, "x86_64=500999;arm64-v8a=400999")]
 		public void ApplicationVersionTests (string applicationVersion, bool seperateApk, string expected)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -546,7 +548,7 @@ namespace Bug12935
 				var expectedItems = expected.Split (';');
 				foreach (var item in expectedItems) {
 					var items = item.Split ('=');
-					var path = seperateApk ? Path.Combine ("android", items [0], "AndroidManifest.xml") : Path.Combine ("android", "manifest", "AndroidManifest.xml");
+					var path = Path.Combine ("android", items [0], "AndroidManifest.xml");
 					var manifest = builder.Output.GetIntermediaryAsText (Root, path);
 					var doc = XDocument.Parse (manifest);
 					var m = doc.XPathSelectElement ("/manifest") as XElement;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -523,6 +523,44 @@ namespace Bug12935
 		}
 
 		[Test]
+		[TestCase ("1", false, "manifest=1")]
+		[TestCase ("1", true, "x86_64=500001;arm64-v8a=400001")]
+		[TestCase ("2", false, "manifest=2")]
+		[TestCase ("2", true, "x86_64=500002;arm64-v8a=400002")]
+		public void ApplicationVersionTests (string applicationVersion, bool seperateApk, string expected)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				MinSdkVersion = null,
+			};
+			proj.SetProperty (proj.ReleaseProperties, "ApplicationVersion", applicationVersion);
+			proj.SetProperty (proj.ReleaseProperties, "ApplicationDisplayVersion", applicationVersion);
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, seperateApk);
+			proj.AndroidManifest = proj.AndroidManifest
+				.Replace ("android:versionCode=\"1\"", string.Empty)
+				.Replace ("android:versionName=\"1.0\"", string.Empty);
+			using (var builder = CreateApkBuilder ()) {
+				Assert.True (builder.Build (proj), "Build should have succeeded.");
+				XNamespace aNS = "http://schemas.android.com/apk/res/android";
+
+				var expectedItems = expected.Split (';');
+				foreach (var item in expectedItems) {
+					var items = item.Split ('=');
+					var path = seperateApk ? Path.Combine ("android", items [0], "AndroidManifest.xml") : Path.Combine ("android", "manifest", "AndroidManifest.xml");
+					var manifest = builder.Output.GetIntermediaryAsText (Root, path);
+					var doc = XDocument.Parse (manifest);
+					var m = doc.XPathSelectElement ("/manifest") as XElement;
+					Assert.IsNotNull (m, "no manifest element found");
+					var vc = m.Attribute (aNS + "versionCode");
+					Assert.IsNotNull (vc, "no versionCode attribute found");
+					StringAssert.AreEqualIgnoringCase (items [1], vc.Value,
+						$"Version Code is incorrect. Found {vc.Value} expect {items [1]}");
+				}
+
+			}
+		}
+
+		[Test]
 		public void ManifestPlaceholders ([Values ("legacy", "manifestmerger.jar")] string manifestMerger)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -599,7 +599,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AndroidPackage>$(ApplicationId)</_AndroidPackage>
     <_ApplicationLabel>$(ApplicationTitle)</_ApplicationLabel>
     <_AndroidVersionName>$(ApplicationDisplayVersion)</_AndroidVersionName>
-    <_AndroidVersionCode Condition=" '$(AndroidCreatePackagePerAbi)' != 'true' ">$(ApplicationVersion)</_AndroidVersionCode>
+    <_AndroidVersionCode Condition=" '$(AndroidCreatePackagePerAbi)' == 'true' And '$(ApplicationVersion)' != '' ">$(ApplicationVersion)</_AndroidVersionCode>
+    <_AndroidVersionCode Condition=" '$(AndroidCreatePackagePerAbi)' != 'true' And '$(_AndroidVersionCode)' == '' ">$(ApplicationVersion)</_AndroidVersionCode>
   </PropertyGroup>
   <AndroidError Code="XA1018"
       ResourceName="XA1018"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -599,8 +599,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AndroidPackage>$(ApplicationId)</_AndroidPackage>
     <_ApplicationLabel>$(ApplicationTitle)</_ApplicationLabel>
     <_AndroidVersionName>$(ApplicationDisplayVersion)</_AndroidVersionName>
-    <_AndroidVersionCode Condition=" '$(AndroidCreatePackagePerAbi)' == 'true' And '$(ApplicationVersion)' != '' ">$(ApplicationVersion)</_AndroidVersionCode>
-    <_AndroidVersionCode Condition=" '$(AndroidCreatePackagePerAbi)' != 'true' And '$(_AndroidVersionCode)' == '' ">$(ApplicationVersion)</_AndroidVersionCode>
+    <_AndroidVersionCode>$(ApplicationVersion)</_AndroidVersionCode>
   </PropertyGroup>
   <AndroidError Code="XA1018"
       ResourceName="XA1018"


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/11139

Users trying to use `maui` and the new `ApplicationVersion` in conjunction with `AndroidCreatePackagePerAbi` find that the version is NOT used in the final set of apks.

This is because when we use `AndroidCreatePackagePerAbi` we are totally ignoring the `ApplicationVersion` number. Instead we pick up the one from the `AndroidManifest.xml` `android:versionCode`. For maui users This is not obvious and is counter intuitive.

So lets use the `ApplicationVersion` when using `AndroidCreatePackagePerAbi`. All the old code will remain in place, if the `ApplicationVersion` is not set we will still fall back to `android:versionCode` and if that is not set default to `1`.