### PR TITLE
[tests] Add backup ssl sites in case of 429 response.

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/SslTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/SslTest.cs
@@ -83,11 +83,24 @@ namespace System.NetTests {
 		void DoHttpsShouldWork ()
 		{
 			// string url = "https://bugzilla.novell.com/show_bug.cgi?id=634817";
-			string url = "https://encrypted.google.com/";
+			string[] urls = new string[]  {
+				"https://dotnet.microsoft.com/",
+				"https://www.bing.com/",
+				"https://httpbin.org/get",
+			};
 			// string url = "http://slashdot.org";
-			HttpWebRequest request = (HttpWebRequest) WebRequest.Create(url);
-			request.Method = "GET";
-			var response = (HttpWebResponse) request.GetResponse ();
+			HttpWebResponse response = null;
+			foreach (var url in urls) {
+				HttpWebRequest request = (HttpWebRequest) WebRequest.Create(url);
+				request.Method = "GET";
+				response = (HttpWebResponse) request.GetResponse ();
+				if (response.StatusCode == HttpStatusCode.TooManyRequests) {
+					// try the next url.
+					continue;
+				}
+				break;
+			}
+			Assert.IsNotNull (response);
 			int len = 0;
 			using (var _r = new StreamReader (response.GetResponseStream ())) {
 				char[] buf = new char [4096];


### PR DESCRIPTION
Our SSL test can fail quite often with a 429 Too Many Requests error. This makes the CI very unstable as we are constantly having to wait and retry the tests. So lets put that logic into the test itself. If we get a 429 we should try some other ssl site.