### PR TITLE
Bump to google/bundletool/main@f17ce94a

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -148,7 +148,7 @@
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>34.0.1</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.8.1</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.15.1</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>

--- a/Documentation/release-notes/bundletool-1.8.1.md
+++ b/Documentation/release-notes/bundletool-1.8.1.md
@@ -1,8 +1,0 @@
-### bundletool version update to 1.8.1
-
-The version of the [`bundletool`][bundletool] executable included in
-Xamarin.Android has been updated from 1.4.0 to [1.8.1][bundletool-1.8.1],
-bringing in several improvements and bug fixes.
-
-[bundletool]: https://developer.android.com/studio/command-line/bundletool
-[bundletool-1.8.1]: https://github.com/google/bundletool/releases/tag/1.8.1

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -672,9 +672,13 @@ namespace Bug12935
 	<XmlPeek Query=""/manifest/*"" XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml"">
 		<Output TaskParameter=""Result"" ItemName=""_XmlNodes"" />
 	</XmlPeek>
+	<PropertyGroup>
+		<_ExistingXml>@(_XmlNodes, ' ')</_ExistingXml>
+		<_NewXml>@(_Permissions, ' ')</_NewXml>
+	</PropertyGroup>
 	<XmlPoke
 		XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml""
-		Value=""@(_XmlNodes->'%(Identity)', ' ')@(_Permissions)""
+		Value=""$(_ExistingXml)$(_NewXml)""
 		Query=""/manifest""
 		Namespaces=""$(Namespace)""
 	/>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -669,9 +669,12 @@ namespace Bug12935
 	<_Permissions Include=""&lt;uses-permission android:name=&quot;android.permission.READ_CONTACTS&quot; /&gt;"" />
 </ItemGroup>
 <Target Name=""_Foo"">
+	<XmlPeek Query=""/manifest/*"" XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml"">
+		<Output TaskParameter=""Result"" ItemName=""_XmlNodes"" />
+	</XmlPeek>
 	<XmlPoke
 		XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml""
-		Value=""@(_Permissions)""
+		Value=""@(_XmlNodes->'%(Identity)', ' ')@(_Permissions)""
 		Query=""/manifest""
 		Namespaces=""$(Namespace)""
 	/>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -665,14 +665,11 @@ namespace Bug12935
 	    <Namespace Prefix=""android"" Uri=""http://schemas.android.com/apk/res/android"" />
 	</Namespace>
 </PropertyGroup>
-<ItemGroup>
-	<_Permissions Include=""&lt;uses-permission android:name=&quot;android.permission.READ_CONTACTS&quot; /&gt;"" />
-</ItemGroup>
 <Target Name=""_Foo"">
 	<XmlPoke
 		XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml""
-		Value=""@(_Permissions)""
-		Query=""/manifest""
+		Value=""12345""
+		Query=""/manifest/@android:versionCode""
 		Namespaces=""$(Namespace)""
 	/>
 </Target>
@@ -684,7 +681,7 @@ namespace Bug12935
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var manifest = builder.Output.GetIntermediaryAsText (Root, Path.Combine ("android", "AndroidManifest.xml"));
-				Assert.IsTrue (manifest.Contains ("READ_CONTACTS"), $"Manifest should contain the READ_CONTACTS");
+				Assert.IsTrue (manifest.Contains ("12345"), $"Manifest should contain versionCode=12345");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -665,11 +665,14 @@ namespace Bug12935
 	    <Namespace Prefix=""android"" Uri=""http://schemas.android.com/apk/res/android"" />
 	</Namespace>
 </PropertyGroup>
+<ItemGroup>
+	<_Permissions Include=""&lt;uses-permission android:name=&quot;android.permission.READ_CONTACTS&quot; /&gt;"" />
+</ItemGroup>
 <Target Name=""_Foo"">
 	<XmlPoke
 		XmlInputPath=""$(IntermediateOutputPath)android\AndroidManifest.xml""
-		Value=""12345""
-		Query=""/manifest/@android:versionCode""
+		Value=""@(_Permissions)""
+		Query=""/manifest""
 		Namespaces=""$(Namespace)""
 	/>
 </Target>
@@ -681,7 +684,7 @@ namespace Bug12935
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var manifest = builder.Output.GetIntermediaryAsText (Root, Path.Combine ("android", "AndroidManifest.xml"));
-				Assert.IsTrue (manifest.Contains ("12345"), $"Manifest should contain versionCode=12345");
+				Assert.IsTrue (manifest.Contains ("READ_CONTACTS"), $"Manifest should contain the READ_CONTACTS");
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/1.15.1
Changes: https://github.com/google/bundletool/compare/1.8.1...1.15.1

We are seeing an error with API 34:

    XABBA7024: Xamarin.Tools.Zip.ZipIOException: The file 'obj\Release\android\bin\base.zip' is not a ZIP archive.

We wonder if updating `bundletool` will help. It was last updated in 989dc07b.