### PR TITLE
[Mono.Android] API-UpsideDownCake Beta 2

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-31_r01",   apiLevel: "31", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-32_r01",   apiLevel: "32", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-33_r02",   apiLevel: "33", pkgRevision: "2"),
-				new AndroidPlatformComponent ("platform-UpsideDownCake_r03",   apiLevel: "UpsideDownCake", pkgRevision: "3"),
+				new AndroidPlatformComponent ("platform-UpsideDownCake_r04",   apiLevel: "UpsideDownCake", pkgRevision: "4"),
 
 				new AndroidToolchainComponent ("sources-33_r01",
 					destDir: Path.Combine ("sources", "android-33"),

--- a/src/Mono.Android/Java.Lang.Invoke/MethodType.cs
+++ b/src/Mono.Android/Java.Lang.Invoke/MethodType.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+
+namespace Java.Lang.Invoke
+{
+#if ANDROID_34
+	// A new interface (Java.Lang.Invoke.ITypeDescriptor.IOfMethod) was added to the MethodType class in API-34.
+	// The existing methods have covariant return types so they cannot fulfill the interface contract,
+	// and we cannot change them without breaking API. Create new versions of these interface
+	// methods that can fulfill the contract.
+	public sealed partial class MethodType
+	{
+		Java.Lang.Object[]? ITypeDescriptor.IOfMethod.ParameterArray ()
+			=> ParameterArray ();
+
+		System.Collections.IList? ITypeDescriptor.IOfMethod.ParameterList ()
+			=> (Android.Runtime.JavaList<Java.Lang.Class>?)ParameterList ();
+
+		// Helper method needed to cast Object to Class for an explicitly implemented method:
+		// Java.Lang.Invoke.ITypeDescriptor.IOfMethod.InsertParameterTypes (int p0, params Java.Lang.Object[]? p1)
+		Java.Lang.Invoke.MethodType? InsertParameterTypes (int num, params Java.Lang.Object []? ptypesToInsert)
+			=> InsertParameterTypes (num, ptypesToInsert?.Cast<Java.Lang.Class> ().ToArray ());
+	}
+#endif
+}

--- a/src/Mono.Android/Java.Lang/Class.cs
+++ b/src/Mono.Android/Java.Lang/Class.cs
@@ -1,6 +1,7 @@
 using System;
 using Android.Runtime;
 using Java.Interop;
+using Java.Lang.Invoke;
 
 namespace Java.Lang {
 
@@ -28,5 +29,14 @@ namespace Java.Lang {
 
 			return Java.Lang.Object.GetObject<Class> (JNIEnv.FindClass (type), JniHandleOwnership.TransferGlobalRef)!;
 		}
+
+#if ANDROID_34
+		// A new interface (Java.Lang.Invoke.ITypeDescriptor.IOfField) was added to this class in API-34.
+		// The new required ComponentType () method conflicts with our ComponentType property created from
+		// the existing getComponentType method. Explicitly implement this method, which Android has documented
+		// as equivalent to the existing getComponentType method.
+		Java.Lang.Object? ITypeDescriptor.IOfField.ComponentType ()
+			=> ComponentType;
+#endif
 	}
 }

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Android.Runtime\IJavaObjectValueMarshaler.cs" />
     <Compile Include="Android.Telecom\InCallService.cs" />
     <Compile Include="Android.Views\WindowManagerLayoutParams.cs" />
+    <Compile Include="Java.Lang.Invoke\MethodType.cs" />
   </ItemGroup>
 
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1779,6 +1779,14 @@
   <!-- A new nested class "Request" was added which has a name conflict with existing methods named "Request" -->
   <attr api-since="34" path="/api/package[@name='android.view']/class[@name='PixelCopy.Request']" name="managedName">PixelCopyRequest</attr>
 
+  <!-- Unsupported covariant return types -->
+  <attr api-since="34" path="/api/package[@name='java.lang']/class[@name='Class']/method[@name='arrayType' and count(parameter)=0]" name="managedReturn">Java.Lang.Object</attr>
+
+  <!-- Existing interface method was given a default implementation, existing implementations need to be changed to override -->
+  <attr api-since="34" path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedElement']/method[@name='isAnnotationPresent' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends java.lang.annotation.Annotation&gt;']]" name="abstract">false</attr>
+  <attr api-since="34" path="/api/package[@name='java.lang.reflect']/class[@name='Constructor']/method[@name='isAnnotationPresent' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends java.lang.annotation.Annotation&gt;']]" name="managedOverride">override</attr>
+  <attr api-since="34" path="/api/package[@name='java.lang.reflect']/class[@name='Field']/method[@name='isAnnotationPresent' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends java.lang.annotation.Annotation&gt;']]" name="managedOverride">override</attr>
+	
   <!-- Rename Namespaces -->
   <attr api-since="34" path="/api/package[@name='android.adservices.adid']" name="managedName">Android.AdServices.AdIds</attr>
   <attr api-since="34" path="/api/package[@name='android.adservices.adselection']" name="managedName">Android.AdServices.AdSelection</attr>
@@ -1795,6 +1803,7 @@
   <attr api-since="34" path="/api/package[@name='android.health.connect.datatypes']" name="managedName">Android.Health.Connect.DataTypes</attr>
   <attr api-since="34" path="/api/package[@name='android.health.connect.datatypes.units']" name="managedName">Android.Health.Connect.DataTypes.Units</attr>
   <attr api-since="34" path="/api/package[@name='android.location.altitude']" name="managedName">Android.Locations.Altitude</attr>
+  <attr api-since="34" path="/api/package[@name='java.lang.runtime']" name="managedName">Java.Lang.Runtimes</attr>
 
   <!--
     ***********************************************************************


### PR DESCRIPTION
Context: https://developer.android.com/about/versions/14
Context: https://android-developers.googleblog.com/2023/05/android-14-beta-2.html

Android 14 Beta 2 has been released.  The Android 14
Developer Preview Program Overview [Timeline and updates][0] section
suggests the following timeline:

  * Feb/Mar: Developer Previews
  * April/May: Unstable Betas
  * June/July: Stable Betas
  * ???: Final

[0]: https://developer.android.com/about/versions/14/overview

This update added several new interfaces to existing classes in `Java.Lang.*`.  Ensuring our classes implemented these interfaces without changing the existing class methods took some creative solutions.  Each instance should be reasonably documented with inline comments.