### PR TITLE
[build] set file extension for common `ToolExe` values

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -180,12 +180,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <AdbToolPath Condition=" '$(AdbToolPath)' == '' ">$(AndroidSdkFullPath)\platform-tools\</AdbToolPath>
-    <AdbToolExe Condition=" '$(AdbToolExe)' == '' ">adb</AdbToolExe>
+    <AdbToolExe Condition=" '$(AdbToolExe)' == '' and '$(HostOS)' != 'Windows' ">adb</AdbToolExe>
+    <AdbToolExe Condition=" '$(AdbToolExe)' == '' and '$(HostOS)' == 'Windows' ">adb.exe</AdbToolExe>
     <AvdManagerHome Condition=" '$(AvdManagerHome)' == '' ">$(AndroidToolchainDirectory)</AvdManagerHome>
-    <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' ">avdmanager</AvdManagerToolExe>
+    <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' and '$(HostOS)' != 'Windows' ">avdmanager</AvdManagerToolExe>
+    <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' and '$(HostOS)' == 'Windows' ">avdmanager.bat</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
-    <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
     <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">7.0</CommandLineToolsFolder>
     <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">8512546_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
@@ -193,7 +194,8 @@
     <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">9364964</EmulatorVersion>
     <EmulatorPkgRevision Condition=" '$(EmulatorPkgRevision)' == '' ">32.1.9</EmulatorPkgRevision>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
-    <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
+    <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' and '$(HostOS)' != 'Windows'  ">emulator</EmulatorToolExe>
+    <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' and '$(HostOS)' == 'Windows'  ">emulator.exe</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' == 'Windows' ">$(AndroidNdkDirectory)\ndk-build.cmd</NdkBuildPath>
     <BundleToolJarPath Condition=" '$(BundleToolJarPath)' == '' ">$(MicrosoftAndroidSdkOutDir)bundletool.jar</BundleToolJarPath>


### PR DESCRIPTION
Running the `-t:Install` target with a local xamarin-android build on Windows, I got the error:

    AndroidAdb
    Errors
        Xamarin.Android.Common.targets(2641,3): error MSB6004:
        The specified task executable location "D:\android-toolchain\sdk\platform-tools\adb" is invalid.

This appears to only happen with a local of xamarin/xamarin-android because it specifies `AdbToolExe=adb` in `Configuration.props`.

It appears that most of our tasks just use the pattern:

    protected override string GenerateFullPathToTool ()
    {
        return Path.Combine (ToolPath, ToolExe);
    }

Where if `ToolExe` was completely blank, it would fall back to the value:

    protected override string ToolName => OS.IsWindows ? "adb.exe" : "adb";

Searching the web:

https://grep.app/search?current=2&q=ToolExe&words=true&filter[lang][0]=C%23&filter[lang][1]=XML

It seems most other tasks use `ToolExe` as-is, if it is passed in. Where most of the time the default value is blank.

So, I think the simple fix here, is to specify the file extension in `Configuration.props` for any of our `$(FooToolExe)` values.

I also removed `$(AndroidToolExe)` because it is unused and may not event exist anymore in the Android SDK.