### PR TITLE
[Xamarin.Android.Build.Tasks] Fix AndroidPackagingOptionsExclude

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -254,12 +254,16 @@ namespace Xamarin.Android.Tasks
 								continue;
 							}
 							// check for ignored items
+							bool exclude = false;
 							foreach (var pattern in excludePatterns) {
 								if(pattern.IsMatch (path)) {
 									Log.LogDebugMessage ($"Ignoring jar entry '{name}' from '{Path.GetFileName (jarFile)}'. Filename matched the exclude pattern '{pattern}'.");
-									continue;
+									exclude = true;
+									break;
 								}
 							}
+							if (exclude)
+								continue;
 							if (string.Compare (Path.GetFileName (name), "AndroidManifest.xml", StringComparison.OrdinalIgnoreCase) == 0) {
 								Log.LogDebugMessage ("Ignoring jar entry {0} from {1}: the same file already exists in the apk", name, Path.GetFileName (jarFile));
 								continue;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -931,7 +931,7 @@ public class Test
 				string expected = $"Ignoring jar entry 'kotlin/Error.kotlin_metadata'";
 				Assert.IsTrue (b.LastBuildOutput.ContainsText (expected), $"Error.kotlin_metadata should have been ignored.");
 				using (var zip = ZipHelper.OpenZip (apk)) {
-					Assert.IsFalse (zip.ContainsEntry ("Error.kotlin_metadata"), "Error.kotlin_metadata should have been ignored.");
+					Assert.IsFalse (zip.ContainsEntry ("kotlin/Error.kotlin_metadata"), "Error.kotlin_metadata should have been ignored.");
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/7902

Commit 2726a386 introduced the ability to ignore certain file patterns when adding files to an apk. Unfortunately it had a bug in the code and the test. The code would log a warning that is was ignoring the file, but then add the file anyway. The test was looking for the wrong path in the apk , so it would always pass the test.

This commit fixes both of these issues.