### PR TITLE
Try this to fix the WearOS tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XASdkProject.cs
@@ -57,7 +57,8 @@ namespace Xamarin.ProjectTools
 			Sdk = "Microsoft.NET.Sdk";
 			TargetFramework = "net8.0-android";
 			SupportedOSPlatformVersion = "21";
-			PackageName = $"com.xamarin.{(packageName ?? ProjectName).ToLower ()}";
+			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
+			PackageName = $"com.xamarin.{(packageName ?? ProjectName + id).ToLower ()}";
 			JavaPackageName = JavaPackageName ?? PackageName.ToLowerInvariant ();
 			GlobalPackagesFolder = FileSystemUtils.FindNugetGlobalPackageFolder ();
 			SetProperty (KnownProperties.OutputType, outputType);

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (DotNetInstallAndRunSource))]
 		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, string targetFramework)
 		{
-			var id = new Random ().Next (1, 5000);
+			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
 
 			XASdkProject proj;
 			if (xamarinForms) {
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void TypeAndMemberRemapping ([Values (false, true)] bool isRelease)
 		{
-			var id = new Random ().Next (1, 5000);
+			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
 
 			var proj = new XASdkProject () {
 				ProjectName = $"TypeAndMemberRemapping{id}",

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -71,13 +71,19 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (DotNetInstallAndRunSource))]
 		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, string targetFramework)
 		{
+			var id = new Random ().Next (1, 5000);
+
 			XASdkProject proj;
 			if (xamarinForms) {
 				proj = new XamarinFormsXASdkProject {
+					ProjectName = $"DotNetInstallAndRun{id}",
+					PackageName = $"com.xamarin.dotnetinstallandrun{id}",
 					IsRelease = isRelease
 				};
 			} else {
 				proj = new XASdkProject {
+					ProjectName = $"DotNetInstallAndRun{id}",
+					PackageName = $"com.xamarin.dotnetinstallandrun{id}",
 					IsRelease = isRelease
 				};
 			}
@@ -88,6 +94,7 @@ namespace Xamarin.Android.Build.Tests
 			var relativeProjDir = Path.Combine ("temp", TestName);
 			var fullProjDir     = Path.Combine (Root, relativeProjDir);
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
+			TestPackageNames[proj.PackageName] = proj.PackageName;
 			var files = proj.Save ();
 			proj.Populate (relativeProjDir, files);
 			proj.CopyNuGetConfig (relativeProjDir);
@@ -105,7 +112,11 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void TypeAndMemberRemapping ([Values (false, true)] bool isRelease)
 		{
+			var id = new Random ().Next (1, 5000);
+
 			var proj = new XASdkProject () {
+				ProjectName = $"TypeAndMemberRemapping{id}",
+				PackageName = $"com.xamarin.typeandmemberremapping{id}",
 				IsRelease = isRelease,
 				OtherBuildItems = {
 					new AndroidItem._AndroidRemapMembers ("RemapActivity.xml") {
@@ -126,6 +137,7 @@ namespace Xamarin.Android.Build.Tests
 			var relativeProjDir = Path.Combine ("temp", TestName);
 			var fullProjDir     = Path.Combine (Root, relativeProjDir);
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
+			TestPackageNames[proj.PackageName] = proj.PackageName;
 			var files = proj.Save ();
 			proj.Populate (relativeProjDir, files);
 			proj.CopyNuGetConfig (relativeProjDir);
@@ -220,6 +232,7 @@ namespace Xamarin.Android.Build.Tests
 			var relativeProjDir = Path.Combine ("temp", TestName);
 			var fullProjDir = Path.Combine (Root, relativeProjDir);
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = fullProjDir;
+			TestPackageNames[proj.PackageName] = proj.PackageName;
 			var files = proj.Save ();
 			proj.Populate (relativeProjDir, files);
 			proj.CopyNuGetConfig (relativeProjDir);

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (DotNetInstallAndRunSource))]
 		public void DotNetInstallAndRun (bool isRelease, bool xamarinForms, string targetFramework)
 		{
-			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
+			//var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
 
 			XASdkProject proj;
 			if (xamarinForms) {
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void TypeAndMemberRemapping ([Values (false, true)] bool isRelease)
 		{
-			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
+			//var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
 
 			var proj = new XASdkProject () {
 				ProjectName = $"TypeAndMemberRemapping",

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -76,14 +76,14 @@ namespace Xamarin.Android.Build.Tests
 			XASdkProject proj;
 			if (xamarinForms) {
 				proj = new XamarinFormsXASdkProject {
-					ProjectName = $"DotNetInstallAndRun{id}",
-					PackageName = $"com.xamarin.dotnetinstallandrun{id}",
+					ProjectName = $"DotNetInstallAndRun",
+					//PackageName = $"com.xamarin.dotnetinstallandrun{id}",
 					IsRelease = isRelease
 				};
 			} else {
 				proj = new XASdkProject {
-					ProjectName = $"DotNetInstallAndRun{id}",
-					PackageName = $"com.xamarin.dotnetinstallandrun{id}",
+					ProjectName = $"DotNetInstallAndRun",
+					//PackageName = $"com.xamarin.dotnetinstallandrun{id}",
 					IsRelease = isRelease
 				};
 			}
@@ -115,8 +115,8 @@ namespace Xamarin.Android.Build.Tests
 			var id = DateTime.Now.ToString ("yyyyMMddHHmmssfff");
 
 			var proj = new XASdkProject () {
-				ProjectName = $"TypeAndMemberRemapping{id}",
-				PackageName = $"com.xamarin.typeandmemberremapping{id}",
+				ProjectName = $"TypeAndMemberRemapping",
+				//PackageName = $"com.xamarin.typeandmemberremapping{id}",
 				IsRelease = isRelease,
 				OtherBuildItems = {
 					new AndroidItem._AndroidRemapMembers ("RemapActivity.xml") {


### PR DESCRIPTION
So when running the WearOS Image we get some weird behaviour. 
When starting an app we don't always get a `ActivityTaskManager: Displayed` or `ActivityManager: Displayed`. 
We do see messsages which start with `mAutoResumeActivity=` about auto resuming an existing activity. 

So I am wondering if because the tests all use the same package id, the OS is not re-running it. 
So lets try a unique package name per test and see if that works.