### PR TITLE
[Mono.Android] Use net6.0 version of mdoc

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <ELFSharpVersion>2.13.1</ELFSharpVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>
-    <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.8.9.2</MdocPackageVersion>
+    <MdocPackageVersion Condition=" '$(MdocPackageVersion)' == '' ">5.9.2.2</MdocPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -81,6 +81,10 @@ stages:
 
     - template: yaml-templates/use-dot-net.yaml
 
+    - template: yaml-templates/use-dot-net.yaml
+      parameters:
+        version: 6.0
+
     - task: NuGetAuthenticate@0
       displayName: authenticate with azure artifacts
       inputs:

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -294,8 +294,8 @@
     <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">33</DocsPlatformId>
     <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">xamarin-android-sdk-13</DocsFxMoniker>
     <_LogPrefix>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))</_LogPrefix>
-    <_Mdoc Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/mdoc.exe"</_Mdoc>
-    <_Mdoc Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/mdoc.exe"</_Mdoc>
+    <_Mdoc Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/net6.0/mdoc.dll"</_Mdoc>
+    <_Mdoc Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/net6.0/mdoc.dll"</_Mdoc>
   </PropertyGroup>
 
   <!-- Generate documentation using MDoc -->
@@ -361,7 +361,7 @@
         Lines="$(FrameworksXmlContent)"
     />
     <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_Lang)"
+        Command="dotnet $(_Mdoc) --debug update --use-docid --delete $(_Libdir) $(_ImportXml) $(_Output) $(_DocTypeArgs) $(_FxConfig) $(_Lang)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>
@@ -392,7 +392,7 @@
       Inputs="@(_MsxDocSourceFile)"
       Outputs="$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml">
     <Exec
-        Command="$(ManagedRuntime) $(ManagedRuntimeArgs) $(_Mdoc) --debug export-msxdoc -o &quot;$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml&quot; &quot;$(XamarinAndroidSourcePath)external/android-api-docs/docs/Mono.Android/en/&quot;"
+        Command="dotnet $(_Mdoc) --debug export-msxdoc -o &quot;$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml&quot; &quot;$(XamarinAndroidSourcePath)external/android-api-docs/docs/Mono.Android/en/&quot;"
     />
   </Target>
 


### PR DESCRIPTION
Updates mdoc to the latest version, and updates Mono.Android.targets to
use the net6.0 version of the tool.