### PR TITLE
[tests] don't set `/uses-sdk@android:targetSdkVersion=34` by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -650,28 +650,6 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			}
 		}
 
-		[Test]
-		[Category ("DotNetIgnore")] // n/a in .NET 5+
-		public void CheckTargetFrameworkVersion ([Values (true, false)] bool isRelease)
-		{
-			var proj = new XamarinAndroidApplicationProject () {
-				IsRelease = isRelease,
-				TargetSdkVersion = null,
-				MinSdkVersion = null,
-			};
-			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
-			using (var builder = CreateApkBuilder ()) {
-				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion, out string[] _);
-				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
-				if (!Directory.Exists (Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, firstFrameworkVersion)))
-					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
-				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={firstFrameworkVersion}"), $"TargetFrameworkVerson should be {firstFrameworkVersion}");
-				Assert.IsTrue (builder.Build (proj, parameters: new [] { $"TargetFrameworkVersion={lastFrameworkVersion}" }), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={lastFrameworkVersion}"), $"TargetFrameworkVersion should be {lastFrameworkVersion}");
-			}
-		}
-
 #pragma warning disable 414
 		public static object [] GeneratorValidateEventNameArgs = new object [] {
 			new object [] { false, true, string.Empty, string.Empty },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -693,10 +693,8 @@ printf ""%d"" x
 		public void DesignTimeBuildHasAndroidDefines ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			var didParse = int.TryParse (proj.TargetSdkVersion, out int apiLevel);
-			Assert.IsTrue (didParse, $"Unable to parse {proj.TargetSdkVersion} as an int.");
 			var androidDefines = new List<string> ();
-			for (int i = 1; i <= apiLevel; ++i) {
+			for (int i = 1; i <= XABuildConfig.AndroidDefaultTargetDotnetApiLevel; ++i) {
 				androidDefines.Add ($"!__ANDROID_{i}__");
 			}
 			proj.Sources.Add (new BuildItem ("Compile", "IsAndroidDefined.cs") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -199,18 +199,22 @@ namespace Xamarin.ProjectTools
 
 		public virtual string ProcessManifestTemplate ()
 		{
-			var uses_sdk = new StringBuilder ("<uses-sdk ");
+			var uses_sdk = new StringBuilder ();
 			if (!string.IsNullOrEmpty (MinSdkVersion)) {
+				uses_sdk.Append ("<uses-sdk ");
 				uses_sdk.Append ("android:minSdkVersion=\"");
 				uses_sdk.Append (MinSdkVersion);
 				uses_sdk.Append ("\" ");
 			}
 			if (!string.IsNullOrEmpty (TargetSdkVersion)) {
+				if (uses_sdk.Length == 0)
+					uses_sdk.Append ("<uses-sdk ");
 				uses_sdk.Append ("android:targetSdkVersion=\"");
 				uses_sdk.Append (TargetSdkVersion);
 				uses_sdk.Append ("\" ");
 			}
-			uses_sdk.Append ("/>");
+			if (uses_sdk.Length > 0)
+				uses_sdk.Append ("/>");
 
 			return AndroidManifest
 				.Replace ("${PROJECT_NAME}", ProjectName)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -70,9 +70,7 @@ namespace Xamarin.ProjectTools
 				MinSdkVersion = "19";
 			}
 			AndroidManifest = default_android_manifest;
-			if (Builder.UseDotNet) {
-				TargetSdkVersion = XABuildConfig.AndroidDefaultTargetDotnetApiLevel.ToString ();
-			} else {
+			if (!Builder.UseDotNet) {
 				TargetSdkVersion = AndroidSdkResolver.GetMaxInstalledPlatform ().ToString ();
 			}
 			LayoutMain = default_layout_main;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -80,7 +80,6 @@ namespace Xamarin.Android.Build.Tests
 			proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				SupportedOSPlatformVersion = "23",
-				TargetSdkVersion = null,
 			};
 			if (isRelease || !CommercialBuildAvailable) {
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8116/commits/95f4b796700b2acaedb9bb58ba24f84b39de8891

When making API 34 the default in .NET 8, some tests tried to build `net7.0-android` projects with an `AndroidManifest.xml` that contains:

    <uses-sdk android:targetSdkVersion="34" />

This won't work until we backport API 34 to .NET 7.

In general, you shouldn't use `<uses-sdk/>` in .NET 6+ apps as the following MSBuild properties should be used instead:

    <TargetFramework>net7.0-android33</TargetFramework>
    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>

Where `33` is implicit if left out.

Let's no longer set `TargetSdkVersion` by default in our MSBuild tests, as this is closer to what customers will do. We also no longer build or test Xamarin.Android in main.

I removed places in tests that set `TargetSdkVersion = null` and removed one test that is no longer valid in main/.NET 6+.