### PR TITLE
[/Mono.Android-Tests] Revert back to example.com

### DIFF
--- a/tests/Mono.Android-Tests/System.Net/ProxyTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/ProxyTest.cs
@@ -13,7 +13,7 @@ namespace System.NetTests {
 		[Test]
 		public void QuoteInvalidQuoteUrlsShouldWork ()
 		{
-			string url      = "http://example.com/?query&foo|bar";
+			string url      = "http://www.msftconnecttest.com/connecttest.txt?query&foo|bar";
 			var request     = (HttpWebRequest) WebRequest.Create (url);
 			request.Method  = "GET";
 			var response    = (HttpWebResponse) request.GetResponse ();

--- a/tests/Mono.Android-Tests/System.Net/ProxyTest.cs
+++ b/tests/Mono.Android-Tests/System.Net/ProxyTest.cs
@@ -13,7 +13,7 @@ namespace System.NetTests {
 		[Test]
 		public void QuoteInvalidQuoteUrlsShouldWork ()
 		{
-			string url      = "https://bing.com/?query&foo|bar";
+			string url      = "http://example.com/?query&foo|bar";
 			var request     = (HttpWebRequest) WebRequest.Create (url);
 			request.Method  = "GET";
 			var response    = (HttpWebResponse) request.GetResponse ();


### PR DESCRIPTION
Commit 112c832 broke the `QuoteInvalidQuoteUrlsShouldWork`. It is now reporting the following error.

```
System.Net.WebException : net_http_ssl_connection_failed
----> System.Net.Http.HttpRequestException : net_http_ssl_connection_failed
----> System.Security.Authentication.AuthenticationException : net_auth_SSPI
----> Interop+AndroidCrypto+SslException : Exception_WasThrown, Interop+AndroidCrypto+SslException
```

Revert back to use the previous url until we can figure this one out.