### PR TITLE
[Xamarin.Android.Build.Tasks] Unable to use import androidx.appcompat.widget.Toolbar into a java file when using AndroidJavaSource

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -187,6 +187,7 @@ properties that determine build ordering.
     </_ResolveLibraryProjectsDependsOn>
     <_CompileBindingJavaDependsOnTargets>
       _AdjustJavacVersionArguments;
+      _GetLibraryImports;
       _DetermineBindingJavaLibrariesToCompile;
       _GetJavaPlatformJar;
     </_CompileBindingJavaDependsOnTargets>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1555,6 +1555,35 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void BuildApplicationWithJavaSourceUsingAndroidX ([Values(true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new BuildItem (AndroidBuildActions.AndroidJavaSource, "ToolbarEx.java") {
+						TextContent = () => @"package com.unnamedproject.unnamedproject;
+import android.content.Context;
+import androidx.appcompat.widget.Toolbar;
+public class ToolbarEx {
+	public static Toolbar GetToolbar (Context context) {
+		return new Toolbar (context);
+	}
+}
+",
+						Encoding = Encoding.ASCII
+					},
+				}
+			};
+			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded");
+
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
Fixes #8191

The implementation of `AndroidJavaSource` was missing one component. It was missing references to the `classes.jar` files which are extracted to the `$(IntemediateOutputPath)lp` directory. As a result we end up with 
errors such as the following

```
Error	JAVAC0000	 error: package androidx.appcompat.widget does not exist
```

What was missing was a dependency on the `_GetLibraryImports` target. This target will call the chain of 
targets which extracts the dependent `classes.jar` files and populates the `@(Jars)` ItemGroup which is used in the `_CompileBindingJava` target. This should allow users to write simple wrapper methods in Java that wrap more 
complex API. 