### PR TITLE
[Xamarin.Android.Build.Tasks] introduce Eol.targets for .NET 6

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
@@ -1,0 +1,44 @@
+<!--
+***********************************************************************************************
+Eol.targets
+
+Imported only by .NET 6 EOL projects, contains settings to force the error:
+
+error NETSDK1202: The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.
+
+Things to note:
+
+* $(WarningsAsErrors) includes NETSDK1202
+* Force $(TargetPlatformVersion) to just be 21.0, to make it past early error messages
+* _ClearMissingWorkloads prevents undesired extra error messages
+
+***********************************************************************************************
+-->
+<Project InitialTargets="_ClearMissingWorkloads">
+  <PropertyGroup>
+    <!-- Force NETSDK1202 to be an error -->
+    <WarningsAsErrors>$(WarningsAsErrors);NETSDK1202</WarningsAsErrors>
+    <!--
+      Along with @(SdkSupportedTargetPlatformVersion), prevents the error:
+      Microsoft.NET.TargetFrameworkInference.targets(229,5):
+      error NETSDK1140: 31.0 is not a valid TargetPlatformVersion for android. Valid versions include:
+    -->
+    <TargetPlatformSupported>true</TargetPlatformSupported>
+    <TargetPlatformVersion>21.0</TargetPlatformVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <SdkSupportedTargetPlatformVersion Include="21.0" />
+    <EolWorkload Include="android" Url="https://aka.ms/maui-support-policy" />
+  </ItemGroup>
+  <Target Name="_ClearMissingWorkloads">
+    <!--
+      Prevents the error:
+      Microsoft.NET.Sdk.ImportWorkloads.targets(38,5): error NETSDK1147:
+      To build this project, the following workloads must be installed: wasm-tools-net6
+      To install these workloads, run the following command: dotnet workload restore
+    -->
+    <ItemGroup>
+      <MissingWorkloadPack Remove="@(MissingWorkloadPack)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -4,7 +4,7 @@
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) " />
     <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net7"
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) " />
-    <Import Project="Sdk.targets" Sdk="Microsoft.Android.Sdk.net6"
+    <Import Project="Eol.targets" Sdk="Microsoft.Android.Sdk.net8"
         Condition=" $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) " />
   </ImportGroup>
 
@@ -16,7 +16,7 @@
     />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0')) ">
     <SdkSupportedTargetPlatformIdentifier Include="android" DisplayName="Android" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -1300,6 +1300,17 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 			Assert.AreEqual (expected, builder.Build (), $"{proj.ProjectName} should {(expected ? "succeed" : "fail")}");
 		}
 
+		[Test]
+		public void EolFrameworks()
+		{
+			var library = new XASdkProject (outputType: "Library") {
+				TargetFramework = "net6.0-android",
+			};
+			var dotnet = CreateDotNetBuilder (library);
+			Assert.IsFalse (dotnet.Restore (), $"{library.ProjectName} should fail");
+			Assert.IsTrue (StringAssertEx.ContainsText (dotnet.LastBuildOutput, "NETSDK1202"), $"{dotnet.BuildLogFile} should have NETSDK1202.");
+		}
+
 		DotNetCLI CreateDotNetBuilder (string relativeProjectDir = null)
 		{
 			if (string.IsNullOrEmpty (relativeProjectDir)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -96,6 +96,12 @@ namespace Xamarin.ProjectTools
 			return Execute (arguments.ToArray ());
 		}
 
+		public bool Restore (string target = null, string runtimeIdentifier = null, string [] parameters = null)
+		{
+			var arguments = GetDefaultCommandLineArgs ("restore", target, runtimeIdentifier, parameters);
+			return Execute (arguments.ToArray ());
+		}
+
 		public bool Build (string target = null, string runtimeIdentifier = null, string [] parameters = null)
 		{
 			var arguments = GetDefaultCommandLineArgs ("build", target, runtimeIdentifier, parameters);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8003

Add a new `Eol.targets` file to be imported for `net6.0-android` projects. It contains the necessary/minimal settings to emit the build error:

    Microsoft.NET.EolTargetFrameworks.targets(35,5): error NETSDK1202:
    The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

We will probably need the latest .NET SDK to flow to us, in order to write a test. I could only test locally by editing `.targets` files in the .NET SDK.