### PR TITLE
$(AndroidPackVersionSuffix)=preview.6; net8 is 34.0.0-preview.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview5

We branched for .NET 8 preview 5 from a2f41716 into `release/8.0.1xx-preview5`.

Update xamarin-android/main's version number to 34.0.0-preview.6 for .NET 8 preview 6.