### PR TITLE
[xaprepare] Add support for Debian trixie release

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -25,6 +25,8 @@ namespace Xamarin.Android.Prepare
 		static readonly Dictionary<string, string> DebianUnstableVersionMap = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase) {
 			{ "bookworm", "12" },
 			{ "bookworm/sid", "12" },
+			{ "trixie", "13" },
+			{ "trixie/sid", "13" },
 		};
 
 		protected Version DebianRelease { get; private set; } = new Version (0, 0);
@@ -56,6 +58,7 @@ namespace Xamarin.Android.Prepare
 			return
 				version!.IndexOf ("bullseye", StringComparison.OrdinalIgnoreCase) >= 0 ||
 				version.IndexOf ("bookworm", StringComparison.OrdinalIgnoreCase) >= 0 ||
+				version.IndexOf ("trixie", StringComparison.OrdinalIgnoreCase) >= 0 ||
 				version.IndexOf ("sid", StringComparison.OrdinalIgnoreCase) >= 0;
 		}
 
@@ -75,7 +78,8 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			return debian_version!.IndexOf ("bookworm", StringComparison.OrdinalIgnoreCase) >= 0;
+			return debian_version!.IndexOf ("bookworm", StringComparison.OrdinalIgnoreCase) >= 0 ||
+			       debian_version!.IndexOf ("trixie", StringComparison.OrdinalIgnoreCase) >= 0;
 		}
 
 		protected override bool EnsureVersionInformation (Context context)


### PR DESCRIPTION
Context: https://bits.debian.org/2023/06/bookworm-released.html
Context: https://siduction.org/

Debian 12, aka bookworm, has just been released and that means work on
the next release, codenamed "trixie", has begun.  The code name appeared
in `/etc/debian_version` and `/etc/os-release` files and `xaprepare`
needs to be updated in order to properly detect trixie.

While this change won't be necessary for users of Debian "stable" or any
distributions based on it, it is necessary for rolling Debian "unstable"
distributions like `siduction` (which is what I use :D)

Debian "unstable" distribution (which eventually becomes the "testing"
distribution, to become "stable" on release) does not use version
numbers in the abovementioned files, just the codename.  This is the
reason we need to fake the OS version number for Debian.
