### PR TITLE
[vs-workload] Set IsOutOfSupportInVisualStudio=true

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1425,7 +1425,6 @@ stages:
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
       useDateTimeVersion: false
-      arcadePackageVersion: 6.0.0-beta.23274.5
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/oos-wl
     endpoint: xamarin
   - repository: sdk-insertions
     type: github
@@ -1425,6 +1425,7 @@ stages:
       propsArtifactName: nuget-unsigned
       signType: $(MicroBuildSignType)
       useDateTimeVersion: false
+      arcadePackageVersion: 6.0.0-beta.23274.5
 
   # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
   - job: push_signed_nugets

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetName>Microsoft.NET.Sdk.Android.Workload</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
+    <IsOutOfSupportInVisualStudio>true</IsOutOfSupportInVisualStudio>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8030
Context: https://github.com/xamarin/yaml-templates/pull/267

Sets the newly introduced `IsOutOfSupportInVisualStudio` MSI generation
task parameter to true for .NET 6 builds.  This will cause the generated
VS manifests to contain a flag that tells the VS installer that these
components should be uninstalled during an upgrade.