### PR TITLE
[Xamarin.Android.Build.Tasks] add metadata about .NET 6 EOL

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props
@@ -16,6 +16,10 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 -->
 <Project>
 
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
+    <EolWorkload Include="android" Url="https://aka.ms/maui-support-policy" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <Using Include="Android.App" Platform="Android" />
     <Using Include="Android.Widget" Platform="Android" />


### PR DESCRIPTION
Context: https://aka.ms/maui-support-policy
Context: https://github.com/xamarin/xamarin-android/issues/8003

To be able to emit a new build warning:

    dotnet\sdk\6.0.409\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5):
    warning NETSDK1138: The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

We can emit a new item group, such as:

    <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
      <EolWorkload Include="android" Url="https://aka.ms/maui-support-policy" />
    </ItemGroup>

Changes in the .NET SDK can be found at: https://github.com/dotnet/sdk/pull/32426

Where a new `_CheckForEolWorkloads` MSBuild target will emit the warning:

    <Target Name="_CheckForEolWorkloads" AfterTargets="_CheckForUnsupportedNETCoreVersion"
            Condition="'@(EolWorkload)' != '' and '$(CheckEolWorkloads)' == 'true'">
        <NETSdkWarning ResourceName="WorkloadIsEol"
                       FormatArguments="%(EolWorkload.Identity);$([MSBuild]::ValueOrDefault('%(EolWorkload.Url)', 'https://aka.ms/dotnet-core-support'))" />
    </Target>

This does not fully solve #8003 as future changes are likely needed in the .NET 8 `android` workload.