### PR TITLE
Bump to dotnet/installer/main@c373093 8.0.100-preview.3.23170.5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,24 +1,24 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.3.23163.4">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-preview.3.23170.5">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>cddf8e60e12dc484fd551d18e0c37bf1412e7ec2</Sha>
+      <Sha>c3730935bc3a06db5d51e8f3f36d88b8056a2cb5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.3.23159.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.3.23168.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a92ed6e2ce778c8b18dfa66f8f75368eca901f99</Sha>
+      <Sha>2aec3816f9bbc0eda3261daa335a05ea0df31b9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23159.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23168.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a92ed6e2ce778c8b18dfa66f8f75368eca901f99</Sha>
+      <Sha>2aec3816f9bbc0eda3261daa335a05ea0df31b9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3" Version="8.0.0-preview.3.23156.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport" Version="8.0.0-preview.3.23167.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>4c1f185a78249c6974c1f6c248dad189fe70497b</Sha>
+      <Sha>25d9f7a5e38a2d61b94ff341bc0d32135fcb15f9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23156.1" CoherentParentDependency="Microsoft.NET.ILLink.Tasks">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23163.1" CoherentParentDependency="Microsoft.NET.ILLink.Tasks">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>b126490cd618d6066ed44e0369b4585e845cf9ab</Sha>
+      <Sha>f32e148d67dbf348685c3076a37e8bc68ab3a30f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,15 +1,15 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.3.23163.4</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.3.23159.4</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.3.23159.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-preview.3.23170.5</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>8.0.0-preview.3.23168.2</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.3.23168.2</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version>8.0.0-preview.3.23156.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version>
-    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview3Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-preview.3.23167.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
+    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23156.1</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.23163.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/059898f8c0dbea2c6d0ed2ff30bc1b584af6b439/eng/Version.Details.xml#L88-L92
Context: https://github.com/dotnet/emsdk/pull/308
Changes: https://github.com/dotnet/installer/compare/cddf8e6...c373093
Changes: https://github.com/dotnet/runtime/compare/a92ed6e...2aec381
Changes: https://github.com/dotnet/emsdk/compare/4c1f185...25d9f7a

Maestro was failing to update with:

    > darc update-dependencies --id 171040
    Looking up build with BAR id 171040
    Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-preview.3.23163.4' => '8.0.100-preview.3.23170.5' (from build '20230320.5' of 'https://github.com/dotnet/installer')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Coherency updates failed for the following dependencies:
    Unable to update Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3 to have coherency with Microsoft.NETCore.App.Ref: https://github.com/dotnet/runtime @ 2aec3816f9bbc0eda3261daa335a05ea0df31b9c does not contain dependency Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3

I got the latest dotnet/installer build number from:

https://maestro-prod.westus2.cloudapp.azure.com/3074/https:%2F%2Fgithub.com%2Fdotnet%2Finstaller/latest/graph

It appears this pack was renamed:

    Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.3

To become:

    Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport

After manually fixing things, I could do:

    > darc update-dependencies --id 171040
    Looking up build with BAR id 171040
    Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-preview.3.23163.4' => '8.0.100-preview.3.23170.5' (from build '20230320.5' of 'https://github.com/dotnet/installer')
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Updating 'Microsoft.NETCore.App.Ref': '8.0.0-preview.3.23159.4' => '8.0.0-preview.3.23168.2' to ensure coherency with Microsoft.Dotnet.Sdk.Internal@8.0.100-preview.3.23170.5
    Updating 'Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100.Transport': '' => '8.0.0-preview.3.23167.1' to ensure coherency with Microsoft.NETCore.App.Ref@8.0.0-preview.3.23159.4
    Updating 'Microsoft.NET.ILLink.Tasks': '8.0.0-preview.3.23159.4' => '8.0.0-preview.3.23168.2' to ensure coherency with Microsoft.Dotnet.Sdk.Internal@8.0.100-preview.3.23170.5
    Updating 'Microsoft.DotNet.Cecil': '0.11.4-alpha.23156.1' => '0.11.4-alpha.23163.1' to ensure coherency with Microsoft.NET.ILLink.Tasks@8.0.0-preview.3.23159.4

This is nice because we shouldn't have to keep manually fixing this for every future .NET 8 preview.