### PR TITLE
[ci] Shut down dotnet processes before retrying failed unit tests.

### DIFF
--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -49,6 +49,13 @@ steps:
       testResultsFiles: $(Agent.TempDirectory)/*.trx
       testRunTitle: ${{ parameters.testRunTitle }}-$(System.JobPositionInPhase)
 
+  - task: DotNetCoreCLI@2
+    displayName: Shut down existing dotnet daemons
+    inputs:
+      command: custom
+      custom: build-server
+      arguments: shutdown
+
   - template: run-nunit-tests.yaml
     parameters:
       testRunTitle: ${{ parameters.testRunTitle }}-$(System.JobPositionInPhase) (Auto-Retry)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8021

The previous attempt to fix the `"Unknown abi"` error on retried unit tests was unsuccessful.  Perhaps the issue is our old friend MSBuild node reuse?

Call `dotnet build-server shutdown` before retrying tests.