### PR TITLE
[CI] Use dotnet-test-slicer in nightly tests

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -170,155 +170,44 @@ stages:
   - group: Xamarin-Secrets
   - group: xamops-azdev-secrets
   jobs:
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: TimeZoneInfoTests1
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode1 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode1"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode1-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode2 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode2"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode2-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode3 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode3"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode3-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
+  - job: mac_timezoneinfo_tests
+    displayName: TimeZoneInfoTests Emulator Tests
+    strategy:
+      parallel: 4
+    pool:
+      vmImage: $(HostedMacImage)
+    timeoutInMinutes: 120
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        installTestSlicer: true
+        installLegacyDotNet: false
+        restoreNUnitConsole: false
+        updateMono: false
+        xaprepareScenario: EmulatorTestDependencies
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: TimeZoneInfoTests2
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode4 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode4"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode4-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode5 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode5"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode5-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode6 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode6"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode6-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: TimeZoneInfoTests3
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode7 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode7"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode7-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode8 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode8"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode8-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode9 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode9"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode9-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/start-stop-emulator.yaml
+      parameters:
+        emulatorMSBuildArgs: -p:TestAvdShowWindow=true
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: TimeZoneInfoTests4
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode10 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode10"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode10-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode11 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode11"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode11-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode12 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode12"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode12-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/run-sliced-nunit-tests.yaml
+      parameters:
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+        testFilter: method == CheckTimeZoneInfoIsCorrectWithSlicer
+        testRunTitle: CheckTimeZoneInfoIsCorrectNode On Device - macOS
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: TimeZoneInfoTests5
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode13 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode13"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode13-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode14 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode14"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode14-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckTimeZoneInfoIsCorrectNode15 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckTimeZoneInfoIsCorrectNode15"
-          testResultsFile: TestResult-CheckTimeZoneInfoIsCorrectNode15-$(XA.Build.Configuration).xml
-          timeoutInMinutes: 75
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        artifactName: Test Results - TimeZoneInfoTests With Emulator - macOS-$(System.JobPositionInPhase)
+
+    - template: yaml-templates/fail-on-issue.yaml
 
 
 # Localization test jobs
@@ -329,137 +218,41 @@ stages:
   - group: Xamarin-Secrets
   - group: xamops-azdev-secrets
   jobs:
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: LocalizationTests1
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode1 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode1"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode1-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode2 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode2"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode2-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode3 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode3"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode3-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
+  - job: mac_localization_tests
+    displayName: Localization Emulator Tests
+    strategy:
+      parallel: 10
+    pool:
+      vmImage: $(HostedMacImage)
+    timeoutInMinutes: 150
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        installTestSlicer: true
+        installLegacyDotNet: false
+        restoreNUnitConsole: false
+        updateMono: false
+        xaprepareScenario: EmulatorTestDependencies
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: LocalizationTests2
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode4 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode4"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode4-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode5 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode5"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode5-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode6 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode6"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode6-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: LocalizationTests3
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode7 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode7"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode7-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode8 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode8"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode8-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode9 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode9"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode9-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/start-stop-emulator.yaml
+      parameters:
+        emulatorMSBuildArgs: -p:TestAvdShowWindow=true
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: LocalizationTests4
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode10 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode10"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode10-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode11 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode11"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode11-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode12 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode12"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode12-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/run-sliced-nunit-tests.yaml
+      parameters:
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
+        testFilter: method == CheckLocalizationIsCorrectWithSlicer
+        testRunTitle: CheckTimeZoneInfoIsCorrect On Device - macOS
 
-  - template: yaml-templates/run-emulator-tests.yaml
-    parameters:
-      jobName: LocalizationTests5
-      emulatorMSBuildArgs: -p:TestAvdShowWindow=true
-      testSteps:
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode13 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode13"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode13-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode14 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode14"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode14-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
-      - template: run-nunit-tests.yaml
-        parameters:
-          testRunTitle: CheckLocalizationIsCorrectNode15 On Device - macOS
-          testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
-          dotNetTestExtraArgs: --filter "Name=CheckLocalizationIsCorrectNode15"
-          testResultsFile: TestResult-CheckLocalizationIsCorrectNode15-$(XA.Build.Configuration).xml
-          retryCountOnTaskFailure: 2
+    - template: yaml-templates/upload-results.yaml
+      parameters:
+        artifactName: Test Results - Localization With Emulator - macOS-$(System.JobPositionInPhase)
+
+    - template: yaml-templates/fail-on-issue.yaml

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", "BuildTests"));
 			CommonSampleLibraryRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", CommonSampleLibraryName));
-			TestOutputDir = Path.Combine (SetUp.TestDirectoryRoot, "temp", "CodeBehind");
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "CodeBehind");
 			if (Builder.UseDotNet) {
 				ProjectName += ".NET";
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EmbeddedDSOTests.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Build.Tests
 		static EmbeddedDSOTests ()
 		{
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "EmbeddedDSOs", "EmbeddedDSO"));
-			TestOutputDir = Path.Combine (SetUp.TestDirectoryRoot, "temp", "EmbeddedDSO");
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "EmbeddedDSO");
 
 			produced_binaries = new List <string> {
 				$"{ProjectAssemblyName}.dll",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[OneTimeTearDown]
-		public void DeviceTearDown ()
+		protected virtual void DeviceTearDown ()
 		{
 			if (IsDeviceAttached ()) {
 				// make sure we are not on a guest user anymore.
@@ -199,9 +199,14 @@ namespace Xamarin.Android.Build.Tests
 				builder.BuildLogFile = logName;
 				Assert.True (builder.RunTarget (proj, "_Run", doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters), "Project should have run.");
 			} else {
-				var result = AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
-				Assert.IsTrue (result.Contains ("Starting: Intent { cmp="), $"Attempt to start activity failed with:\n{result}");
+				StartActivityAndAssert (proj);
 			}
+		}
+
+		protected static void StartActivityAndAssert (XamarinAndroidApplicationProject proj)
+		{
+			var result = AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+			Assert.IsTrue (result.Contains ("Starting: Intent { cmp="), $"Attempt to start activity failed with:\n{result}");
 		}
 
 		protected TimeSpan ProfileFor (Func<bool> func, TimeSpan? timeout = null)


### PR DESCRIPTION
Updates the `TimeZoneInfo` and `Localization` test stages to use the
`dotnet-test-slicer` tool used by other MSBuild test runs.

These test jobs have a pretty high frequency of failing and timing out,
and a few changes have been made to try to reduce the points of failure.

SetUp and TearDown functions have been trimmed down and made standard
across the two fixtures.  OneTimeSetup will prepare the device and
install the project, and we will only attempt to attach log files during
TearDown.

The tests will launch the app activity directly with ADB, rather than
using `dotnet build -t:Run` for every iteration.  The tests will attempt
to reinstall the app if it is not present as a fallback.