### PR TITLE
[Xamarin.Android.Build.Tasks] Handle IOException in Aapt2Daemon

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks {
 				DaemonMaxInstanceCount = maxInstances;
 			else
 				DaemonMaxInstanceCount = Math.Min (DaemonMaxInstanceCount, maxInstances);
-			daemon  = Aapt2Daemon.GetInstance (BuildEngine4, GenerateFullPathToTool (),
+			daemon  = Aapt2Daemon.GetInstance (BuildEngine4, LogDebugMessage, GenerateFullPathToTool (),
 				DaemonMaxInstanceCount, GetRequiredDaemonInstances (), registerInDomain: DaemonKeepInDomain);
 			return base.Execute ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -279,7 +279,7 @@ namespace Xamarin.Android.Tasks
 				aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 			} catch (IOException) {
 				// Ignore this error. It occurs when the Build it cancelled.
-				logger?.Invoke ("Aapt2Daemon: Ignoring IOException. Build was cancelled.");
+				logger?.Invoke ($"{nameof (Aapt2Daemon)}: Ignoring IOException. Build was cancelled.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -271,9 +271,15 @@ namespace Xamarin.Android.Tasks
 			{
 				// Ignore this error. It occurs when the Task is cancelled.
 			}
-			aapt2.StandardInput.WriteLine ("quit");
-			aapt2.StandardInput.WriteLine ();
-			aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
+			try {
+				aapt2.StandardInput.WriteLine ("quit");
+				aapt2.StandardInput.WriteLine ();
+				aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
+			}
+			catch (IOException)
+			{
+				// Ignore this error. It occurs when the Build it cancelled.
+			}
 		}
 
 		bool IsAapt2Warning (string singleLine)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -275,9 +275,7 @@ namespace Xamarin.Android.Tasks
 				aapt2.StandardInput.WriteLine ("quit");
 				aapt2.StandardInput.WriteLine ();
 				aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
-			}
-			catch (IOException)
-			{
+			} catch (IOException) {
 				// Ignore this error. It occurs when the Build it cancelled.
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -279,7 +279,12 @@ namespace Xamarin.Android.Tasks
 				aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 			} catch (IOException) {
 				// Ignore this error. It occurs when the Build it cancelled.
-				logger?.Invoke ($"{nameof (Aapt2Daemon)}: Ignoring IOException. Build was cancelled.");
+				try {
+					logger?.Invoke ($"{nameof (Aapt2Daemon)}: Ignoring IOException. Build was cancelled.");
+				} catch  {
+					// The Logger might not exist if the daemon exits after the logger has been
+					// collected.
+				}
 			}
 		}
 


### PR DESCRIPTION
When cancelling a build on the command line we occasionally see the following exception.

```
Unhandled exception. System.IO.IOException: Broken pipe
 ---> System.Net.Sockets.SocketException (32): Broken pipe
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   --- End of inner exception stack trace ---
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.WriteLine(String value)
   at Xamarin.Android.Tasks.Aapt2Daemon.Aapt2DaemonStart()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
Unhandled exception. System.IO.IOException: Broken pipe
 ---> System.Net.Sockets.SocketException (32): Broken pipe
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   --- End of inner exception stack trace ---
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.WriteLine(String value)
   at Xamarin.Android.Tasks.Aapt2Daemon.Aapt2DaemonStart()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
Unhandled exception. System.IO.IOException: Broken pipe
 ---> System.Net.Sockets.SocketException (32): Broken pipe
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   --- End of inner exception stack trace ---
   at System.IO.Pipes.PipeStream.WriteCore(ReadOnlySpan`1 buffer)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.WriteLine(String value)
   at Xamarin.Android.Tasks.Aapt2Daemon.Aapt2DaemonStart()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
```

This happens because we are calling `Stream.WriteLine` after the process has already exited. So lets catch this exception and ignore it.