### PR TITLE
[ci] Include build components in SBOM

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -497,31 +497,23 @@ stages:
         artifactName: vsdrop-multitarget-signed
         downloadPath: $(Build.StagingDirectory)\packages
 
-    - powershell: |
-        $filesToExtract = Get-ChildItem -Path $(Build.StagingDirectory)\packages\* -Include "*.zip", "*.nupkg" -Exclude "*.Msi.*.nupkg" -Recurse
-        if ($filesToExtract.Count -eq 0) {
-            Write-Error "Did not find any files to extract in '(Build.StagingDirectory)\packages\'."
-            exit -1
-        }
-        Write-Host "Extracting $($filesToExtract.Count) file(s)..."
-        foreach ($archive in $filesToExtract) {
-            $dest = Join-Path $(Build.StagingDirectory)\packages $archive.BaseName
-            if (Test-Path $dest) {
-                Write-Error "    Unable to extract duplicate file: $($archive.FullName)"
-                exit -1
-            }
-            Write-Host "    $($archive.FullName) => $($dest)"
-            Copy-Item $archive.FullName "$($archive.FullName).zip"
-            Expand-Archive "$($archive.FullName).zip" -DestinationPath $dest
-            Remove-Item "$($archive.FullName).zip"
-        }
-      displayName: Extract NUPKG and ZIP files to $(Build.StagingDirectory)\components
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: sbom-components-macos
+        downloadPath: $(Build.StagingDirectory)\components\macos
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: sbom-components-linux
+        downloadPath: $(Build.StagingDirectory)\components\linux
 
     - template: compliance/sbom/scan.v1.yml@yaml-templates
       parameters:
         dropDirectory: $(Build.StagingDirectory)\packages
-        componentsDirectory: $(Build.SourcesDirectory)
+        componentsDirectory: $(Build.StagingDirectory)\components
         packageName: .NET Android
+        packageFilter: '*.nupkg;*.msi'
+        packageVersionRegex: '(?i)^Microsoft.*\.(?<version>\d+\.\d+\.\d+(-.*)?\.\d+).nupkg$'
 
 # Check - "Xamarin.Android (Compliance)"
 - template: security/full/v0.yml@yaml-templates

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -465,6 +465,7 @@ stages:
       clean: all
     steps:
     - checkout: self
+      submodules: recursive
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -504,7 +505,7 @@ stages:
         }
         Write-Host "Extracting $($filesToExtract.Count) file(s)..."
         foreach ($archive in $filesToExtract) {
-            $dest = Join-Path $(Build.StagingDirectory)\components $archive.BaseName
+            $dest = Join-Path $(Build.StagingDirectory)\packages $archive.BaseName
             if (Test-Path $dest) {
                 Write-Error "    Unable to extract duplicate file: $($archive.FullName)"
                 exit -1
@@ -519,7 +520,7 @@ stages:
     - template: compliance/sbom/scan.v1.yml@yaml-templates
       parameters:
         dropDirectory: $(Build.StagingDirectory)\packages
-        componentsDirectory: $(Build.StagingDirectory)\components
+        componentsDirectory: $(Build.SourcesDirectory)
         packageName: .NET Android
 
 # Check - "Xamarin.Android (Compliance)"

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -482,9 +482,9 @@ stages:
         downloadPath: $(Build.StagingDirectory)\packages\zip
 
     - task: DownloadPipelineArtifact@2
-    inputs:
-      artifactName: vs-msi-nugets
-      downloadPath: $(Build.StagingDirectory)\packages\msi
+      inputs:
+        artifactName: vs-msi-nugets
+        downloadPath: $(Build.StagingDirectory)\packages\msi
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -471,11 +471,13 @@ stages:
       inputs:
         artifactName: nuget-signed
         downloadPath: $(Build.StagingDirectory)\packages
+        patterns: '*.nupkg'
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: nuget-linux-signed
         downloadPath: $(Build.StagingDirectory)\packages
+        patterns: '*.nupkg'
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -486,33 +488,36 @@ stages:
       inputs:
         artifactName: vs-msi-nugets
         downloadPath: $(Build.StagingDirectory)\packages
+        patterns: '*.nupkg'
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vsdrop-signed
         downloadPath: $(Build.StagingDirectory)\packages
+        patterns: '*.msi'
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vsdrop-multitarget-signed
         downloadPath: $(Build.StagingDirectory)\packages
+        patterns: '*.msi'
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: sbom-components-macos
-        downloadPath: $(Build.StagingDirectory)\components\macos
+        downloadPath: $(Build.StagingDirectory)\sbom\components-macos
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: sbom-components-linux
-        downloadPath: $(Build.StagingDirectory)\components\linux
+        downloadPath: $(Build.StagingDirectory)\sbom\components-linux
 
     - template: compliance/sbom/scan.v1.yml@yaml-templates
       parameters:
         dropDirectory: $(Build.StagingDirectory)\packages
-        componentsDirectory: $(Build.StagingDirectory)\components
+        componentsDirectory: $(Build.StagingDirectory)\sbom
+        manifestDirectory: $(Build.StagingDirectory)\sbom
         packageName: .NET Android
-        packageFilter: '*.nupkg;*.msi'
         packageVersionRegex: '(?i)^Microsoft.*\.(?<version>\d+\.\d+\.\d+(-.*)?\.\d+).nupkg$'
 
 # Check - "Xamarin.Android (Compliance)"

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -469,37 +469,37 @@ stages:
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: nuget-signed
-        downloadPath: $(Build.StagingDirectory)\packages\zip
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: nuget-linux-signed
-        downloadPath: $(Build.StagingDirectory)\packages\zip
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(WindowsToolchainPdbArtifactName)
-        downloadPath: $(Build.StagingDirectory)\packages\zip
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vs-msi-nugets
-        downloadPath: $(Build.StagingDirectory)\packages\msi
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vsdrop-signed
-        downloadPath: $(Build.StagingDirectory)\packages\msi
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: vsdrop-multitarget-signed
-        downloadPath: $(Build.StagingDirectory)\packages\msi
+        downloadPath: $(Build.StagingDirectory)\packages
 
     - powershell: |
-        $filesToExtract = Get-ChildItem -Path $(Build.StagingDirectory)\packages\zip\* -Include "*.zip", "*.nupkg" -Recurse
+        $filesToExtract = Get-ChildItem -Path $(Build.StagingDirectory)\packages\* -Include "*.zip", "*.nupkg" -Exclude "*.Msi.*.nupkg" -Recurse
         if ($filesToExtract.Count -eq 0) {
-            Write-Error "Did not find any files to extract in '(Build.StagingDirectory)\packages\zip\'."
+            Write-Error "Did not find any files to extract in '(Build.StagingDirectory)\packages\'."
             exit -1
         }
         Write-Host "Extracting $($filesToExtract.Count) file(s)..."

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -452,12 +452,75 @@ stages:
   - dotnet_prepare_release
   condition: and(eq(variables['MicroBuildSignType'], 'Real'), eq(dependencies.dotnet_prepare_release.result, 'Succeeded'))
   jobs:
-  - template: compliance/sbom/job.v1.yml@yaml-templates
-    parameters:
-      artifactNames: [ nuget-signed, nuget-linux-signed, vs-msi-nugets, vsdrop-signed ]
-      packageName: xamarin-android
-      packageFilter: '*.nupkg;*.msi'
-      GitHub.Token: $(GitHub.Token)
+  - job: sbom
+    displayName: Generate SBOM
+    timeoutInMinutes: 60
+    pool:
+      name: AzurePipelines-EO
+      demands:
+      - ImageOverride -equals AzurePipelinesWindows2022compliant
+    variables:
+      Packaging.EnableSBOMSigning: true
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: nuget-signed
+        downloadPath: $(Build.StagingDirectory)\packages\zip
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: nuget-linux-signed
+        downloadPath: $(Build.StagingDirectory)\packages\zip
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(WindowsToolchainPdbArtifactName)
+        downloadPath: $(Build.StagingDirectory)\packages\zip
+
+      - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vs-msi-nugets
+        downloadPath: $(Build.StagingDirectory)\packages\msi
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vsdrop-signed
+        downloadPath: $(Build.StagingDirectory)\packages\msi
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: vsdrop-multitarget-signed
+        downloadPath: $(Build.StagingDirectory)\packages\msi
+
+    - powershell: |
+        $filesToExtract = Get-ChildItem -Path $(Build.StagingDirectory)\packages\zip\* -Include "*.zip", "*.nupkg" -Recurse
+        if ($filesToExtract.Count -eq 0) {
+            Write-Error "Did not find any files to extract in '(Build.StagingDirectory)\packages\zip\'."
+            exit -1
+        }
+        Write-Host "Extracting $($filesToExtract.Count) file(s)..."
+        foreach ($archive in $filesToExtract) {
+            $dest = Join-Path $(Build.StagingDirectory)\components $archive.BaseName
+            if (Test-Path $dest) {
+                Write-Error "    Unable to extract duplicate file: $($archive.FullName)"
+                exit -1
+            }
+            Write-Host "    $($archive.FullName) => $($dest)"
+            Copy-Item $archive.FullName "$($archive.FullName).zip"
+            Expand-Archive "$($archive.FullName).zip" -DestinationPath $dest
+            Remove-Item "$($archive.FullName).zip"
+        }
+      displayName: Extract NUPKG and ZIP files to $(Build.StagingDirectory)\components
+
+    - template: compliance/sbom/scan.v1.yml@yaml-templates
+      parameters:
+        dropDirectory: $(Build.StagingDirectory)\packages
+        componentsDirectory: $(Build.StagingDirectory)\components
+        packageName: .NET Android
 
 # Check - "Xamarin.Android (Compliance)"
 - template: security/full/v0.yml@yaml-templates

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -481,10 +481,10 @@ stages:
         artifactName: $(WindowsToolchainPdbArtifactName)
         downloadPath: $(Build.StagingDirectory)\packages\zip
 
-      - task: DownloadPipelineArtifact@2
-      inputs:
-        artifactName: vs-msi-nugets
-        downloadPath: $(Build.StagingDirectory)\packages\msi
+    - task: DownloadPipelineArtifact@2
+    inputs:
+      artifactName: vs-msi-nugets
+      downloadPath: $(Build.StagingDirectory)\packages\msi
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -85,6 +85,24 @@ stages:
         artifactName: ${{ parameters.nugetArtifactName }}
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: generate components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        BuildDropPath: ''
+        BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
+        ManifestDirPath: $(Build.StagingDirectory)/sbom-components
+        PackageName: .NET Android
+        PackageVersion: $(Build.BuildId)
+        Verbosity: Verbose
+
+    - task: PublishBuildArtifacts@1
+      displayName: publish components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        artifactName: sbom-components-linux
+        pathToPublish: $(Build.StagingDirectory)/sbom-components
+
     - template: upload-results.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -85,11 +85,17 @@ stages:
         artifactName: ${{ parameters.nugetArtifactName }}
         targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
+    - powershell: |
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/sbom-components")
+      displayName: create SBOM directories
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: generate components SBOM
       condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
       inputs:
-        BuildDropPath: ''
+        BuildDropPath: $(Build.StagingDirectory)/empty
         BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
         ManifestDirPath: $(Build.StagingDirectory)/sbom-components
         PackageName: .NET Android

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -99,7 +99,6 @@ stages:
         BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
         ManifestDirPath: $(Build.StagingDirectory)/sbom-components
         PackageName: .NET Android
-        PackageVersion: $(Build.BuildId)
         Verbosity: Verbose
 
     - task: PublishBuildArtifacts@1

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -51,7 +51,6 @@ stages:
       displayName: create SBOM directories
       condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
-    displayName:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: generate components SBOM
       condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -45,30 +45,6 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - powershell: |
-        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")
-        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/sbom-components")
-      displayName: create SBOM directories
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: generate components SBOM
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-      inputs:
-        BuildDropPath: $(Build.StagingDirectory)/empty
-        BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
-        ManifestDirPath: $(Build.StagingDirectory)/sbom-components
-        PackageName: .NET Android
-        PackageVersion: $(Build.BuildId)
-        Verbosity: Verbose
-
-    - task: PublishBuildArtifacts@1
-      displayName: publish components SBOM
-      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-      inputs:
-        artifactName: sbom-components-macos
-        pathToPublish: $(Build.StagingDirectory)/sbom-components
-
     - template: install-microbuild-tooling.yaml
       parameters:
         condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
@@ -83,6 +59,29 @@ stages:
     - template: remove-microbuild-tooling.yaml
       parameters:
         condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    - powershell: |
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/sbom-components")
+      displayName: create SBOM directories
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: generate components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        BuildDropPath: $(Build.StagingDirectory)/empty
+        BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
+        ManifestDirPath: $(Build.StagingDirectory)/sbom-components
+        PackageName: .NET Android
+        Verbosity: Verbose
+
+    - task: PublishBuildArtifacts@1
+      displayName: publish components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        artifactName: sbom-components-macos
+        pathToPublish: $(Build.StagingDirectory)/sbom-components
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -46,8 +46,8 @@ stages:
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
     - powershell: |
-        [IO.Directory]::CreateDirectory($(Build.StagingDirectory)/empty)
-        [IO.Directory]::CreateDirectory($(Build.StagingDirectory)/sbom-components)
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")
+        [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/sbom-components")
       displayName: create SBOM directories
       condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -45,11 +45,18 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
+    - powershell: |
+        [IO.Directory]::CreateDirectory($(Build.StagingDirectory)/empty)
+        [IO.Directory]::CreateDirectory($(Build.StagingDirectory)/sbom-components)
+      displayName: create SBOM directories
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
+    displayName:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: generate components SBOM
       condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
       inputs:
-        BuildDropPath: ''
+        BuildDropPath: $(Build.StagingDirectory)/empty
         BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
         ManifestDirPath: $(Build.StagingDirectory)/sbom-components
         PackageName: .NET Android

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -45,6 +45,24 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: generate components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        BuildDropPath: ''
+        BuildComponentPath: $(System.DefaultWorkingDirectory)/xamarin-android
+        ManifestDirPath: $(Build.StagingDirectory)/sbom-components
+        PackageName: .NET Android
+        PackageVersion: $(Build.BuildId)
+        Verbosity: Verbose
+
+    - task: PublishBuildArtifacts@1
+      displayName: publish components SBOM
+      condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+      inputs:
+        artifactName: sbom-components-macos
+        pathToPublish: $(Build.StagingDirectory)/sbom-components
+
     - template: install-microbuild-tooling.yaml
       parameters:
         condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/263

Updates the main SBOM file we produce to include build component info
from both the macOS and Linux builds.  These two builds will now produce
build component SBOMs which are downloaded and referenced in our main
SBOM afer all building and signing is complete.