### PR TITLE
[Xamarin.Android.Build.Tasks] Bump ZipFlushFilesLimit

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -140,6 +140,12 @@ namespace Xamarin.Android.Tasks
 				refresh = false;
 			}
 			using (var apk = new ZipArchiveEx (apkOutputPath, File.Exists (apkOutputPath) ? FileMode.Open : FileMode.Create )) {
+				if (int.TryParse (ZipFlushFilesLimit, out int flushFilesLimit)) {
+					apk.ZipFlushFilesLimit = flushFilesLimit;
+				}
+				if (int.TryParse (ZipFlushSizeLimit, out int flushSizeLimit)) {
+					apk.ZipFlushSizeLimit = flushSizeLimit;
+				}
 				if (refresh) {
 					for (long i = 0; i < apk.Archive.EntryCount; i++) {
 						ZipEntry e = apk.Archive.ReadEntry ((ulong) i);
@@ -294,12 +300,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			if (int.TryParse (ZipFlushFilesLimit, out int flushFilesLimit)) {
-				ZipArchiveEx.ZipFlushFilesLimit = flushFilesLimit;
-			}
-			if (int.TryParse (ZipFlushSizeLimit, out int flushSizeLimit)) {
-				ZipArchiveEx.ZipFlushSizeLimit = flushSizeLimit;
-			}
 			Aot.TryGetSequencePointsMode (AndroidSequencePointsMode, out sequencePointsMode);
 
 			var outputFiles = new List<string> ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -95,6 +95,10 @@ namespace Xamarin.Android.Tasks
 
 		public bool UseAssemblyStore { get; set; }
 
+		public string ZipFlushFilesLimit { get; set; }
+
+		public string ZipFlushSizeLimit { get; set; }
+
 		[Required]
 		public string ProjectFullPath { get; set; }
 
@@ -206,7 +210,6 @@ namespace Xamarin.Android.Tasks
 					AddFileToArchiveIfNewer (apk, RuntimeConfigBinFilePath, $"{AssembliesPath}rc.bin", compressionMethod: UncompressedMethod);
 				}
 
-				int count = 0;
 				foreach (var file in files) {
 					var item = Path.Combine (file.archivePath.Replace (Path.DirectorySeparatorChar, '/'));
 					existingEntries.Remove (item);
@@ -216,12 +219,7 @@ namespace Xamarin.Android.Tasks
 						continue;
 					}
 					Log.LogDebugMessage ("\tAdding {0}", file.filePath);
-					apk.Archive.AddFile (file.filePath, item, compressionMethod: compressionMethod);
-					count++;
-					if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
-						apk.Flush();
-						count = 0;
-					}
+					apk.AddFileAndFlush (file.filePath, item, compressionMethod: compressionMethod);
 				}
 
 				var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) : null;
@@ -236,7 +234,6 @@ namespace Xamarin.Android.Tasks
 				var jarFilePaths = libraryProjectJars.Concat (jarFiles != null ? jarFiles.Select (j => j.ItemSpec) : Enumerable.Empty<string> ());
 				jarFilePaths = MonoAndroidHelper.DistinctFilesByContent (jarFilePaths);
 
-				count = 0;
 				foreach (var jarFile in jarFilePaths) {
 					using (var stream = File.OpenRead (jarFile))
 					using (var jar = ZipArchive.Open (stream)) {
@@ -278,13 +275,8 @@ namespace Xamarin.Android.Tasks
 								data = d.ToArray ();
 							}
 							Log.LogDebugMessage ($"Adding {path} from {jarFile} as the archive file is out of date.");
-							apk.Archive.AddEntry (data, path);
+							apk.AddEntryAndFlush (data, path);
 						}
-					}
-					count++;
-					if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
-						apk.Flush();
-						count = 0;
 					}
 				}
 				// Clean up Removed files.
@@ -302,6 +294,12 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
+			if (int.TryParse (ZipFlushFilesLimit, out int flushFilesLimit)) {
+				ZipArchiveEx.ZipFlushFilesLimit = flushFilesLimit;
+			}
+			if (int.TryParse (ZipFlushSizeLimit, out int flushSizeLimit)) {
+				ZipArchiveEx.ZipFlushSizeLimit = flushSizeLimit;
+			}
 			Aot.TryGetSequencePointsMode (AndroidSequencePointsMode, out sequencePointsMode);
 
 			var outputFiles = new List<string> ();
@@ -377,7 +375,6 @@ namespace Xamarin.Android.Tasks
 				storeGenerator = null;
 			}
 
-			int count = 0;
 			AssemblyStoreAssemblyInfo storeAssembly = null;
 
 			//
@@ -398,7 +395,6 @@ namespace Xamarin.Android.Tasks
 			AddAssembliesFromCollection (ResolvedUserAssemblies);
 
 			// Add framework assemblies
-			count = 0;
 			AddAssembliesFromCollection (ResolvedFrameworkAssemblies);
 
 			if (!UseAssemblyStore) {
@@ -482,12 +478,6 @@ namespace Xamarin.Android.Tasks
 
 					if (UseAssemblyStore) {
 						storeGenerator.Add (assemblyStoreApkName, storeAssembly);
-					} else {
-						count++;
-						if (count >= ZipArchiveEx.ZipFlushFilesLimit) {
-							apk.Flush();
-							count = 0;
-						}
 					}
 				}
 			}
@@ -554,7 +544,7 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 			Log.LogDebugMessage ($"Adding {file} as the archive file is out of date.");
-			apk.Archive.AddFile (file, inArchivePath, compressionMethod: compressionMethod);
+			apk.AddFileAndFlush (file, inArchivePath, compressionMethod: compressionMethod);
 			return true;
 		}
 
@@ -578,7 +568,7 @@ namespace Xamarin.Android.Tasks
 				source.CopyTo (dest);
 				dest.WriteByte (0);
 				dest.Position = 0;
-				apk.Archive.AddEntry (inArchivePath, dest, compressionMethod);
+				apk.AddEntryAndFlush (inArchivePath, dest, compressionMethod);
 			}
 		}
 
@@ -625,7 +615,7 @@ namespace Xamarin.Android.Tasks
 				return;
 			}
 			Log.LogDebugMessage ($"Adding native library: {filesystemPath} (APK path: {archivePath})");
-			apk.Archive.AddEntry (archivePath, File.OpenRead (filesystemPath), compressionMethod);
+			apk.AddEntryAndFlush (archivePath, File.OpenRead (filesystemPath), compressionMethod);
 		}
 
 		void AddRuntimeLibraries (ZipArchiveEx apk, string [] supportedAbis)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -963,6 +963,32 @@ public class Test
 		}
 
 		[Test]
+		[TestCase (1, -1)]
+		[TestCase (5, -1)]
+		[TestCase (50, -1)]
+		[TestCase (100, -1)]
+		[TestCase (512, -1)]
+		[TestCase (1024, -1)]
+		[TestCase (-1, 1)]
+		[TestCase (-1, 5)]
+		[TestCase (-1, 10)]
+		[TestCase (-1, 100)]
+		[TestCase (-1, 200)]
+		public void BuildApkWithZipFlushLimits (int filesLimit, int sizeLimit)
+		{
+			var proj = new XamarinAndroidApplicationProject  {
+				IsRelease = true,
+			};
+			if (filesLimit > 0)
+				proj.SetProperty ("_ZipFlushFilesLimit", filesLimit.ToString ());
+			if (sizeLimit > 0)
+				proj.SetProperty ("_ZipFlushSizeLimit", (sizeLimit * 1024 * 1024).ToString ());
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void ExtractNativeLibsTrue ()
 		{
 			var proj = new XamarinAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -977,14 +977,28 @@ public class Test
 		public void BuildApkWithZipFlushLimits (int filesLimit, int sizeLimit)
 		{
 			var proj = new XamarinAndroidApplicationProject  {
-				IsRelease = true,
+				IsRelease = false,
+				PackageReferences = {
+					KnownPackages.SupportDesign_27_0_2_1,
+					KnownPackages.SupportV7CardView_27_0_2_1,
+					KnownPackages.AndroidSupportV4_27_0_2_1,
+					KnownPackages.SupportCoreUtils_27_0_2_1,
+					KnownPackages.SupportMediaCompat_27_0_2_1,
+					KnownPackages.SupportFragment_27_0_2_1,
+					KnownPackages.SupportCoreUI_27_0_2_1,
+					KnownPackages.SupportCompat_27_0_2_1,
+					KnownPackages.SupportV7AppCompat_27_0_2_1,
+					KnownPackages.SupportV7MediaRouter_27_0_2_1,
+				},
 			};
+			proj.SetProperty ("EmbedAssembliesIntoApk", "true");
 			if (filesLimit > 0)
 				proj.SetProperty ("_ZipFlushFilesLimit", filesLimit.ToString ());
 			if (sizeLimit > 0)
 				proj.SetProperty ("_ZipFlushSizeLimit", (sizeLimit * 1024 * 1024).ToString ());
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Android.Tasks
 	public class ZipArchiveEx : IDisposable
 	{
 
-		public static int ZipFlushSizeLimit = 100 * 1024 * 1024;
-		public static int ZipFlushFilesLimit = 512;
+		const int DEFAULT_FLUSH_SIZE_LIMIT = 100 * 1024 * 1024;
+		const int DEFAULT_FLUSH_FILES_LIMIT = 512;
 
 		ZipArchive zip;
 		string archive;
@@ -23,6 +23,9 @@ namespace Xamarin.Android.Tasks
 		public bool AutoFlush { get; set; } = true;
 
 		public bool CreateDirectoriesInZip { get; set; } = true;
+
+		public int ZipFlushSizeLimit { get; set; } = DEFAULT_FLUSH_SIZE_LIMIT;
+		public int ZipFlushFilesLimit { get; set; } = DEFAULT_FLUSH_FILES_LIMIT;
 
 		public ZipArchiveEx (string archive) : this (archive, FileMode.CreateNew)
 		{
@@ -65,7 +68,7 @@ namespace Xamarin.Android.Tasks
 		{
 			filesWrittenTotalSize += fileLength;
 			zip.AddFile (filename, archiveFileName, compressionMethod: compressionMethod);
-			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+			if ((filesWrittenTotalSize >= ZipFlushSizeLimit || filesWrittenTotalCount >= ZipFlushFilesLimit) && AutoFlush) {
 				Flush ();
 			}
 		}
@@ -80,7 +83,7 @@ namespace Xamarin.Android.Tasks
 		{
 			filesWrittenTotalSize += data.Length;
 			zip.AddEntry (data, archiveFileName);
-			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+			if ((filesWrittenTotalSize >= ZipFlushSizeLimit || filesWrittenTotalCount >= ZipFlushFilesLimit) && AutoFlush) {
 				Flush ();
 			}
 		}
@@ -89,7 +92,7 @@ namespace Xamarin.Android.Tasks
 		{
 			filesWrittenTotalSize += data.Length;
 			zip.AddEntry (archiveFileName, data, method);
-			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+			if ((filesWrittenTotalSize >= ZipFlushSizeLimit || filesWrittenTotalCount >= ZipFlushFilesLimit) && AutoFlush) {
 				Flush ();
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -70,6 +70,30 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
+		public void AddFileAndFlush (string filename, string archiveFileName, CompressionMethod compressionMethod)
+		{
+			var fi = new FileInfo (filename);
+			AddFileAndFlush (filename, fi.Length, archiveFileName, compressionMethod);
+		}
+
+		public void AddEntryAndFlush (byte[] data, string archiveFileName)
+		{
+			filesWrittenTotalSize += data.Length;
+			zip.AddEntry (data, archiveFileName);
+			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+				Flush ();
+			}
+		}
+
+		public void AddEntryAndFlush (string archiveFileName, Stream data, CompressionMethod method)
+		{
+			filesWrittenTotalSize += data.Length;
+			zip.AddEntry (archiveFileName, data, method);
+			if ((filesWrittenTotalSize >= ZipArchiveEx.ZipFlushSizeLimit || filesWrittenTotalCount >= ZipArchiveEx.ZipFlushFilesLimit) && AutoFlush) {
+				Flush ();
+			}
+		}
+
 		void AddFiles (string folder, string folderInArchive, CompressionMethod method)
 		{
 			foreach (string fileName in Directory.GetFiles (folder, "*.*", SearchOption.TopDirectoryOnly)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Android.Tasks
 	public class ZipArchiveEx : IDisposable
 	{
 
-		public static int ZipFlushSizeLimit = 50 * 1024 * 1024;
-		public static int ZipFlushFilesLimit = 50;
+		public static int ZipFlushSizeLimit = 100 * 1024 * 1024;
+		public static int ZipFlushFilesLimit = 512;
 
 		ZipArchive zip;
 		string archive;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2152,6 +2152,8 @@ because xbuild doesn't support framework reference assemblies.
     CheckedBuild="$(_AndroidCheckedBuild)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
     ExcludeFiles="@(AndroidPackagingOptionsExclude)"
+    ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
+    ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
     UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
@@ -2185,6 +2187,8 @@ because xbuild doesn't support framework reference assemblies.
       CheckedBuild="$(_AndroidCheckedBuild)"
       RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
       ExcludeFiles="@(AndroidPackagingOptionsExclude)"
+      ZipFlushFilesLimit="$(_ZipFlushFilesLimit)"
+      ZipFlushSizeLimit="$(_ZipFlushSizeLimit)"
       UseAssemblyStore="$(AndroidUseAssemblyStore)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>


### PR DESCRIPTION
Context https://i.azdo.io/1782014

On Windows customers are seeing the following error

```
Error XABLD7000: Xamarin.Tools.Zip.ZipException: Renaming temporary file failed: Permission denied
 at Xamarin.Tools.Zip.ZipArchive.Close() in /Users/runner/work/1/s/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs:line 939
```
We have traced this to the use of the `MoveFileExW`/`MoveFileExA` API. When libzip is trying to move its temp file to the final location, Windows is raising this error.

```
Renaming temporary file failed: Permission denied
```

Turning off Anti Virus seems to help, however adding an exclusion does not. This is very confusing. So we are unsure why this error is being raised. The process has the correct permissions and the file being moved is in the same directory, so its not a TEMP folder issue.

So perhaps its the number of temp files we create? Part of the `BuildApk` system is that as we add files we `Flush` the zip file to commit those changes to disk. This is partly to work around how libzip works. It does not write any data to the main file until `zip_close` is called. So to work around issues around too many files being open [1], we added this flush.

The limit of 50 files was picked out of a hat. So lets try pushing the limit up a bit to see if that helps.

[1] https://github.com/xamarin/xamarin-android/commit/9166e0363417d6d121de37a765db8f2ba7cece7b