### PR TITLE
[ci][6.0.4xx] Build and test on macOS Monterey

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@4fa114311a0ab882c1de1ed265450747a7c34c25
+xamarin/monodroid:release/6.0.4xx@fe096b9b4f3ddef2f906c1d8ca8fdd2fbe30e576
 mono/mono:2020-02@adf1bc4335d710088c58e824b6027255096cc295

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -69,7 +69,7 @@ variables:
   - name: MacBuildPoolName
     value: Azure Pipelines
   - name: MacBuildPoolImage
-    value: internal-macos-11
+    value: internal-macos12
 - ${{ if or(and(ne(variables['Build.DefinitionName'],'Xamarin.Android'), ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Test
@@ -91,7 +91,7 @@ stages:
       name: $(MacBuildPoolName)
       vmImage: $(MacBuildPoolImage)
       ${{ if eq(variables['MacBuildPoolName'], 'VSEng-Xamarin-RedmondMac-Android-Untrusted') }}:
-        demands: agent.osversionfamily -equals 10.15
+        demands: macOS.Name -equals Monterey
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -20,7 +20,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-11
+  value: macOS-12
 - name: HostedWinImage
   value: windows-2022
 - name: 1ESWindowsPool


### PR DESCRIPTION
Update the build and test images for 6.0.4xx to run on macOS Monterey to
allow Big Sur machines to be candidates for OS upgrades.