### PR TITLE
[automation] Add 'xaSourcePath' to yaml so they can be used from monodroid

### DIFF
--- a/build-tools/automation/yaml-templates/start-stop-emulator.yaml
+++ b/build-tools/automation/yaml-templates/start-stop-emulator.yaml
@@ -6,6 +6,7 @@ parameters:
   avdAbi:                 # Device ABI, like 'x86', required if 'specificImage' is 'true'
   avdType:                # Device AVD, like 'android-wear', required if 'specificImage' is 'true'
   launchTimeoutMin: 15    # Minutes to wait for the emulator to start
+  xaSourcePath: $(System.DefaultWorkingDirectory) # working directory
 
 steps:
 - ${{ if eq(parameters.command, 'start') }}:
@@ -13,7 +14,7 @@ steps:
     displayName: Start emulator
     continueOnError: false
     inputs:
-      projects: src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
+      projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
         arguments: -c $(XA.Build.Configuration) -t:"InstallAvdImage;AcquireAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/install-emulator-${{ parameters.avdApiLevel }}.binlog
       ${{ else }}:
@@ -25,7 +26,7 @@ steps:
     condition: always()
     continueOnError: true
     inputs:
-      projects: src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
+      projects: ${{ parameters.xaSourcePath }}/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj
       ${{ if eq(parameters.specificImage, true) }}:
         arguments: -c $(XA.Build.Configuration) -t:"AcquireAndroidTarget,ReleaseAndroidTarget" -p:TestDeviceName=${{ parameters.deviceName }} -p:TestAvdApiLevel=${{ parameters.avdApiLevel }} -p:TestAvdAbi=${{ parameters.avdAbi }} -p:TestAvdType=${{ parameters.avdType }} -p:AvdLaunchTimeoutMinutes=${{ parameters.launchTimeoutMin }} -bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
       ${{ else }}:


### PR DESCRIPTION
Lets add the `xaSourcePath` parameter to some yaml files so that they can be called from `monodroid`.