### PR TITLE
[Xamarin.Android.Build.Tasks] Add $(_BindingsToolsLocation) to allow overriding binding tool binaries.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets
@@ -18,6 +18,11 @@ This file is only used by binding projects.
       Inputs="@(EmbeddedJar);@(EmbeddedReferenceJar);@(InputJar);@(ReferenceJar);@(_AndroidMSBuildAllProjects)"
       Outputs="$(ApiOutputFile)">
 
+    <PropertyGroup>
+      <!-- Allow $(_BindingsToolsLocation) to override where to find class-parse/generator -->
+      <_BindingsToolsLocation Condition=" '$(_BindingsToolsLocation)' == '' ">$(MonoAndroidToolsDirectory)</_BindingsToolsLocation>
+    </PropertyGroup>
+
     <ItemGroup>
       <_AndroidDocumentationPath Include="@(_JavaSourceJavadocXml)" />
       <_AndroidDocumentationPath Include="@(JavaDocIndex->'%(RootDir)\%(Directory)')" />
@@ -32,7 +37,7 @@ This file is only used by binding projects.
         SourceJars="@(EmbeddedJar);@(InputJar)"
         DocumentationPaths="@(_AndroidDocumentationPath)"
         NetCoreRoot="$(NetCoreRoot)"
-        ToolPath="$(MonoAndroidToolsDirectory)"
+        ToolPath="$(_BindingsToolsLocation)"
         ToolExe="$(ClassParseToolExe)"
     />
     <BindingsGenerator
@@ -44,7 +49,7 @@ This file is only used by binding projects.
         ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
         MonoAndroidFrameworkDirectories="$(_XATargetFrameworkDirectories)"
         NetCoreRoot="$(NetCoreRoot)"
-        ToolPath="$(MonoAndroidToolsDirectory)"
+        ToolPath="$(_BindingsToolsLocation)"
         ToolExe="$(BindingsGeneratorToolExe)"
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -55,6 +55,11 @@ It is shared between "legacy" binding projects and .NET 5 projects.
       Inputs="$(ApiOutputFile);@(TransformFile);@(ReferencePath);@(ReferenceDependencyPaths);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_GeneratorStampFile)">
 
+    <PropertyGroup>
+      <!-- Allow $(_BindingsToolsLocation) to override where to find class-parse/generator -->
+      <_BindingsToolsLocation Condition=" '$(_BindingsToolsLocation)' == '' ">$(MonoAndroidToolsDirectory)</_BindingsToolsLocation>
+    </PropertyGroup>
+    
     <!-- Delete previous generated files if they still exist -->
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />
 
@@ -87,7 +92,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         MonoAndroidFrameworkDirectories="$(_XATargetFrameworkDirectories)"
         TypeMappingReportFile="$(GeneratedOutputPath)type-mapping.txt"
         NetCoreRoot="$(NetCoreRoot)"
-        ToolPath="$(MonoAndroidToolsDirectory)"
+        ToolPath="$(_BindingsToolsLocation)"
         ToolExe="$(BindingsGeneratorToolExe)"
         LangVersion="$(LangVersion)"
         EnableBindingStaticAndDefaultInterfaceMethods="$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)"


### PR DESCRIPTION
There are a few instances where we would like to run a custom/updated `generator` and `class-parse` with an existing .NET install:

- AndroidX/GPS would like newer fixes that may not have been backported to previous target frameworks that are still shipped
- We would like some CI for `generator` itself that runs proposed changes against a large corpus like AndroidX/GPS before being committed to detect possible bugs sooner
- Being able to easily test local `generator` changes against test cases without using `dotnet-local` (especially for running inside VS)

To facilitate this, add the internal MSBuild option `$(_BindingsToolsLocation)` which can be set to a path where a custom/updated `generator`/`class-parse` exist:

```
dotnet build MyBindings.csproj -p:_BindingsToolsLocation=C:\code\Java.Interop\bin\Debug\
```