### PR TITLE
Bump to mono/mono/2020-02@73df89a7

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d17-5@9b69cb11ce5dafed7126baafad28ac8dff22a5d2
-mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d
+mono/mono:2020-02@73df89a73d2aa08155fca01b75f2cc2944bbb7ea


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7658

Changes: https://github.com/mono/mono/compare/6dd9def57ce969ca04a0ecd9ef72c0a8f069112d...73df89a73d2aa08155fca01b75f2cc2944bbb7ea

  * mono/mono@73df89a73d2: Fix xar url again
  * mono/mono@36fd1837d0d: Switch back to original xar version
  * mono/mono@5bbc709e5dc: Fix xar download url
  * mono/mono@3cb47d8b4dc: [mono] Use `unsigned char` when computing UTF8 string hashes (mono/mono#21633)
  * mono/mono@a102a350e53: [2020-02] [mono][loader] Set status on success; avoid mmap on Android (mono/mono#21610)
  * mono/mono@74f85c2ac33: Fix url to gtksharp msi
  * mono/mono@2f7d584ad2b: Fix build on macOS 13 / Xcode 14 (mono/mono#21597)
  * mono/mono@03b09960787: Disable a failing test