### PR TITLE
[ci] Allow dynamic`$(NuGetArtifactName)` values

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -69,9 +69,9 @@ stages:
     - script: >
         df -h &&
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
-        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/Microsoft.Android.Sdk.Linux*.nupkg
+        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-unsigned/Microsoft.Android.Sdk.Linux*.nupkg
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux &&
-        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)/SignList.xml
+        ln $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-unsigned/SignList.xml
         $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy linux sdk

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -130,7 +130,7 @@ steps:
   displayName: upload nupkgs
   inputs:
     artifactName: ${{ parameters.nugetArtifactName }}
-    targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+    targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned
 
 - script: >
     mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName) &&


### PR DESCRIPTION
We want to be able to override the values of `$(NuGetArtifactName)` and
`$(LinuxNuGetArtifactName)` in the megapipeline so that artifact names
don't overlap.  We shouldn't use these variables to determine where
local build artifacts are being output to.