### PR TITLE
[Xamarin.Android.Build.Tasks] guard `AutoImport.props` against empty values

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -22,7 +22,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
+  <ItemGroup Condition=" '$(MonoAndroidResourcePrefix)' != '' and '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <!-- Default Resource file inclusion -->
     <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
@@ -35,8 +35,14 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(MonoAndroidAssetsPrefix)' != '' and '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <!-- Default Asset file inclusion -->
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(EnableDefaultAndroidItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <!-- Default XPath transforms for bindings -->
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />


### PR DESCRIPTION
There is an email thread about ASP.NET projects in VS -- and something is potentially slowing down builds when optional workloads are installed.

One concern is our `AutoImport.props`, take for instance the following `foo.targets` file:

    <Project>
      <ItemGroup>
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.axml" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.png" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.jpg" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.gif" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.webp" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttf" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
        <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
        <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
      </ItemGroup>
      <Target Name="Build" />
    </Project>

In this case `$(MonoAndroidResourcePrefix)` and `$(MonoAndroidAssetsPrefix)` will be blank, and we get:

    msbuild foo.targets -bl
    ...
      MSBUILD : warning MSB5029: The value "\**\.*\**" of the "Exclude" attribute in element <ItemGroup> in file "foo.targets (13,61)" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.
    1 Warning(s)
    0 Error(s)
    Time Elapsed 00:02:45.14

I'm not sure this is causing an actual problem, but I think it's a good idea to add some safety here.

I will make a similar change in Xamarin.Legacy.Sdk.