### PR TITLE
[ci] Suppress fork PR build warnings

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -78,6 +78,8 @@ variables:
     value: VSEng-Xamarin-RedmondMac-Android-Untrusted
   - name: MacBuildPoolImage
     value: ''
+  - name: DisablePipelineConfigDetector
+    value: true
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:


### PR DESCRIPTION
Context: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/azdo-config-remediation/forked-builds#secure-supply-chain-analysis-build-task-enforcement

We have an exception for our pipeline configuration filed in
https://msazure.visualstudio.com/One/_workitems/edit/15310210.