### PR TITLE
$(AndroidPackVersionSuffix)=preview.5; net8 is 34.0.0-preview.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview4

We branched for .NET 8 preview 4 from a8de67e into `release/8.0.1xx-preview4`.

Update xamarin-android/main's version number to 34.0.0-preview.5 for .NET 8 preview 5.