### PR TITLE
[ci] Don't run classic tests on the Windows build/test stage.

### DIFF
--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -116,14 +116,6 @@ stages:
 
     - template: run-nunit-tests.yaml
       parameters:
-        useDotNet: false
-        testRunTitle: Smoke MSBuild Tests - Windows Build Tree
-        testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\net472\Xamarin.Android.Build.Tests.dll
-        testResultsFile: TestResult-SmokeMSBuildTests-WinBuildTree-$(XA.Build.Configuration).xml
-        nunitConsoleExtraArgs: --where "cat == SmokeTests"
-
-    - template: run-nunit-tests.yaml
-      parameters:
         testRunTitle: Smoke MSBuild Tests - Windows Dotnet Build
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\$(DotNetStableTargetFramework)\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-SmokeMSBuildTests-WinDotnetBuild-$(XA.Build.Configuration).xml


### PR DESCRIPTION
Quick and easy win: don't run Classic smoke tests on the Windows Build/Test stage, saving ~22 minutes.