### PR TITLE
[Xamarin.Android.Build.Tasks] Allow override of `uncompressedGlob`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Android.Tasks
 				});
 
 				var mergeSettings = new JsonMergeSettings () {
-					MergeArrayHandling = MergeArrayHandling.Replace,
+					MergeArrayHandling = MergeArrayHandling.Union,
 					MergeNullValueHandling = MergeNullValueHandling.Ignore
 				};
 				json.Merge (jsonAddition, mergeSettings);

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -29,6 +29,11 @@ namespace Xamarin.Android.Build.Tests
 
 		// Disable split by language
 		const string BuildConfig = @"{
+	""compression"": {
+		""uncompressedGlob"": [
+			""assets/*.data""
+		]
+	},
 	""optimizations"": {
 		""splits_config"": {
 			""split_dimension"": [
@@ -75,6 +80,9 @@ namespace Xamarin.Android.Build.Tests
 				BinaryContent = () => bytes,
 			});
 			app.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("foo.wav") {
+				BinaryContent = () => bytes,
+			});
+			app.OtherBuildItems.Add (new AndroidItem.AndroidAsset ("foo.data") {
 				BinaryContent = () => bytes,
 			});
 			app.OtherBuildItems.Add (new BuildItem ("None", "buildConfig.json") {
@@ -324,6 +332,7 @@ namespace Xamarin.Android.Build.Tests
 				var uncompressed = new List<string> {
 					".bar",
 					".wav",
+					".data",
 				};
 
 				if (usesAssemblyBlobs) {

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -136,21 +136,43 @@ namespace Xamarin.Android.Build.Tests
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
 				/* activityStarts */     true,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* activityStarts */     true,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* activityStarts */     true,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* activityStarts */     false,
+				/* packageFormat */      "apk",
+			},
+			new object[] {
+				/* embedAssemblies */    true,
+				/* fastDevType */        "Assemblies",
+				/* activityStarts */     true,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* activityStarts */     true,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    true,
+				/* fastDevType */        "Assemblies:Dexes",
+				/* activityStarts */     true,
+				/* packageFormat */      "aab",
 			},
 		};
 #pragma warning restore 414
@@ -158,7 +180,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test, Category ("Debugger")]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
 		[Retry(5)]
-		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool activityStarts)
+		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool activityStarts, string packageFormat)
 		{
 			AssertCommercialBuild ();
 			SwitchUser ();
@@ -175,6 +197,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
+			proj.SetProperty ("AndroidPackageFormat", packageFormat);
 			proj.SetDefaultTargetDevice ();
 			proj.Sources.Add (new BuildItem.Source ("MyApplication.cs") {
 				TextContent = () => proj.ProcessSourceTemplate (@"using System;
@@ -281,42 +304,84 @@ namespace ${ROOT_NAMESPACE} {
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  true,
 				/* user */		 null,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  true,
 				/* user */		 null,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
+				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
+				/* packageFormat */      "apk",
+			},
+			new object[] {
+				/* embedAssemblies */    true,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 null,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 null,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  true,
+				/* user */		 null,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    true,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 DeviceTest.GuestUserName,
+				/* packageFormat */      "aab",
+			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 DeviceTest.GuestUserName,
+				/* packageFormat */      "aab",
 			},
 		};
 #pragma warning restore 414
@@ -324,7 +389,7 @@ namespace ${ROOT_NAMESPACE} {
 		[Test, Category ("Debugger")]
 		[TestCaseSource (nameof(DebuggerTestCases))]
 		[Retry (5)]
-		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username)
+		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username, string packageFormat)
 		{
 			AssertCommercialBuild ();
 			SwitchUser ();
@@ -367,6 +432,7 @@ namespace ${ROOT_NAMESPACE} {
 				EmbedAssembliesIntoApk = embedAssemblies,
 				AndroidFastDeploymentType = fastDevType
 			};
+			app.SetProperty ("AndroidPackageFormat", packageFormat);
 			app.MainPage = app.MainPage.Replace ("InitializeComponent ();", "InitializeComponent (); new Foo ();");
 			app.AddReference (lib);
 			app.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -163,12 +163,6 @@ namespace Xamarin.Android.Build.Tests
 				/* packageFormat */      "aab",
 			},
 			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
-				/* activityStarts */     true,
-				/* packageFormat */      "aab",
-			},
-			new object[] {
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies:Dexes",
 				/* activityStarts */     true,
@@ -356,28 +350,7 @@ namespace ${ROOT_NAMESPACE} {
 				/* packageFormat */      "aab",
 			},
 			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
-				/* allowDeltaInstall */  false,
-				/* user */		 null,
-				/* packageFormat */      "aab",
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
-				/* allowDeltaInstall */  true,
-				/* user */		 null,
-				/* packageFormat */      "aab",
-			},
-			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
-				/* allowDeltaInstall */  false,
-				/* user */		 DeviceTest.GuestUserName,
-				/* packageFormat */      "aab",
-			},
-			new object[] {
-				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,


### PR DESCRIPTION
Users reported that when they added a custom `uncompressedGlob` entry to the `$(AndroidBundleConfigurationFile)`, it was ignored. This is because the `MergeArrayHandling` option we were using in the `BuildAppBundle` task was set to `MergeArrayHandling.Replace`.

As a result we would just overwrite the user config with our own. We should be using the `MergeArrayHandling.Union` option instead. This with merge the arrays , but will remove duplicates. This should allow users to provide additional `uncompressedGlob` options.

A unit test has been added to test this new behaviour.