### PR TITLE
[ci] Don't checkout monodroid's unneeded XA submodule

### DIFF
--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -32,9 +32,18 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make prepare-update-mono
 
-# Clone and prepare monodroid with submodules, but disregard the unused xamarin-android submodule.
+# Clone 'monodroid' without submodules
 - checkout: monodroid
   clean: true
+  path: s/xamarin-android/external/monodroid
+
+# Tell git to ignore the 'xamarin-android' submodule, which is large and unneeded
+- script: git config submodule."external/xamarin-android".update none
+  workingDirectory: xamarin-android/external/monodroid
+  displayName: Ignore XA submodule
+
+# Clone 'monodroid' with the rest of the submodules
+- checkout: monodroid
   submodules: recursive
   path: s/xamarin-android/external/monodroid
   persistCredentials: true


### PR DESCRIPTION
Today, our CI checks out the private `monodroid` repository in order to build its proprietary code.  Checking this repository out recursively with its submodules can take quite a lot of time.  A large portion of this time is checking out a `xamarin-android` submodule.  However, we do not use this submodule, in fact we immediately delete it to ensure that it does not get used.

Ideally we would not spend the time checking out this submodule just to delete it, however this is trickier than one might expect.

The solution that seems to work is:
- Check out `monodroid` without any submodules
- Use `git config submodule."external/xamarin-android".update none` to tell `git` to ignore the submodule
- Check out `monodroid` with recursive submodules, but `git` will skip XA

This saves about 2-3 minutes on an XA PR Mac Build:

| Action | Duration|
| --- | --- |
| `main` `monodroid` checkout | 4:47 |
| PR `monodroid` checkout | 2:30 |