### PR TITLE
[build] Use .NET preview to create nupkgs

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -10,7 +10,7 @@ create-installers: create-nupkgs
 create-nupkgs:
 	@echo Disk usage before create-nupkgs
 	-df -h
-	$(call SYSTEM_DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
+	$(call DOTNET_BINLOG,create-all-packs) -t:CreateAllPacks $(topdir)/build-tools/create-packs/Microsoft.Android.Sdk.proj
 
 create-pkg:
 	$(call SYSTEM_DOTNET_BINLOG,create-pkg) /t:CreatePkg \


### PR DESCRIPTION
Recent `make create-installers` attempts have been failing, seemingly due to recent changes to dotnet host resolution:

    Restored /Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj (in 257 ms).
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : You must install or update .NET to run this application. [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : App: /Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/bincore/csc.dll [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : Architecture: x64 [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : Framework: 'Microsoft.NETCore.App', version '8.0.0-rc.1.23371.3' (x64) [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : .NET location: /Users/runner/.dotnet/ [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : The following frameworks were found: [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]
        1>/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-rc.1.23373.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error : 7.0.9 at [/Users/runner/.dotnet/shared/Microsoft.NETCore.App] [/Users/runner/work/1/s/xamarin-android/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj] [/Users/runner/work/1/s/xamarin-android/build-tools/create-packs/Microsoft.Android.Sdk.proj]

Attempt to fix this by using the .NET preview version we install into bin/$(Configuration)/dotnet to build the `<CreateAllPacks/>` target.