### PR TITLE
[tests] Bump NUnit versions to latest

### DIFF
--- a/build-tools/scripts/NUnitReferences.projitems
+++ b/build-tools/scripts/NUnitReferences.projitems
@@ -1,9 +1,9 @@
 <Project>
   <!-- This file assumes Configuration.props has been imported -->
   <ItemGroup>
-    <PackageReference Include="NUnit"               Version="3.13.2" />
+    <PackageReference Include="NUnit"               Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="$(NUnitConsoleVersion)" />
-    <PackageReference Include="NUnit3TestAdapter"   Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter"   Version="4.3.1" />
   </ItemGroup>
   <!-- Required packages for .NET Core -->
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0' ">


### PR DESCRIPTION
The tests on the `run MSBuildDeviceIntegration On Device - macOS-1 - One .NET` job are not running due to this error:

```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Exception NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryException,    Exception thrown executing tests in /Users/runner/work/1/s/xamarin-android/bin/TestRelease/MSBuildDeviceIntegration/net7.0/MSBuildDeviceIntegration.dll
Not a TestFixture, SetUpFixture or TestSuite, but ParameterizedFixture
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ExtractTestFixtures(NUnitDiscoveryCanHaveTestFixture parent, XElement node) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 272
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 223
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 229
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 229
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 229
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.ConvertXml(NUnitResults discovery) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 179
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.DiscoveryConverter.Convert(NUnitResults discoveryResults, String assemblyPath) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\DiscoveryConverter.cs:line 134
   at NUnit.VisualStudio.TestAdapter.NUnit3TestExecutor.RunAssembly(String assemblyPath, IGrouping`2 testCases, TestFilter filter) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnit3TestExecutor.cs:line 279
No test matches the given testcase filter `TestCategory = Node-1 & TestCategory != TimeZoneInfo & TestCategory != Localization & TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != S...` in /Users/runner/work/1/s/xamarin-android/bin/TestRelease/MSBuildDeviceIntegration/net7.0/MSBuildDeviceIntegration.dll
Results File: /Users/runner/work/1/s/xamarin-android/TestResult-MSBuildDeviceIntegration-mac_dotnetdevice_tests_1-Release.xml
```
Source: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7343148&view=logs&j=ef53a832-6b9d-50db-0090-851acbb6bf0a&t=fba7f8c5-5b66-5210-3a07-28605b5a156a

This is fixed in `NUnit3TestAdapter` version `4.1`:
https://github.com/nunit/nunit3-vs-adapter/discussions/867#discussioncomment-1709528

Update NUnit to latest versions to fix, which results in:

```
Passed!  - Failed:     0, Passed:    60, Skipped:     0, Total:    60, Duration: 52 m 32 s - MSBuildDeviceIntegration.dll (net7.0)
Finishing: run MSBuildDeviceIntegration On Device - macOS-1 - One .NET
```