### PR TITLE
[Xamarin.Android.Build.Tasks] Remove MAM targets from CoreResolve

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -110,8 +110,6 @@ projects, these properties are set in Xamarin.Android.Legacy.targets.
       _CreatePropertiesCache;
       _SeparateAppExtensionReferences;
       $(ResolveReferencesDependsOn);
-      _ConvertAndroidMamMappingFileToXml;
-      _CollectAndroidRemapMembers;
       _AddAndroidCustomMetaData;
       _ResolveAars;
     </CoreResolveReferencesDependsOn>


### PR DESCRIPTION
Context: f6f11a5a797cd8602854942dccb0f2b1db57c473

We're working with the InTune team to make use of our member remapping support (f6f11a5a7), and they hit a bit of a snag:

> I'm having some issues integrating it into the Xamarin build.
> We need our process to run after `_CompileJava` so we can analyze
> the inheritance of the app's classes. Now, we also need our process
> to run before `_CollectAndroidRemapMembers` so that the XML
> generated in that process can be consumed properly. Unfortunately,
> this generates a circular dependency:
>
>     error MSB4006: There is a circular dependency in the target dependency graph
>       involving target "_CollectAndroidRemapMembers".
>       Since "_ResolveLibraryProjectImports" has "DependsOn" dependence on
>       "_CollectAndroidRemapMembers", the circular is
>       "_CollectAndroidRemapMembers<-_ResolveLibraryProjectImports<-_ExtractLibraryProjectImports<-_GetLibraryImports<-_CompileJava<-…<-_CollectAndroidRemapMembers".

Commit f6f11a5a7 updated `$(CoreResolveReferencesDependsOn)` to add the `_ConvertAndroidMamMappingFileToXml` and `_CollectAndroidRemapMembers` targets, but @jonpryor does not remember *why* these targets needed to be added to `$(CoreResolveReferencesDependsOn)` in the first place.

Update `$(CoreResolveReferencesDependsOn)` to remove the `_ConvertAndroidMamMappingFileToXml` and `_CollectAndroidRemapMembers` targets.  This will hopefully remove the circular dependency.