### PR TITLE
[ci] Install fewer Android SDK platforms on test agents.

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,7 +12,7 @@ parameters:
   installLegacyDotNet: true
   restoreNUnitConsole: true
   updateMono: true
-  androidSdkPlatforms: 21,26,32,33
+  androidSdkPlatforms: 26,32,33
 
 steps:
 - checkout: self

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,7 +12,7 @@ parameters:
   installLegacyDotNet: true
   restoreNUnitConsole: true
   updateMono: true
-  androidSdkPlatforms: 19,21,26,32,33
+  androidSdkPlatforms: 21,26,32,33
 
 steps:
 - checkout: self

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,7 +12,7 @@ parameters:
   installLegacyDotNet: true
   restoreNUnitConsole: true
   updateMono: true
-  androidSdkPlatforms: 32,33
+  androidSdkPlatforms: 33
 
 steps:
 - checkout: self

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,7 +12,7 @@ parameters:
   installLegacyDotNet: true
   restoreNUnitConsole: true
   updateMono: true
-  androidSdkPlatforms: 26,32,33
+  androidSdkPlatforms: 32,33
 
 steps:
 - checkout: self


### PR DESCRIPTION
[Previously](https://github.com/xamarin/xamarin-android/pull/6874), we reduced the number of Android SDK Platforms that needed to be installed on CI test agents to `19,21,26,32,33`.  This can significantly reduce the amount of time needed to `xaprepare` an agent.

With most uses of Classic gone from `main`, retesting this reveals more platforms that can be removed.

Removing `19,21,26,32` saves up to 2 minutes of `xaprepare` time, particularly on Windows.

- Green after removing API 19:
  - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7456544&view=results
- Green after removing API 21:
  - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7456980&view=results
- Green after removing API 26:
  - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7457765&view=results
- Green after removing API 32:
  - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7458056&view=results

Note: API 27+ should be already installed on our images:
- [Mac preinstalled software](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#android)
- [Windows preinstalled software](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#android)