### PR TITLE
[build] consider $NUGET_PACKAGES for $(XAPackagesDir)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -149,6 +149,7 @@
     <XAPlatformToolsVersion>34.0.1</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.8.1</XABundleToolVersion>
+    <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>


### PR DESCRIPTION
Context: https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-environment-variables

I recently paved my Windows PC and set `%NUGET_PACKAGES%` to a Dev Drive at:

    D:\.nuget\packages

This caused Xamarin.Android's build to fail with:

    Mono.Android.targets(220,5): error : CompatApi command: dotnet "C:\Users\jonat\.nuget\packages/microsoft.dotnet.apicompat/7.0.0-beta.22103.1/tools/net472/..\netcoreapp3.1\Microsoft.DotNet.ApiCompat.dll" "D:\src\xamarin-android\tests\api-compatibility\reference\net8.0\Mono.Android.dll" -i "D:\src\xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\Microsoft.Android\33" --allow-default-interface-methods --baseline "D:\src\xamarin-android\tests\api-compatibility\acceptable-breakages-vReference-net8.0.txt" --validate-baseline --exclude-attributes "D:\src\xamarin-android\tests\api-compatibility\api-compat-exclude-attributes.txt"
    error : CheckApiCompatibility found nonacceptable Api breakages for ApiLevel: v13.0.
    error : Could not execute because the specified command or file was not found.
    error : Possible reasons for this include:
    error : * You misspelled a built-in dotnet command.
    error : * You intended to execute a .NET program, but dotnet-C:\Users\jonat\.nuget\packages/microsoft.dotnet.apicompat/7.0.0-beta.22103.1/tools/net472/..\netcoreapp3.1\Microsoft.DotNet.ApiCompat.dll does not exist.
    error : * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.

I added a check for `$(NUGET_PACKAGES)`.

This may not 100% match NuGet behavior, but solves the issue.