### PR TITLE
[Xamarin.Android.Build.Tasks] fix cases of missing `@(Reference)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -44,7 +44,7 @@ _ResolveAssemblies MSBuild target.
   </PropertyGroup>
 
   <Target Name="_ComputeFilesToPublishForRuntimeIdentifiers"
-      DependsOnTargets="_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
+      DependsOnTargets="BuildOnlySettings;_FixupIntermediateAssembly;ResolveReferences;ComputeFilesToPublish;$(_RunAotMaybe)"
       Returns="@(ResolvedFileToPublish)">
       <ItemGroup>
         <ResolvedFileToPublish Remove="@(_SourceItemsToCopyToPublishDirectory)" />
@@ -90,6 +90,7 @@ _ResolveAssemblies MSBuild target.
       <_AdditionalProperties>
         _ComputeFilesToPublishForRuntimeIdentifiers=true
         ;AppendRuntimeIdentifierToOutputPath=true
+        ;ResolveAssemblyReferencesFindRelatedSatellites=false
         ;SkipCompilerExecution=true
         ;_OuterIntermediateAssembly=@(IntermediateAssembly)
         ;_OuterOutputPath=$(OutputPath)


### PR DESCRIPTION
Context: https://github.com/dotnet/msbuild/blob/c75672a6e7387bc5c1f99c166e9277351144b14c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L2327
Fixes: https://github.com/dotnet/maui/issues/10154

This partially reverts c1efcb5678c8d93c4d5bdd0452a79a8ffab2f6b7.

Previously, we removed this change because it broke .NET MAUI's build
with:

    Unable to open file 'obj\Release\net8.0-android\android-x64\aot\x86_64\Microsoft.Maui.Controls.resources\temp.s': Permission denied

The problem being that the .NET SDK was placing satellite assemblies
in the `@(ResolvedFileToPublish)` item group.

Let's apply our change from before, but also set
`$(ResolveAssemblyReferencesFindRelatedSatellites)` to `false` for
our "inner build" per `$(RuntimeIdentifier)`.

This solves the original issue for dotnet/maui#10154 without changing
behavior of satellite assemblies.

I added `.resx` files in our new test, and assert that satellite
assemblies are inside the resulting `.apk` for good measure.