### PR TITLE
[ci] Use hosted Linux build pool for PR builds

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -285,7 +285,8 @@ stages:
   # Check - "Xamarin.Android (Linux > Tests > MSBuild)"
   - job: linux_tests_smoke
     displayName: Linux > Tests > MSBuild
-    pool: android-devdiv-ubuntu-vmss
+    pool:
+      vmImage: ubuntu-22.04
     timeoutInMinutes: 180
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -71,6 +71,10 @@ variables:
     value: Azure Pipelines
   - name: MacBuildPoolImage
     value: internal-macos12
+  - name: LinuxBuildPoolName
+    value: android-devdiv-ubuntu-vmss
+  - name: LinuxBuildPoolImage
+    value: ''
 - ${{ if or(and(ne(variables['Build.DefinitionName'],'Xamarin.Android'), ne(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - name: MicroBuildSignType
     value: Test
@@ -78,6 +82,10 @@ variables:
     value: VSEng-Xamarin-RedmondMac-Android-Untrusted
   - name: MacBuildPoolImage
     value: ''
+  - name: LinuxBuildPoolName
+    value: Azure Pipelines
+  - name: LinuxBuildPoolImage
+    value: ubuntu-22.04
   - name: DisablePipelineConfigDetector
     value: true
 

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -1,5 +1,6 @@
 parameters:
-  buildPool: android-devdiv-ubuntu-vmss
+  buildPoolName: $(LinuxBuildPoolName)
+  buildPoolImage: $(LinuxBuildPoolImage)
   buildResultArtifactName: Build Results - Linux
   checkoutCommit: ''
   checkoutPath: 's/xamarin-android'
@@ -22,7 +23,9 @@ stages:
   jobs:
   - job: ${{ parameters.jobName }}
     displayName: ${{ parameters.jobDisplayName }}
-    pool: ${{ parameters.buildPool }}
+    pool:
+      name: ${{ parameters.buildPoolName }}
+      vmImage: ${{ parameters.buildPoolImage }}
     timeoutInMinutes: 180
     workspace:
       clean: all


### PR DESCRIPTION
We should use Microsoft hosted machines for PR builds wherever possible.