### PR TITLE
[ci] Run Codesign Verify task against new MSI folder

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -470,7 +470,9 @@ stages:
       - task: MicroBuildCodesignVerify@3
         displayName: verify signed msi content
         inputs:
-          TargetFolders: $(Build.StagingDirectory)\bin\manifests
+          TargetFolders: |
+            $(Build.ArtifactStagingDirectory)\bin\manifests
+            $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
           ExcludeSNVerify: true
           ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
 


### PR DESCRIPTION
Fixes the codesign validation task to run against all of the outputs of the workload MSI generation task.