### PR TITLE
Fix native code generation when marshal methods are disabled

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -413,7 +413,7 @@ namespace Xamarin.Android.Tasks
 					Log
 				);
 			} else {
-				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (uniqueAssemblyNames);
+				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (assemblyCount, uniqueAssemblyNames);
 			}
 			marshalMethodsAsmGen.Init ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -12,6 +12,7 @@ namespace Xamarin.ProjectTools
 		public const string AndroidUseLatestPlatformSdk = "AndroidUseLatestPlatformSdk";
 		public const string AndroidUseAapt2 = "AndroidUseAapt2";
 		public const string AndroidCreatePackagePerAbi = "AndroidCreatePackagePerAbi";
+		public const string AndroidEnableMarshalMethods = "AndroidEnableMarshalMethods";
 
 		public const string AndroidSupportedAbis = "AndroidSupportedAbis";
 		public const string RuntimeIdentifier = "RuntimeIdentifier";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -23,6 +23,8 @@ namespace Xamarin.ProjectTools
 		static readonly string default_main_activity_cs, default_main_activity_fs;
 		static readonly string default_android_manifest;
 
+		public bool? EnableMarshalMethods { get; set; } = null;
+
 		static XamarinAndroidApplicationProject ()
 		{
 			var folder = Builder.UseDotNet ? "DotNet" : "Base";
@@ -41,6 +43,10 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			if (Builder.UseDotNet) {
+				if (EnableMarshalMethods.HasValue) {
+					SetProperty (KnownProperties.AndroidEnableMarshalMethods, EnableMarshalMethods.Value ? "True" : "False");
+				}
+
 				SetProperty (KnownProperties.OutputType, "Exe");
 				SetProperty (KnownProperties.Nullable, "enable");
 				SetProperty (KnownProperties.ImplicitUsings, "enable");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -23,8 +23,6 @@ namespace Xamarin.ProjectTools
 		static readonly string default_main_activity_cs, default_main_activity_fs;
 		static readonly string default_android_manifest;
 
-		public bool? EnableMarshalMethods { get; set; } = null;
-
 		static XamarinAndroidApplicationProject ()
 		{
 			var folder = Builder.UseDotNet ? "DotNet" : "Base";
@@ -43,10 +41,6 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			if (Builder.UseDotNet) {
-				if (EnableMarshalMethods.HasValue) {
-					SetProperty (KnownProperties.AndroidEnableMarshalMethods, EnableMarshalMethods.Value ? "True" : "False");
-				}
-
 				SetProperty (KnownProperties.OutputType, "Exe");
 				SetProperty (KnownProperties.Nullable, "enable");
 				SetProperty (KnownProperties.ImplicitUsings, "enable");
@@ -170,6 +164,11 @@ namespace Xamarin.ProjectTools
 				return Enum.TryParse<AndroidLinkMode> (GetProperty (ReleaseProperties, KnownProperties.AndroidLinkMode), out m) ? m : AndroidLinkMode.None;
 			}
 			set { SetProperty (ReleaseProperties, KnownProperties.AndroidLinkMode, value.ToString ()); }
+		}
+
+		public bool EnableMarshalMethods {
+			get { return string.Equals (GetProperty (KnownProperties.AndroidEnableMarshalMethods), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.AndroidEnableMarshalMethods, value.ToString ()); }
 		}
 
 		public string AndroidManifest { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -204,8 +204,9 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are DISABLED
 		/// </summary>
-		public MarshalMethodsNativeAssemblyGenerator (ICollection<string> uniqueAssemblyNames)
+		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames)
 		{
+			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 			this.uniqueAssemblyNames = uniqueAssemblyNames ?? throw new ArgumentNullException (nameof (uniqueAssemblyNames));
 			generateEmptyCode = true;
 		}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void NativeAssemblyCacheWithSatelliteAssemblies ()
+		public void NativeAssemblyCacheWithSatelliteAssemblies ([Values (true, false)] bool enableMarshalMethods)
 		{
 			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidLibraryProject {
@@ -49,6 +49,7 @@ namespace Xamarin.Android.Build.Tests
 
 			proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
+				EnableMarshalMethods = enableMarshalMethods,
 			};
 			proj.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");


### PR DESCRIPTION
Fix native code generation when marshal methods are disabled

Disabling marshal method generation turns off a lot of native code
generation in the `MarshalMethodsNativeAssemblyGenerator` class, but the
class is also responsible for outputting correctly sized cache area (an
array of X pointers) to be used by the native runtime to cache pointers
to `MonoImage` instances.

Native runtime trusts the managed runtime to generate correct code and,
thus, does not verify the size of generated array.  This trust,
unfortunately, was broken because with marshal methods disabled, the
native code generator output cache array that was 0 entries in size,
thus leading to segfault when attempting to run the application.

Fix the issue and also parametrize one of the on-device tests to be
built twice, with marshal methods explicitly disabled and explicitly
enabled.