### PR TITLE
[Mono.Android] Remove `monoandroid10` target framework.

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>monoandroid10;$(DotNetTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTargetFramework)</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoStdLib>true</NoStdLib>
@@ -12,48 +12,11 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
 
     <!-- Ignore "unused member" warnings from code that originates from Mono.CodeGeneration -->
     <NoWarn>$(NoWarn);CS0169;CS0414;CS0649</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
-    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
-    <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
-    <Reference Include="mscorlib">
-      <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System">
-      <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml">
-      <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Java.Interop">
-      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj" />
@@ -61,13 +24,13 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <!-- Only build the .NET 6+ version of 'Mono.Android.Export.dll' for the latest stable Android version. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' != '$(AndroidLatestStableApiLevel)' ">
+  <!-- Only build 'Mono.Android.Export.dll' for the latest stable Android version. -->
+  <PropertyGroup Condition=" '$(AndroidApiLevel)' != '$(AndroidLatestStableApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
 
   <!-- Copy .NET ref/runtime assemblies to bin/$(Configuration)/dotnet/packs folder -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' == '$(AndroidLatestStableApiLevel)' ">
+  <PropertyGroup Condition=" '$(AndroidApiLevel)' == '$(AndroidLatestStableApiLevel)' ">
     <BuildDependsOn>
       $(BuildDependsOn);
       _CopyToPackDirs;

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>monoandroid10;$(DotNetTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTargetFramework)</TargetFrameworks>
     <RootNamespace>Android</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -24,15 +24,7 @@
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
-    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
-    <DefineConstants>$(DefineConstants);NET_2_0</DefineConstants>
-    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
+  <PropertyGroup>
     <DefineConstants Condition=" '$(AndroidApiLevel)' &gt; '$(AndroidLatestStableApiLevel)' ">$(DefineConstants);ANDROID_UNSTABLE</DefineConstants>
     <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
   </PropertyGroup>
@@ -55,50 +47,7 @@
     <DefineConstants>$(DefineConstants);ENABLE_MARSHAL_METHODS</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
-    <Reference Include="mscorlib">
-      <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System">
-      <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Collections">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Collections.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>$(OutputPath)..\v1.0\System.Net.Http.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Runtime.Serialization">
-      <HintPath>$(OutputPath)..\v1.0\System.Runtime.Serialization.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml">
-      <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Java.Interop">
-      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Drawing.Common.dll">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Drawing.Common.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
+  <ItemGroup>
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
     <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml">
       <LogicalName>ILLink.LinkAttributes.xml</LogicalName>
@@ -374,8 +323,7 @@
     <Compile Include="System.Drawing/SizeFConverter.cs" />
     <Compile Include="System.IO\AndroidExtensions.cs" />
     <Compile Include="System.Linq\Extensions.cs" />
-    <Compile Condition=" '$(TargetFramework)' != 'monoandroid10' " Include="Xamarin.Android.Net\AndroidClientHandler.cs" />
-    <Compile Condition=" '$(TargetFramework)' == 'monoandroid10' " Include="Xamarin.Android.Net\AndroidClientHandler.Legacy.cs" />
+    <Compile Include="Xamarin.Android.Net\AndroidClientHandler.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidMessageHandler.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidHttpResponseMessage.cs" />
     <Compile Include="Xamarin.Android.Net\AuthDigestHeaderParser.cs" />
@@ -386,8 +334,7 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
     <Compile Include="Xamarin.Android.Net\ServerCertificateCustomValidator.cs" />
-    <Compile Condition=" '$(TargetFramework)' != 'monoandroid10' " Include="Xamarin.Android.Net\NegotiateAuthenticationHelper.cs" />
-    <Compile Condition=" '$(TargetFramework)' == 'monoandroid10' " Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
+    <Compile Include="Xamarin.Android.Net\NegotiateAuthenticationHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -410,16 +357,11 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Only build the .NET 6+ version of 'Mono.Android.dll' for the default API level that is supported or higher. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &lt; '$(AndroidDefaultTargetDotnetApiLevel)' ">
-    <BuildDependsOn></BuildDependsOn>
-  </PropertyGroup>
-
-  <!-- Do not build classic for API versions above 33 -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' And '$(AndroidApiLevel)' &gt; '33'">
+  <PropertyGroup Condition=" '$(AndroidApiLevel)' &lt; '$(AndroidDefaultTargetDotnetApiLevel)' ">
     <BuildDependsOn></BuildDependsOn>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' And '$(AndroidApiLevel)' &gt;= '$(AndroidDefaultTargetDotnetApiLevel)' ">
+  <PropertyGroup Condition=" '$(AndroidApiLevel)' &gt;= '$(AndroidDefaultTargetDotnetApiLevel)' ">
     <BuildDependsOn>
       $(BuildDependsOn);
       _ExportMsxDoc;

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -21,36 +21,6 @@
     <_ApiXmlLocation>..\..\bin\Build$(Configuration)\api\</_ApiXmlLocation>
   </PropertyGroup>
   
-  <!-- Builds the 'monoandroid1.0' version of 'Java.Interop.dll' -->
-  <Target Name="_BuildJavaInterop"
-      BeforeTargets="BeforeResolveReferences"
-      Condition=" '$(TargetFramework)' == 'monoandroid10' "
-      Inputs="$(MSBuildThisFile);$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
-      Outputs="$(OutputPath)\..\v1.0\Java.Interop.dll">
-    <PropertyGroup>
-      <_GlobalProperties>
-        JavaInteropProfile=Net45;
-        XAInstallPrefix=$(XAInstallPrefix);
-      </_GlobalProperties>
-    </PropertyGroup>
-    <MSBuild
-        Projects="$(JavaInteropFullPath)\build-tools\jnienv-gen\jnienv-gen.csproj"
-        Properties="TargetFramework=net472;"
-    />
-    <MSBuild
-        Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop-MonoAndroid.csproj"
-        Properties="$(_GlobalProperties)"
-    />
-    <ItemGroup>
-      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)Net45\*.dll" />
-      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)Net45\*.pdb" />
-    </ItemGroup>
-    <Copy
-        SourceFiles="@(Assembly)"
-        DestinationFolder="$(OutputPath)\..\v1.0"
-    />
-  </Target>
-  
   <!-- Creates 'AssemblyInfo.cs' with appropriate version information -->
   <Target Name="_BuildAssemblyInfo_cs"
       DependsOnTargets="GetXAVersionInfo"
@@ -58,11 +28,7 @@
       Condition="!Exists ('$(IntermediateOutputPath)AssemblyInfo.cs')"
       Inputs="Properties\AssemblyInfo.cs.in"
       Outputs="$(IntermediateOutputPath)AssemblyInfo.cs">
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'monoandroid10' ">
-      <_PackageVersion>$(ProductVersion)</_PackageVersion>
-      <_PackageVersionBuild>$(XAVersionCommitCount)</_PackageVersionBuild>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' != 'monoandroid10' ">
+    <PropertyGroup>
       <_PackageVersion>$(AndroidPackVersion)</_PackageVersion>
       <_PackageVersionBuild>$(PackVersionCommitCount)</_PackageVersionBuild>
     </PropertyGroup>
@@ -204,27 +170,9 @@
     <JavaCallableWrapperSource Include="java\**\*.java" />
   </ItemGroup>
   
-  <!-- Generates 'FrameworkList.xml' file -->
-  <Target Name="_GenerateFrameworkList"
-      BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"
-      Condition=" '$(TargetFramework)' == 'monoandroid10' "
-      Inputs="$(MSBuildProjectFullPath)"
-      Outputs="$(OutputPath)RedistList\FrameworkList.xml">
-   <MakeDir Directories="$(OutputPath)RedistList" />
-   <ItemGroup>
-     <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android $(AndroidFrameworkVersion) Support&quot; IncludeFramework=&quot;$(AndroidPreviousFrameworkVersion)&quot;&gt;" />
-     <FrameworkList Include="&lt;/FileList&gt;" />
-   </ItemGroup>
-   <WriteLinesToFile
-       File="$(OutputPath)RedistList\FrameworkList.xml"
-       Lines="@(FrameworkList)"
-       Overwrite="True"
-   />
-  </Target>
-  
   <!-- Generates 'AndroidApiInfo.xml' file -->
   <Target Name="_GenerateAndroidApiInfo"
-      BeforeTargets="_GenerateFrameworkList"
+      BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"
       Inputs="$(MSBuildProjectFullPath);..\..\bin\Build$(Configuration)\Mono.Android.Apis.projitems"
       Outputs="$(OutputPath)AndroidApiInfo.xml">
    <MakeDir Directories="$(OutputPath)" />
@@ -264,7 +212,7 @@
   </ItemGroup>
   <Target
       Name="_CheckApiCompatibility"
-      Condition=" '$(DisableApiCompatibilityCheck)' != 'True' And '$(TargetFramework)' != 'monoandroid10'"
+      Condition=" '$(DisableApiCompatibilityCheck)' != 'True' "
       AfterTargets="CopyFilesToOutputDirectory"
 
       Inputs="$(TargetPath);@(ApiCompatibilityFiles)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -14,7 +14,7 @@
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
-    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\monoandroid10\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
+    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\$(DotNetTargetFramework)\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
     <NoWarn>8632</NoWarn>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Remove `monoandroid10` target framework from `Mono.Android.csproj` and `Mono.Android.Export.csproj`.

This enables removing `net472` from Java.Interop: https://github.com/xamarin/java.interop/pull/1099.