### PR TITLE
Bump to mono/mono/2020-02@d9a6e871

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d17-5@9b69cb11ce5dafed7126baafad28ac8dff22a5d2
-mono/mono:2020-02@73df89a73d2aa08155fca01b75f2cc2944bbb7ea
+mono/mono:2020-02@d9a6e8710b37cd7f16cf52eff4f772556e57cc41

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Build.Tests
 				var proj = new XamarinAndroidApplicationProject {
 					TargetSdkVersion = apiLevel.ToString (),
 				};
-				const string ExpectedPlatformToolsVersion = "34.0.3";
+				const string ExpectedPlatformToolsVersion = "34.0.4";
 				using (var b = CreateApkBuilder ()) {
 					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8028
Fixes: https://github.com/xamarin/xamarin-android/issues/8175

Changes: https://github.com/mono/mono/compare/73df89a73d2aa08155fca01b75f2cc2944bbb7ea...d9a6e8710b37cd7f16cf52eff4f772556e57cc41

  * mono/mono@d9a6e8710b3: [libs][TimeZoneInfo] Bound transition time conversion (mono/mono#21686)
  * mono/mono@7e58b2a0c54: Install temurin-8-jdk instead of adoptopenjdk
  * mono/mono@efee217811d: Update sdks-archive.groovy
  * mono/mono@a9de9b041f6: [Mono.Security] Adjust test after EKU fix
  * mono/mono@9784c2bc5e4: [libs] Update TimeZoneInfo to read new version of tzdata (mono/mono#21682)
  * mono/mono@ba344d3416d: [Mono.Security] Add additional validation to AuthenticodeDeformatter
  * mono/mono@f648ec1e0a6: Bump nuget.exe to v6.6.1