### PR TITLE
[ci] Optimize 'APK's .NET' test job overhead.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -57,6 +57,8 @@ variables:
   value: '& TestCategory != DotNetIgnore & TestCategory != HybridAOT & TestCategory != MkBundle & TestCategory != MonoSymbolicate & TestCategory != PackagesConfig & TestCategory != StaticProject & TestCategory != SystemApplication'
 - name: ExcludedNUnitCategories
   value: '& cat != DotNetIgnore & cat != HybridAOT & cat != MkBundle & cat != MonoSymbolicate & cat != PackagesConfig & cat != StaticProject & cat != SystemApplication'
+- name: DefaultTestSdkPlatforms  # Comma-separated SDK Platform(s) to install on test agents (no spaces)
+  value: 33
 - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private') }}:
   - group: AzureDevOps-Artifact-Feeds-Pats
   - group: DotNet-MSRC-Storage
@@ -312,11 +314,14 @@ stages:
       parameters:
         provisionClassic: false
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
+        installLegacyDotNet: false
+        restoreNUnitConsole: false
+        updateMono: false
 
     - template: yaml-templates/run-xaprepare.yaml
       parameters:
         displayName: install emulator
-        arguments: --s=EmulatorTestDependencies
+        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(DefaultTestSdkPlatforms)"
         
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -334,7 +339,7 @@ stages:
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
-          -t:PrepareJavaInterop -c Debug -m:1 -v:n
+          -t:PrepareJavaInterop -c Debug --no-restore
           -p:DotNetPreviewTool=$(System.DefaultWorkingDirectory)/bin/$(XA.Build.Configuration)/dotnet/dotnet
         displayName: prepare java.interop Debug
         continueOnError: false
@@ -342,9 +347,11 @@ stages:
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
-        arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) -m:1 -v:n
+        arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
+      
+    - template: yaml-templates/start-stop-emulator.yaml
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -411,15 +418,9 @@ stages:
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Tools.Aidl-Tests.dll
         testResultsFile: TestResult-Aidl-Tests-macOS-$(XA.Build.Configuration).xml
 
-    - task: MSBuild@1
-      displayName: shut down emulator
-      inputs:
-        solution: tests/Mono.Android-Tests/Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /t:AcquireAndroidTarget,ReleaseAndroidTarget
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
-      condition: always()
+    - template: yaml-templates/start-stop-emulator.yaml
+      parameters:
+        command: stop
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -44,7 +44,8 @@ steps:
 - script: >
     DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/" &&
     mkdir -p "$DEST" &&
-    cp "${{ parameters.artifactSource }}" "$DEST"
+    cp "${{ parameters.artifactSource }}" "$DEST" ||
+    echo "copy apk/aab failed"  # We don't need to report the error
   displayName: copy apk/aab
   condition: ne(variables['Agent.JobStatus'], 'Succeeded')
   continueOnError: true

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,7 +12,7 @@ parameters:
   installLegacyDotNet: true
   restoreNUnitConsole: true
   updateMono: true
-  androidSdkPlatforms: 33
+  androidSdkPlatforms: $(DefaultTestSdkPlatforms)
 
 steps:
 - checkout: self

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -21,8 +21,6 @@ stages:
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
-    variables:
-      androidSdkPlatforms: 33
     steps:
     - template: setup-test-environment.yaml
       parameters:
@@ -38,7 +36,7 @@ stages:
     - template: run-xaprepare.yaml
       parameters:
         displayName: install emulator
-        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(androidSdkPlatforms)"
+        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(DefaultTestSdkPlatforms)"
         
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/start-stop-emulator.yaml
+++ b/build-tools/automation/yaml-templates/start-stop-emulator.yaml
@@ -5,6 +5,7 @@ parameters:
   avdApiLevel:            # Device API level, like '30', required if 'specificImage' is 'true'
   avdAbi:                 # Device ABI, like 'x86', required if 'specificImage' is 'true'
   avdType:                # Device AVD, like 'android-wear', required if 'specificImage' is 'true'
+  launchTimeoutMin: 15    # Minutes to wait for the emulator to start
 
 steps:
 - ${{ if eq(parameters.command, 'start') }}:
@@ -14,9 +15,9 @@ steps:
     inputs:
       projects: src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
-        arguments: -c $(XA.Build.Configuration) -t:"InstallAvdImage;AcquireAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-${{ parameters.avdApiLevel }}.binlog
+        arguments: -c $(XA.Build.Configuration) -t:"InstallAvdImage;AcquireAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-${{ parameters.avdApiLevel }}.binlog
       ${{ else }}:
-        arguments: -c $(XA.Build.Configuration) -t:AcquireAndroidTarget -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+        arguments: -c $(XA.Build.Configuration) -t:AcquireAndroidTarget -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
 - ${{ if eq(parameters.command, 'stop') }}:
   - task: DotNetCoreCLI@2
@@ -26,6 +27,6 @@ steps:
     inputs:
       projects: src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
-        arguments: -c $(XA.Build.Configuration) -t:"AcquireAndroidTarget,ReleaseAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+        arguments: -c $(XA.Build.Configuration) -t:"AcquireAndroidTarget,ReleaseAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       ${{ else }}:
-        arguments: -c $(XA.Build.Configuration) -t:"AcquireAndroidTarget,ReleaseAndroidTarget" -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+        arguments: -c $(XA.Build.Configuration) -t:"AcquireAndroidTarget,ReleaseAndroidTarget" -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog


### PR DESCRIPTION
Optimize overhead for `APK's .NET` ci job:

- Use new `start-stop-emulator.yaml` template to start the emulator before the tests begin.  If the emulator isn't working, then each test step tries to run, waits 10 minutes, and then errors out (see screenshot below).  Instead, let's just error out completely at the beginning if the emulator isn't available.
- Bump emulator timeout to 15 minutes (from 10 minutes).  Using public Mac bots can be slow, maybe giving them a little extra time will result in more successful builds.
- Call `Xamarin.Android.sln -t:PrepareJavaInterop` with ` --no-restore` to prevent it from running restore on the entire solution.
- Don't waste time installing unneeded dependencies:
  - Legacy dotnet
  - Mono
  - NUnit.Console
  - Extra Android SDK platforms

![image](https://user-images.githubusercontent.com/179295/226654253-2d73b593-f7cd-4a1f-bf50-6a105c63283b.png)
