### PR TITLE
Bump `$(AndroidNet7Version)`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -42,7 +42,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.26</AndroidNet7Version>
+    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.46</AndroidNet7Version>
     <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.485</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/457579
Context: https://github.com/xamarin/xamarin-android/commit/58a54aef5213e50e3e59008e244a64896fe971b6

Bumps the net7.0 package reference to the latest version in VS.