### PR TITLE
[monodroid] Prevent overlapped decompression of embedded assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -5,49 +5,49 @@
       "Size": 3032
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 58991
+      "Size": 58989
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88024
+      "Size": 88029
     },
     "assemblies/rc.bin": {
       "Size": 1182
     },
     "assemblies/System.Console.dll": {
-      "Size": 6527
+      "Size": 6525
     },
     "assemblies/System.Linq.dll": {
-      "Size": 9223
+      "Size": 9224
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 464288
+      "Size": 464285
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2346
+      "Size": 2348
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 2234
+      "Size": 2232
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3631
+      "Size": 3628
     },
     "classes.dex": {
       "Size": 368636
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 427328
+      "Size": 371888
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3074520
+      "Size": 3075360
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 93704
+      "Size": 93768
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 148696
+      "Size": 151624
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 9680
@@ -86,5 +86,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 2639930
+  "PackageSize": 2627642
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -8,7 +8,7 @@
       "Size": 58989
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88025
+      "Size": 88028
     },
     "assemblies/rc.bin": {
       "Size": 1182

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -8,7 +8,7 @@
       "Size": 58989
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 88029
+      "Size": 88025
     },
     "assemblies/rc.bin": {
       "Size": 1182
@@ -29,13 +29,13 @@
       "Size": 2232
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 3628
+      "Size": 3622
     },
     "classes.dex": {
       "Size": 368636
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 371888
+      "Size": 371504
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3075360
@@ -62,7 +62,7 @@
       "Size": 2560
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4762
+      "Size": 4791
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleLegacy.apkdesc
@@ -5,43 +5,43 @@
       "Size": 2604
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 68921
+      "Size": 69019
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 259883
+      "Size": 264177
     },
     "assemblies/mscorlib.dll": {
-      "Size": 769017
+      "Size": 769014
     },
     "assemblies/System.Core.dll": {
-      "Size": 28199
+      "Size": 28190
     },
     "assemblies/System.dll": {
-      "Size": 9179
+      "Size": 9178
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2877
+      "Size": 2873
     },
     "classes.dex": {
-      "Size": 362940
+      "Size": 370828
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
     },
+    "lib/arm64-v8a/libmonodroid.so": {
+      "Size": 277152
+    },
     "lib/arm64-v8a/libmono-native.so": {
       "Size": 750976
     },
-    "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 332128
-    },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 4051864
+      "Size": 4039176
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 66184
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 20240
+      "Size": 20328
     },
     "META-INF/ANDROIDD.RSA": {
       "Size": 1213
@@ -74,5 +74,5 @@
       "Size": 1724
     }
   },
-  "PackageSize": 4028116
+  "PackageSize": 4015828
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -11,7 +11,7 @@
       "Size": 66840
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 445269
+      "Size": 445271
     },
     "assemblies/mscorlib.dll": {
       "Size": 3830

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -8,16 +8,16 @@
       "Size": 7114
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 66845
+      "Size": 66840
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 445336
+      "Size": 445342
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3829
+      "Size": 3830
     },
     "assemblies/netstandard.dll": {
-      "Size": 5546
+      "Size": 5550
     },
     "assemblies/rc.bin": {
       "Size": 1182
@@ -26,7 +26,7 @@
       "Size": 10612
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15447
+      "Size": 15446
     },
     "assemblies/System.Collections.NonGeneric.dll": {
       "Size": 7597
@@ -35,97 +35,97 @@
       "Size": 2118
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2614
+      "Size": 2615
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6168
+      "Size": 6169
     },
     "assemblies/System.Console.dll": {
-      "Size": 6693
+      "Size": 6690
     },
     "assemblies/System.Core.dll": {
-      "Size": 1953
+      "Size": 1956
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6712
+      "Size": 6708
     },
     "assemblies/System.dll": {
-      "Size": 2309
+      "Size": 2312
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 1991
+      "Size": 1993
     },
     "assemblies/System.Drawing.Primitives.dll": {
       "Size": 12129
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 16760
+      "Size": 16759
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
-      "Size": 10114
+      "Size": 10111
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19286
+      "Size": 19288
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 164020
+      "Size": 164017
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 66971
+      "Size": 66969
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 21981
+      "Size": 21983
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3716
+      "Size": 3715
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8137
+      "Size": 8139
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 772506
+      "Size": 772515
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 192495
+      "Size": 192548
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42378
+      "Size": 42377
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 215549
+      "Size": 215543
     },
     "assemblies/System.Private.Xml.Linq.dll": {
       "Size": 16806
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2545
+      "Size": 2548
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 2234
+      "Size": 2232
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1917
+      "Size": 1918
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2647
+      "Size": 2646
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3819
+      "Size": 3820
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 7913
+      "Size": 7915
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 154174
+      "Size": 154283
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1805
+      "Size": 1806
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1827
+      "Size": 1828
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117372
+      "Size": 117371
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 5872
@@ -197,19 +197,19 @@
       "Size": 3480884
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 427328
+      "Size": 371888
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3074520
+      "Size": 3075360
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723840
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 93704
+      "Size": 93768
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
-      "Size": 148696
+      "Size": 151624
     },
     "lib/arm64-v8a/libxamarin-app.so": {
       "Size": 99272
@@ -1967,5 +1967,5 @@
       "Size": 341228
     }
   },
-  "PackageSize": 7991796
+  "PackageSize": 7975412
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -11,7 +11,7 @@
       "Size": 66840
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 445342
+      "Size": 445269
     },
     "assemblies/mscorlib.dll": {
       "Size": 3830
@@ -125,7 +125,7 @@
       "Size": 1828
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 117371
+      "Size": 117367
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
       "Size": 5872
@@ -197,7 +197,7 @@
       "Size": 3480884
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 371888
+      "Size": 371504
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
       "Size": 3075360
@@ -779,7 +779,7 @@
       "Size": 470
     },
     "res/drawable-hdpi-v4/icon.png": {
-      "Size": 4762
+      "Size": 4791
     },
     "res/drawable-hdpi-v4/notification_bg_low_normal.9.png": {
       "Size": 212

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsLegacy.apkdesc
@@ -5,133 +5,133 @@
       "Size": 3140
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7215
+      "Size": 7207
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 69945
+      "Size": 70053
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 570605
+      "Size": 571692
     },
     "assemblies/Mono.Security.dll": {
-      "Size": 68433
+      "Size": 68430
     },
     "assemblies/mscorlib.dll": {
-      "Size": 915406
+      "Size": 915394
     },
     "assemblies/System.Core.dll": {
-      "Size": 164047
+      "Size": 164043
     },
     "assemblies/System.dll": {
-      "Size": 388864
+      "Size": 388861
     },
     "assemblies/System.Drawing.Common.dll": {
-      "Size": 12365
+      "Size": 12356
     },
     "assemblies/System.Net.Http.dll": {
       "Size": 110693
     },
     "assemblies/System.Numerics.dll": {
-      "Size": 15682
+      "Size": 15681
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 186660
+      "Size": 186653
     },
     "assemblies/System.ServiceModel.Internals.dll": {
-      "Size": 26593
+      "Size": 26586
     },
     "assemblies/System.Xml.dll": {
-      "Size": 395656
+      "Size": 395651
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 116896
+      "Size": 116889
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 7697
+      "Size": 7689
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6648
+      "Size": 6640
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 125328
+      "Size": 125325
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 7367
+      "Size": 7357
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 18272
+      "Size": 18264
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 131930
+      "Size": 131923
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 15426
+      "Size": 15421
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 43135
+      "Size": 43130
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6715
+      "Size": 6708
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 7062
+      "Size": 7055
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 7194
+      "Size": 7186
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 4873
+      "Size": 4861
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 13585
+      "Size": 13578
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 102327
+      "Size": 102322
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 6268
+      "Size": 6265
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 11272
+      "Size": 11261
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 19423
+      "Size": 19416
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 524736
+      "Size": 524728
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 384872
+      "Size": 384861
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
       "Size": 56878
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 55801
+      "Size": 55795
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 43497
+      "Size": 43489
     },
     "classes.dex": {
-      "Size": 3475144
+      "Size": 3482812
     },
     "lib/arm64-v8a/libmono-btls-shared.so": {
       "Size": 1613872
     },
+    "lib/arm64-v8a/libmonodroid.so": {
+      "Size": 277152
+    },
     "lib/arm64-v8a/libmono-native.so": {
       "Size": 750976
     },
-    "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 332128
-    },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 4051864
+      "Size": 4039176
     },
     "lib/arm64-v8a/libxa-internal-api.so": {
       "Size": 66184
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 105288
+      "Size": 105376
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -145,10 +145,10 @@
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
     },
-    "META-INF/androidx.appcompat_appcompat-resources.version": {
+    "META-INF/androidx.appcompat_appcompat.version": {
       "Size": 6
     },
-    "META-INF/androidx.appcompat_appcompat.version": {
+    "META-INF/androidx.appcompat_appcompat-resources.version": {
       "Size": 6
     },
     "META-INF/androidx.arch.core_core-runtime.version": {
@@ -196,10 +196,10 @@
     "META-INF/androidx.legacy_legacy-support-v4.version": {
       "Size": 6
     },
-    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
+    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
       "Size": 6
     },
-    "META-INF/androidx.lifecycle_lifecycle-livedata.version": {
+    "META-INF/androidx.lifecycle_lifecycle-livedata-core.version": {
       "Size": 6
     },
     "META-INF/androidx.lifecycle_lifecycle-runtime.version": {
@@ -235,10 +235,10 @@
     "META-INF/androidx.transition_transition.version": {
       "Size": 6
     },
-    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
+    "META-INF/androidx.vectordrawable_vectordrawable.version": {
       "Size": 6
     },
-    "META-INF/androidx.vectordrawable_vectordrawable.version": {
+    "META-INF/androidx.vectordrawable_vectordrawable-animated.version": {
       "Size": 6
     },
     "META-INF/androidx.versionedparcelable_versionedparcelable.version": {
@@ -255,12 +255,6 @@
     },
     "META-INF/proguard/androidx-annotations.pro": {
       "Size": 339
-    },
-    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
-      "Size": 616
-    },
-    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
-      "Size": 616
     },
     "res/anim/abc_fade_in.xml": {
       "Size": 388
@@ -358,9 +352,6 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
-    "res/animator-v21/design_appbar_state_list_animator.xml": {
-      "Size": 1216
-    },
     "res/animator/design_fab_hide_motion_spec.xml": {
       "Size": 796
     },
@@ -388,38 +379,14 @@
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
     },
-    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 464
+    "res/animator-v21/design_appbar_state_list_animator.xml": {
+      "Size": 1216
     },
-    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
-      "Size": 500
+    "res/anim-v21/design_bottom_sheet_slide_in.xml": {
+      "Size": 616
     },
-    "res/color-v23/abc_btn_colored_text_material.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_color_highlight_material.xml": {
-      "Size": 544
-    },
-    "res/color-v23/abc_tint_btn_checkable.xml": {
-      "Size": 624
-    },
-    "res/color-v23/abc_tint_default.xml": {
-      "Size": 1120
-    },
-    "res/color-v23/abc_tint_edittext.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_seek_thumb.xml": {
-      "Size": 500
-    },
-    "res/color-v23/abc_tint_spinner.xml": {
-      "Size": 668
-    },
-    "res/color-v23/abc_tint_switch_track.xml": {
-      "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
+    "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -523,10 +490,10 @@
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
-    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
+    "res/color/mtrl_tabs_icon_color_selector.xml": {
       "Size": 464
     },
-    "res/color/mtrl_tabs_icon_color_selector.xml": {
+    "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
       "Size": 464
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
@@ -544,11 +511,227 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 464
+    },
+    "res/color-v23/abc_btn_colored_borderless_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_btn_colored_text_material.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_color_highlight_material.xml": {
+      "Size": 544
+    },
+    "res/color-v23/abc_tint_btn_checkable.xml": {
+      "Size": 624
+    },
+    "res/color-v23/abc_tint_default.xml": {
+      "Size": 1120
+    },
+    "res/color-v23/abc_tint_edittext.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_seek_thumb.xml": {
+      "Size": 500
+    },
+    "res/color-v23/abc_tint_spinner.xml": {
+      "Size": 668
+    },
+    "res/color-v23/abc_tint_switch_track.xml": {
+      "Size": 664
+    },
+    "res/color-v23/design_tint_password_toggle.xml": {
+      "Size": 376
+    },
+    "res/drawable/abc_btn_borderless_material.xml": {
+      "Size": 588
+    },
+    "res/drawable/abc_btn_check_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_btn_check_material_anim.xml": {
+      "Size": 816
+    },
+    "res/drawable/abc_btn_colored_material.xml": {
+      "Size": 344
+    },
+    "res/drawable/abc_btn_default_mtrl_shape.xml": {
+      "Size": 932
+    },
+    "res/drawable/abc_btn_radio_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_btn_radio_material_anim.xml": {
+      "Size": 816
+    },
+    "res/drawable/abc_cab_background_internal_bg.xml": {
+      "Size": 372
+    },
+    "res/drawable/abc_cab_background_top_material.xml": {
+      "Size": 336
+    },
+    "res/drawable/abc_dialog_material_background.xml": {
+      "Size": 716
+    },
+    "res/drawable/abc_edit_text_material.xml": {
+      "Size": 868
+    },
+    "res/drawable/abc_ic_ab_back_material.xml": {
+      "Size": 692
+    },
+    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
+      "Size": 1000
+    },
+    "res/drawable/abc_ic_clear_material.xml": {
+      "Size": 684
+    },
+    "res/drawable/abc_ic_go_search_api_material.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_ic_menu_overflow_material.xml": {
+      "Size": 792
+    },
+    "res/drawable/abc_ic_search_api_material.xml": {
+      "Size": 812
+    },
+    "res/drawable/abc_ic_voice_search_api_material.xml": {
+      "Size": 828
+    },
+    "res/drawable/abc_item_background_holo_dark.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_item_background_holo_light.xml": {
+      "Size": 1012
+    },
+    "res/drawable/abc_list_divider_material.xml": {
+      "Size": 480
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
+      "Size": 424
+    },
+    "res/drawable/abc_list_selector_holo_dark.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_list_selector_holo_light.xml": {
+      "Size": 1064
+    },
+    "res/drawable/abc_ratingbar_indicator_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_ratingbar_small_material.xml": {
+      "Size": 664
+    },
+    "res/drawable/abc_seekbar_thumb_material.xml": {
+      "Size": 1100
+    },
+    "res/drawable/abc_seekbar_tick_mark_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_seekbar_track_material.xml": {
+      "Size": 1408
+    },
+    "res/drawable/abc_spinner_textfield_background_material.xml": {
+      "Size": 1160
+    },
+    "res/drawable/abc_switch_thumb_material.xml": {
+      "Size": 464
+    },
+    "res/drawable/abc_tab_indicator_material.xml": {
+      "Size": 468
+    },
+    "res/drawable/abc_text_cursor_material.xml": {
+      "Size": 516
+    },
+    "res/drawable/abc_textfield_search_material.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_vector_test.xml": {
+      "Size": 612
+    },
+    "res/drawable/btn_checkbox_checked_mtrl.xml": {
+      "Size": 2688
+    },
+    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
+      "Size": 2660
+    },
+    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
+      "Size": 688
+    },
+    "res/drawable/btn_radio_off_mtrl.xml": {
+      "Size": 1728
+    },
+    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/btn_radio_on_mtrl.xml": {
+      "Size": 1656
+    },
+    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
+      "Size": 680
+    },
+    "res/drawable/design_bottom_navigation_item_background.xml": {
+      "Size": 784
+    },
+    "res/drawable/design_fab_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/design_password_eye.xml": {
+      "Size": 464
+    },
+    "res/drawable/design_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/ic_mtrl_chip_checked_black.xml": {
+      "Size": 600
+    },
+    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
+      "Size": 940
+    },
+    "res/drawable/ic_mtrl_chip_close_circle.xml": {
+      "Size": 808
+    },
+    "res/drawable/mtrl_snackbar_background.xml": {
+      "Size": 484
+    },
+    "res/drawable/mtrl_tabs_default_indicator.xml": {
+      "Size": 628
+    },
+    "res/drawable/navigation_empty_icon.xml": {
+      "Size": 516
+    },
+    "res/drawable/notification_bg.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_bg_low.xml": {
+      "Size": 532
+    },
+    "res/drawable/notification_icon_background.xml": {
+      "Size": 372
+    },
+    "res/drawable/notification_tile_bg.xml": {
+      "Size": 304
+    },
+    "res/drawable/tooltip_frame_dark.xml": {
+      "Size": 484
+    },
+    "res/drawable/tooltip_frame_light.xml": {
+      "Size": 484
     },
     "res/drawable-anydpi-v21/design_ic_visibility.xml": {
       "Size": 540
+    },
+    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
+      "Size": 1144
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -691,11 +874,11 @@
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
-      "Size": 507
-    },
     "res/drawable-hdpi-v4/design_ic_visibility.png": {
       "Size": 470
+    },
+    "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
+      "Size": 507
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 4762
@@ -706,11 +889,11 @@
     "res/drawable-hdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 225
     },
-    "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 225
-    },
     "res/drawable-hdpi-v4/notification_bg_normal.9.png": {
       "Size": 212
+    },
+    "res/drawable-hdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 225
     },
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
@@ -901,11 +1084,11 @@
     "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
     },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
     "res/drawable-mdpi-v4/design_ic_visibility.png": {
       "Size": 309
+    },
+    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
+      "Size": 351
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 2200
@@ -916,11 +1099,11 @@
     "res/drawable-mdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 223
     },
-    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 223
-    },
     "res/drawable-mdpi-v4/notification_bg_normal.9.png": {
       "Size": 215
+    },
+    "res/drawable-mdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 223
     },
     "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 98
@@ -1129,11 +1312,11 @@
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
     },
-    "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 629
-    },
     "res/drawable-xhdpi-v4/design_ic_visibility.png": {
       "Size": 593
+    },
+    "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
+      "Size": 629
     },
     "res/drawable-xhdpi-v4/icon.png": {
       "Size": 7462
@@ -1144,11 +1327,11 @@
     "res/drawable-xhdpi-v4/notification_bg_low_pressed.9.png": {
       "Size": 252
     },
-    "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
-      "Size": 247
-    },
     "res/drawable-xhdpi-v4/notification_bg_normal.9.png": {
       "Size": 221
+    },
+    "res/drawable-xhdpi-v4/notification_bg_normal_pressed.9.png": {
+      "Size": 247
     },
     "res/drawable-xhdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 138
@@ -1294,11 +1477,11 @@
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 884
-    },
     "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
       "Size": 868
+    },
+    "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
+      "Size": 884
     },
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 13092
@@ -1381,206 +1564,14 @@
     "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 1201
-    },
     "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
       "Size": 1155
     },
+    "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
+      "Size": 1201
+    },
     "res/drawable-xxxhdpi-v4/icon.png": {
       "Size": 20118
-    },
-    "res/drawable/abc_btn_borderless_material.xml": {
-      "Size": 588
-    },
-    "res/drawable/abc_btn_check_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_btn_check_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_btn_colored_material.xml": {
-      "Size": 344
-    },
-    "res/drawable/abc_btn_default_mtrl_shape.xml": {
-      "Size": 932
-    },
-    "res/drawable/abc_btn_radio_material_anim.xml": {
-      "Size": 816
-    },
-    "res/drawable/abc_btn_radio_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_cab_background_internal_bg.xml": {
-      "Size": 372
-    },
-    "res/drawable/abc_cab_background_top_material.xml": {
-      "Size": 336
-    },
-    "res/drawable/abc_dialog_material_background.xml": {
-      "Size": 716
-    },
-    "res/drawable/abc_edit_text_material.xml": {
-      "Size": 868
-    },
-    "res/drawable/abc_ic_ab_back_material.xml": {
-      "Size": 692
-    },
-    "res/drawable/abc_ic_arrow_drop_right_black_24dp.xml": {
-      "Size": 1000
-    },
-    "res/drawable/abc_ic_clear_material.xml": {
-      "Size": 684
-    },
-    "res/drawable/abc_ic_go_search_api_material.xml": {
-      "Size": 640
-    },
-    "res/drawable/abc_ic_menu_overflow_material.xml": {
-      "Size": 792
-    },
-    "res/drawable/abc_ic_search_api_material.xml": {
-      "Size": 812
-    },
-    "res/drawable/abc_ic_voice_search_api_material.xml": {
-      "Size": 828
-    },
-    "res/drawable/abc_item_background_holo_dark.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_item_background_holo_light.xml": {
-      "Size": 1012
-    },
-    "res/drawable/abc_list_divider_material.xml": {
-      "Size": 480
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_dark.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_background_transition_holo_light.xml": {
-      "Size": 424
-    },
-    "res/drawable/abc_list_selector_holo_dark.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_list_selector_holo_light.xml": {
-      "Size": 1064
-    },
-    "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 664
-    },
-    "res/drawable/abc_seekbar_thumb_material.xml": {
-      "Size": 1100
-    },
-    "res/drawable/abc_seekbar_tick_mark_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_seekbar_track_material.xml": {
-      "Size": 1408
-    },
-    "res/drawable/abc_spinner_textfield_background_material.xml": {
-      "Size": 1160
-    },
-    "res/drawable/abc_switch_thumb_material.xml": {
-      "Size": 464
-    },
-    "res/drawable/abc_tab_indicator_material.xml": {
-      "Size": 468
-    },
-    "res/drawable/abc_text_cursor_material.xml": {
-      "Size": 516
-    },
-    "res/drawable/abc_textfield_search_material.xml": {
-      "Size": 756
-    },
-    "res/drawable/abc_vector_test.xml": {
-      "Size": 612
-    },
-    "res/drawable/btn_checkbox_checked_mtrl.xml": {
-      "Size": 2688
-    },
-    "res/drawable/btn_checkbox_checked_to_unchecked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_checkbox_unchecked_mtrl.xml": {
-      "Size": 2660
-    },
-    "res/drawable/btn_checkbox_unchecked_to_checked_mtrl_animation.xml": {
-      "Size": 688
-    },
-    "res/drawable/btn_radio_off_mtrl.xml": {
-      "Size": 1728
-    },
-    "res/drawable/btn_radio_off_to_on_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/btn_radio_on_mtrl.xml": {
-      "Size": 1656
-    },
-    "res/drawable/btn_radio_on_to_off_mtrl_animation.xml": {
-      "Size": 680
-    },
-    "res/drawable/design_bottom_navigation_item_background.xml": {
-      "Size": 784
-    },
-    "res/drawable/design_fab_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/design_password_eye.xml": {
-      "Size": 464
-    },
-    "res/drawable/design_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/ic_mtrl_chip_checked_black.xml": {
-      "Size": 600
-    },
-    "res/drawable/ic_mtrl_chip_checked_circle.xml": {
-      "Size": 940
-    },
-    "res/drawable/ic_mtrl_chip_close_circle.xml": {
-      "Size": 808
-    },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
-    },
-    "res/drawable/mtrl_tabs_default_indicator.xml": {
-      "Size": 628
-    },
-    "res/drawable/navigation_empty_icon.xml": {
-      "Size": 516
-    },
-    "res/drawable/notification_bg_low.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_bg.xml": {
-      "Size": 532
-    },
-    "res/drawable/notification_icon_background.xml": {
-      "Size": 372
-    },
-    "res/drawable/notification_tile_bg.xml": {
-      "Size": 304
-    },
-    "res/drawable/tooltip_frame_dark.xml": {
-      "Size": 484
-    },
-    "res/drawable/tooltip_frame_light.xml": {
-      "Size": 484
-    },
-    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
-      "Size": 400
-    },
-    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
-      "Size": 400
-    },
-    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
-      "Size": 400
     },
     "res/interpolator/btn_checkbox_checked_mtrl_animation_interpolator_0.xml": {
       "Size": 316
@@ -1609,53 +1600,20 @@
     "res/interpolator/mtrl_fast_out_slow_in.xml": {
       "Size": 144
     },
-    "res/interpolator/mtrl_linear_out_slow_in.xml": {
-      "Size": 136
-    },
     "res/interpolator/mtrl_linear.xml": {
       "Size": 132
     },
-    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
-      "Size": 528
+    "res/interpolator/mtrl_linear_out_slow_in.xml": {
+      "Size": 136
     },
-    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 528
+    "res/interpolator-v21/mtrl_fast_out_linear_in.xml": {
+      "Size": 400
     },
-    "res/layout-v16/notification_template_custom_big.xml": {
-      "Size": 3208
+    "res/interpolator-v21/mtrl_fast_out_slow_in.xml": {
+      "Size": 400
     },
-    "res/layout-v21/abc_screen_toolbar.xml": {
-      "Size": 1504
-    },
-    "res/layout-v21/fallbacktoolbardonotuse.xml": {
-      "Size": 496
-    },
-    "res/layout-v21/notification_action_tombstone.xml": {
-      "Size": 1228
-    },
-    "res/layout-v21/notification_action.xml": {
-      "Size": 1052
-    },
-    "res/layout-v21/notification_template_custom_big.xml": {
-      "Size": 2456
-    },
-    "res/layout-v21/notification_template_icon_group.xml": {
-      "Size": 988
-    },
-    "res/layout-v21/toolbar.xml": {
-      "Size": 496
-    },
-    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1584
-    },
-    "res/layout-v26/abc_screen_toolbar.xml": {
-      "Size": 1560
-    },
-    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
-      "Size": 1208
-    },
-    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
-      "Size": 1352
+    "res/interpolator-v21/mtrl_linear_out_slow_in.xml": {
+      "Size": 400
     },
     "res/layout/abc_action_bar_title_item.xml": {
       "Size": 872
@@ -1675,11 +1633,11 @@
     "res/layout/abc_action_mode_close_item_material.xml": {
       "Size": 840
     },
-    "res/layout/abc_activity_chooser_view_list_item.xml": {
-      "Size": 1304
-    },
     "res/layout/abc_activity_chooser_view.xml": {
       "Size": 1684
+    },
+    "res/layout/abc_activity_chooser_view_list_item.xml": {
+      "Size": 1304
     },
     "res/layout/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1536
@@ -1720,11 +1678,11 @@
     "res/layout/abc_screen_content_include.xml": {
       "Size": 548
     },
-    "res/layout/abc_screen_simple_overlay_action_mode.xml": {
-      "Size": 792
-    },
     "res/layout/abc_screen_simple.xml": {
       "Size": 832
+    },
+    "res/layout/abc_screen_simple_overlay_action_mode.xml": {
+      "Size": 792
     },
     "res/layout/abc_screen_toolbar.xml": {
       "Size": 1452
@@ -1759,11 +1717,11 @@
     "res/layout/design_bottom_sheet_dialog.xml": {
       "Size": 1184
     },
-    "res/layout/design_layout_snackbar_include.xml": {
-      "Size": 1444
-    },
     "res/layout/design_layout_snackbar.xml": {
       "Size": 528
+    },
+    "res/layout/design_layout_snackbar_include.xml": {
+      "Size": 1444
     },
     "res/layout/design_layout_tab_icon.xml": {
       "Size": 408
@@ -1774,6 +1732,9 @@
     "res/layout/design_menu_item_action_area.xml": {
       "Size": 320
     },
+    "res/layout/design_navigation_item.xml": {
+      "Size": 536
+    },
     "res/layout/design_navigation_item_header.xml": {
       "Size": 440
     },
@@ -1783,14 +1744,11 @@
     "res/layout/design_navigation_item_subheader.xml": {
       "Size": 564
     },
-    "res/layout/design_navigation_item.xml": {
-      "Size": 536
+    "res/layout/design_navigation_menu.xml": {
+      "Size": 528
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
-    },
-    "res/layout/design_navigation_menu.xml": {
-      "Size": 528
     },
     "res/layout/design_text_input_password_icon.xml": {
       "Size": 564
@@ -1807,17 +1765,17 @@
     "res/layout/main.xml": {
       "Size": 544
     },
-    "res/layout/mtrl_layout_snackbar_include.xml": {
-      "Size": 1404
-    },
     "res/layout/mtrl_layout_snackbar.xml": {
       "Size": 528
     },
-    "res/layout/notification_action_tombstone.xml": {
-      "Size": 1332
+    "res/layout/mtrl_layout_snackbar_include.xml": {
+      "Size": 1404
     },
     "res/layout/notification_action.xml": {
       "Size": 1156
+    },
+    "res/layout/notification_action_tombstone.xml": {
+      "Size": 1332
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -1825,17 +1783,17 @@
     "res/layout/notification_media_cancel_action.xml": {
       "Size": 744
     },
+    "res/layout/notification_template_big_media.xml": {
+      "Size": 1696
+    },
     "res/layout/notification_template_big_media_custom.xml": {
       "Size": 3044
-    },
-    "res/layout/notification_template_big_media_narrow_custom.xml": {
-      "Size": 3216
     },
     "res/layout/notification_template_big_media_narrow.xml": {
       "Size": 1824
     },
-    "res/layout/notification_template_big_media.xml": {
-      "Size": 1696
+    "res/layout/notification_template_big_media_narrow_custom.xml": {
+      "Size": 3216
     },
     "res/layout/notification_template_icon_group.xml": {
       "Size": 392
@@ -1843,11 +1801,11 @@
     "res/layout/notification_template_lines_media.xml": {
       "Size": 2872
     },
-    "res/layout/notification_template_media_custom.xml": {
-      "Size": 2756
-    },
     "res/layout/notification_template_media.xml": {
       "Size": 1292
+    },
+    "res/layout/notification_template_media_custom.xml": {
+      "Size": 2756
     },
     "res/layout/notification_template_part_chronometer.xml": {
       "Size": 440
@@ -1879,9 +1837,51 @@
     "res/layout/toolbar.xml": {
       "Size": 452
     },
+    "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
+      "Size": 528
+    },
+    "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
+      "Size": 528
+    },
+    "res/layout-v16/notification_template_custom_big.xml": {
+      "Size": 3208
+    },
+    "res/layout-v21/abc_screen_toolbar.xml": {
+      "Size": 1504
+    },
+    "res/layout-v21/fallbacktoolbardonotuse.xml": {
+      "Size": 496
+    },
+    "res/layout-v21/notification_action.xml": {
+      "Size": 1052
+    },
+    "res/layout-v21/notification_action_tombstone.xml": {
+      "Size": 1228
+    },
+    "res/layout-v21/notification_template_custom_big.xml": {
+      "Size": 2456
+    },
+    "res/layout-v21/notification_template_icon_group.xml": {
+      "Size": 988
+    },
+    "res/layout-v21/toolbar.xml": {
+      "Size": 496
+    },
+    "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1584
+    },
+    "res/layout-v26/abc_screen_toolbar.xml": {
+      "Size": 1560
+    },
+    "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
+      "Size": 1208
+    },
+    "res/layout-watch-v20/abc_alert_dialog_title_material.xml": {
+      "Size": 1352
+    },
     "resources.arsc": {
       "Size": 341040
     }
   },
-  "PackageSize": 9545886
+  "PackageSize": 9533598
 }

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -223,9 +223,10 @@ namespace xamarin::android::internal {
 #else // def NET
 		static MonoAssembly* open_from_bundles_refonly (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
 #endif // ndef NET
-		static void get_assembly_data (uint8_t *data, uint32_t data_size, const char *name, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
-		static void get_assembly_data (XamarinAndroidBundledAssembly const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
-		static void get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
+		void set_assembly_data_and_size (uint8_t* source_assembly_data, uint32_t source_assembly_data_size, uint8_t*& dest_assembly_data, uint32_t& dest_assembly_data_size) noexcept;
+		void get_assembly_data (uint8_t *data, uint32_t data_size, const char *name, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
+		void get_assembly_data (XamarinAndroidBundledAssembly const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
+		void get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData const& e, uint8_t*& assembly_data, uint32_t& assembly_data_size) noexcept;
 
 		void zip_load_entries (int fd, const char *apk_name, monodroid_should_register should_register);
 		void zip_load_individual_assembly_entries (std::vector<uint8_t> const& buf, uint32_t num_entries, monodroid_should_register should_register, ZipEntryLoadState &state) noexcept;
@@ -333,6 +334,7 @@ namespace xamarin::android::internal {
 
 		AssemblyStoreHeader *index_assembly_store_header = nullptr;
 		AssemblyStoreHashEntry             *assembly_store_hashes;
+		std::mutex             assembly_decompress_mutex;
 	};
 }
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7335
Context: #7732
Context: d236af54538ef1fe62d0125798cdde78e46dcd8e

Commit d236af54 introduced embedded assembly compression, using LZ4,
which speeds up startup and reduces final package size.

Assemblies are compressed at build time and, at the same time, pre-
allocated buffers for the **decompressed** data are allocated in
`libxamarin-app.so`.  The buffers are then passed to the LZ4 APIs,
all threads using the same output buffer.  The assumption was that we
can do fine without locking as even if overlapped decompression
happens, the output data will be the same and so even if two threads
do the same thing at the same time, the data will be valid at all
times, so long as at least one thread completes the decompression.

This assumption proved to be **largely** true, but it appears that in
high concurrency cases it is possible that the data in the
decompression buffer differs.  This can result in app crashes:
    
        A/libc: Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 3092 (.NET ThreadPool), pid 2727 (myapp.name)
        A/DEBUG: pid: 2727, tid: 3092, name: .NET ThreadPool  >>> myapp.name <<<
        A/DEBUG:       #01 pc 0000000000029b1c  /data/app/myapp.name-B9t_3dF9i8mDxJEKodZw5w==/split_config.arm64_v8a.apk!libmono-android.release.so (offset 0x103d000) (xamarin::android::internal::MonodroidRuntime::mono_log_handler(char const*, char const*, char const*, int, void*)+144) (BuildId: 29c5a3805a0bedee1eede9b6668d7c676aa63371)
        A/DEBUG:       #02 pc 00000000002680bc  /data/app/myapp.name-B9t_3dF9i8mDxJEKodZw5w==/split_config.arm64_v8a.apk!libmonosgen-2.0.so (offset 0x109b000) (BuildId: 4a5dd4396e8816b7f69881838bd549285213d53b)
        A/DEBUG:       #03 pc 00000000002681e8  /data/app/myapp.name-B9t_3dF9i8mDxJEKodZw5w==/split_config.arm64_v8a.apk!libmonosgen-2.0.so (offset 0x109b000) (BuildId: 4a5dd4396e8816b7f69881838bd549285213d53b)
        A/DEBUG:       #04 pc 000000000008555c  /data/app/myapp.name-B9t_3dF9i8mDxJEKodZw5w==/split_config.arm64_v8a.apk!libmonosgen-2.0.so (offset 0x109b000) (mono_metadata_string_heap+188) (BuildId: 4a5dd4396e8816b7f69881838bd549285213d53b)
        …

My guess is that LZ4 either uses the output buffer as a scratchpad
area when decompressing or that it initializes/modifies the buffer
before writing actual data in it.  With overlapped decompression, it
may lead to one thread overwriting valid data previously written by
another thread, so that when the latter returns the buffer it thought
to have had valid data may contain certain bytes temporarily
overwritten by the decompression session in the other, still running,
thread.  It may happen that MonoVM reads the corrupted data just when
it is still invalid (before the still running decompression session
actually writes the valid data), a classic race condition.

To fix this, the decompression block is now protected with a startup-
aware mutex.  Mutex will be held only after the initial startup phase
is completed, so there should not be much loss of startup performance.