### PR TITLE
[build] pass `--skip-sign-check` to `dotnet workload`

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -129,6 +129,7 @@
       <_InstallArguments Include="android" />
       <_InstallArguments Include="android-$(AndroidLatestUnstableApiLevel)" Condition=" '@(_PreviewPacks->Count())' != '0' " />
       <_InstallArguments Include="--skip-manifest-update" />
+      <_InstallArguments Include="--skip-sign-check" />
       <_InstallArguments Include="--verbosity diag" />
       <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
@@ -278,7 +279,7 @@
         Overwrite="true"
     />
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-deps --configfile &quot;$(XamarinAndroidSourcePath)NuGet.config&quot; --skip-manifest-update --verbosity diag"
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install android-deps --configfile &quot;$(XamarinAndroidSourcePath)NuGet.config&quot; --skip-manifest-update --skip-sign-check --verbosity diag"
         EnvironmentVariables="DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=$(BuildOutputDirectory)lib\sdk-manifests"
         WorkingDirectory="$(XamarinAndroidSourcePath)"
     />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7397299&view=logs&j=28f7b402-0b52-5743-3f46-b0c973acb4f8&t=06392762-0cbe-5837-5fae-a131d329206a&l=81
Context: 978b74f

Many times on release branches, parts of the .NET installer is signed, and we need to allow unsigned workloads to be installed via the `--skip-sign-check` flag:

    Rolling back pack Microsoft.Android.Sdk.Windows installation...
    Workload installation failed: Failed to validate package signing.
    Verifying Microsoft.Android.Sdk.Windows.34.0.0-ci.darc-release-8-0-1xx-preview2-cef50a92-f62d-4147-9b74-08689588cab8.180

This is testing a local build of the `android` workload, so it will not be signed at this stage.

Let's put this change in main, so we don't have to keep doing this release branches.