### PR TITLE
[Mono.Android] Add `pathSuffix` and `pathAdvancedPattern` to `[IntentFilter]`

### DIFF
--- a/build-tools/manifest-attribute-codegen/manifest-definition.xml
+++ b/build-tools/manifest-attribute-codegen/manifest-definition.xml
@@ -345,6 +345,7 @@
         <a name='sspPrefix' format='string' api-level='19' />
         <a name='sspPattern' format='string' api-level='19' />
         <a name='pathAdvancedPattern' api-level='26' />
+        <a name='pathSuffix' api-level='31' />
     </e>
     <e name='category'>
         <parent>intent-filter</parent>

--- a/src/Mono.Android/Android.App/IntentFilterAttribute.cs
+++ b/src/Mono.Android/Android.App/IntentFilterAttribute.cs
@@ -43,5 +43,13 @@ namespace Android.App {
 #if ANDROID_25
 		public string?    RoundIcon       {get; set;}
 #endif
+#if ANDROID_26
+		public string?    DataPathAdvancedPattern  {get; set;}
+		public string[]?  DataPathAdvancedPatterns {get; set;}
+#endif
+#if ANDROID_31
+		public string?    DataPathSuffix {get; set;}
+		public string[]?  DataPathSuffixes {get; set;}
+#endif
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/IntentFilterAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/IntentFilterAttribute.Partial.cs
@@ -27,6 +27,8 @@ namespace Android.App {
 			{ "DataPort",         "port" },
 			{ "DataScheme",       "scheme" },
 			{ "AutoVerify",       "autoVerify" },
+			{ "DataPathSuffix",   "pathSuffix" },
+			{ "DataPathAdvancedPattern", "pathAdvancedPattern" },
 		};
 
 		static readonly Dictionary<string, Action<IntentFilterAttribute, object>> setters = new Dictionary<string, Action<IntentFilterAttribute, object>> () {
@@ -50,6 +52,10 @@ namespace Android.App {
 			{ "DataSchemes",      (self, value) => self.DataSchemes     = ToStringArray (value) },
 			{ "AutoVerify",       (self, value) => self._AutoVerify     = (bool) value },
 			{ "RoundIcon",        (self, value) => self._RoundIcon      = (string) value },
+			{ "DataPathSuffix",   (self, value) => self.DataPathSuffix  = (string) value },
+			{ "DataPathSuffixes", (self, value) => self.DataPathSuffixes  = ToStringArray (value) },
+			{ "DataPathAdvancedPattern",   (self, value) => self.DataPathAdvancedPattern        = (string) value },
+			{ "DataPathAdvancedPatterns",  (self, value) => self.DataPathAdvancedPatterns       = ToStringArray (value) },
 		};
 
 		static string[] ToStringArray (object value)
@@ -126,6 +132,8 @@ namespace Android.App {
 			Func<string,XAttribute> toPathPrefix  = v => ToAttribute ("DataPathPrefix",  ReplacePackage (v, packageName));
 			Func<string,XAttribute> toPort        = v => ToAttribute ("DataPort",        ReplacePackage (v, packageName));
 			Func<string,XAttribute> toScheme      = v => ToAttribute ("DataScheme",      ReplacePackage (v, packageName));
+			Func<string,XAttribute> toPathSuffix      = v => ToAttribute ("DataPathSuffix",			  ReplacePackage (v, packageName));
+			Func<string,XAttribute> toPathAdvancedPattern = v => ToAttribute ("DataPathAdvancedPattern",      ReplacePackage (v, packageName));
 			Func<Func<string,XAttribute>, string, XElement> toData = (f, s) => string.IsNullOrEmpty (s) ? null : new XElement ("data", f (s));
 			var empty = Array.Empty<string> ();
 			var dataList = Enumerable.Empty<XElement> ()
@@ -135,11 +143,13 @@ namespace Android.App {
 				.Concat ((DataPathPatterns ?? empty).Select (p => toData (toPathPattern, p)))
 				.Concat ((DataPathPrefixes ?? empty).Select (p => toData (toPathPrefix, p)))
 				.Concat ((DataPorts ?? empty).Select (p => toData (toPort, p)))
-				.Concat ((DataSchemes ?? empty).Select (p => toData (toScheme, p)));
+				.Concat ((DataSchemes ?? empty).Select (p => toData (toScheme, p)))
+				.Concat ((DataPathSuffixes ?? empty).Select (p => toData (toPathSuffix, p)))
+				.Concat ((DataPathAdvancedPatterns ?? empty).Select (p => toData (toPathAdvancedPattern, p)));
 			if (string.IsNullOrEmpty (DataHost) && string.IsNullOrEmpty (DataMimeType) &&
 					string.IsNullOrEmpty (DataPath) && string.IsNullOrEmpty (DataPathPattern) && string.IsNullOrEmpty (DataPathPrefix) &&
-					string.IsNullOrEmpty (DataPort) && string.IsNullOrEmpty (DataScheme) &&
-					!dataList.Any ())
+					string.IsNullOrEmpty (DataPort) && string.IsNullOrEmpty (DataScheme) && string.IsNullOrEmpty (DataPathSuffix) &&
+					string.IsNullOrEmpty (DataPathAdvancedPattern) && !dataList.Any ())
 				return null;
 			return new XElement [] {
 					toData (toHost, DataHost),
@@ -148,7 +158,9 @@ namespace Android.App {
 					toData (toPathPattern, DataPathPattern),
 					toData (toPathPrefix, DataPathPrefix),
 					toData (toPort, DataPort),
-					toData (toScheme, DataScheme) }
+					toData (toScheme, DataScheme),
+					toData (toPathSuffix, DataPathSuffix),
+					toData (toPathAdvancedPattern, DataPathAdvancedPattern)}
 				.Concat (dataList).Where (x => x != null);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -1121,8 +1121,13 @@ class TestActivity : Activity { }"
 			}
 		}
 
-		[IntentFilter (new [] { "myaction" }, DataPathSuffix = "mysuffix", DataPathAdvancedPattern = "mypattern")]
-		[IntentFilter (new [] { "myaction" }, DataPathSuffixes = new [] { "mysuffix", "mysuffix2" }, DataPathAdvancedPatterns = new [] { "mypattern", "mypattern2" })]
+		[IntentFilter (new [] { "singularAction" },
+		    DataPathSuffix = "singularSuffix",
+		    DataPathAdvancedPattern = "singularPattern")]
+		[IntentFilter (new [] { "pluralAction" },
+		    DataPathSuffixes = new [] { "pluralSuffix1", "pluralSuffix2" },
+		    DataPathAdvancedPatterns = new [] { "pluralPattern1", "pluralPattern2" })]
+
 		public class IntentFilterAttributeDataPathTestClass { }
 
 		[Test]
@@ -1131,14 +1136,14 @@ class TestActivity : Activity { }"
 			var asm = AssemblyDefinition.ReadAssembly (typeof (IntentFilterAttributeDataPathTestClass).Assembly.Location);
 			var type = asm.MainModule.GetType ("Xamarin.Android.Build.Tests.ManifestTest/IntentFilterAttributeDataPathTestClass");
 
-			var intent = IntentFilterAttribute.FromTypeDefinition (type).First ();
-			var xml = intent.ToElement ("blah").ToString ();
+			var intent = IntentFilterAttribute.FromTypeDefinition (type).Single (f => f.Actions.Contains ("singularAction"));
+			var xml = intent.ToElement ("dummy.packageid").ToString ();
 
 			var expected =
 @"<intent-filter>
-  <action p2:name=""myaction"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathSuffix=""mysuffix"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathAdvancedPattern=""mypattern"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <action p2:name=""singularAction"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathSuffix=""singularSuffix"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathAdvancedPattern=""singularPattern"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
 </intent-filter>";
 
 			StringAssertEx.AreMultiLineEqual (expected, xml);
@@ -1150,16 +1155,16 @@ class TestActivity : Activity { }"
 			var asm = AssemblyDefinition.ReadAssembly (typeof (IntentFilterAttributeDataPathTestClass).Assembly.Location);
 			var type = asm.MainModule.GetType ("Xamarin.Android.Build.Tests.ManifestTest/IntentFilterAttributeDataPathTestClass");
 
-			var intent = IntentFilterAttribute.FromTypeDefinition (type).ElementAt (1);
-			var xml = intent.ToElement ("blah").ToString ();
+			var intent = IntentFilterAttribute.FromTypeDefinition (type).Single (f => f.Actions.Contains ("pluralAction"));
+			var xml = intent.ToElement ("dummy.packageid").ToString ();
 
 			var expected =
 @"<intent-filter>
-  <action p2:name=""myaction"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathSuffix=""mysuffix"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathSuffix=""mysuffix2"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathAdvancedPattern=""mypattern"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
-  <data p2:pathAdvancedPattern=""mypattern2"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <action p2:name=""pluralAction"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathSuffix=""pluralSuffix1"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathSuffix=""pluralSuffix2"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathAdvancedPattern=""pluralPattern1"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
+  <data p2:pathAdvancedPattern=""pluralPattern2"" xmlns:p2=""http://schemas.android.com/apk/res/android"" />
 </intent-filter>";
 
 			StringAssertEx.AreMultiLineEqual (expected, xml);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -93,6 +93,15 @@ namespace Xamarin.Android.Build.Tests
 			}
 			return found == count;
 		}
+
+		// Checks if two string are equal after normalizing string line endings
+		public static void AreMultiLineEqual (string expected, string actual)
+		{
+			expected = expected.ReplaceLineEndings ();
+			actual = actual.ReplaceLineEndings ();
+
+			Assert.AreEqual (expected, actual);
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -13,7 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24;ANDROID_26;ANDROID_31</DefineConstants>
     <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\$(DotNetTargetFramework)\android-$(AndroidLatestStablePlatformId)\mcw</AndroidGeneratedClassDirectory>
     <NoWarn>8632</NoWarn>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
Fixes: #8235

Adds the following properties to `[IntentFilter]` to allow the specified `AndroidManifest.xml` attributes to be generated:
- `DataPathSuffix` -> `pathSuffix`
- `DataPathSuffixes` -> `pathSuffix`
- `DataPathAdvancedPattern` -> `pathAdvancedPattern`
- `DataPathAdvancedPatterns` -> `pathAdvancedPattern`

Note that while we have a script to detect new elements added to `AndroidManifest.xml`, the code must be written manually.  Filed #8272 because we really should automate this code generation.