### PR TITLE
[xaprepare] update Debian dependencies for current unstable (trixie)

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -16,6 +16,14 @@ namespace Xamarin.Android.Prepare
 			new DebianLinuxProgram ("openjdk-8-jdk"),
 		};
 
+		static readonly List<DebianLinuxProgram> packagesPreTrixie = new List<DebianLinuxProgram> {
+			new DebianLinuxProgram ("libncurses5-dev"),
+		};
+
+		static readonly List<DebianLinuxProgram> packagesTrixieAndLater = new List<DebianLinuxProgram> {
+			new DebianLinuxProgram ("libncurses-dev"),
+		};
+
 		// zulu-8 does NOT exist as official Debian package! We need it for our bots, but we have to figure out what to
 		// do with Debian 10+ in general, as it does not contain OpenJDK 8 anymore and we require it to work.
 		static readonly List<DebianLinuxProgram> packages10AndNewerBuildBots = new List<DebianLinuxProgram> {
@@ -45,8 +53,26 @@ namespace Xamarin.Android.Prepare
 			if (DebianRelease.Major >= 10 || (IsTesting && String.Compare ("buster", CodeName, StringComparison.OrdinalIgnoreCase) == 0)) {
 				if (Context.IsRunningOnHostedAzureAgent)
 					Dependencies.AddRange (packages10AndNewerBuildBots);
-			} else
+				if (DebianRelease.Major >= 13) {
+					Dependencies.AddRange (packagesTrixieAndLater);
+				} else {
+					Dependencies.AddRange (packagesPreTrixie);
+				}
+			} else {
 				Dependencies.AddRange (packagesPre10);
+				Dependencies.AddRange (packagesPreTrixie);
+			}
+		}
+
+		static bool IsDebian13OrNewer (string? version)
+		{
+			if (String.IsNullOrEmpty (version)) {
+				return false;
+			}
+
+			return
+				version.IndexOf ("trixie", StringComparison.OrdinalIgnoreCase) >= 0 ||
+				version.IndexOf ("sid", StringComparison.OrdinalIgnoreCase) >= 0;
 		}
 
 		static bool IsDebian10OrNewer (string? version)

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Android.Prepare
 			new DebianLinuxProgram ("g++-mingw-w64"),
 			new DebianLinuxProgram ("gcc-mingw-w64"),
 			new DebianLinuxProgram ("git"),
-			new DebianLinuxProgram ("libncurses5-dev"),
 			new DebianLinuxProgram ("libtool"),
 			new DebianLinuxProgram ("libz-mingw-w64-dev"),
 			new DebianLinuxProgram ("linux-libc-dev"),


### PR DESCRIPTION
Current Debian/unstable (otherwise known as `sid`), codename `trixie`, made `libncurses5-dev` a 
transitional package and the package replacing it is `libncurses-dev`