### PR TITLE
$(AndroidPackVersionSuffix)=preview.3; net8 is 34.0.0-preview.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview2

We branched for .NET 8 preview 2 from d0701eb into `release/8.0.1xx-preview2`.

Update xamarin-android/main's version number to 34.0.0-preview.3 for .NET 8 preview 3.