### PR TITLE
[ci] Add MAUI integration job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -366,7 +366,7 @@ stages:
       retryCountOnTaskFailure: 3
       inputs:
         projects: $(Build.SourcesDirectory)/xamarin-android/Xamarin.Android.sln
-        arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
+        arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -p:MauiWorkloadToInstall=maui -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
 
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -365,8 +365,8 @@ stages:
       displayName: Install MAUI workload packs
       retryCountOnTaskFailure: 3
       inputs:
-        projects: $(Build.SourcesDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
-        arguments: -t:ExtractMauiWorkloadPacks -c $(XA.Build.Configuration) -v:n -bl:$(Build.StagingDirectory)/logs/extract-workloads.binlog
+        projects: $(Build.SourcesDirectory)/xamarin-android/Xamarin.Android.sln
+        arguments: -t:InstallMaui -p:MauiUseLocalPacks=true -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/install-maui.binlog
 
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -30,6 +30,11 @@ resources:
     name: xamarin/release-scripts
     ref: refs/heads/sign-and-notarized
     endpoint: xamarin
+  - repository: maui
+    type: github
+    name: dotnet/maui
+    ref: refs/heads/net8.0
+    endpoint: xamarin
 
 parameters:
 - name: provisionatorChannel
@@ -277,12 +282,138 @@ stages:
         artifactName: Test Results - MSBuild Smoke - Linux
 
     - template: yaml-templates/fail-on-issue.yaml
-      
+
 - template: yaml-templates/stage-msbuild-tests.yaml
-      
+
 - template: yaml-templates/stage-msbuild-emulator-tests.yaml
   parameters:
     usesCleanImages: ${{ parameters.macTestAgentsUseCleanImages }}
+
+- stage: maui_tests
+  displayName: MAUI Tests
+  dependsOn: mac_build
+  condition: eq(variables['System.PullRequest.TargetBranch'], 'main')
+  jobs:
+  # Check - "Xamarin.Android (MAUI Tests MAUI Integration)"
+  - job: maui_tests_integration
+    displayName: MAUI Integration
+    pool: $(1ESWindowsPool)
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    variables:
+      BuildVersion: $(Build.BuildId)
+    steps:
+    - checkout: maui
+      clean: true
+      submodules: recursive
+      path: s/maui
+      persistCredentials: true
+
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+        provisionClassic: false
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
+        installLegacyDotNet: false
+        restoreNUnitConsole: false
+        updateMono: false
+        androidSdkPlatforms: 23,24,25,26,27,28,29,30,31,32,$(DefaultTestSdkPlatforms)
+
+    - task: NuGetAuthenticate@0
+      displayName: authenticate with azure artifacts
+      inputs:
+        forceReinstallCredentialProvider: true
+
+    - script: |
+        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_11_X64%
+        echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_11_X64%
+      displayName: set JI_JAVA_HOME, JAVA_HOME
+
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifactName: $(NuGetArtifactName)
+        downloadPath: $(Build.StagingDirectory)/android-packs
+
+    - pwsh: |
+        $searchPath = Join-Path $(Build.StagingDirectory) android-packs
+        $wlmanPack = Get-ChildItem $searchPath -Filter *Android*Manifest*.nupkg | Select-Object -First 1
+        $dest = Join-Path $searchPath "tmp-wlman" "$($wlmanPack.BaseName)"
+        Expand-Archive -LiteralPath $wlmanPack -DestinationPath $dest
+        $wlmanJsonPath = Join-Path $dest "data" "WorkloadManifest.json"
+        $json = Get-Content $wlmanJsonPath | ConvertFrom-Json -AsHashtable
+        Write-Host "Setting variable ANDROID_PACK_VERSION = $($json["version"])"
+        Write-Host "##vso[task.setvariable variable=ANDROID_PACK_VERSION;]$($json["version"])"
+      displayName: Set ANDROID_PACK_VERSION
+
+    - pwsh: >-
+        $(Build.SourcesDirectory)/maui/eng/scripts/update-version-props.ps1
+        -xmlFileName "$(Build.SourcesDirectory)/maui/eng/Versions.props"
+        -androidVersion $(ANDROID_PACK_VERSION)
+      displayName: Update MAUI's Android dependency
+
+    - pwsh: ./build.ps1 --target=dotnet --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
+      displayName: Install .NET
+      retryCountOnTaskFailure: 3
+      workingDirectory: $(Build.SourcesDirectory)/maui
+
+    - pwsh: ./build.ps1 --target=dotnet-pack --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
+      displayName: Pack .NET Maui
+      workingDirectory: $(Build.SourcesDirectory)/maui
+
+    - task: DotNetCoreCLI@2
+      displayName: Install MAUI workload packs
+      retryCountOnTaskFailure: 3
+      inputs:
+        projects: $(Build.SourcesDirectory)/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj
+        arguments: -t:ExtractMauiWorkloadPacks -c $(XA.Build.Configuration) -v:n -bl:$(Build.StagingDirectory)/logs/extract-workloads.binlog
+
+    - template: yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        command: new
+        arguments: maui -o $(Build.StagingDirectory)/MauiTestProj
+        xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+        displayName: Create MAUI template
+        continueOnError: false
+
+    - template: yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+        arguments: >-
+          -f $(DotNetTargetFramework)-android -c Debug
+          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Debug.binlog
+        xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+        displayName: Build MAUI template - Debug
+
+    - template: yaml-templates/run-dotnet-preview.yaml
+      parameters:
+        project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+        arguments: >-
+          -f $(DotNetTargetFramework)-android -c Release
+          --configfile $(Build.SourcesDirectory)/maui/NuGet.config
+          -bl:$(Build.StagingDirectory)/logs/MauiTestProj-Release.binlog
+        xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
+        displayName: Build MAUI template - Release
+
+    - task: CopyFiles@2
+      displayName: copy build logs
+      condition: always()
+      inputs:
+        Contents: |
+          $(Build.SourcesDirectory)/maui/artifacts/logs/**
+        TargetFolder: $(Build.StagingDirectory)/logs
+        flattenFolders: true
+
+    - template: yaml-templates/publish-artifact.yaml
+      parameters:
+        displayName: upload build and test results
+        artifactName: Test Results - MAUI Integration
+        targetPath: $(Build.StagingDirectory)/logs
+        condition: or(ne(variables['Agent.JobStatus'], 'Succeeded'), eq(variables['XA.PublishAllLogs'], 'true'))
+
+    - template: yaml-templates/fail-on-issue.yaml
+
 
 - stage: dotnet_prepare_release
   displayName: Prepare .NET Release

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -165,49 +165,6 @@
     <RemoveDir Directories="@(_PackFoldersToDelete)" />
   </Target>
 
-  <Target Name="ExtractMauiWorkloadPacks" >
-    <PropertyGroup>
-      <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(XamarinAndroidSourcePath)..\maui</MauiSourcePath>
-      <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
-      <_SdkManifestsFolder>$(DotNetPreviewPath)sdk-manifests\$(DotNetSdkManifestsFolder)\</_SdkManifestsFolder>
-    </PropertyGroup>
-    <ItemGroup>
-      <_WLManifest Include="$(MauiPackagePath)/Microsoft.NET.Sdk.Maui.Manifest-$(DotNetSdkManifestsFolder.Substring (0,3))*.nupkg" />
-    </ItemGroup>
-    <Unzip
-        SourceFiles="@(_WLManifest)"
-        DestinationFolder="$(_SdkManifestsFolder)temp"
-    />
-    <ItemGroup>
-      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\LICENSE.TXT" />
-      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\data\*" />
-    </ItemGroup>
-    <Move SourceFiles="@(_WLExtractedFiles)" DestinationFolder="$(_SdkManifestsFolder)microsoft.net.sdk.maui" />
-    <RemoveDir Directories="$(_SdkManifestsFolder)temp\" />
-
-    <XmlPeek
-        XmlInputPath="$(MauiSourcePath)\NuGet.config"
-        Query="/configuration/packageSources/add/@value">
-      <Output TaskParameter="Result" ItemName="_NuGetSources" />
-    </XmlPeek>
-    <PropertyGroup>
-      <_TempDirectory>$(IntermediateOutputPath).workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
-    </PropertyGroup>
-    <ItemGroup>
-      <_NuGetSources Include="$(MauiPackagePath.TrimEnd('\'))" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-      <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
-    </ItemGroup>
-    <MakeDir Directories="$(_TempDirectory)" />
-    <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; workload install maui --skip-manifest-update --skip-sign-check --verbosity diag --temp-dir &quot;$(_TempDirectory)&quot; @(_InstallArguments, ' ')"
-        WorkingDirectory="$(_TempDirectory)"
-        EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
-    />
-    <RemoveDir Directories="$(_TempDirectory)" />
-  </Target>
-
   <Target Name="PushManifestToBuildAssetRegistry" >
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)*.nupkg" />

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -165,6 +165,49 @@
     <RemoveDir Directories="@(_PackFoldersToDelete)" />
   </Target>
 
+  <Target Name="ExtractMauiWorkloadPacks" >
+    <PropertyGroup>
+      <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(XamarinAndroidSourcePath)..\maui</MauiSourcePath>
+      <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
+      <_SdkManifestsFolder>$(DotNetPreviewPath)sdk-manifests\$(DotNetSdkManifestsFolder)\</_SdkManifestsFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <_WLManifest Include="$(MauiPackagePath)/Microsoft.NET.Sdk.Maui.Manifest-$(DotNetSdkManifestsFolder.Substring (0,3))*.nupkg" />
+    </ItemGroup>
+    <Unzip
+        SourceFiles="@(_WLManifest)"
+        DestinationFolder="$(_SdkManifestsFolder)temp"
+    />
+    <ItemGroup>
+      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\LICENSE.TXT" />
+      <_WLExtractedFiles Include="$(_SdkManifestsFolder)temp\data\*" />
+    </ItemGroup>
+    <Move SourceFiles="@(_WLExtractedFiles)" DestinationFolder="$(_SdkManifestsFolder)microsoft.net.sdk.maui" />
+    <RemoveDir Directories="$(_SdkManifestsFolder)temp\" />
+
+    <XmlPeek
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
+        Query="/configuration/packageSources/add/@value">
+      <Output TaskParameter="Result" ItemName="_NuGetSources" />
+    </XmlPeek>
+    <PropertyGroup>
+      <_TempDirectory>$(IntermediateOutputPath).workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <_NuGetSources Include="$(MauiPackagePath.TrimEnd('\'))" />
+      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+      <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
+    </ItemGroup>
+    <MakeDir Directories="$(_TempDirectory)" />
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install maui --skip-manifest-update --skip-sign-check --verbosity diag --temp-dir &quot;$(_TempDirectory)&quot; @(_InstallArguments, ' ')"
+        WorkingDirectory="$(_TempDirectory)"
+        EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
+    />
+    <RemoveDir Directories="$(_TempDirectory)" />
+  </Target>
+
   <Target Name="PushManifestToBuildAssetRegistry" >
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)*.nupkg" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -3,24 +3,28 @@
     <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
     <_BinlogPathPrefix>$(_Root)bin/Build$(Configuration)/msbuild-$([System.DateTime]::Now.ToString("yyyyMMddTHHmmss"))</_BinlogPathPrefix>
   </PropertyGroup>
+
   <Target Name="BuildExternal">
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; build monodroid.proj -c $(Configuration) -p:DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir) -p:CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild/Novell -bl:$(_BinlogPathPrefix)-build-monodroid.binlog"
         WorkingDirectory="$(_Root)external\monodroid"
     />
   </Target>
+
   <Target Name="PrepareJavaInterop">
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_BinlogPathPrefix)-prepare-java-interop.binlog"
         WorkingDirectory="$(_Root)external\Java.Interop"
     />
   </Target>
+
   <Target Name="BuildDotNet"
       DependsOnTargets="PrepareJavaInterop">
     <MSBuild Projects="$(_Root)build-tools\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(_Root)Xamarin.Android.sln" Properties="DisableApiCompatibilityCheck=true" />
     <MSBuild Projects="$(_Root)build-tools\create-packs\Microsoft.Android.Sdk.proj" Targets="ConfigureLocalWorkload" />
   </Target>
+
   <Target Name="PackDotNet">
     <!-- Build extra versions of Mono.Android.dll if necessary -->
     <MSBuild
@@ -42,34 +46,58 @@
     </ItemGroup>
     <RemoveDir Directories="@(_DirectoriesToRemove)" />
   </Target>
+
   <Target Name="InstallMaui">
-    <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' " />
+    <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' and '$(MauiUseLocalPacks)' != 'true' " />
     <PropertyGroup>
       <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
       <MauiVersionBand Condition=" '$(MauiVersionBand)' == '' ">$(DotNetSdkManifestsFolder)</MauiVersionBand>
+      <MauiUseLocalPacks Condition=" '$(MauiUseLocalPacks)' == '' ">false</MauiUseLocalPacks>
+      <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(XamarinAndroidSourcePath)..\maui</MauiSourcePath>
+      <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
     </PropertyGroup>
     <MakeDir Directories="$(_TempDirectory)" />
+
+    <!-- Restore or extract WorkloadManifest.* files-->
     <Exec
+        Condition=" '$(MauiUseLocalPacks)' != 'true' "
         Command="&quot;$(DotNetPreviewTool)&quot; restore maui.proj -p:MauiVersion=$(MauiVersion) -p:MauiVersionBand=$(MauiVersionBand)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
         EnvironmentVariables="NUGET_PACKAGES=$(_TempDirectory);DOTNET_MULTILEVEL_LOOKUP=0"
     />
+    <ItemGroup>
+      <_WLManifestPack Include="$(MauiPackagePath)\Microsoft.NET.Sdk.Maui.Manifest-$(MauiVersionBand.Substring (0,3))*.nupkg" />
+    </ItemGroup>
+    <Unzip
+        Condition=" '$(MauiUseLocalPacks)' == 'true' "
+        SourceFiles="@(_WLManifestPack)"
+        DestinationFolder="$(_TempDirectory)"
+    />
 
     <!-- Copy WorkloadManifest.* files-->
     <ItemGroup>
-      <_WLManifest Include="$(_TempDirectory)\microsoft.net.sdk.maui.manifest-$(MauiVersionBand)\$(MauiVersion)\data\WorkloadManifest.*" />
+      <_WLManifest Condition=" '$(MauiUseLocalPacks)' != 'true' " Include="$(_TempDirectory)\microsoft.net.sdk.maui.manifest-$(MauiVersionBand)\$(MauiVersion)\data\WorkloadManifest.*" />
+      <_WLManifest Condition=" '$(MauiUseLocalPacks)' == 'true' " Include="$(_TempDirectory)\data\*" />
     </ItemGroup>
     <Copy SourceFiles="@(_WLManifest)" DestinationFolder="$(DotNetPreviewPath)sdk-manifests\$(DotNetSdkManifestsFolder)\microsoft.net.sdk.maui" />
 
     <!-- Parse NuGet.config -->
     <XmlPeek
+        Condition=" '$(MauiUseLocalPacks)' != 'true' "
         XmlInputPath="$(XamarinAndroidSourcePath)NuGet.config"
+        Query="/configuration/packageSources/add/@value">
+      <Output TaskParameter="Result" ItemName="_NuGetSources" />
+    </XmlPeek>
+    <XmlPeek
+        Condition=" '$(MauiUseLocalPacks)' == 'true' "
+        XmlInputPath="$(MauiSourcePath)\NuGet.config"
         Query="/configuration/packageSources/add/@value">
       <Output TaskParameter="Result" ItemName="_NuGetSources" />
     </XmlPeek>
 
     <!-- dotnet workload install maui-android -->
     <ItemGroup>
+      <_NuGetSources Condition=" '$(MauiUseLocalPacks)' == 'true' " Include="$(MauiPackagePath.TrimEnd('\'))" />
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <_InstallArguments Include="--skip-manifest-update" />

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -55,6 +55,7 @@
       <MauiUseLocalPacks Condition=" '$(MauiUseLocalPacks)' == '' ">false</MauiUseLocalPacks>
       <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(XamarinAndroidSourcePath)..\maui</MauiSourcePath>
       <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
+      <MauiWorkloadToInstall Condition=" '$(MauiWorkloadToInstall)' == '' ">maui-android</MauiWorkloadToInstall>
     </PropertyGroup>
     <MakeDir Directories="$(_TempDirectory)" />
 
@@ -106,7 +107,7 @@
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />
     </ItemGroup>
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; workload install maui-android @(_InstallArguments, ' ')"
+        Command="&quot;$(DotNetPreviewTool)&quot; workload install $(MauiWorkloadToInstall) @(_InstallArguments, ' ')"
         WorkingDirectory="$(_TempDirectory)"
         EnvironmentVariables="DOTNET_MULTILEVEL_LOOKUP=0"
     />


### PR DESCRIPTION
Adds a new MAUI test stage and job that will run against PR builds
targeting xamarin-android/main.

The new job will build dotnet/maui against the Android packs produced by
the PR build.  If that is successful, it will install the MAUI packs
into Androids dotnet preview sandbox, and create and build a template.