### PR TITLE
[vs-workload] Remove @(MultiTargetPackNames)

### DIFF
--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -14,6 +14,5 @@
     </ShortNames>
     <ComponentResources Include="android" Version="@WORKLOAD_VERSION@" Category=".NET" Title=".NET SDK for Android" Description=".NET SDK Workload for building Android applications."/>
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Android.Manifest*.nupkg" Version="@WORKLOAD_VERSION@" SupportsMachineArch="true" />
-    <MultiTargetPackNames Include="Microsoft.Android.Sdk" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/251

The VS manifest files generated during MSI conversion will now be split up using the workload pack type rather than a substring match.