### PR TITLE
[ci] Use new 1ES Hosted Linux PR build pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -85,9 +85,9 @@ variables:
   - name: MacBuildPoolImage
     value: ''
   - name: LinuxBuildPoolName
-    value: Azure Pipelines
+    value: android-devdiv-ubuntu-vmss-pr
   - name: LinuxBuildPoolImage
-    value: ubuntu-22.04
+    value: ''
   - name: DisablePipelineConfigDetector
     value: true
 
@@ -264,7 +264,7 @@ stages:
   - job: linux_tests_smoke
     displayName: Linux > Tests > MSBuild
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: android-devdiv-ubuntu-vmss-pr
     timeoutInMinutes: 180
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -264,7 +264,7 @@ stages:
   - job: linux_tests_smoke
     displayName: Linux > Tests > MSBuild
     pool:
-      vmImage: android-devdiv-ubuntu-vmss-pr
+      name: android-devdiv-ubuntu-vmss-pr
     timeoutInMinutes: 180
     workspace:
       clean: all


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-android/commit/ca5ff9b06b2aab969f837b869883459b944f8e04 migrated our Linux PR build and test jobs to Microsoft
hosted agents.  At the time it seemed that we had trimmed our build
output and provisioning requirements enough to fit within the 10GB disk
space limit of the hosted agents.  However, we've been running into disk
issues recently:

    System.IO.IOException: No space left on device : '/home/vsts/agents/3.220.2/_diag/Worker_20230605-125326-utc.log'

A new [`android-devdiv-ubuntu-vmss-pr`][0] scaling pool has been set up
for Linux PR builds and tests, with the same configuration as the
`android-devdiv-ubuntu-vmss` pool used for non PR builds.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourcegroups/devdiv-vm-scale-sets/providers/Microsoft.CloudTest/hostedpools/android-devdiv-ubuntu-vmss-pr/overview