### PR TITLE
[Mono.Android] Use 'platform33-r2'.

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-31_r01",   apiLevel: "31", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-32_r01",   apiLevel: "32", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-33_r01",   apiLevel: "33", pkgRevision: "1"),
+				new AndroidPlatformComponent ("platform-33_r02",   apiLevel: "33", pkgRevision: "2"),
 				new AndroidPlatformComponent ("platform-UpsideDownCake_r03",   apiLevel: "UpsideDownCake", pkgRevision: "3"),
 
 				new AndroidToolchainComponent ("sources-33_r01",


### PR DESCRIPTION
Google released an `r2` of `platform-33` while we are still using `r1`.  Our CI machines come pre-loaded with `r2`, so this means we have to provision `r1` instead on every run.

- [Windows agent image](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#android)
- [Mac agent image](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#android)

Running `class-parse` against both versions of `android.jar` produce an identical file, so there are no API changes in `r2`.