### PR TITLE
[AndroidDependenciesTests] Use platform-tools 34.0.3

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Build.Tests
 				var proj = new XamarinAndroidApplicationProject {
 					TargetSdkVersion = apiLevel.ToString (),
 				};
-				const string ExpectedPlatformToolsVersion = "34.0.1";
+				const string ExpectedPlatformToolsVersion = "34.0.3";
 				using (var b = CreateApkBuilder ()) {
 					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;


### PR DESCRIPTION
The `InstallAndroidDependenciesTest` has been failing:

    Failed InstallAndroidDependenciesTest [1 m 39 s]
      Error Message:
       Multiple failures or warnings in test:
      1) _AndroidSdkDirectory not set to new SDK path `/Users/runner/work/1/a/TestDebug/05-24_20.34.58/temp/InstallAndroidDependenciesTest/android-sdk`, *probably* because Google's repository has a newer platform-tools package!  repository2-3.xml contains platform-tools <major>34</major>.<minor>0</minor>.<micro>3</micro>; expected 34.0.1!
      2)   _AndroidSdkDirectory was not set to new SDK path `/Users/runner/work/1/a/TestDebug/05-24_20.34.58/temp/InstallAndroidDependenciesTest/android-sdk`.
      Expected: True
      But was:  False

Attempt to fix this by bumping the platform-tools version that we try to install during this test to 34.0.3.