### PR TITLE
Bump NDK to r25c

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "25b";
-		public const string AndroidNdkPkgRevision = "25.1.8937393";
+		public const string AndroidNdkVersion = "25c";
+		public const string AndroidNdkPkgRevision = "25.2.9519653";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 19;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r25#r25c

Changes potentially useful for us:

  - Updated LLVM to clang-r450784d1, based on LLVM 14 development. 
  - Issue 1832: Improvements to aarch64 vector code generation.