### PR TITLE
[build] Ignore CA1305 in more projects

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -248,7 +248,7 @@
 
   <!-- Don't analyze code from external repos -->
   <PropertyGroup Condition=" !$(MSBuildProjectDirectory.Contains ('external')) and !$(MSBuildProjectDirectory.Contains ('NUnitLite')) ">
-    <XAShouldAnalyzeAssembly>True</XAShouldAnalyzeAssembly>
+    <EnableNETAnalyzers>True</EnableNETAnalyzers>
   </PropertyGroup>
 
   <!-- The .NET 6+ versions of these analyzers are stricter and require overloads not available in .NET Framework, so start with just .NET Framework -->
@@ -261,5 +261,4 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\Ndk.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RoslynAnalyzers.projitems" Condition=" '$(EnableRoslynAnalyzers)' == 'true' " />
 </Project>

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -50,7 +50,7 @@ stages:
 
     - template: yaml-templates/commercial-build.yaml
       parameters:
-        makeMSBuildArgs: /p:EnableRoslynAnalyzers=true /p:EnableNativeAnalyzers=true
+        makeMSBuildArgs: /p:EnableNativeAnalyzers=true
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/scripts/RoslynAnalyzers.projitems
+++ b/build-tools/scripts/RoslynAnalyzers.projitems
@@ -1,9 +1,0 @@
-<Project>
-
-  <ItemGroup Condition=" '$(XAShouldAnalyzeAssembly)' == 'True' ">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);CA1305</NoWarn>
   </PropertyGroup>
   <Import Project="..\..\..\..\Configuration.props" />
   <Import Project="..\..\..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\MSBuildReferences.projitems" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -19,7 +19,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <!-- Causes issues with linker files imported from Mono -->
-    <NoWarn>$(NoWarn);CA1310</NoWarn>
+    <NoWarn>$(NoWarn);CA1310;CA1305</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -6,6 +6,7 @@
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);CA1305</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Android.Cecil">

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -5,6 +5,7 @@
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1305</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
Commit 04e4bb1e turned `CA1305` into a build error for projects in the
`src` directory, however the .NET analyzers that detect this issue only
run by default on projects targeting .NET 5.0 or later.  Sources that
target `netstandard2.0` (including our build tasks) contain instances of
`CA1305` that should be fixed, but these errors weren't being reported
in our regular builds.

Our nightly build managed to catch _some_ of these issues, as this build
set an MSBuild property that would cause our sources to import the FxCop
NuGet package.

FxCop is deprecated, and it should be replaced by using the first-party
.NET analyzers.  These analyzers can be enabled for projects with older
target frameworks by setting the [`$(EnableNETAnalyzers)`][0] property
to `true`.  This property is now set to true for all build types (pr,
CI, nightly) and projects in xamarin-android.

After enabling .NET analyzers on projects with older target frameworks,
the following projects needed to suppress `CA1305` warnings as errors to
fix the regular and nightly builds:

 * `src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj`
 * `src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj`
 * `src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj`
 * `src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj`

We should try to address the `CA1305` issues in these non-test projects
in a future PR.

[0]: https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablenetanalyzers