### PR TITLE
[MSBuildDeviceIntegration] Fix duplicated test parameter

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Build.Tests
 			new object[] {
 				/* isRelease */      true,
 				/* xamarinForms */   false,
-				/* targetFramework*/ "net8.0-android",
+				/* targetFramework*/ "net7.0-android",
 			},
 			new object[] {
 				/* isRelease */      false,


### PR DESCRIPTION
The following test case is duplicated in `MSBuildDeviceIntegration.XASdkDeployTests (...)`:

```csharp
new object[] {
	/* isRelease */      true,
	/* xamarinForms */   false,
	/* targetFramework*/ "net8.0-android",
},
```

This was likely a c/p error and the correct `targetFramework` is `net7.0-android`.