### PR TITLE
[build] remove darc dependency for System.IO.Hashing

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,10 +20,6 @@
       <Uri>https://github.com/dotnet/cecil</Uri>
       <Sha>68e0c35d0b4b6651b9a062a52e7dd694d7a43927</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Hashing" Version="8.0.0-alpha.1.23080.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9529803ae29c2804880c6bd8ca710b8c037cb498</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23113.1</MicrosoftDotNetCecilPackageVersion>
-    <SystemIOHashingPackageVersion>8.0.0-alpha.1.23080.2</SystemIOHashingPackageVersion>
+    <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
Maestro is currently failing to open new PRs due to:

    > darc update-dependencies --id 169161
    Looking up build with BAR id 169161
    Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-preview.3.23128.1' => '8.0.100-preview.3.23153.7' (from build '20230303.7' of 'https://github.com/dotnet/installer')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Coherency updates failed for the following dependencies:
    Unable to update System.IO.Hashing to have coherency with Microsoft.Dotnet.Sdk.Internal: https://github.com/dotnet/installer @ 9cf0095d0892d385a7e26772752d75e3bb68d8e4 does not contain dependency System.IO.Hashing

In 5d68699, we added a new dependency of System.IO.Hashing from dotnet/runtime.

But for this to work, we'd have to:

1. List `System.IO.Hashing` as a dependency of dotnet/installer

or

2. Just use manage `$(SystemIOHashingPackageVersion)` to match the overall version of dotnet/runtime.

In dotnet/maui, at lot of times they've been going with no. 2. If needed on release branches, we can also hardcode the number or switch over to using a stable version on NuGet.org.

Let's remove the Maestro dependency and use `$(MicrosoftNETCoreAppRefPackageVersion)` for now.