### PR TITLE
Fix dotnet-local script to work.

### DIFF
--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -20,7 +20,8 @@ MSBuild version 15 or later is required.
 
  5. In a [Developer Command Prompt][developer-prompt], prepare the project:
 
-        dotnet msbuild Xamarin.Android.sln -t:Prepare
+        dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false -m:1
+        dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false -m:1
 
     This will ensure that the build dependencies are installed, perform
     `git submodule update`, download NuGet dependencies, and other
@@ -28,13 +29,9 @@ MSBuild version 15 or later is required.
 
  6. Build the project:
 
-        dotnet-local.cmd build Xamarin.Android.sln -m:1
+        dotnet-local.cmd build Xamarin.Android.sln  -nr:false -m:1
 
- 7. In order to use the in-tree Xamarin.Android, build xabuild:
-
-         msbuild tools/xabuild/xabuild.csproj /restore
-
- 8. (For Microsoft team members only - Optional) In a [Developer Command
+ 7. (For Microsoft team members only - Optional) In a [Developer Command
     Prompt][developer-prompt], build external proprietary git
     dependencies:
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -20,8 +20,8 @@ MSBuild version 15 or later is required.
 
  5. In a [Developer Command Prompt][developer-prompt], prepare the project:
 
-        dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false -m:1
-        dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false -m:1
+        dotnet msbuild Xamarin.Android.sln -t:Prepare -nodeReuse:false
+        dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nodeReuse:false
 
     This will ensure that the build dependencies are installed, perform
     `git submodule update`, download NuGet dependencies, and other
@@ -29,7 +29,7 @@ MSBuild version 15 or later is required.
 
  6. Build the project:
 
-        dotnet-local.cmd build Xamarin.Android.sln  -nr:false -m:1
+        dotnet-local.cmd build Xamarin.Android.sln  -nodeReuse:false
 
  7. (For Microsoft team members only - Optional) In a [Developer Command
     Prompt][developer-prompt], build external proprietary git

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -228,6 +228,7 @@ stages:
         testResultsFile: TestResult-Aidl-Tests-macOS-$(XA.Build.Configuration).xml
 
     - task: ShellScript@2
+      displayName: Test dotnet-local.sh
       inputs:
         scriptPath: dotnet-local.sh
         args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
@@ -282,6 +283,7 @@ stages:
         testResultsFile: TestResult-NETSmokeMSBuildTests-Linux-$(XA.Build.Configuration).xml
 
     - task: ShellScript@2
+      displayName: Test dotnet-local.sh
       inputs:
         scriptPath: dotnet-local.sh
         args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -230,7 +230,7 @@ stages:
     - task: ShellScript@2
       inputs:
         scriptPath: dotnet-local.sh
-        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj -c Release
+        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
 
     - ${{ if ne(parameters.macTestAgentsUseCleanImages, true) }}:
       - template: yaml-templates/start-stop-emulator.yaml
@@ -284,7 +284,7 @@ stages:
     - task: ShellScript@2
       inputs:
         scriptPath: dotnet-local.sh
-        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj -c Release
+        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -112,7 +112,7 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
-        
+
     - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
@@ -140,7 +140,7 @@ stages:
         arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) --no-restore
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
-      
+
     - template: yaml-templates/start-stop-emulator.yaml
 
     - template: yaml-templates/apk-instrumentation.yaml
@@ -201,7 +201,7 @@ stages:
         extraBuildArgs: -p:TestsFlavor=AotLlvm -p:EnableLLVM=true -p:AndroidEnableProfiledAot=false
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-AotLlvm
-        
+
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
@@ -220,12 +220,17 @@ stages:
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Xamarin.Android.JcwGen_Tests-Signed.apk
         artifactFolder: $(DotNetTargetFramework)-FastDev_Assemblies_Dexes
         extraBuildArgs: /p:AndroidFastDeploymentType=Assemblies:Dexes
-        
+
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Tools.Aidl-Tests - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Tools.Aidl-Tests.dll
         testResultsFile: TestResult-Aidl-Tests-macOS-$(XA.Build.Configuration).xml
+
+    - task: ShellScript@2
+      inputs:
+        scriptPath: dotnet-local.sh
+        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj -c Release
 
     - ${{ if ne(parameters.macTestAgentsUseCleanImages, true) }}:
       - template: yaml-templates/start-stop-emulator.yaml
@@ -275,6 +280,11 @@ stages:
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
         dotNetTestExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
         testResultsFile: TestResult-NETSmokeMSBuildTests-Linux-$(XA.Build.Configuration).xml
+
+    - task: ShellScript@2
+      inputs:
+        scriptPath: dotnet-local.sh
+        args: build samples/HelloWorld/HelloWorld/HelloWorld.DotNet.csproj -c Release
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -98,6 +98,12 @@ stages:
         testResultsFile: TestResult-SmokeMSBuildTests-WinDotnetBuild-$(XA.Build.Configuration).xml
         dotNetTestExtraArgs: --filter "TestCategory = SmokeTests $(DotNetNUnitCategories)"
 
+    - task: BatchScript@1
+      displayName: Test dotnet-local.cmd
+      inputs:
+        filename: dotnet-local.cmd
+        arguments: build samples\HelloWorld\HelloWorld\HelloWorld.DotNet.csproj
+
     - template: upload-results.yaml
       parameters:
         artifactName: ${{ parameters.buildResultArtifactName }}

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -24,5 +24,6 @@
     />
     <Exec Command="dotnet $(_XAPrepareExe) $(_XAPrepareStandardArgs) -a" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(_TopDir)\Xamarin.Android.BootstrapTasks.sln" Targets="Restore;Build" />
+    <CallTarget Targets="PrepareJavaInterop" />
   </Target>
 </Project>

--- a/build.cmd
+++ b/build.cmd
@@ -8,22 +8,22 @@ IF ERRORLEVEL 1 CALL:FAILED_CASE
 IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 :Prepare_CASE
-    dotnet build Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false
     GOTO END_CASE
 :PrepareExternal_CASE
     dotnet build Xamarin.Android.sln -t:PrepareExternal -nr:false
     GOTO END_CASE
 :Build_CASE
     dotnet-local.cmd build Xamarin.Android.sln  -nr:false
-    dotnet-local.cmd build tools/xabuild/xabuild.csproj -nr:false
     GOTO END_CASE
 :Pack_CASE
     dotnet-local.cmd build  Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE
 :DEFAULT_CASE
-    dotnet build Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -nr:false
-    dotnet-local.cmd build tools/xabuild/xabuild.csproj -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE
 :FAILED_CASE

--- a/build.cmd
+++ b/build.cmd
@@ -9,7 +9,7 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 :Prepare_CASE
     dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
-    dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:PrepareJavaInterop -nr:false
     GOTO END_CASE
 :PrepareExternal_CASE
     dotnet build Xamarin.Android.sln -t:PrepareExternal -nr:false
@@ -22,7 +22,7 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
     GOTO END_CASE
 :DEFAULT_CASE
     dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
-    dotnet msbuild external\Java.Interop\Java.Interop.sln -t:Prepare -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:PrepareJavaInterop -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE

--- a/build.cmd
+++ b/build.cmd
@@ -8,21 +8,21 @@ IF ERRORLEVEL 1 CALL:FAILED_CASE
 IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 :Prepare_CASE
-    dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:Prepare -nodeReuse:false
     GOTO END_CASE
 :PrepareExternal_CASE
-    dotnet build Xamarin.Android.sln -t:PrepareExternal -nr:false
+    dotnet build Xamarin.Android.sln -t:PrepareExternal -nodeReuse:false
     GOTO END_CASE
 :Build_CASE
-    dotnet-local.cmd build Xamarin.Android.sln  -nr:false
+    dotnet-local.cmd build Xamarin.Android.sln  -nodeReuse:false
     GOTO END_CASE
 :Pack_CASE
-    dotnet-local.cmd build  Xamarin.Android.sln -t:PackDotNet -nr:false
+    dotnet-local.cmd build  Xamarin.Android.sln -t:PackDotNet -nodeReuse:false
     GOTO END_CASE
 :DEFAULT_CASE
-    dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
-    dotnet-local.cmd build Xamarin.Android.sln -nr:false
-    dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nr:false
+    dotnet msbuild Xamarin.Android.sln -t:Prepare -nodeReuse:false
+    dotnet-local.cmd build Xamarin.Android.sln -nodeReuse:false
+    dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nodeReuse:false
     GOTO END_CASE
 :FAILED_CASE
     echo "Failed to find an instance of Visual Studio. Please check it is correctly installed."

--- a/build.cmd
+++ b/build.cmd
@@ -9,7 +9,6 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 :Prepare_CASE
     dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
-    dotnet msbuild Xamarin.Android.sln -t:PrepareJavaInterop -nr:false
     GOTO END_CASE
 :PrepareExternal_CASE
     dotnet build Xamarin.Android.sln -t:PrepareExternal -nr:false
@@ -22,7 +21,6 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
     GOTO END_CASE
 :DEFAULT_CASE
     dotnet msbuild Xamarin.Android.sln -t:Prepare -nr:false
-    dotnet msbuild Xamarin.Android.sln -t:PrepareJavaInterop -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -nr:false
     dotnet-local.cmd build Xamarin.Android.sln -t:PackDotNet -nr:false
     GOTO END_CASE

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -4,13 +4,11 @@ IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
     SET DOTNET_ROOT=%ROOT%\bin\Release\dotnet
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Release\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Release\lib
-    SET PATH=%DOTNET_ROOT%;%PATH%
     call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
     SET DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Debug\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Debug\lib
-    SET PATH=%DOTNET_ROOT%;%PATH%
     call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,12 +1,14 @@
 @echo off
 SET ROOT=%~dp0
 IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
-    SET DOTNET_ROOT=%ROOT%\bin\Release\dotnet
+    SET XA_DOTNET_ROOT=%ROOT%\bin\Release\dotnet
+    SET PATH=%XA_DOTNET_ROOT%;%PATH%
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Release\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Release\lib
     call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
-    SET DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
+    SET XA_DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
+    SET PATH=%XA_DOTNET_ROOT%;%PATH%
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Debug\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Debug\lib
     call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,17 +1,23 @@
 @echo off
+SETLOCAL
+
 SET ROOT=%~dp0
+
 IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
     SET XA_DOTNET_ROOT=%ROOT%\bin\Release\dotnet
-    SET PATH=%XA_DOTNET_ROOT%;%PATH%
-    SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Release\lib\sdk-manifests
-    SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Release\lib
-    call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
+    SET XA_CONFIG=Release
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
     SET XA_DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
-    SET PATH=%XA_DOTNET_ROOT%;%PATH%
-    SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Debug\lib\sdk-manifests
-    SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Debug\lib
-    call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*
+    SET XA_CONFIG=Debug
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."
+    goto :exit
 )
+
+SET PATH=%XA_DOTNET_ROOT%;%PATH%
+SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\%XA_CONFIG%\lib\sdk-manifests
+SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\%XA_CONFIG%\lib
+
+call "%XA_DOTNET_ROOT%\dotnet.exe" %*
+
+:exit

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -4,16 +4,15 @@ SETLOCAL
 SET ROOT=%~dp0
 
 IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
-    SET XA_DOTNET_ROOT=%ROOT%\bin\Release\dotnet
     SET XA_CONFIG=Release
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
-    SET XA_DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
     SET XA_CONFIG=Debug
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."
     goto :exit
 )
 
+SET XA_DOTNET_ROOT=%ROOT%\bin\%XA_CONFIG%\dotnet
 SET PATH=%XA_DOTNET_ROOT%;%PATH%
 SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\%XA_CONFIG%\lib\sdk-manifests
 SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\%XA_CONFIG%\lib

--- a/dotnet-local.cmd
+++ b/dotnet-local.cmd
@@ -1,12 +1,16 @@
 @echo off
 SET ROOT=%~dp0
 IF EXIST "%ROOT%\bin\Release\dotnet\dotnet.exe" (
+    SET DOTNET_ROOT=%ROOT%\bin\Release\dotnet
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Release\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Release\lib
+    SET PATH=%DOTNET_ROOT%;%PATH%
     call "%ROOT%\bin\Release\dotnet\dotnet.exe" %*
 ) ELSE IF EXIST "%ROOT%\bin\Debug\dotnet\dotnet.exe" (
+    SET DOTNET_ROOT=%ROOT%\bin\Debug\dotnet
     SET DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=%ROOT%\bin\Debug\lib\sdk-manifests
     SET DOTNETSDK_WORKLOAD_PACK_ROOTS=%ROOT%\bin\Debug\lib
+    SET PATH=%DOTNET_ROOT%;%PATH%
     call "%ROOT%\bin\Debug\dotnet\dotnet.exe" %*
 ) ELSE (
     echo "You need to run 'msbuild Xamarin.Android.sln /t:Prepare' first."

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -2,9 +2,11 @@
 ROOT="$(dirname "${BASH_SOURCE}")"
 FULLROOT="$(cd "${ROOT}"; pwd)"
 if [[ -x "${ROOT}/bin/Release/dotnet/dotnet" ]]; then
-    DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Release/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Release/lib exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
+    DOTNET_ROOT=${FULLROOT}/bin/Release/dotnet
+    PATH=${DOTNET_ROOT}:PATH DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Release/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Release/lib exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
 elif [[ -x "${ROOT}/bin/Debug/dotnet/dotnet" ]]; then
-    DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Debug/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Debug/lib exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
+    DOTNET_ROOT=${FULLROOT}/bin/Debug/dotnet
+    PATH=${DOTNET_ROOT}:PATH DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Debug/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Debug/lib exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
 else
     echo "You need to run 'make prepare' first."
 fi

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 ROOT="$(dirname "${BASH_SOURCE}")"
 FULLROOT="$(cd "${ROOT}"; pwd)"
-if [[ -x "${ROOT}/bin/Release/dotnet/dotnet" ]]; then
-    DOTNET_ROOT=${FULLROOT}/bin/Release/dotnet
-    PATH=${DOTNET_ROOT}:PATH DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Release/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Release/lib exec ${ROOT}/bin/Release/dotnet/dotnet "$@"
-elif [[ -x "${ROOT}/bin/Debug/dotnet/dotnet" ]]; then
-    DOTNET_ROOT=${FULLROOT}/bin/Debug/dotnet
-    PATH=${DOTNET_ROOT}:PATH DOTNETSDK_WORKLOAD_MANIFEST_ROOTS=${FULLROOT}/bin/Debug/lib/sdk-manifests DOTNETSDK_WORKLOAD_PACK_ROOTS=${FULLROOT}/bin/Debug/lib exec ${ROOT}/bin/Debug/dotnet/dotnet "$@"
-else
-    echo "You need to run 'make prepare' first."
-fi
+for config in Release Debug ; do
+    if [[ ! -x "${ROOT}/bin/${config}/dotnet/dotnet" ]] ; then
+        continue
+    fi
+    export DOTNET_ROOT="${FULLROOT}/bin/${config}/dotnet"
+    export PATH="${DOTNET_ROOT}:${PATH}"
+    export DOTNETSDK_WORKLOAD_MANIFEST_ROOTS="${FULLROOT}/bin/${config}/lib/sdk-manifests"
+    export DOTNETSDK_WORKLOAD_PACK_ROOTS="${FULLROOT}/bin/${config}/lib"
+    exec "${ROOT}/bin/${config}/dotnet/dotnet" "$@"
+done
+
+echo "You need to run 'make prepare' first."

--- a/dotnet-local.sh
+++ b/dotnet-local.sh
@@ -5,8 +5,8 @@ for config in Release Debug ; do
     if [[ ! -x "${ROOT}/bin/${config}/dotnet/dotnet" ]] ; then
         continue
     fi
-    export DOTNET_ROOT="${FULLROOT}/bin/${config}/dotnet"
-    export PATH="${DOTNET_ROOT}:${PATH}"
+    XA_DOTNET_ROOT="${FULLROOT}/bin/${config}/dotnet"
+    export PATH="${XA_DOTNET_ROOT}:${PATH}"
     export DOTNETSDK_WORKLOAD_MANIFEST_ROOTS="${FULLROOT}/bin/${config}/lib/sdk-manifests"
     export DOTNETSDK_WORKLOAD_PACK_ROOTS="${FULLROOT}/bin/${config}/lib"
     exec "${ROOT}/bin/${config}/dotnet/dotnet" "$@"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -152,7 +152,7 @@ namespace Xamarin.ProjectTools
 				$"/flp1:LogFile=\"{BuildLogFile}\";Encoding=UTF-8;Verbosity={Verbosity}",
 				$"/bl:\"{Path.Combine (testDir, $"{(string.IsNullOrEmpty (target) ? "msbuild" : target)}.binlog")}\"",
 				"-m:1",
-				"-nr:false",
+				"-nodeReuse:false",
 				"/p:_DisableParallelAot=true",
 			};
 			if (!string.IsNullOrEmpty (target)) {


### PR DESCRIPTION
The recent bump to dotnet broke the dotnet-local scripts. It now seems that the "local" path must be FIRST in the PATH in order to pick up the packs.

Also added a smoke test step to make sure the script works, at least one Mac and Linux.