### PR TITLE
$(AndroidPackVersionSuffix)=rc.1; net8 is 34.0.0-rc.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-preview7

We branched for .NET 8 preview 7 from 7bf4eddb into `release/8.0.1xx-preview7`.

Update xamarin-android/main's version number to 34.0.0-rc.1 for .NET 8 RC 1.