### PR TITLE
[ci] Retry .NET install attempts

### DIFF
--- a/build-tools/automation/yaml-templates/use-dot-net.yaml
+++ b/build-tools/automation/yaml-templates/use-dot-net.yaml
@@ -5,6 +5,7 @@ parameters:
   version: $(DotNetSdkVersion)
   quality: $(DotNetSdkQuality)
   remove_dotnet: false
+  retryCountOnTaskFailure: 3
 
 steps:
 
@@ -41,6 +42,7 @@ steps:
       & .\dotnet-install.ps1 -Channel ${{ parameters.version }} -Quality ${{ parameters.quality }} -InstallDir $DotNetRoot -SkipNonVersionedFiles -Verbose
     displayName: install .NET Core ${{ parameters.version }}
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+    retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
   - bash: >
       DOTNET_ROOT=~/.dotnet/ &&
@@ -53,6 +55,7 @@ steps:
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET Core ${{ parameters.version }}
     condition: and(succeeded(), ne(variables['agent.os'], 'Windows_NT'))
+    retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
   - script: dotnet --info
     displayName: display dotnet --info


### PR DESCRIPTION
We've recently seen an increase in intermittent issues causing .NET SDK
installation steps to fail in CI.  We should be able to make these
job steps more robust by adding a "task retry".