### PR TITLE
[build] remove .NET 6 support

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -43,7 +43,6 @@
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
     <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.46</AndroidNet7Version>
-    <AndroidNet6Version Condition=" '$(AndroidNet6Version)' == '' ">32.0.485</AndroidNet6Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
+++ b/build-tools/create-packs/Microsoft.NET.Sdk.Android.proj
@@ -35,12 +35,12 @@ about the various Microsoft.Android workloads.
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.json"
         DestinationFile="$(WorkloadManifestJsonPath)"
-        Replacements="@WORKLOAD_VERSION@=$(WorkloadVersion);@NET7_VERSION@=$(AndroidNet7Version);@NET6_VERSION@=$(AndroidNet6Version)">
+        Replacements="@WORKLOAD_VERSION@=$(WorkloadVersion);@NET7_VERSION@=$(AndroidNet7Version)">
     </ReplaceFileContents>
     <ReplaceFileContents
         SourceFile="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.NET.Sdk.Android\WorkloadManifest.in.targets"
         DestinationFile="$(WorkloadManifestTargetsPath)"
-        Replacements="@NET7_VERSION@=$(AndroidNet7Version);@NET6_VERSION@=$(AndroidNet6Version)">
+        Replacements="@NET7_VERSION@=$(AndroidNet7Version)">
     </ReplaceFileContents>
 
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json
@@ -6,7 +6,6 @@
       "packs": [
         "Microsoft.Android.Sdk.net8",
         "Microsoft.Android.Sdk.net7",
-        "Microsoft.Android.Sdk.net6",
         "Microsoft.Android.Ref.33",
         "Microsoft.Android.Runtime.33.android-arm",
         "Microsoft.Android.Runtime.33.android-arm64",
@@ -16,8 +15,6 @@
       ],
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
       "extends" : [ 
-        "microsoft-net-runtime-android-net6",
-        "microsoft-net-runtime-android-aot-net6",
         "microsoft-net-runtime-android-net7",
         "microsoft-net-runtime-android-aot-net7",
         "microsoft-net-runtime-android",
@@ -41,18 +38,6 @@
     "Microsoft.Android.Sdk.net7": {
       "kind": "sdk",
       "version": "@NET7_VERSION@",
-      "alias-to": {
-        "osx-x64": "Microsoft.Android.Sdk.Darwin",
-        "osx-arm64": "Microsoft.Android.Sdk.Darwin",
-        "win-x86": "Microsoft.Android.Sdk.Windows",
-        "win-x64": "Microsoft.Android.Sdk.Windows",
-        "win-arm64": "Microsoft.Android.Sdk.Windows",
-        "linux-x64": "Microsoft.Android.Sdk.Linux"
-      }
-    },
-    "Microsoft.Android.Sdk.net6": {
-      "kind": "sdk",
-      "version": "@NET6_VERSION@",
       "alias-to": {
         "osx-x64": "Microsoft.Android.Sdk.Darwin",
         "osx-arm64": "Microsoft.Android.Sdk.Darwin",

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -15,13 +15,6 @@
         TargetingPackVersion="@NET7_VERSION@"
     />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-    <KnownFrameworkReference
-        Update="Microsoft.Android"
-        LatestRuntimeFrameworkVersion="@NET6_VERSION@"
-        TargetingPackVersion="@NET6_VERSION@"
-    />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
     <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -271,16 +271,6 @@ namespace Xamarin.Android.Build.Tests
 
 		static readonly object[] DotNetPackTargetFrameworks = new object[] {
 			new object[] {
-				"net6.0",
-				"android",
-				31,
-			},
-			new object[] {
-				"net6.0",
-				"android31",
-				31,
-			},
-			new object[] {
 				"net7.0",
 				"android",
 				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
@@ -372,11 +362,7 @@ public class JavaSourceTest {
 			nupkg.AssertDoesNotContainEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/nopack.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
-
-			//TODO: this issue is not fixed in net6.0-android MSBuild targets
-			if (dotnetVersion != "net6.0") {
-				nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/baz.aar");
-			}
+			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/baz.aar");
 		}
 
 		[Test]
@@ -870,11 +856,6 @@ public class FooA {
 
 		static readonly object[] DotNetTargetFrameworks = new object[] {
 			new object[] {
-				"net6.0",
-				"android",
-				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
-			},
-			new object[] {
 				"net7.0",
 				"android",
 				XABuildConfig.AndroidDefaultTargetDotnetApiLevel,
@@ -1009,10 +990,10 @@ public class FooA {
 		}
 
 		[Test]
-		public void XamarinLegacySdk ([Values ("net6.0-android32.0", "net7.0-android33.0", "net8.0-android33.0")] string dotnetTargetFramework)
+		public void XamarinLegacySdk ([Values ("net7.0-android33.0", "net8.0-android33.0")] string dotnetTargetFramework)
 		{
 			var proj = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha2",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha4",
 				Sources = {
 					new AndroidItem.AndroidLibrary ("javaclasses.jar") {
 						BinaryContent = () => ResourceData.JavaSourceJarTestJar,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -36,19 +36,12 @@ namespace Xamarin.ProjectTools
 		}
 
 		/// <summary>
-		/// Projects targeting net6.0/net7.0 require ref/runtime packs on NuGet.org or dotnet6/dotnet7
+		/// Projects targeting net7.0 require ref/runtime packs on NuGet.org or dotnet6/dotnet7
 		/// </summary>
 		public void AddNuGetSourcesForOlderTargetFrameworks (string targetFramework = null)
 		{
 			targetFramework ??= TargetFramework;
-			if (targetFramework.IndexOf ("net6.0", StringComparison.OrdinalIgnoreCase) != -1) {
-				ExtraNuGetConfigSources = new List<string> {
-					"https://api.nuget.org/v3/index.json",
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json",
-					// NOTE: .NET 6 currently uses .NET 7 linker
-					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json",
-				};
-			} else if (targetFramework.IndexOf ("net7.0", StringComparison.OrdinalIgnoreCase) != -1) {
+			if (targetFramework.IndexOf ("net7.0", StringComparison.OrdinalIgnoreCase) != -1) {
 				ExtraNuGetConfigSources = new List<string> {
 					"https://api.nuget.org/v3/index.json",
 					"https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json",

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -730,7 +730,7 @@ using System.Runtime.Serialization.Json;
 			}
 			// Build a NuGet Package
 			var nuget = new XASdkProject (outputType: "Library") {
-				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha2",
+				Sdk = "Xamarin.Legacy.Sdk/0.2.0-alpha4",
 				ProjectName = "Test.Nuget.Package",
 				IsRelease = true,
 			};

--- a/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs
@@ -55,16 +55,6 @@ namespace Xamarin.Android.Build.Tests
 				/* xamarinForms */   true,
 				/* targetFramework*/ "net7.0-android",
 			},
-			new object[] {
-				/* isRelease */      false,
-				/* xamarinForms */   true,
-				/* targetFramework*/ "net6.0-android",
-			},
-			new object[] {
-				/* isRelease */      true,
-				/* xamarinForms */   true,
-				/* targetFramework*/ "net6.0-android",
-			},
 		};
 
 		[Test]
@@ -207,7 +197,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[Category ("Debugger")]
 		[Retry(5)]
-		public void DotNetDebug ([Values("net6.0-android", "net7.0-android")] string targetFramework)
+		public void DotNetDebug ([Values("net7.0-android", "net8.0-android")] string targetFramework)
 		{
 			AssertCommercialBuild ();
 


### PR DESCRIPTION
Context: https://dotnet.microsoft.com/platform/support/policy/maui

> A major version of .NET MAUI receives support for a minimum of 6
> months after a successor (the next major release) ships. For
> example, .NET MAUI 6.0 will be supported for 6 months after .NET
> MAUI 7.0 ships. Similarly, .NET MAUI 7.0 will receive support for 6
> months after .NET MAUI 8.0 ships.

By the time .NET 8 GA ships, .NET 6 MAUI projects will not be supported.

Remove .NET 6 support from the `android` workload.

I removed `net6.0-android` parameters from various tests, making sure we still have .NET 7 and .NET 8 tests.