### PR TITLE
[Xamarin.Android.Build.Tasks] fix System.Text.Json with default trimmer settings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -112,7 +112,7 @@
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
-    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == '' and '$(TrimMode)' == 'partial'">true</JsonSerializerIsReflectionEnabledByDefault>
     <_SystemReflectionForceInterpretedInvoke Condition="'$(_SystemReflectionForceInterpretedInvoke)' == ''">true</_SystemReflectionForceInterpretedInvoke>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' and '$(PublishTrimmed)' == 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -112,6 +112,7 @@
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">true</JsonSerializerIsReflectionEnabledByDefault>
     <_SystemReflectionForceInterpretedInvoke Condition="'$(_SystemReflectionForceInterpretedInvoke)' == ''">true</_SystemReflectionForceInterpretedInvoke>
     <!-- Verify DI trimmability at development-time, but turn the validation off for production/trimmed builds. -->
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == '' and '$(PublishTrimmed)' == 'true'">false</VerifyDependencyInjectionOpenGenericServiceTrimmability>

--- a/tests/Mono.Android-Tests/Mono.Android-Test.Shared.projitems
+++ b/tests/Mono.Android-Tests/Mono.Android-Test.Shared.projitems
@@ -45,6 +45,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System.Net\NetworkInterfaces.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\DllImportTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.Text\EncodingTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System.Text.Json\JsonSerializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System.Threading\InterlockedTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\JavaObjectExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Android.Net\AndroidClientHandlerTests.cs" />

--- a/tests/Mono.Android-Tests/System.Text.Json/JsonSerializerTest.cs
+++ b/tests/Mono.Android-Tests/System.Text.Json/JsonSerializerTest.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Text.Json;
+
+using NUnit.Framework;
+
+namespace System.Text.JsonTests {
+
+	[TestFixture]
+	public class JsonSerializerTest {
+
+		[Test]
+		public void Serialize ()
+		{
+			string text = JsonSerializer.Serialize(42);
+			Assert.AreEqual("42", text);
+		}
+
+		[Test]
+		public void Deserialize ()
+		{
+			object value = JsonSerializer.Deserialize("42", typeof(int));
+			Assert.AreEqual(42, value);
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/16038

Changes to trimmer defaults in .NET 8 require a new `$(JsonSerializerIsReflectionEnabledByDefault)` MSBuild property to be set by default for project types that use `$(TrimMode)=partial` like when running on mobile (iOS/Android).

I added a very basic System.Text.Json test, which fails with the exception:

    System.InvalidOperationException : JsonSerializerIsReflectionDisabled
    at System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()
    at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions , Type )
    at System.Text.Json.JsonSerializer.Deserialize(String , Type , JsonSerializerOptions )
    at System.Text.JsonTests.JsonSerializerTest.Deserialize()
    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object , BindingFlags )

Simply running the test again with the MSBuild property set allows the test to pass. This will be a good smoke test for System.Text.Json going forward.

The iOS side of this is tracked here:

https://github.com/xamarin/xamarin-macios/issues/18057