### PR TITLE
[build] create `xamarin-android-tools.override.props`

### DIFF
--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2577,5 +2577,27 @@ namespace UnnamedProject
 			using var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 		}
+
+		/// <summary>
+		/// Build with MSBuild.exe on .NET framework, instead of 'dotnet build'
+		/// </summary>
+		[Test]
+		public void BuildWithMSBuild ([Values (true, false)] bool isRelease)
+		{
+			if (!IsWindows)
+				Assert.Ignore ("Test is only valid on Windows platforms");
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+			using var builder = CreateApkBuilder ();
+
+			// Use MSBuild.exe, setting %PATH% to our local 'dotnet' directory
+			builder.BuildTool = TestEnvironment.GetVisualStudioInstance ().MSBuildPath;
+			var environment = new Dictionary<string, string> ();
+			environment ["PATH"] = $"{TestEnvironment.DotNetPreviewDirectory};{Environment.GetEnvironmentVariable ("PATH")}";
+
+			Assert.IsTrue (builder.Build (proj, environmentVariables: environment), "Build should have succeeded.");
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
@@ -20,11 +20,6 @@ namespace Xamarin.ProjectTools
 
 		public string StringsXml { get; set; }
 
-		/// <summary>
-		/// /t:Restore or /restore is always required
-		/// </summary>
-		public override bool ShouldRestorePackageReferences => true;
-
 		public string TargetFrameworks {
 			get => GetProperty (nameof (TargetFrameworks));
 			set => SetProperty (nameof (TargetFrameworks), value);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -265,6 +265,7 @@ namespace Xamarin.ProjectTools
 				}
 
 				psi.SetEnvironmentVariable ("MSBUILD", "msbuild");
+				psi.SetEnvironmentVariable ("MSBUILDLOGALLENVIRONMENTVARIABLES", "1"); // So .binlog files contain all env vars
 				sw.WriteLine ($"/bl:\"{Path.GetFullPath (Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), $"{binlogName}.binlog"))}\"");
 
 				if (environmentVariables != null) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -23,9 +23,6 @@ namespace Xamarin.ProjectTools
 			Language = XamarinAndroidProjectLanguage.CSharp;
 		}
 
-		// NetStandard projects always need to restore
-		public override bool ShouldRestorePackageReferences => true;
-
 		public string PackageTargetFallback {
 			get { return GetProperty ("PackageTargetFallback"); }
 			set { SetProperty ("PackageTargetFallback", value); }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -70,7 +70,7 @@ namespace Xamarin.ProjectTools
 				project.NuGetRestore (Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory), PackagesDirectory);
 			}
 
-			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, restore: project.ShouldRestorePackageReferences, binlogName: Path.GetFileNameWithoutExtension (BuildLogFile));
+			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, binlogName: Path.GetFileNameWithoutExtension (BuildLogFile));
 			built_before = true;
 
 			if (CleanupAfterSuccessfulBuild)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -67,7 +67,7 @@ namespace Xamarin.ProjectTools
 
 		public bool BuildProject(XamarinProject project, string target = "Build")
 		{
-			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target, restore: project.ShouldRestorePackageReferences);
+			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target);
 			return BuildSucceeded;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -33,7 +33,6 @@ namespace Xamarin.ProjectTools
 		public string GlobalPackagesFolder { get; set; } = FileSystemUtils.FindNugetGlobalPackageFolder ();
 		public IList<string> ExtraNuGetConfigSources { get; set; } = new List<string> ();
 
-		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;
 		/// <summary>
 		/// If true, the ProjectDirectory will be deleted and populated on the first build
 		/// </summary>


### PR DESCRIPTION
If you installed the `android` workload via:

    dotnet workload install android --skip-sign-check \
        --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/net8.0.json \
        --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json \
        --source https://api.nuget.org/v3/index.json

`dotnet new android` & `dotnet build` succeeds.

But `MSBuild.exe` fails with:

    D:\src\dotnet-sdk-8.0.100-preview.6.23318.1-win-x64\packs\Microsoft.Android.Sdk.Windows\34.0.0-preview.6.323\tools\Xamarin.Android.EmbeddedResource.targets(39,5): error XARLP7028: System.IO.FileNotFoundException: Could not load file or assembly 'libZipSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=276db85bc4e20efc' or one of its dependencies. The system cannot find the file specified.
    File name: 'libZipSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=276db85bc4e20efc'
    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments, ICollection`1 proguardConfigFiles)
    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask()
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25
    WRN: Assembly binding logging is turned OFF.
    To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
    Note: There is some performance penalty associated with assembly bind failure logging.
    To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].

It turns out that for references to `libZipSharp.dll`:

* `Microsoft.Android.Build.BaseTasks.dll` references 2.1.0.0
* `Xamarin.Android.Build.Tasks.dll` references 3.0.0.0

However, this appears to already be solved in the 34.0.0-preview.6.355 version of the `android` workload. It is broken in `34.0.0-preview.6.323`.

In that time window, we updated `$(LibZipSharpVersion)` in xamarin/xamarin-android, but not yet bumped to the latest xamarin/xamarin-android-tools:

https://github.com/xamarin/xamarin-android/commit/f1d59181c8daaa8d2abcdfd151b592ece49155ca

To solve this issue, we can use the extension points we added to:

https://github.com/xamarin/xamarin-android-tools/commit/34e98e2b65917d105169f868b5648f67e68b6784

And import xamarin-android's `Directory.Build.props` from `xamarin-android-tools.override.props`. With this change in place, I can set the value of `$(LibZipSharpVersion)` to any value and the value from xamarin-android overrides it.

This probably slipped through because we dropped the "classic" Xamarin.Android test suite that used .NET framework MSBuild on Windows. All tests now use `dotnet build`, so we need to add something to test `MSBuild.exe`?