### PR TITLE
[Xamarin.Android.Build.Tasks] pass `-S` for `am start` commands

### DIFF
--- a/Documentation/guides/building-apps/build-targets.md
+++ b/Documentation/guides/building-apps/build-targets.md
@@ -113,7 +113,7 @@ property to the activity name.
 This is equivalent to:
 
 ```shell
-adb shell am start @PACKAGE_NAME@/$(AndroidLaunchActivity)
+adb shell am start -S -n @PACKAGE_NAME@/$(AndroidLaunchActivity)
 ```
 
 Added in Xamarin.Android 10.2.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -19,7 +19,7 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
       <Output TaskParameter="ActivityName" PropertyName="AndroidLaunchActivity" />
     </GetAndroidActivityName>
-    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;" />
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -S -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;" />
   </Target>
   <Target Name="StopAndroidPackage"
       DependsOnTargets="_ResolveMonoAndroidSdks;_GetAndroidPackageName">


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1777086
Context: https://github.com/xamarin/xamarin-android/blob/17c74c5cfcc383464931e6a2f828a689ba998965/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs#L187-L190

If an android app is already running, and you do one of:

    dotnet build -t:Run
    dotnet build -t:StartAndroidActivity

It doesn't actually close and restart the app.

To do this, we need to pass `-S`:

    am start: start an Activity.  Options are:
    ...
    -S: force stop the target app before starting the activity

This appears to work fine going back to API 21, we are already using this flag in unit tests.

Now the `<Exec/>` task prints an extra line:

    Stopping: com.companyname.foo
    Starting: Intent { cmp=com.companyname.foo/crc642c1279b4112b2ad7.MainActivity }

Note that this only fixes the OSS side of xamarin-android, we will need a change in:

https://github.com/xamarin/monodroid/blob/84a2ae648143924eafb8daa59b2a4e9f05f54359/tools/msbuild/Tasks/RunActivity.cs

To fix this in the commercial product.