### PR TITLE
[Mono.Android.dll] Fix [SupportedOSPlatform] warnings.

### DIFF
--- a/src/Mono.Android/Android.Content/ContentValues.cs
+++ b/src/Mono.Android/Android.Content/ContentValues.cs
@@ -125,7 +125,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Boolean_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Boolean;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Boolean (value))
+				using (var val = Java.Lang.Boolean.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Boolean_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -140,7 +140,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Byte_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Byte;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Byte (value))
+				using (var val = Java.Lang.Byte.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Byte_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -155,7 +155,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Short_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Short;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Short (value))
+				using (var val = Java.Lang.Short.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Short_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -170,7 +170,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Integer_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Integer;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Integer (value))
+				using (var val = Java.Lang.Integer.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Integer_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -185,7 +185,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Long_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Long;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Long (value))
+				using (var val = Java.Lang.Long.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Long_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -200,7 +200,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Float_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Float;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Float (value))
+				using (var val = Java.Lang.Float.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Float_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -215,7 +215,7 @@ namespace Android.Content {
 				id_put_Ljava_lang_String_Ljava_lang_Double_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Double;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = new Java.Lang.Double (value))
+				using (var val = Java.Lang.Double.ValueOf (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Double_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);

--- a/src/Mono.Android/Android.Content/ContentValues.cs
+++ b/src/Mono.Android/Android.Content/ContentValues.cs
@@ -119,13 +119,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Boolean_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Boolean;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, bool value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Boolean_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Boolean_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Boolean;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Boolean.ValueOf (value))
+				using (var val = new Java.Lang.Boolean (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Boolean_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -134,13 +135,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Byte_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Byte;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, sbyte value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Byte_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Byte_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Byte;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Byte.ValueOf (value))
+				using (var val = new Java.Lang.Byte (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Byte_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -149,13 +151,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Short_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Short;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, short value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Short_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Short_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Short;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Short.ValueOf (value))
+				using (var val = new Java.Lang.Short (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Short_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -164,13 +167,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Integer_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Integer;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, int value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Integer_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Integer_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Integer;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Integer.ValueOf (value))
+				using (var val = new Java.Lang.Integer (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Integer_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -179,13 +183,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Long_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Long;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, long value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Long_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Long_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Long;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Long.ValueOf (value))
+				using (var val = new Java.Lang.Long (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Long_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -194,13 +199,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Float_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Float;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, float value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Float_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Float_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Float;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Float.ValueOf (value))
+				using (var val = new Java.Lang.Float (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Float_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);
@@ -209,13 +215,14 @@ namespace Android.Content {
 
 		static IntPtr id_put_Ljava_lang_String_Ljava_lang_Double_;
 		[Register ("put", "(Ljava/lang/String;Ljava/lang/Double;)V", "")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public void Put (string key, double value)
 		{
 			if (id_put_Ljava_lang_String_Ljava_lang_Double_ == IntPtr.Zero)
 				id_put_Ljava_lang_String_Ljava_lang_Double_ = JNIEnv.GetMethodID (class_ref, "put", "(Ljava/lang/String;Ljava/lang/Double;)V");
 			IntPtr jkey = JNIEnv.NewString (key);
 			try {
-				using (var val = Java.Lang.Double.ValueOf (value))
+				using (var val = new Java.Lang.Double (value))
 					JNIEnv.CallVoidMethod (Handle, id_put_Ljava_lang_String_Ljava_lang_Double_, new JValue (jkey), new JValue (val));
 			} finally {
 				JNIEnv.DeleteLocalRef (jkey);

--- a/src/Mono.Android/Android.Content/Context.cs
+++ b/src/Mono.Android/Android.Content/Context.cs
@@ -20,9 +20,11 @@ namespace Android.Content {
 
 #if ANDROID_34
 		// Add correctly enumified overloads
+		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android26.0")]
 		public Intent? RegisterReceiver (BroadcastReceiver? receiver, IntentFilter? filter, ReceiverFlags flags)
 			=> RegisterReceiver (receiver, filter, (ActivityFlags)flags);
 
+		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android26.0")]
 		public Intent? RegisterReceiver (BroadcastReceiver? receiver, IntentFilter? filter, string? broadcastPermission, Handler? scheduler, ReceiverFlags flags)
 			=> RegisterReceiver (receiver, filter, broadcastPermission, scheduler, (ActivityFlags)flags);
 #endif

--- a/src/Mono.Android/Android.Media/AudioTrack.cs
+++ b/src/Mono.Android/Android.Media/AudioTrack.cs
@@ -4,12 +4,14 @@ namespace Android.Media
 {
 	public partial class AudioTrack
 	{
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android26.0")]
 		[Obsolete ("ChannelConfiguration is obsolete. Please use another overload with ChannelOut instead")]
 		public AudioTrack ([global::Android.Runtime.GeneratedEnum] Android.Media.Stream streamType, int sampleRateInHz, [global::Android.Runtime.GeneratedEnum] Android.Media.ChannelConfiguration channelConfig, [global::Android.Runtime.GeneratedEnum] Android.Media.Encoding audioFormat, int bufferSizeInBytes, [global::Android.Runtime.GeneratedEnum] Android.Media.AudioTrackMode mode)
 			: this (streamType, sampleRateInHz, (ChannelOut) (int) channelConfig, audioFormat, bufferSizeInBytes, mode)
 		{
 		}
 #if ANDROID_9
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android26.0")]
 		[Obsolete ("ChannelConfiguration is obsolete. Please use another overload with ChannelOut instead")]
 		public AudioTrack ([global::Android.Runtime.GeneratedEnum] Android.Media.Stream streamType, int sampleRateInHz, [global::Android.Runtime.GeneratedEnum] Android.Media.ChannelConfiguration channelConfig, [global::Android.Runtime.GeneratedEnum] Android.Media.Encoding audioFormat, int bufferSizeInBytes, [global::Android.Runtime.GeneratedEnum] Android.Media.AudioTrackMode mode, int sessionId)
 			: this (streamType, sampleRateInHz, (ChannelOut) (int) channelConfig, audioFormat, bufferSizeInBytes, mode, sessionId)

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -7,6 +7,7 @@ using Java.Interop;
 
 namespace Android.OS {
 
+	[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0")]
 	[Register ("android/os/AsyncTask", DoNotGenerateAcw=true)]
 	public abstract class AsyncTask<TParams, TProgress, TResult> : AsyncTask {
 

--- a/src/Mono.Android/Android.OS/Handler.cs
+++ b/src/Mono.Android/Android.OS/Handler.cs
@@ -5,6 +5,7 @@ namespace Android.OS {
 
 	public partial class Handler {
 
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0")]
 		public Handler (Action<Message> handler)
 			: this (new ActionHandlerCallback (handler))
 		{

--- a/src/Mono.Android/Android.OS/Vibrator.cs
+++ b/src/Mono.Android/Android.OS/Vibrator.cs
@@ -6,6 +6,7 @@ namespace Android.OS {
 
 	public partial class Vibrator {
 
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android31.0", "Use VibratorManager to retrieve the default system vibrator.")]
 		public static Vibrator? FromContext (Context context)
 		{
 			return context.GetSystemService (Context.VibratorService!) as Vibrator;

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -237,6 +237,7 @@ namespace Android.Runtime {
 		//
 		//  Rationale
 		//     No longer called by the indicated caller, however we keep it for backward compatibility.
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android31.0")]
 		static void GetDisplayDPI (out float x_dpi, out float y_dpi)
 		{
 			var wm = Application.Context.GetSystemService (Context.WindowService).JavaCast <IWindowManager> ();

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -10,26 +10,25 @@ namespace Android.Runtime {
 			if (obj == null)
 				return IntPtr.Zero;
 
-			Type type = obj.GetType ();
-			if (type == typeof (bool))
-				return new Java.Lang.Boolean ((bool)obj).Handle;
-			else if (type == typeof (sbyte))
-				return new Java.Lang.Byte ((sbyte)obj).Handle;
-			else if (type == typeof (char))
-				return new Java.Lang.Character ((char)obj).Handle;
-			else if (type == typeof (short))
-				return new Java.Lang.Short ((short)obj).Handle;
-			else if (type == typeof (int))
-				return new Java.Lang.Integer ((int)obj).Handle;
-			else if (type == typeof (long))
-				return new Java.Lang.Long ((long)obj).Handle;
-			else if (type == typeof (float))
-				return new Java.Lang.Float ((float)obj).Handle;
-			else if (type == typeof (double))
-				return new Java.Lang.Double ((double)obj).Handle;
-			else if (type == typeof (string))
-				return JNIEnv.NewString ((string)obj);
-			else if (typeof (IJavaObject).IsAssignableFrom (type))
+			if (obj is bool bool_obj)
+				return Java.Lang.Boolean.ValueOf (bool_obj).Handle;
+			else if (obj is sbyte sbyte_obj)
+				return Java.Lang.Byte.ValueOf (sbyte_obj).Handle;
+			else if (obj is char char_obj)
+				return Java.Lang.Character.ValueOf (char_obj).Handle;
+			else if (obj is short short_obj)
+				return Java.Lang.Short.ValueOf (short_obj)!.Handle;
+			else if (obj is int int_obj)
+				return Java.Lang.Integer.ValueOf (int_obj).Handle;
+			else if (obj is long long_obj)
+				return Java.Lang.Long.ValueOf (long_obj).Handle;
+			else if (obj is float float_obj)
+				return Java.Lang.Float.ValueOf (float_obj).Handle;
+			else if (obj is double double_obj)
+				return Java.Lang.Double.ValueOf (double_obj).Handle;
+			else if (obj is string string_obj)
+				return JNIEnv.NewString (string_obj);
+			else if (typeof (IJavaObject).IsAssignableFrom (obj.GetType ()))
 				return ((IJavaObject)obj).Handle;
 			else
 				return new JavaObject (obj).Handle;
@@ -37,29 +36,28 @@ namespace Android.Runtime {
 
 		public static object? GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
-			Java.Lang.Object? jlo = Java.Lang.Object.GetObject (handle, transfer) as Java.Lang.Object;
-			if (jlo == null)
+			if (Java.Lang.Object.GetObject (handle, transfer) is not Java.Lang.Object jlo)
 				return null;
-			else if (jlo is Java.Lang.Boolean)
-				return Dispose ((Java.Lang.Boolean) jlo, v => v.BooleanValue ());
-			else if (jlo is Java.Lang.Byte)
-				return Dispose ((Java.Lang.Byte) jlo, v => v.ByteValue ());
-			else if (jlo is Java.Lang.Character)
-				return Dispose ((Java.Lang.Character) jlo, v => v.CharValue ());
-			else if (jlo is Java.Lang.Short)
-				return Dispose ((Java.Lang.Short) jlo, v => v.ShortValue ());
-			else if (jlo is Java.Lang.Integer)
-				return Dispose ((Java.Lang.Integer) jlo, v => v.IntValue ());
-			else if (jlo is Java.Lang.Long)
-				return Dispose ((Java.Lang.Long) jlo, v => v.LongValue ());
-			else if (jlo is Java.Lang.Float)
-				return Dispose ((Java.Lang.Float) jlo, v => v.FloatValue ());
-			else if (jlo is Java.Lang.Double)
-				return Dispose ((Java.Lang.Double) jlo, v => v.DoubleValue ());
+			else if (jlo is Java.Lang.Boolean bool_jlo)
+				return Dispose (bool_jlo, v => v.BooleanValue ());
+			else if (jlo is Java.Lang.Byte byte_jlo)
+				return Dispose (byte_jlo, v => v.ByteValue ());
+			else if (jlo is Java.Lang.Character chat_jlo)
+				return Dispose (chat_jlo, v => v.CharValue ());
+			else if (jlo is Java.Lang.Short short_jlo)
+				return Dispose (short_jlo, v => v.ShortValue ());
+			else if (jlo is Java.Lang.Integer int_jlo)
+				return Dispose (int_jlo, v => v.IntValue ());
+			else if (jlo is Java.Lang.Long long_jlo)
+				return Dispose (long_jlo, v => v.LongValue ());
+			else if (jlo is Java.Lang.Float float_jlo)
+				return Dispose (float_jlo, v => v.FloatValue ());
+			else if (jlo is Java.Lang.Double double_jlo)
+				return Dispose (double_jlo, v => v.DoubleValue ());
 			else if (jlo is Java.Lang.String)
 				return Dispose (jlo, v => JNIEnv.GetString (v.Handle, JniHandleOwnership.DoNotTransfer));
-			else if (jlo is JavaObject)
-				return ((JavaObject) jlo).inst;
+			else if (jlo is JavaObject jobj_jlo)
+				return (jobj_jlo).inst;
 			else
 				return jlo;
 		}

--- a/src/Mono.Android/Android.Runtime/JavaObject.cs
+++ b/src/Mono.Android/Android.Runtime/JavaObject.cs
@@ -5,30 +5,32 @@ namespace Android.Runtime {
 	[Register ("mono/android/runtime/JavaObject")]
 	internal sealed class JavaObject : Java.Lang.Object {
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static IntPtr GetHandle (object obj)
 		{
 			if (obj == null)
 				return IntPtr.Zero;
 
-			if (obj is bool bool_obj)
-				return Java.Lang.Boolean.ValueOf (bool_obj).Handle;
-			else if (obj is sbyte sbyte_obj)
-				return Java.Lang.Byte.ValueOf (sbyte_obj).Handle;
-			else if (obj is char char_obj)
-				return Java.Lang.Character.ValueOf (char_obj).Handle;
-			else if (obj is short short_obj)
-				return Java.Lang.Short.ValueOf (short_obj)!.Handle;
-			else if (obj is int int_obj)
-				return Java.Lang.Integer.ValueOf (int_obj).Handle;
-			else if (obj is long long_obj)
-				return Java.Lang.Long.ValueOf (long_obj).Handle;
-			else if (obj is float float_obj)
-				return Java.Lang.Float.ValueOf (float_obj).Handle;
-			else if (obj is double double_obj)
-				return Java.Lang.Double.ValueOf (double_obj).Handle;
-			else if (obj is string string_obj)
-				return JNIEnv.NewString (string_obj);
-			else if (typeof (IJavaObject).IsAssignableFrom (obj.GetType ()))
+			Type type = obj.GetType ();
+			if (type == typeof (bool))
+				return new Java.Lang.Boolean ((bool)obj).Handle;
+			else if (type == typeof (sbyte))
+				return new Java.Lang.Byte ((sbyte)obj).Handle;
+			else if (type == typeof (char))
+				return new Java.Lang.Character ((char)obj).Handle;
+			else if (type == typeof (short))
+				return new Java.Lang.Short ((short)obj).Handle;
+			else if (type == typeof (int))
+				return new Java.Lang.Integer ((int)obj).Handle;
+			else if (type == typeof (long))
+				return new Java.Lang.Long ((long)obj).Handle;
+			else if (type == typeof (float))
+				return new Java.Lang.Float ((float)obj).Handle;
+			else if (type == typeof (double))
+				return new Java.Lang.Double ((double)obj).Handle;
+			else if (type == typeof (string))
+				return JNIEnv.NewString ((string)obj);
+			else if (typeof (IJavaObject).IsAssignableFrom (type))
 				return ((IJavaObject)obj).Handle;
 			else
 				return new JavaObject (obj).Handle;
@@ -36,28 +38,29 @@ namespace Android.Runtime {
 
 		public static object? GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
-			if (Java.Lang.Object.GetObject (handle, transfer) is not Java.Lang.Object jlo)
+			Java.Lang.Object? jlo = Java.Lang.Object.GetObject (handle, transfer) as Java.Lang.Object;
+			if (jlo == null)
 				return null;
-			else if (jlo is Java.Lang.Boolean bool_jlo)
-				return Dispose (bool_jlo, v => v.BooleanValue ());
-			else if (jlo is Java.Lang.Byte byte_jlo)
-				return Dispose (byte_jlo, v => v.ByteValue ());
-			else if (jlo is Java.Lang.Character chat_jlo)
-				return Dispose (chat_jlo, v => v.CharValue ());
-			else if (jlo is Java.Lang.Short short_jlo)
-				return Dispose (short_jlo, v => v.ShortValue ());
-			else if (jlo is Java.Lang.Integer int_jlo)
-				return Dispose (int_jlo, v => v.IntValue ());
-			else if (jlo is Java.Lang.Long long_jlo)
-				return Dispose (long_jlo, v => v.LongValue ());
-			else if (jlo is Java.Lang.Float float_jlo)
-				return Dispose (float_jlo, v => v.FloatValue ());
-			else if (jlo is Java.Lang.Double double_jlo)
-				return Dispose (double_jlo, v => v.DoubleValue ());
+			else if (jlo is Java.Lang.Boolean)
+				return Dispose ((Java.Lang.Boolean) jlo, v => v.BooleanValue ());
+			else if (jlo is Java.Lang.Byte)
+				return Dispose ((Java.Lang.Byte) jlo, v => v.ByteValue ());
+			else if (jlo is Java.Lang.Character)
+				return Dispose ((Java.Lang.Character) jlo, v => v.CharValue ());
+			else if (jlo is Java.Lang.Short)
+				return Dispose ((Java.Lang.Short) jlo, v => v.ShortValue ());
+			else if (jlo is Java.Lang.Integer)
+				return Dispose ((Java.Lang.Integer) jlo, v => v.IntValue ());
+			else if (jlo is Java.Lang.Long)
+				return Dispose ((Java.Lang.Long) jlo, v => v.LongValue ());
+			else if (jlo is Java.Lang.Float)
+				return Dispose ((Java.Lang.Float) jlo, v => v.FloatValue ());
+			else if (jlo is Java.Lang.Double)
+				return Dispose ((Java.Lang.Double) jlo, v => v.DoubleValue ());
 			else if (jlo is Java.Lang.String)
 				return Dispose (jlo, v => JNIEnv.GetString (v.Handle, JniHandleOwnership.DoNotTransfer));
-			else if (jlo is JavaObject jobj_jlo)
-				return (jobj_jlo).inst;
+			else if (jlo is JavaObject)
+				return ((JavaObject) jlo).inst;
 			else
 				return jlo;
 		}

--- a/src/Mono.Android/Android.Telecom/InCallService.cs
+++ b/src/Mono.Android/Android.Telecom/InCallService.cs
@@ -7,6 +7,7 @@ namespace Android.Telecom
 	{
 #if ANDROID_23
 		[Obsolete ("Incorrect enum parameter, use the overload that takes a CallAudioRoute parameter instead.")]
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android34.0")]
 		[global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android23.0")]
 		public void SetAudioRoute ([global::Android.Runtime.GeneratedEnum] Android.Telecom.VideoQuality route)
 		{

--- a/src/Mono.Android/Android.Telephony/CellInfo.cs
+++ b/src/Mono.Android/Android.Telephony/CellInfo.cs
@@ -11,6 +11,7 @@ namespace Android.Telephony {
 
 		static Delegate? cb_getCellIdentity;
 #pragma warning disable 0169
+		[global::System.Runtime.Versioning.SupportedOSPlatform ("android28.0")]
 		static Delegate GetGetCellIdentityHandler ()
 		{
 			if (cb_getCellIdentity == null)
@@ -18,6 +19,7 @@ namespace Android.Telephony {
 			return cb_getCellIdentity;
 		}
 
+		[global::System.Runtime.Versioning.SupportedOSPlatform ("android28.0")]
 		static IntPtr n_GetCellIdentity (IntPtr jnienv, IntPtr native__this)
 		{
 			var __this = global::Java.Lang.Object.GetObject<Android.Telephony.CellInfo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
@@ -25,6 +27,7 @@ namespace Android.Telephony {
 		}
 #pragma warning restore 0169
 
+		[global::System.Runtime.Versioning.SupportedOSPlatform ("android28.0")]
 		public unsafe virtual Android.Telephony.CellIdentity CellIdentity {
 			// Metadata.xml XPath method reference: path="/api/package[@name='android.telephony']/class[@name='CellInfo']/method[@name='getCellIdentity' and count(parameter)=0]"
 			[Register ("getCellIdentity", "()Landroid/telephony/CellIdentity;", "GetGetCellIdentityHandler", ApiSince = 30)]

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -77,6 +77,7 @@ namespace Android.Views {
 
 #if ANDROID_11
 		[Obsolete ("Please Use DispatchSystemUiVisibilityChanged(SystemUiFlags)")]
+		[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0")]
 		public void DispatchSystemUiVisibilityChanged (int visibility)
 		{
 			DispatchSystemUiVisibilityChanged ((SystemUiFlags) visibility);

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -274,16 +274,17 @@ namespace Java.Interop {
 			return Convert.ChangeType (value, targetType, CultureInfo.InvariantCulture);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		static Dictionary<Type, Func<object, IJavaObject>> JavaObjectConverters = new Dictionary<Type, Func<object, IJavaObject>>() {
-			{ typeof (bool),   value => Java.Lang.Boolean.ValueOf ((bool) value) },
-			{ typeof (byte),   value => Java.Lang.Byte.ValueOf ((sbyte) (byte) value) },
-			{ typeof (sbyte),  value => Java.Lang.Byte.ValueOf ((sbyte) value) },
-			{ typeof (char),   value => Java.Lang.Character.ValueOf ((char) value) },
-			{ typeof (short),  value => Java.Lang.Short.ValueOf ((short) value)! },
-			{ typeof (int),    value => Java.Lang.Integer.ValueOf ((int) value) },
-			{ typeof (long),   value => Java.Lang.Long.ValueOf ((long) value) },
-			{ typeof (float),  value => Java.Lang.Float.ValueOf ((float) value) },
-			{ typeof (double), value => Java.Lang.Double.ValueOf ((double) value) },
+			{ typeof (bool),   value => new Java.Lang.Boolean ((bool) value) },
+			{ typeof (byte),   value => new Java.Lang.Byte ((sbyte) (byte) value) },
+			{ typeof (sbyte),  value => new Java.Lang.Byte ((sbyte) value) },
+			{ typeof (char),   value => new Java.Lang.Character ((char) value) },
+			{ typeof (short),  value => new Java.Lang.Short ((short) value) },
+			{ typeof (int),    value => new Java.Lang.Integer ((int) value) },
+			{ typeof (long),   value => new Java.Lang.Long ((long) value) },
+			{ typeof (float),  value => new Java.Lang.Float ((float) value) },
+			{ typeof (double), value => new Java.Lang.Double ((double) value) },
 			{ typeof (string), value => new Java.Lang.String (value.ToString ()!) },
 		};
 
@@ -306,41 +307,42 @@ namespace Java.Interop {
 			return new Android.Runtime.JavaObject (value);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		static Dictionary<Type, Func<object, IntPtr>> LocalJniHandleConverters = new Dictionary<Type, Func<object, IntPtr>> {
 			{ typeof (bool),   value => {
-				using (var v = Java.Lang.Boolean.ValueOf ((bool) value))
+				using (var v = new Java.Lang.Boolean ((bool) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (byte),   value => {
-				using (var v = Java.Lang.Byte.ValueOf ((sbyte) (byte) value))
+				using (var v = new Java.Lang.Byte ((sbyte) (byte) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (sbyte),  value => {
-				using (var v = Java.Lang.Byte.ValueOf ((sbyte) value))
+				using (var v = new Java.Lang.Byte ((sbyte) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (char),   value => {
-				using (var v = Java.Lang.Character.ValueOf ((char) value))
+				using (var v = new Java.Lang.Character ((char) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (short),  value => {
-				using (var v = Java.Lang.Short.ValueOf ((short) value))
+				using (var v = new Java.Lang.Short ((short) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (int),    value => {
-				using (var v = Java.Lang.Integer.ValueOf ((int) value))
+				using (var v = new Java.Lang.Integer ((int) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (long),   value => {
-				using (var v = Java.Lang.Long.ValueOf ((long) value))
+				using (var v = new Java.Lang.Long ((long) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (float),  value => {
-				using (var v = Java.Lang.Float.ValueOf ((float) value))
+				using (var v = new Java.Lang.Float ((float) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (double), value => {
-				using (var v = Java.Lang.Double.ValueOf ((double) value))
+				using (var v = new Java.Lang.Double ((double) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (string), value => {

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -275,15 +275,15 @@ namespace Java.Interop {
 		}
 
 		static Dictionary<Type, Func<object, IJavaObject>> JavaObjectConverters = new Dictionary<Type, Func<object, IJavaObject>>() {
-			{ typeof (bool),   value => new Java.Lang.Boolean ((bool) value) },
-			{ typeof (byte),   value => new Java.Lang.Byte ((sbyte) (byte) value) },
-			{ typeof (sbyte),  value => new Java.Lang.Byte ((sbyte) value) },
-			{ typeof (char),   value => new Java.Lang.Character ((char) value) },
-			{ typeof (short),  value => new Java.Lang.Short ((short) value) },
-			{ typeof (int),    value => new Java.Lang.Integer ((int) value) },
-			{ typeof (long),   value => new Java.Lang.Long ((long) value) },
-			{ typeof (float),  value => new Java.Lang.Float ((float) value) },
-			{ typeof (double), value => new Java.Lang.Double ((double) value) },
+			{ typeof (bool),   value => Java.Lang.Boolean.ValueOf ((bool) value) },
+			{ typeof (byte),   value => Java.Lang.Byte.ValueOf ((sbyte) (byte) value) },
+			{ typeof (sbyte),  value => Java.Lang.Byte.ValueOf ((sbyte) value) },
+			{ typeof (char),   value => Java.Lang.Character.ValueOf ((char) value) },
+			{ typeof (short),  value => Java.Lang.Short.ValueOf ((short) value)! },
+			{ typeof (int),    value => Java.Lang.Integer.ValueOf ((int) value) },
+			{ typeof (long),   value => Java.Lang.Long.ValueOf ((long) value) },
+			{ typeof (float),  value => Java.Lang.Float.ValueOf ((float) value) },
+			{ typeof (double), value => Java.Lang.Double.ValueOf ((double) value) },
 			{ typeof (string), value => new Java.Lang.String (value.ToString ()!) },
 		};
 
@@ -308,39 +308,39 @@ namespace Java.Interop {
 
 		static Dictionary<Type, Func<object, IntPtr>> LocalJniHandleConverters = new Dictionary<Type, Func<object, IntPtr>> {
 			{ typeof (bool),   value => {
-				using (var v = new Java.Lang.Boolean ((bool) value))
+				using (var v = Java.Lang.Boolean.ValueOf ((bool) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (byte),   value => {
-				using (var v = new Java.Lang.Byte ((sbyte) (byte) value))
+				using (var v = Java.Lang.Byte.ValueOf ((sbyte) (byte) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (sbyte),  value => {
-				using (var v = new Java.Lang.Byte ((sbyte) value))
+				using (var v = Java.Lang.Byte.ValueOf ((sbyte) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (char),   value => {
-				using (var v = new Java.Lang.Character ((char) value))
+				using (var v = Java.Lang.Character.ValueOf ((char) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (short),  value => {
-				using (var v = new Java.Lang.Short ((short) value))
+				using (var v = Java.Lang.Short.ValueOf ((short) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (int),    value => {
-				using (var v = new Java.Lang.Integer ((int) value))
+				using (var v = Java.Lang.Integer.ValueOf ((int) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (long),   value => {
-				using (var v = new Java.Lang.Long ((long) value))
+				using (var v = Java.Lang.Long.ValueOf ((long) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (float),  value => {
-				using (var v = new Java.Lang.Float ((float) value))
+				using (var v = Java.Lang.Float.ValueOf ((float) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (double), value => {
-				using (var v = new Java.Lang.Double ((double) value))
+				using (var v = Java.Lang.Double.ValueOf ((double) value))
 					return JNIEnv.ToLocalJniHandle (v);
 			} },
 			{ typeof (string), value => {

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using Java.Interop.Tools.TypeNameMappings;
 
 using Android.Runtime;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Java.Interop {
 

--- a/src/Mono.Android/Java.Lang/Object.cs
+++ b/src/Mono.Android/Java.Lang/Object.cs
@@ -316,9 +316,10 @@ namespace Java.Lang {
 			return new Java.Lang.Object (JNIEnv.NewArray (value), JniHandleOwnership.TransferLocalRef);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (bool value)
 		{
-			return Java.Lang.Boolean.ValueOf (value);
+			return new Java.Lang.Boolean (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Byte)(sbyte) value`", error: true)]
@@ -327,14 +328,16 @@ namespace Java.Lang {
 			throw new InvalidOperationException ("Should not be reached");
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (sbyte value)
 		{
-			return Java.Lang.Byte.ValueOf (value);
+			return new Java.Lang.Byte (value);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (char value)
 		{
-			return Java.Lang.Character.ValueOf (value);
+			return new Java.Lang.Character (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Integer)(int) value`", error: true)]
@@ -343,9 +346,10 @@ namespace Java.Lang {
 			throw new InvalidOperationException ("Should not be reached");
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (int value)
 		{
-			return Java.Lang.Integer.ValueOf (value);
+			return new Java.Lang.Integer (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Long)(long) value`", error: true)]
@@ -354,19 +358,22 @@ namespace Java.Lang {
 			throw new InvalidOperationException ("Should not be reached");
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (long value)
 		{
-			return Java.Lang.Long.ValueOf (value);
+			return new Java.Lang.Long (value);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (float value)
 		{
-			return Java.Lang.Float.ValueOf (value);
+			return new Java.Lang.Float (value);
 		}
 
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Interoperability", "CA1422:Validate platform compatibility", Justification = "Suggested replacement uses instance sharing")]
 		public static implicit operator Java.Lang.Object (double value)
 		{
-			return Java.Lang.Double.ValueOf (value);
+			return new Java.Lang.Double (value);
 		}
 
 		public static implicit operator Java.Lang.Object? (string? value)

--- a/src/Mono.Android/Java.Lang/Object.cs
+++ b/src/Mono.Android/Java.Lang/Object.cs
@@ -318,7 +318,7 @@ namespace Java.Lang {
 
 		public static implicit operator Java.Lang.Object (bool value)
 		{
-			return new Java.Lang.Boolean (value);
+			return Java.Lang.Boolean.ValueOf (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Byte)(sbyte) value`", error: true)]
@@ -329,12 +329,12 @@ namespace Java.Lang {
 
 		public static implicit operator Java.Lang.Object (sbyte value)
 		{
-			return new Java.Lang.Byte (value);
+			return Java.Lang.Byte.ValueOf (value);
 		}
 
 		public static implicit operator Java.Lang.Object (char value)
 		{
-			return new Java.Lang.Character (value);
+			return Java.Lang.Character.ValueOf (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Integer)(int) value`", error: true)]
@@ -345,7 +345,7 @@ namespace Java.Lang {
 
 		public static implicit operator Java.Lang.Object (int value)
 		{
-			return new Java.Lang.Integer (value);
+			return Java.Lang.Integer.ValueOf (value);
 		}
 
 		[Obsolete ("Use `(Java.Lang.Long)(long) value`", error: true)]
@@ -356,17 +356,17 @@ namespace Java.Lang {
 
 		public static implicit operator Java.Lang.Object (long value)
 		{
-			return new Java.Lang.Long (value);
+			return Java.Lang.Long.ValueOf (value);
 		}
 
 		public static implicit operator Java.Lang.Object (float value)
 		{
-			return new Java.Lang.Float (value);
+			return Java.Lang.Float.ValueOf (value);
 		}
 
 		public static implicit operator Java.Lang.Object (double value)
 		{
-			return new Java.Lang.Double (value);
+			return Java.Lang.Double.ValueOf (value);
 		}
 
 		public static implicit operator Java.Lang.Object? (string? value)

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -41,10 +41,6 @@
     <NoWarn>$(NoWarn);CS1572;CS1573;CS1574;CS1584;CS1587;CS1591;CS1658;</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(_EnableCodeAnalyzerPlatformWarnings)' == '' ">
-    <NoWarn>$(NoWarn);CA1422;CA1416</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI\API-$(AndroidApiLevel)\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\API-$(AndroidApiLevel)\PublicAPI.Unshipped.txt" />


### PR DESCRIPTION
Fixes #7590

Fix the remaining `[SupportedOSPlatform]` warnings in manually bound code.  Other issues we were previously seeing appear to have been a bug in earlier .NET 8 previews.

Of particular note, the constructors for `Java.Lang.Boolean`, `Java.Lang.Integer`, etc. have been marked as `Deprecated` in API-33. ([source](https://developer.android.com/reference/java/lang/Integer?hl=en#Integer(int))).

This PR replaces them with the suggested `valueOf` methods.

@jonpryor Please verify this change is acceptable for our use case.