### PR TITLE
[Xamarin.Android.Build.Tasks] Move MonoAndroidAssetsDirIntermediate

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -363,6 +363,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidPackagingOptionsExclude Include="$([MSBuild]::Escape('*.kotlin_*'))" />
 </ItemGroup>
 
+<!-- Assets build properties -->
+<PropertyGroup>
+	<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+	<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
+</PropertyGroup>
+
 <!--
 *******************************************
           Imports
@@ -439,7 +445,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Outputs="$(MonoAndroidAssetsDirIntermediate)xa-internal/xa-mam-mapping.xml">
   <MakeDir
       Condition=" '@(_AndroidMamMappingFile->Count())' != '0' "
-      Directories="$(MonoAndroidAssetsDirIntermediate)/xa-internal"
+      Directories="$(MonoAndroidAssetsDirIntermediate)xa-internal"
   />
   <MamJsonToXml
       MappingFiles="@(_AndroidMamMappingFile)"
@@ -464,7 +470,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Outputs="$(_XARemapMembersFilePath)">
   <MakeDir
       Condition=" '@(_AndroidRemapMembers->Count())' != '0' "
-      Directories="$(MonoAndroidAssetsDirIntermediate)/xa-internal"
+      Directories="$(MonoAndroidAssetsDirIntermediate)xa-internal"
   />
   <MergeRemapXml
       InputRemapXmlFiles="@(_AndroidRemapMembers)"
@@ -879,12 +885,6 @@ because xbuild doesn't support framework reference assemblies.
 		JavaSdkPath="$(_JavaSdkDirectory)"
 	/>
 </Target>
-
-<!-- Assets build properties -->
-<PropertyGroup>
-	<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
-	<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
-</PropertyGroup>
 
 <!-- Assets Build -->
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8095

Context: f99fc814b0dcc021a441e70bb5a487b2034f6760

Initialize `$(MonoAndroidAssetsDirIntermediate)` earlier in `Xamarin.Android.Common.targets`, so that the existing `$(_XARemapMembersFilePath)` property (f99fc814) is able to correctly use it.