### PR TITLE
[ci] Always download nupkgs to nuget-unsigned

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -92,12 +92,12 @@ steps:
 - task: DownloadPipelineArtifact@2
   inputs:
     artifactName: $(NuGetArtifactName)
-    downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/$(NuGetArtifactName)
+    downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/nuget-unsigned
 
 - task: DownloadPipelineArtifact@2
   inputs:
     artifactName: $(LinuxNuGetArtifactName)
-    downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/$(NuGetArtifactName)
+    downloadPath: ${{ parameters.xaSourcePath }}/bin/Build${{ parameters.configuration }}/nuget-unsigned
   condition: and(succeeded(), eq(variables['agent.os'], 'Linux'))
 
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
The `ExtractWorkloadPacks` target used in test environment setup expects
nuget artifacts to be in a `nuget-unsigned` folder, so we should always
download to this folder even if the names of the nuget artifacts differ.