### PR TITLE
Attempt to fix a macOS lib{c,m} link error

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -735,12 +735,12 @@ if(ANDROID AND ENABLE_NET)
 
   target_compile_options(
     c
-    PRIVATE -nostdlib
+    PRIVATE -nostdlib -fno-exceptions -fno-rtti
   )
 
   target_link_options(
     c
-    PRIVATE -nostdlib
+    PRIVATE -nostdlib -fno-exceptions -fno-rtti
   )
 
   set_target_properties(
@@ -761,12 +761,12 @@ if(ANDROID AND ENABLE_NET)
 
   target_compile_options(
     m
-    PRIVATE -nostdlib
+    PRIVATE -nostdlib -fno-exceptions -fno-rtti
   )
 
   target_link_options(
     m
-    PRIVATE -nostdlib
+    PRIVATE -nostdlib -fno-exceptions -fno-rtti
   )
 
   set_target_properties(


### PR DESCRIPTION
Context: 0e4c29aabb2af023d3ff66f02d42c2b487575d85
    
0e4c29aa introduced builds of two library stubs, for libc
and libm libraries, to be used when no NDK is installed.

It appears that it can sometimes cause these link errors:

    ld : error : undefined symbol: vtable for __cxxabiv1::__function_type_info [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]
             >>> referenced by stub.cc
             >>>               CMakeFiles/c.dir/libstub/stub.cc.o:(typeinfo for void ())
             >>> the vtable symbol may be undefined because the class is missing its key function (see https://lld.llvm.org/missingkeyfunction)
         >clang++ : error : linker command failed with exit code 1 (use -v to see invocation) [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]

The missing symbol suggests that the problem lies in the
lack of RTTI infrastructure in the library stub.  Attempt
to mitigate the issue by disabling both exceptions and
RTTI when building the stubs.