### PR TITLE
[monodroid] Fix `ld` build error on Nightly Builds.

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -40,8 +40,10 @@ option(ENABLE_CLANG_UBSAN "Enable the clang UndefinedBehaviorSanitizer support" 
 
 if(ENABLE_CLANG_ASAN OR ENABLE_CLANG_UBSAN)
   set(STRIP_DEBUG_DEFAULT OFF)
+  set(ANALYZERS_ENABLED ON)
 else()
   set(STRIP_DEBUG_DEFAULT ON)
+  set(ANALYZERS_ENABLED OFF)
 endif()
 
 option(ENABLE_NET "Enable compilation for .NET 6+" OFF)
@@ -722,7 +724,7 @@ target_link_libraries(
   ${LINK_LIBS} xamarin-app
   )
 
-if(ANDROID AND ENABLE_NET)
+if(ANDROID AND ENABLE_NET AND (NOT ANALYZERS_ENABLED))
   add_library(
     c
     SHARED ${XAMARIN_STUB_LIB_SOURCES}


### PR DESCRIPTION
We are seeing the following build error on Nightly builds.

```
ld : error : undefined symbol: vtable for __cxxabiv1::__function_type_info [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]
clang++ : error : linker command failed with exit code 1 (use -v to see invocation) [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]
ld : error : undefined symbol: vtable for __cxxabiv1::__function_type_info [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]
clang++ : error : linker command failed with exit code 1 (use -v to see invocation) [/Users/builder/azdo/_work/3/s/xamarin-android/src/monodroid/monodroid.csproj]
```

The code changes in the PR will fix this.