### PR TITLE
[ci] Fix MAUI integration test job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -352,6 +352,12 @@ stages:
         -androidVersion $(ANDROID_PACK_VERSION)
       displayName: Update MAUI's Android dependency
 
+    - task: DotNetCoreCLI@2
+      displayName: Update Android SDK band in Workloads.csproj
+      inputs:
+        projects: $(Build.SourcesDirectory)/xamarin-android/Xamarin.Android.sln
+        arguments: -t:UpdateMauiWorkloadsProj -c $(XA.Build.Configuration) --no-restore -v:n -bl:$(Build.StagingDirectory)/logs/update-maui-workloadsproj.binlog
+
     - pwsh: ./build.ps1 --target=dotnet --configuration="$(XA.Build.Configuration)" --nugetsource="$(Build.StagingDirectory)\android-packs" --verbosity=diagnostic
       displayName: Install .NET
       retryCountOnTaskFailure: 3

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <_Root>$(MSBuildThisFileDirectory)..\..\</_Root>
     <_BinlogPathPrefix>$(_Root)bin/Build$(Configuration)/msbuild-$([System.DateTime]::Now.ToString("yyyyMMddTHHmmss"))</_BinlogPathPrefix>
+    <MauiUseLocalPacks Condition=" '$(MauiUseLocalPacks)' == '' ">false</MauiUseLocalPacks>
+    <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(_Root)..\maui</MauiSourcePath>
+    <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
+    <MauiWorkloadToInstall Condition=" '$(MauiWorkloadToInstall)' == '' ">maui-android</MauiWorkloadToInstall>
   </PropertyGroup>
 
   <Target Name="BuildExternal">
@@ -47,15 +51,18 @@
     <RemoveDir Directories="@(_DirectoriesToRemove)" />
   </Target>
 
+  <Target Name="UpdateMauiWorkloadsProj">
+    <XmlPoke
+      XmlInputPath="$(MauiSourcePath)\src\DotNet\Dependencies\Workloads.csproj"
+      Value="Microsoft.NET.Sdk.Android.Manifest-$(DotNetSdkManifestsFolder)"
+      Query="/Project/ItemGroup/PackageDownload[contains(@Include,'Microsoft.NET.Sdk.Android.Manifest-')]/@Include" />
+  </Target>
+
   <Target Name="InstallMaui">
     <Error Text="%24(MauiVersion) must be specified." Condition=" '$(MauiVersion)' == '' and '$(MauiUseLocalPacks)' != 'true' " />
     <PropertyGroup>
       <_TempDirectory>$(DotNetPreviewPath)..\.xa-workload-temp-$([System.IO.Path]::GetRandomFileName())</_TempDirectory>
       <MauiVersionBand Condition=" '$(MauiVersionBand)' == '' ">$(DotNetSdkManifestsFolder)</MauiVersionBand>
-      <MauiUseLocalPacks Condition=" '$(MauiUseLocalPacks)' == '' ">false</MauiUseLocalPacks>
-      <MauiSourcePath Condition=" '$(MauiSourcePath)' == '' ">$(XamarinAndroidSourcePath)..\maui</MauiSourcePath>
-      <MauiPackagePath Condition=" '$(MauiPackagePath)' == '' ">$(MauiSourcePath)\artifacts</MauiPackagePath>
-      <MauiWorkloadToInstall Condition=" '$(MauiWorkloadToInstall)' == '' ">maui-android</MauiWorkloadToInstall>
     </PropertyGroup>
     <MakeDir Directories="$(_TempDirectory)" />
 


### PR DESCRIPTION
The new MAUI build and test job has been failing:

    C:\a\_work\2\s\maui\src\DotNet\Dependencies\Workloads.csproj : error NU1102: Unable to find package Microsoft.NET.Sdk.Android.Manifest-8.0.100-preview.7 with version (= 34.0.0-ci.pr.gh8185.402) [C:\a\_work\2\s\maui\src\DotNet\DotNet.csproj]

This is because our main branch has bumped from .NET 8 preview.7 builds to .NET 8 rc.1 builds.  We can fix this by writing our SDK band to the Microsoft.NET.Sdk.Android.Manifest item in the workload restore project.