### PR TITLE
[ci] Automatically retry failed apk-instrumentation tests.

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -11,6 +11,7 @@ parameters:
   artifactFolder: ""
   useDotNet: true
   condition: succeeded()
+  retryCountOnTaskFailure: 1
 
 steps:
 - ${{ if eq(parameters.useDotNet, false) }}:
@@ -26,6 +27,7 @@ steps:
         ${{ parameters.extraBuildArgs }}
     condition: ${{ parameters.condition }}
     continueOnError: true
+    retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
 - ${{ if eq(parameters.useDotNet, true) }}:
   - template: run-dotnet-preview.yaml
@@ -40,6 +42,7 @@ steps:
         -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
       condition: ${{ parameters.condition }}
       continueOnError: true
+      retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
 - script: >
     DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/" &&

--- a/build-tools/automation/yaml-templates/run-dotnet-preview.yaml
+++ b/build-tools/automation/yaml-templates/run-dotnet-preview.yaml
@@ -8,6 +8,7 @@ parameters:
   displayName: run dotnet preview
   condition: succeeded()
   continueOnError: true
+  retryCountOnTaskFailure: 0
 
 steps:
 - powershell: |
@@ -25,3 +26,4 @@ steps:
   displayName: ${{ parameters.displayName }}
   condition: ${{ parameters.condition }}
   continueOnError: ${{ parameters.continueOnError }}
+  retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}


### PR DESCRIPTION
The `apk-instrumentation` tests are a good candidate for using `retryCountOnTaskFailure`.  This is because they only take a few minutes to run, and have a low enough flaky rate that it is likely that rerunning the entire test suite will succeed.

As noted in https://github.com/xamarin/java.interop/pull/1095, AzDO's support for this isn't perfect.  The initial failure will still show up in the Error Log, however the task will be green and will not show up as a failed build.

Ironically, you can see it in action on this build because we have an HTTP test that is currently failing with 504.  🤷‍♂️ 