### PR TITLE
[ci] Stop building classic test suites.

### DIFF
--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -45,12 +45,6 @@ stages:
       parameters:
         remove_dotnet: true
 
-    # xabuild still depends on .NET Core 3 or earlier
-    - template: use-dot-net.yaml
-      parameters:
-        version: 3.1
-        quality: GA
-
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
     # The VS installer will attempt to resume any failed or partial installation before trying to downgrade Xamarin.Android.
     # VSIXInstaller.exe will exit non-zero when the downgrade attempt is a no-op, so we will allow this step to fail silently.
@@ -91,19 +85,6 @@ stages:
           -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build.binlog
         displayName: Build Solution
         continueOnError: false
-
-    - task: MSBuild@1
-      displayName: msbuild xabuild
-      inputs:
-        solution: tools\xabuild\xabuild.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-xabuild.binlog
-
-    - task: CmdLine@1
-      displayName: xabuild Xamarin.Android-Tests
-      inputs:
-        filename: bin\$(XA.Build.Configuration)\bin\xabuild.exe
-        arguments: Xamarin.Android-Tests.sln /restore /p:Configuration=$(XA.Build.Configuration) /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\dotnet-build-tests.binlog
 
     - template: install-apkdiff.yaml
 

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -60,11 +60,6 @@ steps:
   displayName: CodeQL 3000 Finalize
   condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-# Build test assemblies
-- script: make all-tests CONFIGURATION=$(XA.Build.Configuration)
-  workingDirectory: ${{ parameters.xaSourcePath }}
-  displayName: make all-tests
-
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
 - task: MSBuild@1
   displayName: msbuild /t:Restore sign-content.proj


### PR DESCRIPTION
Now that we no longer run any Classic test suites in `main`, we no longer need to build them with `Xamarin.Android-Tests.sln`.

The .NET test suites that we do use are built in `Xamarin.Android.sln` or built locally on the test agents with the installed XA test packages.

This saves about 7.5 minutes from the Mac Build.