### PR TITLE
[ci] Use fewer agents for macOS MSBuild tests

### DIFF
--- a/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
@@ -21,7 +21,7 @@ stages:
       testOS: macOS
       jobName: mac_msbuild_tests
       jobDisplayName: macOS > Tests > MSBuild
-      agentCount: 10
+      agentCount: 8
       xaSourcePath: ${{ parameters.xaSourcePath }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}


### PR DESCRIPTION
Recent MSBuild test updates and removals seem to have sped up the tests
enough that we can split them across fewer agents.