### PR TITLE
[github] Use ".NET Android", not "Android for .NET"

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
+      - .NET Android (net6.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - .NET Android (net6.0-android, etc.)
+      - .NET Android (net7.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
+      - .NET Android (net6.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - .NET Android (net6.0-android, etc.)
+      - .NET Android (net7.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -20,7 +20,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
+      - .NET Android (net6.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -20,7 +20,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - .NET Android (net6.0-android, etc.)
+      - .NET Android (net7.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -17,7 +17,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
+      - .NET Android (net6.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -17,7 +17,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - .NET Android (net6.0-android, etc.)
+      - .NET Android (net7.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
+      - .NET Android (net6.0-android, etc.)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -15,7 +15,7 @@ body:
       multiple: true
       options:
       - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - .NET Android (net6.0-android, etc.)
+      - .NET Android (net7.0-android, etc.)
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Our current terminology is to use ".NET Android", not "Android for .NET".

Update our GitHub templates accordingly.