### PR TITLE
Bump to xamarin/Java.Interop/main@bbaeda6f

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
     branch = main
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
-    url = https://github.com/xamarin/java.interop.git
-    branch = main
+    url = https://github.com/jonpryor/java.interop.git
+    branch = jonp-use-right-class-for-remapped-static-method-invocations
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
     branch = main
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
-    url = https://github.com/jonpryor/java.interop.git
-    branch = jonp-use-right-class-for-remapped-static-method-invocations
+    url = https://github.com/xamarin/java.interop.git
+    branch = main
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -35,9 +35,16 @@
       <_DestDir>$(IntermediateOutputPath)__CreateTestJarFile-bin</_DestDir>
       <_AndroidJar>-bootclasspath "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
       <_CP>-cp "$(_JavaInteropJarPath)"</_CP>
+      <_JavacFilesResponse>$(IntermediateOutputPath)__javac_response.txt</_JavacFilesResponse>
     </PropertyGroup>
+    <WriteLinesToFile
+        File="$(_JavacFilesResponse)"
+        Lines="@(_JavacSource)"
+        Overwrite="True"
+    />
     <MakeDir Directories="$(_DestDir)" />
-    <Exec Command="$(_Javac) $(_Targets) -d &quot;$(_DestDir)&quot; $(_AndroidJar) $(_CP) @(_JavacSource->'&quot;%(Identity)&quot;', ' ')" />
+    <Exec Command="$(_Javac) $(_Targets) -d &quot;$(_DestDir)&quot; $(_AndroidJar) $(_CP) &quot;@$(_JavacFilesResponse)&quot;" />
+    <Delete Files="$(_JavacFilesResponse)" />
     <Exec
         Command="$(_Jar) cf &quot;classes.jar&quot; ."
         WorkingDirectory="$(_DestDir)"

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -314,9 +314,12 @@ namespace Android.Runtime {
 				desugarType.Append ("Desugar").Append (name);
 			}
 
+			var typeWithPrefix  = desugarType.ToString ();
+			var typeWithSuffix  = $"{jniSimpleReference}$-CC";
+
 			return new[]{
-				desugarType.ToString (),
-				$"{jniSimpleReference}$-CC"
+				GetReplacementTypeCore (typeWithPrefix) ?? typeWithPrefix,
+				GetReplacementTypeCore (typeWithSuffix) ?? typeWithSuffix,
 			};
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ResourceData.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Android.Build.Tests
 		static Lazy<byte []> javaSourceTestInterface = new Lazy<byte []> (() => GetResourceData ("JavaSourceTestInterface.java"));
 		static Lazy<byte []> remapActivityJava = new Lazy<byte []> (() => GetResourceData ("RemapActivity.java"));
 		static Lazy<byte []> remapActivityXml = new Lazy<byte []> (() => GetResourceData ("RemapActivity.xml"));
+		static Lazy<byte []> idmStaticMethodsInterface = new Lazy<byte []> (() => GetResourceData ("StaticMethodsInterface.java"));
 
 		public  static  byte[]  JavaSourceJarTestJar            => javaSourceJarTestJar.Value;
 		public  static  byte[]  JavaSourceJarTestSourcesJar     => javaSourceJarTestSourcesJar.Value;
@@ -34,6 +35,7 @@ namespace Xamarin.Android.Build.Tests
 		public  static  string JavaSourceTestInterface => Encoding.ASCII.GetString (javaSourceTestInterface.Value);
 		public  static  string RemapActivityJava => Encoding.UTF8.GetString (remapActivityJava.Value);
 		public  static  string RemapActivityXml => Encoding.UTF8.GetString (remapActivityXml.Value);
+		public  static  string IdmStaticMethodsInterface => Encoding.UTF8.GetString (idmStaticMethodsInterface.Value);
 
 		static byte[] GetResourceData (string name)
 		{

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -31,6 +31,9 @@
     <EmbeddedResource Include="Resources\RemapActivity*">
       <LogicalName>%(FileName)%(Extension)</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\StaticMethodsInterface*">
+      <LogicalName>%(FileName)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/Resources/StaticMethodsInterface.java
+++ b/tests/MSBuildDeviceIntegration/Resources/StaticMethodsInterface.java
@@ -1,0 +1,7 @@
+package example;
+
+public interface StaticMethodsInterface {
+    static int getValue() {
+        return 3;
+    }
+}

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Remaps.xml
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Remaps.xml
@@ -2,6 +2,9 @@
   <replace-type
       from="com/xamarin/interop/RenameClassBase1"
       to="com/xamarin/interop/RenameClassBase2" />
+  <replace-type
+      from="com/xamarin/interop/AndroidInterface"
+      to="com/xamarin/interop/DesugarAndroidInterface$_CC" />
   <replace-method
       source-type="java/lang/Object"
       source-method-name="remappedToToString"


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/9e0a4690adb71c04cd88a5b54bea3c3f8da73cc0...bbaeda6f698369bdd48bfc2dd1a32a41c9d23229
    
  * xamarin/java.interop@bbaeda6f: [Java.Interop] Support Desugar + interface static methods (xamarin/java.interop#1077)

Context: https://github.com/xamarin/java.interop/commit/bbaeda6f698369bdd48bfc2dd1a32a41c9d23229
Context: https://github.com/xamarin/java.interop/commit/1f27ab552d03aeb74cdc6f8985fcffbfdb9a7ddf
Context: f6f11a5a797cd8602854942dccb0f2b1db57c473

[Desugaring][0] is the process of rewriting Java bytecode so that Java 8+ constructs can be used on Android pre-7.0 (API-24), as API-24 is the Android version which added native support for Java 8 features such as [interface default methods][1].

One of the implications of desugaring is that methods can "move"; consider this Java interface:

	package example;
	public interface StaticMethodsInterface {
	    static int getValue() { return 3; }
	}

Java.Interop bindings will attempt to invoke the `getValue().I` method on the type `example/StaticMethodsInterface`:

	public partial interface IStaticMethodsInterface : IJavaObject, IJavaPeerable {
	    private static readonly JniPeerMembers _members = new XAPeerMembers ("example/StaticMethodsInterface", typeof (IStaticMethodsInterface), isInterface: true);
	    static unsafe int Value {
	        get {
	            const string __id = "getValue.()I";
	            var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
	            return __rm;
	        }
	    }
	}

The problem is that, after Desugaring, the Java side *actually* looks like this:

	package example;
	public interface StaticMethodsInterface {
	}
	public class StaticMethodsInterface$-CC {
	    public static int getValue() {return 3;}
	}

Commits xamarin/java.interop@1f27ab55 and f6f11a5a added partial runtime support for this scenario via
`AndroidTypeManager.GetStaticMethodFallbackTypesCore()`, which would attempt to lookup types with a `$-CC` suffix.

While this was a good start, it wasn't ever actually *tested* end-to-end.  Consequently, instead of *working*, this would instead cause the process to *abort*:

	JNI DETECTED ERROR IN APPLICATION: can't call static int example.StaticMethodsInterface$-CC.getValue() with class java.lang.Class<example.StaticMethodsInterface>
	    in call to CallStaticIntMethodA
	    from void crc….MainActivity.n_onCreate(android.os.Bundle)

Oops.

xamarin/java.interop#1077 improves our runtime support for invoking *`static`* methods on interfaces.

Add a new `XASdkDeployTests.SupportDesugaringStaticInterfaceMethods()` test which performs an on-device, end-to-end invocation of a static method on a Java interface, to ensure that things *actually* work.

*Note*: if `$(SupportedOSPlatformVersion)` is 24 or higher, this test will work even without xamarin/java.interop#1077, as Desugaring is *disabled* in that case.

[0]: https://developer.android.com/studio/write/java8-support#library-desugaring
[1]: https://docs.oracle.com/javase/tutorial/java/IandI/defaultmethods.html