### PR TITLE
[xaprepare] Combine 'AndroidTestDependencies' and 'EmulatorTestDependencies' scenarios.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -120,11 +120,7 @@ stages:
         installLegacyDotNet: false
         restoreNUnitConsole: false
         updateMono: false
-
-    - template: yaml-templates/run-xaprepare.yaml
-      parameters:
-        displayName: install emulator
-        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(DefaultTestSdkPlatforms)"
+        xaprepareScenario: EmulatorTestDependencies
         
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -12,6 +12,7 @@ parameters:
   androidSdkPlatforms: $(DefaultTestSdkPlatforms)
   repositoryAlias: 'self'
   commit: ''
+  xaprepareScenario: AndroidTestDependencies        # Use 'EmulatorTestDependencies' for agents that need the emulator installed
 
 steps:
 
@@ -69,7 +70,7 @@ steps:
 
 - template: run-xaprepare.yaml
   parameters:
-    arguments: --s=AndroidTestDependencies  --android-sdk-platforms="${{ parameters.androidSdkPlatforms }}"
+    arguments: --s=${{ parameters.xaprepareScenario }}  --android-sdk-platforms="${{ parameters.androidSdkPlatforms }}"
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
 - ${{ if eq(parameters.restoreNUnitConsole, true) }}:

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -39,11 +39,7 @@ stages:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
-
-    - template: run-xaprepare.yaml
-      parameters:
-        displayName: install emulator
-        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(DefaultTestSdkPlatforms)"
+        xaprepareScenario: EmulatorTestDependencies
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -96,16 +92,12 @@ stages:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}
+        xaprepareScenario: EmulatorTestDependencies
 
     - template: run-xaprepare.yaml
       parameters:
         displayName: install required brew tools and prepare java.interop
         arguments: --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes
-
-    - template: run-xaprepare.yaml
-      parameters:
-        displayName: install emulator
-        arguments: --s=EmulatorTestDependencies --android-sdk-platforms="$(androidSdkPlatforms)"
 
     - script: echo "##vso[task.setvariable variable=Java8SdkDirectory]$JAVA_HOME_8_X64"
       displayName: set Java8SdkDirectory

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -5,8 +5,14 @@ namespace Xamarin.Android.Prepare
 	[Scenario (isDefault: false)]
 	partial class Scenario_AndroidTestDependencies : ScenarioNoStandardEndSteps
 	{
+		protected virtual AndroidToolchainComponentType AndroidSdkNdkType => AndroidToolchainComponentType.CoreDependency;
+
 		public Scenario_AndroidTestDependencies () 
 			: base ("AndroidTestDependencies", "Install Android SDK, OpenJDK and .NET preview test dependencies.")
+		{}
+
+		protected Scenario_AndroidTestDependencies (string name, string description) 
+			: base (name, description)
 		{}
 
 		protected override void AddSteps (Context context)
@@ -14,7 +20,7 @@ namespace Xamarin.Android.Prepare
 			Steps.Add (new Step_InstallDotNetPreview ());
 			Steps.Add (new Step_InstallAdoptOpenJDK8 ());
 			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
-			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.CoreDependency));
+			Steps.Add (new Step_Android_SDK_NDK (AndroidSdkNdkType));
 
 			// disable installation of missing programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_EmulatorTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_EmulatorTestDependencies.cs
@@ -3,21 +3,12 @@ using System;
 namespace Xamarin.Android.Prepare
 {
 	[Scenario (isDefault: false)]
-	partial class Scenario_EmulatorTestDependencies : ScenarioNoStandardEndSteps
+	partial class Scenario_EmulatorTestDependencies : Scenario_AndroidTestDependencies
 	{
+		protected override AndroidToolchainComponentType AndroidSdkNdkType => AndroidToolchainComponentType.CoreDependency | AndroidToolchainComponentType.EmulatorDependency;
+
 		public Scenario_EmulatorTestDependencies () 
-			: base ("EmulatorTestDependencies", "Install Android SDK emulator dependencies.")
+			: base ("EmulatorTestDependencies", "Install Android SDK (with emulator), OpenJDK, and .NET preview test dependencies.")
 		{}
-
-		protected override void AddSteps (Context context)
-		{
-			Steps.Add (new Step_Android_SDK_NDK (AndroidToolchainComponentType.EmulatorDependency));
-
-			// disable installation of missing programs...
-			context.SetCondition (KnownConditions.AllowProgramInstallation, false);
-
-			// ...but do not signal an error when any are missing
-			context.SetCondition (KnownConditions.IgnoreMissingPrograms, true);
-		}
 	}
 }


### PR DESCRIPTION
For test agents that run emulator tests, we currently run `xaprepare` twice with different scenarios:
- AndroidTestDependencies
- EmulatorTestDependencies

As there is some overhead to running `xaprepare`, we can instead make `EmulatorTestDependencies` depend on the `AndroidTestDependencies` scenario.  Then we only need to run a single `xaprepare` invocation.

These steps vary wildly on each run, but averaging 8 runs seems to save over a minute.

| | `main`, 2 steps total time | PR, 1 step |
|-|-|-|
| MSBuild 1 | 5:50 | 3:52 |
| MSBuild 2 | 2:52 | 2:44 |
| MSBuild 3 | 3:26 | 4:32 |
| MSBuild 4 | 4:18 | 2:44 |
| MSBuild 5 | 3:00 | 2:02 |
| MSBuild 6 | 6:52 | 6:05 |
| MSBuild 7 | 6:41 | 2:48 |
| MSBuild 8 | 7:31 | 4:34 |
| Average | 5:03 | 3:40 |