### PR TITLE
[Mono.Android-Tests] Stop using google URL that is returning 429 - Too Many Requests

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -83,7 +83,7 @@ namespace System.NetTests {
 		void DoHttpsShouldWork ()
 		{
 			// string url = "https://bugzilla.novell.com/show_bug.cgi?id=634817";
-			string url = "https://encrypted.google.com/";
+			string url = "https://dotnet.microsoft.com/";
 			// string url = "http://slashdot.org";
 			HttpWebRequest request = (HttpWebRequest) WebRequest.Create(url);
 			request.Method = "GET";


### PR DESCRIPTION
Tests hitting `https://encrypted.google.com/` are failing with:

```
System.Net.WebException : net_servererror, 429, Too Many Requests
```

Change to a Microsoft domain (`https://dotnet.microsoft.com/`) that hopefully won't get rate limited.  🤷‍♂️ 