### PR TITLE
[ci] Don't stop emulator on test agents that won't get reused.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -35,6 +35,8 @@ parameters:
 - name: provisionatorChannel
   type: string
   default: latest           # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
+- name: macTestAgentsUseCleanImages   # Test agents we do not need to clean up when finished because they are not reused
+  default: true
 
 # Global variables
 variables:
@@ -240,9 +242,10 @@ stages:
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Tools.Aidl-Tests.dll
         testResultsFile: TestResult-Aidl-Tests-macOS-$(XA.Build.Configuration).xml
 
-    - template: yaml-templates/start-stop-emulator.yaml
-      parameters:
-        command: stop
+    - ${{ if ne(parameters.macTestAgentsUseCleanImages, true) }}:
+      - template: yaml-templates/start-stop-emulator.yaml
+        parameters:
+          command: stop
 
     - template: yaml-templates/upload-results.yaml
       parameters:
@@ -298,6 +301,8 @@ stages:
 - template: yaml-templates/stage-msbuild-tests.yaml
       
 - template: yaml-templates/stage-msbuild-emulator-tests.yaml
+  parameters:
+    usesCleanImages: ${{ parameters.macTestAgentsUseCleanImages }}
 
 - stage: dotnet_prepare_release
   displayName: Prepare .NET Release

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -10,6 +10,7 @@ parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)
   repositoryAlias: 'self'
   commit: ''
+  usesCleanImages: true
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -59,9 +60,10 @@ stages:
         testRunTitle: MSBuildDeviceIntegration On Device - macOS
         testResultsTitle: TestResult-MSBuildDeviceIntegration-${{ parameters.job_name }}
 
-    - template: start-stop-emulator.yaml
-      parameters:
-        command: stop
+    - ${{ if ne(parameters.usesCleanImages, true) }}:
+      - template: start-stop-emulator.yaml
+        parameters:
+          command: stop
 
     - template: upload-results.yaml
       parameters:
@@ -130,14 +132,15 @@ stages:
         dotNetTestExtraArgs: --filter "TestCategory = WearOS"
         testResultsFile: TestResult-WearOS--$(XA.Build.Configuration).xml
 
-    - template: start-stop-emulator.yaml
-      parameters:
-        command: stop
-        specificImage: true
-        deviceName: $(deviceName)
-        avdApiLevel: $(avdApiLevel)
-        avdAbi: $(avdAbi)
-        avdType: $(avdType)
+    - ${{ if ne(parameters.usesCleanImages, true) }}:
+      - template: start-stop-emulator.yaml
+        parameters:
+          command: stop
+          specificImage: true
+          deviceName: $(deviceName)
+          avdApiLevel: $(avdApiLevel)
+          avdAbi: $(avdAbi)
+          avdType: $(avdType)
 
     - template: upload-results.yaml
       parameters:


### PR DESCRIPTION
The "stop emulator" step on CI generally takes ~35-40 seconds.

However, our Mac agents are public images that are not reused, so there is no benefit to cleaning up after ourselves.

Create a new parameter called `macTestAgentsUseCleanImages` and don't bother stopping the emulator if it set to true.  (We currently only run emulators on Macs.)