### PR TITLE
[Xamarin.Android.Build.Tasks] fix `.aar` files flowing from project references

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -103,6 +103,7 @@ This item group populates the Build Action drop-down in IDEs.
       <AndroidJavaLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
       <EmbeddedJar        Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
       <!-- .aar files should be copied to $(OutputPath) in .NET 6-->
+      <None Include="@(AndroidAarLibrary)" TfmSpecificPackageFile="%(AndroidAarLibrary.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
       <None Include="@(LibraryProjectZip)" TfmSpecificPackageFile="%(LibraryProjectZip.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
     </ItemGroup>
     <!-- Legacy binding projects -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -132,6 +132,10 @@ namespace Xamarin.Android.Build.Tests
 					new AndroidItem.AndroidLibrary ("sub\\directory\\bar.aar") {
 						WebContent = "https://repo1.maven.org/maven2/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar",
 					},
+					new AndroidItem.AndroidLibrary ("sub\\directory\\baz.aar") {
+						WebContent = "https://repo1.maven.org/maven2/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar",
+						MetadataValues = "Bind=false",
+					},
 					new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
 						Encoding = Encoding.ASCII,
 						TextContent = () => ResourceData.JavaSourceTestExtension,
@@ -149,6 +153,10 @@ namespace Xamarin.Android.Build.Tests
 			});
 			libB.OtherBuildItems.Add (new AndroidItem.AndroidLibrary ("sub\\directory\\arm64-v8a\\libfoo.so") {
 				BinaryContent = () => Array.Empty<byte> (),
+			});
+			libB.OtherBuildItems.Add (new AndroidItem.AndroidLibrary (default (Func<string>)) {
+				Update = () => "sub\\directory\\baz.aar",
+				MetadataValues = "Bind=false",
 			});
 			libB.OtherBuildItems.Add (new AndroidItem.AndroidNativeLibrary (default (Func<string>)) {
 				Update = () => "libfoo.so",
@@ -172,6 +180,7 @@ namespace Xamarin.Android.Build.Tests
 			aarPath = Path.Combine (libBOutputPath, $"{libB.ProjectName}.aar");
 			FileAssert.Exists (aarPath);
 			FileAssert.Exists (Path.Combine (libBOutputPath, "bar.aar"));
+			FileAssert.Exists (Path.Combine (libBOutputPath, "baz.aar"));
 			using (var aar = ZipHelper.OpenZip (aarPath)) {
 				aar.AssertContainsEntry (aarPath, "assets/foo/foo.txt");
 				aar.AssertContainsEntry (aarPath, "res/layout/mylayout.xml");
@@ -234,6 +243,10 @@ namespace Xamarin.Android.Build.Tests
 			string className = "Lcom/xamarin/android/test/msbuildtest/JavaSourceJarTest;";
 			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 			className = "Lcom/xamarin/android/test/msbuildtest/JavaSourceTestExtension;";
+			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
+			className = "Lcom/balysv/material/drawable/menu/MaterialMenu;"; // from material-menu-1.1.0.aar
+			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
+			className = "Lcom/soundcloud/android/crop/Crop;"; // from android-crop-1.0.1.aar
 			Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 
 			// Check environment variable


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8190

In a customer sample, they have an `.aar` file they need the Java code from, but do not want a C# binding for it:

    <AndroidLibrary Update="FooNonBinding-release.aar" Bind="false" />

`Bind="false"` looks to have the side effect where:

1. It does not get copied to the output directory.

2. The Java types don't make it to the final app.

3. Crash at runtime:
```
java.lang.ClassNotFoundException: Didn't find class "com.example.foononbinding.FooSample" on path
```
A workaround is to add a line such as:

    <None Include="FooNonBinding-release.aar" CopyToOutputDirectory="PreserveNewest" />

I could reproduce this issue by updating our existing `DotNetBuildLibrary` test. I could assert the file exists in the output directory, as well as actually using `dexdump` to verify Java classes make it to the app. They did not!

The solution here being that we are missing a line such as:

```diff
<!-- .aar files should be copied to $(OutputPath) in .NET 6-->
++<None Include="@(AndroidAarLibrary)" TfmSpecificPackageFile="%(AndroidAarLibrary.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
<None Include="@(LibraryProjectZip)" TfmSpecificPackageFile="%(LibraryProjectZip.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
```

Now the `DotNetBuildLibrary` test passes.