### PR TITLE
[AndroidDependenciesTests] Use platform-tools 34.0.4

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Build.Tests
 				var proj = new XamarinAndroidApplicationProject {
 					TargetSdkVersion = apiLevel.ToString (),
 				};
-				const string ExpectedPlatformToolsVersion = "34.0.3";
+				const string ExpectedPlatformToolsVersion = "34.0.4";
 				using (var b = CreateApkBuilder ()) {
 					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;


### PR DESCRIPTION
The `InstallAndroidDependenciesTest` test has been failing:

    _AndroidSdkDirectory not set to new SDK path /Users/runner/work/1/a/TestRelease/07-11_21.59.53/temp/InstallAndroidDependenciesTest/android-sdk, probably because Google's repository has a newer platform-tools package!  repository2-3.xml contains platform-tools <major>34</major>.<minor>0</minor>.<micro>4</micro>; expected 34.0.3!

Fix this by bumping the platform-tools version that we try to install during this test to 34.0.4.