### PR TITLE
[Xamarin.Android.Build.Tasks] fix duplicate `.aar` files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -103,8 +103,9 @@ This item group populates the Build Action drop-down in IDEs.
       <AndroidJavaLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
       <EmbeddedJar        Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
       <!-- .aar files should be copied to $(OutputPath) in .NET 6-->
-      <None Include="@(AndroidAarLibrary)" TfmSpecificPackageFile="%(AndroidAarLibrary.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
-      <None Include="@(LibraryProjectZip)" TfmSpecificPackageFile="%(LibraryProjectZip.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
+      <None Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' " TfmSpecificPackageFile="%(AndroidLibrary.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
+      <!-- @(LibraryProjectZip) items that are not in @(AndroidLibrary) -->
+      <None Include="@(LibraryProjectZip)" Exclude="@(AndroidLibrary)" TfmSpecificPackageFile="%(LibraryProjectZip.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
     </ItemGroup>
     <!-- Legacy binding projects -->
     <ItemGroup Condition=" '$(_AndroidIsBindingProject)' == 'true' and '$(UsingAndroidNETSdk)' != 'true' ">


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/16024#issuecomment-1640461682

.NET MAUI's build currently fails with:

    Xamarin.Android.Aapt2.targets(123,3): error APT2144: invalid file path 'D:\a\_work\1\s\src\Core\src\obj\Debug\net8.0-android\lp\129.stamp'.

What is very wrong about this, it is trying to `aapt2 compile` a `*.stamp` file:

    Executing compile -o /Users/builder/azdo/_work/1/s/src/Core/src/obj/Release/net8.0-android/lp/87/jl/res/../flat/ /Users/builder/azdo/_work/1/s/src/Core/src/obj/Release/net8.0-android/lp/87.stamp

Normally this runs against `*.flat` or `*.flata` files.

This problem was introduced in 26ffd5d7:

1. Library A uses an AndroidX package, the AndroidX `.aar` file is added to `@(AndroidAarLibrary)`. The NuGet package does this in a `.targets` file.

2. With the change in 26ffd5d7, the `.aar` is copied to Library A's build output.

3. Library B uses the same AndroidX package and references Library A.

4. Library B now has duplicate `.aar` files & has the weird build error!

I could reproduce the issue in a test.

There *may* be a second bug here, but we should update our logic to be:

    <!-- .aar files should be copied to $(OutputPath) in .NET 6-->
    <None Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' " ... />
    <!-- @(LibraryProjectZip) items that are not in @(AndroidLibrary) -->
    <None Include="@(LibraryProjectZip)" Exclude="@(AndroidLibrary)" ... />

So we now only copy:

* The new `@(AndroidLibrary)` item group with an `.aar` extension. *Not* `@(AndroidAarLibrary)`.

* Any `@(LibraryProjectZip)` that are *not* in `@(AndroidLibrary)`. This supports the classic item group name, keeping our behavior before.

Now the new test and the test updated in 26ffd5d7 both pass.