### PR TITLE
[build] Bump `$(XABuildToolsVersion)`=34

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -130,13 +130,13 @@
       For some reason, the URL for platform-tools/build-tools 32.0.0 is prefixed with what appears to be a GIT commit hash or some other checksum...
       Linux packages don't have any prefix, but this forces us to have *some* mechanism to handle this...
     -->
-    <XABuildToolsPackagePrefixMacOS>5219cc671e844de73762e969ace287c29d2e14cd.</XABuildToolsPackagePrefixMacOS>
-    <XABuildToolsPackagePrefixWindows>210b77e4bc623bd4cdda4dae790048f227972bd2.</XABuildToolsPackagePrefixWindows>
+    <XABuildToolsPackagePrefixMacOS></XABuildToolsPackagePrefixMacOS>
+    <XABuildToolsPackagePrefixWindows></XABuildToolsPackagePrefixWindows>
     <XABuildToolsPackagePrefixLinux></XABuildToolsPackagePrefixLinux>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildToolsPackagePrefixMacOS)</XABuildToolsPackagePrefix>
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
-    <XABuildToolsVersion>32</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">32.0.0</XABuildToolsFolder>
+    <XABuildToolsVersion>34</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">34.0.0</XABuildToolsFolder>
     <!-- build-tools 30, for DX tests -->
     <XABuildTools30PackagePrefixMacOS>f6d24b187cc6bd534c6c37604205171784ac5621.</XABuildTools30PackagePrefixMacOS>
     <XABuildTools30PackagePrefixWindows>91936d4ee3ccc839f0addd53c9ebf087b1e39251.</XABuildTools30PackagePrefixWindows>


### PR DESCRIPTION
Context: https://github.com/android/ndk/issues/1299
Context: https://developer.android.com/tools/releases/build-tools

Similar to the Android NDK (android/ndk#1299), `aapt2` from the Android SDK build-tools package is also a native binary.

`aapt2` from build-tools_r32 only contains an x64 slice:

	% file aapt2
	aapt2: Mach-O 64-bit executable x86_64

`aapt2` in build-tools_r33 and build-tools_r34 contains both x64 and arm64 slices:

	% file aapt2
	aapt2: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
	aapt2 (for architecture x86_64):	Mach-O 64-bit executable x86_64
	aapt2 (for architecture arm64):	Mach-O 64-bit executable arm64

Update `$(XABuildToolsVersion)`=34, so that we redistribute this newer `aapt2` binary.  This will remove *a* place that Rosetta 2 is required to use .NET Android.