### PR TITLE
[ci] Target hosted macOS-13 Ventura pool

### DIFF
--- a/build-tools/automation/yaml-templates/install-apkdiff.yaml
+++ b/build-tools/automation/yaml-templates/install-apkdiff.yaml
@@ -9,7 +9,14 @@ steps:
   ignoreLASTEXITCODE: true
   condition: ${{ parameters.condition }}
 
-- script: dotnet tool update apkdiff --version ${{ parameters.version }} --add-source https://api.nuget.org/v3/index.json -g
+- task: DotNetCoreCLI@2
   displayName: install apkdiff ${{ parameters.version }}
   condition: ${{ parameters.condition }}
   continueOnError: ${{ parameters.continueOnError }}
+  inputs:
+    command: custom
+    custom: tool
+    arguments: >-
+      update apkdiff -g
+      --version ${{ parameters.version }}
+      --add-source "https://api.nuget.org/v3/index.json"

--- a/build-tools/automation/yaml-templates/install-dotnet-test-slicer.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-test-slicer.yaml
@@ -9,7 +9,14 @@ steps:
   ignoreLASTEXITCODE: true
   condition: ${{ parameters.condition }}
 
-- script: dotnet tool update dotnet-test-slicer --version ${{ parameters.version }} --add-source https://api.nuget.org/v3/index.json -g
+- task: DotNetCoreCLI@2
   displayName: install dotnet-test-slicer ${{ parameters.version }}
   condition: ${{ parameters.condition }}
   continueOnError: ${{ parameters.continueOnError }}
+  inputs:
+    command: custom
+    custom: tool
+    arguments: >-
+      update dotnet-test-slicer -g
+      --version ${{ parameters.version }}
+      --add-source "https://api.nuget.org/v3/index.json"

--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -33,6 +33,7 @@ jobs:
     parameters:
       installTestSlicer: true
       installLegacyDotNet: false
+      installLegacyXamarinAndroid: true
       restoreNUnitConsole: false
       updateMono: false
       xaSourcePath: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -7,6 +7,7 @@ parameters:
   installTestSlicer: false
   installApkDiff: true
   installLegacyDotNet: true
+  installLegacyXamarinAndroid: false
   restoreNUnitConsole: true
   updateMono: true
   androidSdkPlatforms: $(DefaultTestSdkPlatforms)
@@ -65,6 +66,19 @@ steps:
       arguments: --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes
       condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
       xaSourcePath: ${{ parameters.xaSourcePath }}
+
+- ${{ if eq(parameters.installLegacyXamarinAndroid, true) }}:
+  - task: DotNetCoreCLI@2
+    displayName: install boots 1.1.0.36
+    inputs:
+      command: custom
+      custom: tool
+      arguments: >-
+        update boots -g
+        --version 1.1.0.36
+        --add-source "https://api.nuget.org/v3/index.json"
+  - powershell: boots --stable Xamarin.Android
+    displayName: install Xamarin.Android stable
 
 - template: run-xaprepare.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -36,8 +36,9 @@ stages:
         installTestSlicer: true
         installApkDiff: false
         installLegacyDotNet: false
+        installLegacyXamarinAndroid: true
         restoreNUnitConsole: false
-        updateMono: false
+        updateMono: true
         xaSourcePath: ${{ parameters.xaSourcePath }}
         repositoryAlias: ${{ parameters.repositoryAlias }}
         commit: ${{ parameters.commit }}

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -24,7 +24,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-12
+  value: macOS-13
 - name: HostedWinImage
   value: windows-2022
 - name: 1ESWindowsPool


### PR DESCRIPTION
Updates our macOS test jobs to run on the latest hosted macOS images.

The [Ventura images][0] do not contain classic Xamarin or Mono packages,
so these have been added to the test jobs that still require them.

[0]: https://github.com/actions/runner-images/blob/96f1383301c4d6866d3186b31c52c4d84e7b8812/images/macos/macos-13-Readme.md