### PR TITLE
[Mono.Android] suppress/solve more illink warnings

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -482,7 +482,7 @@ namespace Android.Runtime {
 
 		public override void RegisterNativeMembers (
 				JniType nativeClass,
-				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
 				Type type,
 				string? methods) =>
 			RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
@@ -492,7 +492,7 @@ namespace Android.Runtime {
 		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
 		public void RegisterNativeMembers (
 				JniType nativeClass,
-				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type,
 				ReadOnlySpan<char> methods)
 		{
 			try {

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -391,6 +391,7 @@ namespace Android.Runtime {
 
 		// See ExportAttribute.cs
 		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Mono.Android.Export.dll is preserved when [Export] is used via [DynamicDependency].")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "Mono.Android.Export.dll is preserved when [Export] is used via [DynamicDependency].")]
 		static Delegate CreateDynamicCallback (MethodInfo method)
 		{
 			if (dynamic_callback_gen == null) {
@@ -479,10 +480,13 @@ namespace Android.Runtime {
 			}
 		}
 
-		public override void RegisterNativeMembers (JniType nativeClass, Type type, string? methods) =>
+		public override void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type, string? methods) =>
 			RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
 
-		public void RegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
+		[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value parsed from parameter 'methods'.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
+		public void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type, ReadOnlySpan<char> methods)
 		{
 			try {
 				if (methods.IsEmpty) {

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -480,13 +480,20 @@ namespace Android.Runtime {
 			}
 		}
 
-		public override void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type, string? methods) =>
+		public override void RegisterNativeMembers (
+				JniType nativeClass,
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+				Type type,
+				string? methods) =>
 			RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
 
 		[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value parsed from parameter 'methods'.")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
-		public void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type, ReadOnlySpan<char> methods)
+		public void RegisterNativeMembers (
+				JniType nativeClass,
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type,
+				ReadOnlySpan<char> methods)
 		{
 			try {
 				if (methods.IsEmpty) {

--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -122,6 +122,7 @@ namespace Java.Interop {
 		// typeof(Foo) -> FooInvoker
 		// typeof(Foo<>) -> FooInvoker`1
 		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "*Invoker types are preserved by the MarkJavaObjects linker step.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "*Invoker types are preserved by the MarkJavaObjects linker step.")]
 		internal static Type? GetInvokerType (Type type)
 		{
 			const string suffix = "Invoker";

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -324,7 +324,11 @@ namespace Java.Interop {
 		static  readonly    Type[]  XAConstructorSignature  = new Type [] { typeof (IntPtr), typeof (JniHandleOwnership) };
 		static  readonly    Type[]  JIConstructorSignature  = new Type [] { typeof (JniObjectReference).MakeByRefType (), typeof (JniObjectReferenceOptions) };
 
-		internal static object CreateProxy ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type, IntPtr handle, JniHandleOwnership transfer)
+		internal static object CreateProxy (
+				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+				Type type,
+				IntPtr handle,
+				JniHandleOwnership transfer)
 		{
 			// Skip Activator.CreateInstance() as that requires public constructors,
 			// and we want to hide some constructors for sanity reasons.

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -325,7 +325,7 @@ namespace Java.Interop {
 		static  readonly    Type[]  JIConstructorSignature  = new Type [] { typeof (JniObjectReference).MakeByRefType (), typeof (JniObjectReferenceOptions) };
 
 		internal static object CreateProxy (
-				[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 				Type type,
 				IntPtr handle,
 				JniHandleOwnership transfer)

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -116,6 +117,7 @@ namespace Java.Interop {
 		}
 #endif	// !JAVA_INTEROP
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value from parameter 'signature'.")]
 		static Type[] GetParameterTypes (string? signature)
 		{
 			if (String.IsNullOrEmpty (signature))
@@ -127,6 +129,7 @@ namespace Java.Interop {
 			return result;
 		}
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value from parameter 'typename_ptr'.")]
 		static void n_Activate (IntPtr jnienv, IntPtr jclass, IntPtr typename_ptr, IntPtr signature_ptr, IntPtr jobject, IntPtr parameters_ptr)
 		{
 			var o   = Java.Lang.Object.PeekObject (jobject);
@@ -163,6 +166,7 @@ namespace Java.Interop {
 			Activate (jobject, cinfo, parms);
 		}
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "RuntimeHelpers.GetUninitializedObject() does not statically know the return value from ConstructorInfo.DeclaringType.")]
 		internal static void Activate (IntPtr jobject, ConstructorInfo cinfo, object? []? parms)
 		{
 			try {
@@ -257,6 +261,8 @@ namespace Java.Interop {
 			return CreateInstance (handle, transfer, null);
 		}
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "TypeManager.CreateProxy() does not statically know the value of the 'type' local variable.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "TypeManager.CreateProxy() does not statically know the value of the 'type' local variable.")]
 		internal static IJavaPeerable CreateInstance (IntPtr handle, JniHandleOwnership transfer, Type? targetType)
 		{
 			Type? type = null;
@@ -318,7 +324,7 @@ namespace Java.Interop {
 		static  readonly    Type[]  XAConstructorSignature  = new Type [] { typeof (IntPtr), typeof (JniHandleOwnership) };
 		static  readonly    Type[]  JIConstructorSignature  = new Type [] { typeof (JniObjectReference).MakeByRefType (), typeof (JniObjectReferenceOptions) };
 
-		internal static object CreateProxy (Type type, IntPtr handle, JniHandleOwnership transfer)
+		internal static object CreateProxy ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type, IntPtr handle, JniHandleOwnership transfer)
 		{
 			// Skip Activator.CreateInstance() as that requires public constructors,
 			// and we want to hide some constructors for sanity reasons.


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5652

Building an app such as:

    dotnet new android
    dotnet build -c Release -p:SuppressTrimAnalysisWarnings=false -p:TrimmerSingleWarn=false

Results in many illink/trimmer warnings:

    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniMarshalMemberBuilder.cs(57,4): warning IL2072: Java.Interop.JniRuntime.SetMarshalMemberBuilder(JniRuntime.CreationOptions): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(464,32): warning IL2067: Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type, JniNativeMethodRegistrationArguments): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethods(Type)'. The parameter 'marshalType' of method 'Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type, JniNativeMethodRegistrationArguments)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(414,5): warning IL2070: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicNestedTypes' in call to 'System.Type.GetNestedType(String, BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(418,5): warning IL2072: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String): 'name' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethod(Type, String, Type[])'. The return value of method 'System.Type.GetNestedType(String, BindingFlags)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(338,5): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(577,5): warning IL2060: Java.Interop.JniRuntime.JniValueManager.GetObjectArrayMarshaler(Type): Call to 'System.Reflection.MethodInfo.MakeGenericMethod(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(523,6): warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(537,5): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(559,27): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(569,6): warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(93,5): warning IL2057: Java.Interop.ManagedPeer.Construct(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(156,5): warning IL2057: Java.Interop.ManagedPeer.GetParameterTypes(String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(198,5): warning IL2057: Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(403,5): warning IL2075: Android.Runtime.AndroidTypeManager.CreateDynamicCallback(MethodInfo): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(526,8): warning IL2070: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter 'type' of method 'Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(540,9): warning IL2057: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(546,8): warning IL2072: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>): 'target' argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in call to 'System.Delegate.CreateDelegate(Type, Type, String)'. The return value of method 'System.Type.BaseType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(546,8): warning IL2067: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>): 'target' argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in call to 'System.Delegate.CreateDelegate(Type, Type, String)'. The parameter 'type' of method 'Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan<Char>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs(182,4): warning IL2070: Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName(Type, ExportParameterKind): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName(Type, ExportParameterKind)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\JavaObjectExtensions.cs(139,4): warning IL2055: Java.Interop.JavaObjectExtensions.GetInvokerType(Type): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    src\Mono.Android\Java.Interop\TypeManager.cs(169,5): warning IL2072: Java.Interop.TypeManager.Activate(IntPtr, ConstructorInfo, Object[]): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(Type)'. The return value of method 'System.Reflection.MemberInfo.DeclaringType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\TypeManager.cs(326,4): warning IL2070: Java.Interop.TypeManager.CreateProxy(Type, IntPtr, JniHandleOwnership): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructor(BindingFlags, Binder, Type[], ParameterModifier[])'. The parameter 'type' of method 'Java.Interop.TypeManager.CreateProxy(Type, IntPtr, JniHandleOwnership)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\TypeManager.cs(330,4): warning IL2070: Java.Interop.TypeManager.CreateProxy(Type, IntPtr, JniHandleOwnership): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructor(BindingFlags, Binder, Type[], ParameterModifier[])'. The parameter 'type' of method 'Java.Interop.TypeManager.CreateProxy(Type, IntPtr, JniHandleOwnership)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\TypeManager.cs(126,5): warning IL2057: Java.Interop.TypeManager.GetParameterTypes(String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Java.Interop\TypeManager.cs(146,4): warning IL2057: Java.Interop.TypeManager.n_Activate(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.

This commit suppresses/solves the ones in `Mono.Android.dll` and we are left with 15 that can be solved in the xamarin/java.interop repo:

    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniMarshalMemberBuilder.cs(57,4): warning IL2072: Java.Interop.JniRuntime.SetMarshalMemberBuilder(JniRuntime.CreationOptions): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'System.Reflection.Assembly.GetType(String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(464,32): warning IL2067: Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type, JniNativeMethodRegistrationArguments): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethods(Type)'. The parameter 'marshalType' of method 'Java.Interop.JniRuntime.JniTypeManager.FindAndCallRegisterMethod(Type, JniNativeMethodRegistrationArguments)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(414,5): warning IL2070: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicNestedTypes' in call to 'System.Type.GetNestedType(String, BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(418,5): warning IL2072: Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String): 'name' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Reflection.RuntimeReflectionExtensions.GetRuntimeMethod(Type, String, Type[])'. The return value of method 'System.Type.GetNestedType(String, BindingFlags)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(338,5): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetActivationConstructor(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(577,5): warning IL2060: Java.Interop.JniRuntime.JniValueManager.GetObjectArrayMarshaler(Type): Call to 'System.Reflection.MethodInfo.MakeGenericMethod(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(523,6): warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(537,5): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(559,27): warning IL2070: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(569,6): warning IL2072: Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(93,5): warning IL2057: Java.Interop.ManagedPeer.Construct(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(156,5): warning IL2057: Java.Interop.ManagedPeer.GetParameterTypes(String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    external\Java.Interop\src\Java.Interop\Java.Interop\ManagedPeer.cs(198,5): warning IL2057: Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidRuntime.cs(484,4): warning IL2092: Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, String): 'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the parameter 'type' of method 'Android.Runtime.AndroidTypeManager.RegisterNativeMembers(JniType, Type, String)' don't match overridden parameter 'type' of method 'Java.Interop.JniRuntime.JniTypeManager.RegisterNativeMembers(JniType, Type, String)'. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
    external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs(182,4): warning IL2070: Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName(Type, ExportParameterKind): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName(Type, ExportParameterKind)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

This *may* actually make the trimmer better in the places I decorated `Type` parameters with `[DynamicallyAccessedMembers]`, but most of the places are simply suppressing the warning where we have preserved the types via other means.