### PR TITLE
Bump to 33.0.59 $(AndroidNet7Version)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -42,7 +42,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.56</AndroidNet7Version>
+    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.59</AndroidNet7Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android/compare/837ca0d8...d96a7a1a

The change needed here, is an updated .NET 6 version in .NET 7:

https://github.com/xamarin/xamarin-android/commit/45e0df49607da568344576e67f42f47c76241af7