### PR TITLE
Bump NUnit versions.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -238,7 +238,7 @@
   <!-- Unit Test Properties -->
   <PropertyGroup>
     <!-- When changing the version below, please also update the 'build-tools/scripts/nunit3-console*' scripts -->
-    <NUnitConsoleVersion Condition=" '$(NUnitConsoleVersion)' == '' ">3.12.0</NUnitConsoleVersion>
+    <NUnitConsoleVersion Condition=" '$(NUnitConsoleVersion)' == '' ">3.16.3</NUnitConsoleVersion>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime) $(ManagedRuntimeArgs)</_Runtime>
     <_NUnit>$(_Runtime) $(XAPackagesDir)\nunit.consolerunner\$(NUnitConsoleVersion)\tools\nunit3-console.exe</_NUnit>
   </PropertyGroup>

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -14,7 +14,7 @@ variables:
 - name: WindowsToolchainPdbArtifactName
   value: windows-toolchain-pdb
 - name: NUnitConsoleVersion
-  value: 3.11.1
+  value: 3.16.3
 - name: NUnit.NumberOfTestWorkers
   value: 4
 - name: DotNetSdkVersion

--- a/build-tools/scripts/NUnitReferences.projitems
+++ b/build-tools/scripts/NUnitReferences.projitems
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit"               Version="3.13.3" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="$(NUnitConsoleVersion)" />
-    <PackageReference Include="NUnit3TestAdapter"   Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter"   Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
   </ItemGroup>
 </Project>

--- a/build-tools/scripts/nunit3-console
+++ b/build-tools/scripts/nunit3-console
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-NUNIT_VERSION=3.11.1
+NUNIT_VERSION=3.16.3
 MYDIR="$(dirname $0)"
 PACKAGES_PATH=
 

--- a/build-tools/scripts/nunit3-console.cmd
+++ b/build-tools/scripts/nunit3-console.cmd
@@ -1,6 +1,6 @@
 @echo off
 SETLOCAL
-set NUNIT_VERSION=3.11.1
+set NUNIT_VERSION=3.16.3
 set PACKAGES_PATH=
 set MYDIR=%~dp0
 


### PR DESCRIPTION
With the new auto-retry for failed emulator tests we are seeing some weird results.

Example:

The first run failed with:
```
Failed DotNetInstallAndRun(True,True,"net8.0-android") [12 m 11 s]
  Error Message:
     `dotnet run` should succeed
  Expected: True
  But was:  False

  Stack Trace:
     at Xamarin.Android.Build.Tests.XASdkDeployTests.DotNetInstallAndRun(Boolean isRelease, Boolean xamarinForms, String targetFramework) in /Users/builder/azdo/_work/1/s/xamarin-android/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs:line 87
1)    at Xamarin.Android.Build.Tests.XASdkDeployTests.DotNetInstallAndRun(Boolean isRelease, Boolean xamarinForms, String targetFramework) in /Users/builder/azdo/_work/1/s/xamarin-android/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs:line 87
```

The retry failed with:
```
  Failed DotNetInstallAndRun(True,True,"net8.0-android") [1 s]
  Error Message:
   System.InvalidOperationException : Unknown abi: 
  Stack Trace:
     at Xamarin.ProjectTools.AbiUtils.AbiToRuntimeIdentifier(String androidAbi) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/AbiUtils.cs:line 18
   at Xamarin.ProjectTools.ProjectExtensions.SetRuntimeIdentifier(IShortFormProject project, String androidAbi) in /Users/builder/azdo/_work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs:line 34
   at Xamarin.Android.Build.Tests.XASdkDeployTests.DotNetInstallAndRun(Boolean isRelease, Boolean xamarinForms, String targetFramework) in /Users/builder/azdo/_work/1/s/xamarin-android/tests/MSBuildDeviceIntegration/Tests/XASdkDeployTests.cs:line 76
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```

There are other instances of failing with this message, including timing tests that initially failed simply because the process took too long.

It seems like the valid ABIs aren't getting set on the second run, which is done via `[OneTimeSetUp]`.  As crazy as this seems, since the second run is a completely new process, this does appear to have been a bug in NUnit at some point: https://github.com/nunit/nunit3-vs-adapter/issues/649.

I am not sure if all of our NUnit assemblies have been updated enough to contain the fix for this.  Since it's a good idea to update to the latest anyways, this PR updates us to the latest version of NUnit and hopes it fixes the issue.  🤷‍♂️