### PR TITLE
[monodroid] add support for Mono's `log` profiler

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1623,10 +1623,11 @@ MonodroidRuntime::set_profile_options ()
 		value.assign (prop_value);
 	}
 
-	// NET+ supports only the AOT Mono profiler, if the prefix is absent or different than 'aot:' we consider the
+	// In NET+ if the prefix is absent or different than 'aot:' or 'log:' we consider the
 	// property to contain value for the dotnet tracing profiler.
 	constexpr char AOT_PREFIX[] = "aot:";
-	if (!value.starts_with (AOT_PREFIX)) {
+	constexpr char LOG_PREFIX[] = "log:";
+	if (!value.starts_with (AOT_PREFIX) && !value.starts_with (LOG_PREFIX)) {
 		// setenv(3) makes copies of its arguments
 		setenv ("DOTNET_DiagnosticPorts", value.get (), 1);
 		return;
@@ -1655,12 +1656,18 @@ MonodroidRuntime::set_profile_options ()
 	if (!have_output_arg) {
 		constexpr char PROFILE_FILE_NAME_PREFIX[] = "profile.";
 		constexpr char AOT_EXT[] = "aotprofile";
+		constexpr char MLPD_EXT[] = "mlpd";
 
 		output_path
 			.assign_c (androidSystem.get_override_dir (0))
 			.append (MONODROID_PATH_SEPARATOR)
-			.append (PROFILE_FILE_NAME_PREFIX)
-			.append (AOT_EXT);
+			.append (PROFILE_FILE_NAME_PREFIX);
+
+		if (value.starts_with (AOT_PREFIX)) {
+			output_path.append (AOT_EXT);
+		} else if (value.starts_with (LOG_PREFIX)) {
+			output_path.append (MLPD_EXT);
+		}
 
 		value
 			.append (",")


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/Mono.Profiler.Android/pull/7

This gets things further, but doesn't fully work:

    03-08 11:55:22.909 17150 17150 W monodroid: Initializing profiler with options: log:calls,output=/data/user/0/com.mono.profiler.helloandroid/files/.__override__/profile.mlpd
    03-08 11:55:22.910 17150 17150 I monodroid-assembly: Trying to load shared library '/data/app/~~rcpOoWK9a_3JchgDKSqibw==/com.mono.profiler.helloandroid-idytaFjgVoWfT2SoQY9Nkg==/lib/x86_64/libmono-profiler-log.so'
    03-08 11:55:22.910 17150 17150 W monodroid: Looking for profiler init symbol 'mono_profiler_init_log'? 0x0
    03-08 11:55:22.910 17150 17150 I monodroid-assembly: Trying to load shared library '/data/app/~~rcpOoWK9a_3JchgDKSqibw==/com.mono.profiler.helloandroid-idytaFjgVoWfT2SoQY9Nkg==/lib/x86_64/libmono-profiler-log.so'
    03-08 11:55:22.910 17150 17150 W monodroid: Looking for profiler init symbol 'mono_profiler_init_log'? 0x0
    03-08 11:55:22.911 17150 17150 W monodroid: The 'log' profiler wasn't found in the main executable nor could it be loaded from 'libmono-profiler-log.so'.