### PR TITLE
[Mono.Android] delay JNINativeWrapper.get_runtime_types()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -34,8 +34,6 @@ namespace Android.Runtime {
 			if (dlg.Method == null)
 				throw new ArgumentException ();
 
-			get_runtime_types ();
-
 			var delegateType = dlg.GetType ();
 			var result = CreateBuiltInDelegate (dlg, delegateType);
 			if (result != null)
@@ -44,6 +42,8 @@ namespace Android.Runtime {
 			if (JNIEnvInit.LogAssemblyCategory) {
 				RuntimeNativeMethods.monodroid_log (LogLevel.Debug, LogCategories.Assembly, $"Falling back to System.Reflection.Emit for delegate type '{delegateType}': {dlg.Method}");
 			}
+
+			get_runtime_types ();
 
 			var ret_type = dlg.Method.ReturnType;
 			var parameters = dlg.Method.GetParameters ();


### PR DESCRIPTION
Reviewing `dotnet-trace` output, I noticed in a `dotnet new maui` app on a Pixel 5:

    6.38ms mono.android!Android.Runtime.JNINativeWrapper.CreateDelegate(System.Delegate)
    1.16ms mono.android!Android.Runtime.JNINativeWrapper.get_runtime_types()

We spend ~1ms looking up `AndroidEnvironment.UnhandledException` and `AndroidRuntimeInternal.WaitForBridgeProcessing`.

However, in this app *all* calls go to the "fast path" via `JNINativeWrapper.CreateBuiltInDelegate()`. We don't *need* to look up these methods in this app at all.

Delay the call to `get_runtime_types()` to only when it is needed via the "slow path". Will help us a small amount in .NET 8.