### PR TITLE
Bump 'InstallAndroidDependenciesTest' to use PlatformTools 34.0.0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -39,13 +39,13 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsTrue (b.Build (proj, parameters: new string [] {
 						"AcceptAndroidSDKLicenses=true",
 						"AndroidManifestType=GoogleV2",     // Need GoogleV2 so we can install API-32
-						"AndroidSdkPlatformToolsVersion=33.0.3",
+						"AndroidSdkPlatformToolsVersion=34.0.0",
 					}), "InstallAndroidDependencies should have succeeded.");
 					b.Target = defaultTarget;
 					b.BuildLogFile = "build.log";
 					Assert.IsTrue (b.Build (proj, true), "build should have succeeded.");
-					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"Output Property: _AndroidSdkDirectory={sdkPath}"), "_AndroidSdkDirectory was not set to new SDK path.");
-					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"JavaPlatformJarPath={sdkPath}"), "JavaPlatformJarPath did not contain new SDK path.");
+					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"Output Property: _AndroidSdkDirectory={sdkPath}"), $"_AndroidSdkDirectory was not set to new SDK path `{sdkPath}`.");
+					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"JavaPlatformJarPath={sdkPath}"), $"JavaPlatformJarPath did not contain new SDK path `{sdkPath}`.");
 				}
 			} finally {
 				Environment.SetEnvironmentVariable ("TEST_ANDROID_SDK_PATH", old);


### PR DESCRIPTION
We are seeing the `InstallAndroidDependenciesTest` test fail allot recently.
Looking at the logs we see the following warning.

```
warning : Dependency `platform-tools` should have been installed but could not be resolved. You can attempt to install it with: /Users/dean/Documents/Sandbox/Xamarin/WI1714603/bin/TestRelease/temp/InstallAndroidDependenciesTest/android-sdk/cmdline-tools/7.0/lib/sdkmanager-classpath.jar --install "platform-tools"
```

As a result `platform-tools` is not installed. This causes the `ResolveSdks` task to ignore the test sdk directory because `adb` is missing. So lets update the `AndroidSdkPlatformToolsVersion ` to use one that does work.