### PR TITLE
[Mono.Android] Use PublicApiAnalyzers to ensure we do not break API.

### DIFF
--- a/build-tools/automation/guardian/PoliCheck.Exclusions.xml
+++ b/build-tools/automation/guardian/PoliCheck.Exclusions.xml
@@ -1,9 +1,9 @@
 <PoliCheckExclusions>
+  <!-- Reminder: you are only allowed one exclusion element of each type, to have multiple values you must pipe separate them in a single element -->
   <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
   <Exclusion Type="FolderPathFull">LICENSE-DATA|NREFACTORY|LOCALIZE</Exclusion>
-  <Exclusion Type="FolderPathStart">src\Mono.Android\Profiles</Exclusion>
   <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be skipped -->
-  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <Exclusion Type="FolderPathStart">src\Mono.Android\Profiles|src\Mono.Android\PublicAPI</Exclusion>
   <!-- Each of these file types will be completely skipped for the entire scan -->
   <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
   <!-- The specified file names will be skipped during the scan regardless which folder they are in -->

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -835,7 +835,9 @@ namespace Android.Runtime {
 				JniEnvironment.Arrays.GetDoubleArrayRegion (new JniObjectReference (array), start, length, p);
 		}
 
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 		public static void CopyArray (IntPtr src, Array dest, Type? elementType = null)
+#pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 		{
 			if (dest == null)
 				throw new ArgumentNullException ("dest");

--- a/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
+++ b/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
@@ -6,7 +6,9 @@ namespace Android {
 	[Obsolete ("This attribute is no longer supported.", error: true)]
 	public class IncludeAndroidResourcesFromAttribute : ReferenceFilesAttribute
 	{
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
 		public IncludeAndroidResourcesFromAttribute (string path)
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
 		{
 			ResourceDirectory = path;
 		}

--- a/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
+++ b/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
@@ -6,7 +6,9 @@ namespace Java.Interop {
 	[Obsolete ("This attribute is no longer supported.", error: true)]
 	public class JavaLibraryReferenceAttribute : Android.ReferenceFilesAttribute
 	{
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
 		public JavaLibraryReferenceAttribute (string filename)
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
 		{
 			LibraryFileName = filename;
 		}

--- a/src/Mono.Android/Java.Interop/JavaTypeParametersAttribute.cs
+++ b/src/Mono.Android/Java.Interop/JavaTypeParametersAttribute.cs
@@ -3,7 +3,10 @@ using System;
 #if NET
 using System.Runtime.CompilerServices;
 
+// PublicApiAnalyzers doesn't like TypeForwards
+#pragma warning disable RS0016 // Symbol is not part of the declared API
 [assembly: TypeForwardedTo (typeof (Java.Interop.JavaTypeParametersAttribute))]
+#pragma warning restore RS0016 // Symbol is not part of the declared API
 
 #else   // !NET
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Android</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>0618;0809;0108;0114;0465;8609;8610;8614;8617;8613;8764;8765;8766;8767</NoWarn>
+    <NoWarn>0618;0809;0108;0114;0465;8609;8610;8614;8617;8613;8764;8765;8766;8767;RS0041</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);JAVA_INTEROP</DefineConstants>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\android-$(AndroidPlatformId)\</IntermediateOutputPath>
@@ -27,6 +27,7 @@
   <PropertyGroup>
     <DefineConstants Condition=" '$(AndroidApiLevel)' &gt; '$(AndroidLatestStableApiLevel)' ">$(DefineConstants);ANDROID_UNSTABLE</DefineConstants>
     <OutputPath>$(_MonoAndroidNETDefaultOutDir)</OutputPath>
+    <RunAnalyzers Condition=" '$(DisableApiCompatibilityCheck)' == 'True' ">false</RunAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IncludeAndroidJavadoc)' == 'True' ">
@@ -39,6 +40,11 @@
     <NoWarn>$(NoWarn);CA1422;CA1416</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI\API-$(AndroidApiLevel)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\API-$(AndroidApiLevel)\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
   </PropertyGroup>
@@ -336,6 +342,13 @@
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
     <Compile Include="Xamarin.Android.Net\ServerCertificateCustomValidator.cs" />
     <Compile Include="Xamarin.Android.Net\NegotiateAuthenticationHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mono.Android/Properties/AssemblyInfo.cs.in
+++ b/src/Mono.Android/Properties/AssemblyInfo.cs.in
@@ -7,6 +7,7 @@
 // Copyright 2014 Xamarin, Inc.
 // Copyright 2016 Microsoft Corporation.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
@@ -26,6 +27,8 @@ using System.Runtime.Versioning;
 [assembly: SupportedOSPlatform("Android@MIN_API_LEVEL@.0")]
 #endif
 
+// PublicApiAnalyzers doesn't like TypeForwards
+#pragma warning disable RS0016 // Symbol is not part of the declared API
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.Color))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.ColorConverter))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.KnownColor))]
@@ -36,9 +39,13 @@ using System.Runtime.Versioning;
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.Size))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.SizeF))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Drawing.SystemColors))]
+#pragma warning restore RS0016 // Symbol is not part of the declared API
+
 [assembly: InternalsVisibleTo("Mono.Android.Export, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
 [assembly: InternalsVisibleTo("Mono.Android-Tests, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
 [assembly: InternalsVisibleTo("Java.Interop-Tests, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
 [assembly: InternalsVisibleTo("Mono.Android-TestsMultiDex, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
 [assembly: InternalsVisibleTo("Mono.Android-TestsAppBundle, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
 [assembly: InternalsVisibleTo("Mono.Android.NET-Tests, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]
+
+[assembly: SuppressMessage ("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "Analyzer fails due to extended characters.", Scope = "member", Target = "~F:Android.Util.Patterns.GoodIriChar")]

--- a/src/Mono.Android/PublicAPI/API-34/PublicAPI.Shipped.txt
+++ b/src/Mono.Android/PublicAPI/API-34/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable


### PR DESCRIPTION
Fixes #7421

Enable Microsoft's [PublicApiAnalyzers](https://github.com/dotnet/roslyn-analyzers/tree/main/src/PublicApiAnalyzers) for `Mono.Android.dll`.

We currently have `ApiCompat`, which ensures that we do not break backwards compatibility between Android API levels, but now that we are in the .NET `TargetFramework` world we also need to ensure we do not *add* any new API to a TF once it has shipped.  A `TargetFramework` is essentially a contract that we cannot change.  (Imagine if you had different minor versions of .NET on your local machine and CI machine, what works on one should work on the other.)

Running the `PublicApiAnalyzer` adds about 25 seconds to a local build.  One can use our existing `$(DisableApiCompatibilityCheck)` property we have to also disable them to facilitate faster local build if desired.

Additionally, disable [`RS0041`](https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md#rs0041-public-members-should-not-use-oblivious-types) ("Public members should not use oblivious types").  We should look at getting `Android.Runtime.JniEnv.g.cs` properly annotated with NRT and then we could enable this analyzer.