### PR TITLE
[ci] Report when dotnet-test-slicer fails

### DIFF
--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -15,6 +15,7 @@ steps:
       --total-slices=$(System.TotalJobsInPhase)
       --outfile="${{ parameters.testAssembly }}.runsettings"
     displayName: Slice unit tests with filter
+    failOnStderr: true
 - ${{ else }}:
   - pwsh: >-
       dotnet-test-slicer slice
@@ -23,6 +24,7 @@ steps:
       --total-slices=$(System.TotalJobsInPhase)
       --outfile="${{ parameters.testAssembly }}.runsettings"
     displayName: Slice unit tests
+    failOnStderr: true
 
 - ${{ if eq(parameters.retryFailedTests, 'false') }}:
   # If we aren't using auto-retry logic, then this is just a simple template call


### PR DESCRIPTION
Changes to the `dotnet-test-slicer` task from commit a4276880 may have
caused it to fail silently if any issues occur.  Updating the task to
fail if anything is written to stderr should fix this.