### PR TITLE
[ci] Remove .NET branches from classic release trigger

### DIFF
--- a/build-tools/automation/azure-pipelines-release-trigger.yaml
+++ b/build-tools/automation/azure-pipelines-release-trigger.yaml
@@ -12,6 +12,10 @@ resources:
     trigger:
       stages:
       - post_build
+      branches:
+        exclude:
+        - main
+        - release/*
 
 jobs:
 - job: release_trigger


### PR DESCRIPTION
The "Xamarin.Android Release Definition Trigger" pipeline is used to
create PRs into VS for classic Xamarin.Android, and should not run
against branches that only produce .NET Android artifacts.