### PR TITLE
[ci] Fix condition for MAUI integration test job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -292,7 +292,7 @@ stages:
 - stage: maui_tests
   displayName: MAUI Tests
   dependsOn: mac_build
-  condition: eq(variables['System.PullRequest.TargetBranch'], 'main')
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['System.PullRequest.TargetBranch'], 'main'))
   jobs:
   # Check - "Xamarin.Android (MAUI Tests MAUI Integration)"
   - job: maui_tests_integration


### PR DESCRIPTION
This test job should only run if the initial build was successful.