### PR TITLE
Add ability to disable android implicit usings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,7 +16,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and 'AndroidDisableImplicitUsings' != 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and '$(AndroidDisableImplicitUsings)' != 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Include="Android.App" Platform="Android" />
     <Using Include="Android.Widget" Platform="Android" />
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,7 +16,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and 'AndroidDisableImplicitUsings' != 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Include="Android.App" Platform="Android" />
     <Using Include="Android.Widget" Platform="Android" />
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" />


### PR DESCRIPTION
`ImplicitUsings` is a property used by the .NET SDK to generate https://github.com/dotnet/sdk/blob/b5fc2fd0c35b40c2bffc2ce8e0780a2398ae4305/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props#L25-L34

Since the same property is used here too, there is direct no way to say "I want the usings from the .NET SDK, but not from Android". A possible workaround is `<Using Remove="@(Using->HasMetadata('Platform'))" />`

This PR allows to set `<AndroidDisableImplicitUsings>true</AndroidDisableImplicitUsings>` so that the `System.*` ones are produced, but not the Android ones. This is *almost* equivalent to `<Using Remove="@(Using->HasMetadata('Platform'))" />`