### PR TITLE
[vs-workload] Set EnableSideBySideManifests=true

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/dev/pjc/sxs-wl-versions
+    ref: refs/heads/main
     endpoint: xamarin
   - repository: sdk-insertions
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml-templates
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/pjc/sxs-wl-versions
     endpoint: xamarin
   - repository: sdk-insertions
     type: github

--- a/build-tools/create-packs/vs-workload.in.props
+++ b/build-tools/create-packs/vs-workload.in.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetName>Microsoft.NET.Sdk.Android.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@WORKLOAD_VERSION@</ManifestBuildVersion>
+    <EnableSideBySideManifests>true</EnableSideBySideManifests>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/274

Enables side by side workload manifest support when generating workload MSIs.

This should only be enabled for builds shipping with .NET 8 Preview 7 or later.