### PR TITLE
[One .NET] fix 'dotnet publish' with no arguments

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -69,6 +69,11 @@
     <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and ('$(AndroidLinkMode)' == 'SdkOnly' or '$(AndroidLinkMode)' == 'Full') ">true</PublishTrimmed>
     <PublishTrimmed Condition=" '$(PublishTrimmed)' == '' and '$(Configuration)' == 'Release' and '$(AndroidLinkMode)' != 'None' ">true</PublishTrimmed>
+    <!--
+      This prevents an early error message during 'dotnet publish'.
+      We handle $(SelfContained) in a custom way where it is forced to be true.
+    -->
+    <PublishSelfContained Condition=" '$(PublishSelfContained)' == '' ">false</PublishSelfContained>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- For compat with user code not marked trimmable, only trim opt-in by default. -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -875,6 +875,18 @@ public class FooA {
 		}
 
 		[Test]
+		public void DotNetPublishDefaultValues([Values (false, true)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease
+			};
+			var builder = CreateDllBuilder ();
+			builder.Save (proj);
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+			Assert.IsTrue (dotnet.Publish (), "`dotnet publish` should succeed");
+		}
+
+		[Test]
 		public void DotNetPublish ([Values (false, true)] bool isRelease, [ValueSource(nameof(DotNetTargetFrameworks))] object[] data)
 		{
 			var dotnetVersion = (string)data[0];


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/15696
Context: https://github.com/dotnet/sdk/pull/30038

In .NET 8 Preview 5, there are various changes to default values:

* `dotnet publish` is now `Release` by default

* Builds that provide a `$(RuntimeIdentifier)` are no longer "self contained" by default.

The result of this change is the problem:

    dotnet new android
    dotnet publish
    Microsoft.NET.RuntimeIdentifierInference.targets(212,5): error NETSDK1191: A runtime identifier for the property 'SelfContained' couldn't be inferred. Specify a rid explicitly.

While these commands all work:

    dotnet build
    dotnet build -c Release
    dotnet publish -c Debug
    dotnet publish -r android-arm64

`Debug` configurations work fine, because trimming is not involved. `dotnet build` works fine, because the offending default appears to be:

https://github.com/dotnet/sdk/blob/540b197311bc8d1c2a991fed1b935b094a4d7b2d/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L64-L76

`Microsoft.NET.RuntimeIdentifierInference.targets` has a lot of MSBuild validation logic, that its main job is to emit nice error messages for incorrect combinations of MSBuild properties/settings.

Android is kind of the odd one out when you compare to .NET console apps, NativeAOT, etc.:

* We default to `RuntimeIdentifiers=android-arm;android-arm64;android-x86;android-x64`.

* We do our own "inner build" for each `RuntimeIdentifier`.

* Inside our build we force `$(SelfContained)` to `true` no matter what. As there is no such thing as a system-wide .NET on Android.

The fix appears to be to default `PublishSelfContained=false` and let our existing logic force `SelfContained=true`.

I added a new test for this scenario. Our existing test didn't catch this because it was passing a `RuntimeIdentifier`.