### PR TITLE
[ci] Install .NET Core runtime 3.1 for notarization

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1789,6 +1789,12 @@ stages:
         Write-Host "##vso[task.setvariable variable=XA.Unsigned.Pkg]$pkg"
       displayName: set variables to unsigned installers
 
+    - task: UseDotNet@2
+      displayName: Install .NET Core 3.1.x
+      inputs:
+        packageType: runtime
+        version: 3.1.x
+
     - template: yaml-templates/install-microbuild-tooling.yaml
 
     - task: MSBuild@1

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1789,11 +1789,13 @@ stages:
         Write-Host "##vso[task.setvariable variable=XA.Unsigned.Pkg]$pkg"
       displayName: set variables to unsigned installers
 
-    - task: UseDotNet@2
-      displayName: Install .NET Core 3.1.x
-      inputs:
-        packageType: runtime
-        version: 3.1.x
+    - template: yaml-templates\use-dot-net.yaml
+
+    # Signing depends on .NET Core 3
+    - template: yaml-templates\use-dot-net.yaml
+      parameters:
+        version: 3.1
+        quality: GA
 
     - template: yaml-templates/install-microbuild-tooling.yaml
 


### PR DESCRIPTION
Notarization attempts have been failing on d17-5:

    dotnet DDSignFiles.dll
    You must install or update .NET to run this application.
    App: DDSignFiles.dll
    Architecture: x64
    Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
    .NET location: /Users/runner/.dotnet/

Attempt to fix this by installing the .NET Core 3.1 runtime on our notarization agents.