### PR TITLE
[Mono.Android] add "built-in" delegate for _JniMarshal_PPII_L

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs
@@ -9,7 +9,11 @@ namespace Android.Runtime
 		static bool _unhandled_exception (Exception e)
 		{
 			if (Debugger.IsAttached || !JNIEnvInit.PropagateExceptions) {
+#if NETCOREAPP
 				AndroidRuntimeInternal.mono_unhandled_exception?.Invoke (e);
+#else
+				JNIEnvInit.mono_unhandled_exception?.Invoke (e);
+#endif
 				return false;
 			}
 			return true;
@@ -155,6 +159,17 @@ namespace Android.Runtime
 			} catch (Exception e) when (_unhandled_exception (e)) {
 				AndroidEnvironment.UnhandledException (e);
 
+			}
+		}
+
+		internal static IntPtr Wrap_JniMarshal_PPII_L (this _JniMarshal_PPII_L callback, IntPtr jnienv, IntPtr klazz, int p0, int p1)
+		{
+			AndroidRuntimeInternal.WaitForBridgeProcessing ();
+			try {
+				return callback (jnienv, klazz, p0, p1);
+			} catch (Exception e) when (_unhandled_exception (e)) {
+				AndroidEnvironment.UnhandledException (e);
+				return default;
 			}
 		}
 
@@ -473,6 +488,8 @@ namespace Android.Runtime
 					return new _JniMarshal_PPJ_Z (Unsafe.As<_JniMarshal_PPJ_Z> (dlg).Wrap_JniMarshal_PPJ_Z);
 				case nameof (_JniMarshal_PPII_V):
 					return new _JniMarshal_PPII_V (Unsafe.As<_JniMarshal_PPII_V> (dlg).Wrap_JniMarshal_PPII_V);
+				case nameof (_JniMarshal_PPII_L):
+					return new _JniMarshal_PPII_L (Unsafe.As<_JniMarshal_PPII_L> (dlg).Wrap_JniMarshal_PPII_L);
 				case nameof (_JniMarshal_PPLI_V):
 					return new _JniMarshal_PPLI_V (Unsafe.As<_JniMarshal_PPLI_V> (dlg).Wrap_JniMarshal_PPLI_V);
 				case nameof (_JniMarshal_PPLZ_V):

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.tt
@@ -83,6 +83,12 @@ var delegateTypes = new [] {
 		Invoke = "jnienv, klazz, p0, p1",
 	},
 	new {
+		Type = "_JniMarshal_PPII_L",
+		Signature = "IntPtr jnienv, IntPtr klazz, int p0, int p1",
+		Return = "IntPtr",
+		Invoke = "jnienv, klazz, p0, p1",
+	},
+	new {
 		Type = "_JniMarshal_PPLI_V",
 		Signature = "IntPtr jnienv, IntPtr klazz, IntPtr p0, int p1",
 		Return = "void",
@@ -271,7 +277,7 @@ foreach (var info in delegateTypes) {
 				<#= info.Return != "void" ? "return " : "" #>callback (<#= info.Invoke #>);
 			} catch (Exception e) when (_unhandled_exception (e)) {
 				AndroidEnvironment.UnhandledException (e);
-				<#= info.Return != "void" ? "return default;" : "" #>
+<#= info.Return != "void" ? "\t\t\t\treturn default;" : "" #>
 			}
 		}
 


### PR DESCRIPTION
I noticed some methods appear when creating a new `.aotprofile` for .NET MAUI:

    void System.Reflection.Emit.RuntimeILGenerator:.ctor (System.Reflection.Module,System.Reflection.Emit.ITokenGenerator,int)
    void System.Reflection.Emit.RuntimeILGenerator:BeginCatchBlock (System.Type)
    void System.Reflection.Emit.RuntimeILGenerator:Emit (System.Reflection.Emit.OpCode,int)
    void System.Reflection.Emit.RuntimeILGenerator:Emit (System.Reflection.Emit.OpCode,System.Reflection.Emit.Label)
    void System.Reflection.Emit.RuntimeILGenerator:Emit (System.Reflection.Emit.OpCode,System.Reflection.Emit.LocalBuilder)
    void System.Reflection.Emit.RuntimeILGenerator:Emit (System.Reflection.Emit.OpCode,System.Reflection.MethodInfo)
    void System.Reflection.Emit.RuntimeILGenerator:Emit (System.Reflection.Emit.OpCode)

We generally don't want S.R.E to run at application startup. This can happen when `Android.Runtime.JNINativeWrapper:CreateBuiltInDelegate` doesn't find a match. We fallback to S.R.E in that case.

Running a `dotnet new maui` app w/ .NET 8 Preview 7 logs the message:

    08-07 10:01:51.674 16590 16590 D monodroid-assembly: Falling back to System.Reflection.Emit for delegate type '_JniMarshal_PPII_L': IntPtr n_GetClipPath_II(IntPtr, IntPtr, Int32, Int32)

This may also coincide with `AndroidEnableMarshalMethods` being turned off by default. We would not have seen this log message when it was on.

After this change, we skip the S.R.E code path:

    08-07 10:37:23.089 17661 17661 D Mono    : AOT NOT FOUND: (wrapper native-to-managed) Android.Runtime.JNINativeWrapper:Wrap_JniMarshal_PPII_L (intptr,intptr,int,int).

We should update the `.aotprofile` in xamarin-android and dotnet/maui after this change.

To update `JNINativeWrapper.g.tt`:

    dotnet tool install -g dotnet-t4
    t4 src\Mono.Android\Android.Runtime\JNINativeWrapper.g.tt -o src\Mono.Android\Android.Runtime\JNINativeWrapper.g.cs

Other changes:

* Fixed code formatting, so we don't have empty tabs in output.