### PR TITLE
$(AndroidPackVersionSuffix)=preview.4; net8 is 34.0.0-preview.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview3

We branched for .NET 8 preview 3 from 7d97205 into `release/8.0.1xx-preview3`.

Update xamarin-android/main's version number to 34.0.0-preview.4 for .NET 8 preview 4.