### PR TITLE
[Microsoft.Android.Sdk.ILLink] target `net7.0` temporarily

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
-    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
     <DefineConstants>ILLINK</DefineConstants>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/pull/17560
Context: https://github.com/dotnet/runtime/issues/82241

On macOS, if you have both .NET 7 and .NET 8 Preview 1 installed, and you do:

* `dotnet new android`

* `dotnet build -c Release`

You get a build error:

    Fatal error in IL Linker
    Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
    File name: 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
        at Microsoft.Android.Sdk.ILLink.PreserveSubStepDispatcher..ctor()
        at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
        --- End of inner exception stack trace ---
        at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
        at Mono.Linker.Driver.AddCustomStep(Pipeline pipeline, String arg)
        at Mono.Linker.Driver.SetupContext(ILogger customLogger)
        at Mono.Linker.Driver.Run(ILogger customLogger)
        at Mono.Linker.Driver.Main(String[] args)

This happens because the linker is actually trying to run against the .NET 7 runtime! It promptly blows up against `net8.0` linker steps.

Trying the same workaround as xamarin-macios, to build our linker steps for `net7.0`