### PR TITLE
[ci] Remove plots-to-appinsights.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -253,27 +253,6 @@ stages:
         artifactName: Test Results - APKs .NET Debug - macOS
         configuration: Debug
 
-    - task: MSBuild@1
-      displayName: build plots-to-appinsights
-      inputs:
-        solution: build-tools/plots-to-appinsights/ProcessPlotCSVFile.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >-
-          /restore
-          /t:Build
-          /v:normal
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/plots-to-appinsights.binlog
-      continueOnError: true
-      condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-
-    - template: yaml-templates/plots-to-appinsights.yaml
-      parameters:
-        condition: and(succeeded(), or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Manual')))
-        configuration: $(XA.Build.Configuration)
-        plotGroup: Test times
-        plotTitle: Runtime merged $(DotNetTargetFramework)
-        plotPathAndFilename: $(System.DefaultWorkingDirectory)/TestResult-Mono.Android.NET_Tests-times.csv
-
     - template: yaml-templates/fail-on-issue.yaml
 
 - stage: linux_tests


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-android/commit/ecb207baf07c1829adbbe41231cc7913097a2c61 broke the `plots-to-appinsights` process that only gets run on `main` (not PR builds).

As we do not believe this data is consumed anymore, we are electing to remove it from CI rather than make the necessary updates to get it working again.

Note there are some alternatives to this data that are used today:
- Unit tests that test build time and use `apidiff` to test apk size
- MAUI maintains a dashboard of similar graphs for their builds, which are our builds.