### PR TITLE
[ci] Add variable to request all build logs be published to build artifacts.

### DIFF
--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -3,7 +3,7 @@ parameters:
   configuration: $(XA.Build.Configuration)
   artifactName: results
   includeBuildResults: false
-  condition: ne(variables['Agent.JobStatus'], 'Succeeded')
+  condition: or(ne(variables['Agent.JobStatus'], 'Succeeded'), eq(variables['XA.PublishAllLogs'], 'true'))
 
 steps:
 - template: run-xaprepare.yaml


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8157/commits/f59a3c2e3c1dad24ac9f42696553ced23d992a96

By default, we only store the CI build logs of jobs that fail.  However there are times when we would like to see the build logs for successful jobs.

This adds the ability to specify that a CI run should publish *all* of its build logs.

When running a job from the UI, set the `XA.PublishAllLogs` variable to `true`:

![image](https://github.com/xamarin/xamarin-android/assets/179295/928069b9-edca-449f-97cb-899f254df102)

Test CI run:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8067357&view=results