### PR TITLE
$(AndroidPackVersionSuffix)=preview.7; net8 is 34.0.0-preview.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview6

We branched for .NET 8 preview 6 from dab495ff into `release/8.0.1xx-preview6`.

Update xamarin-android/main's version number to 34.0.0-preview.7 for .NET 8 preview 7.