### PR TITLE
[ci] Simplify `run-sliced-nunit-tests.yaml`.

### DIFF
--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -6,25 +6,15 @@ parameters:
   retryFailedTests: true  # Retry failed tests once
 
 steps:
-- ${{if parameters.testFilter}}:
-  - pwsh: >-
-      dotnet-test-slicer slice
-      --test-assembly="${{ parameters.testAssembly }}"
-      --test-filter="${{ parameters.testFilter }}"
-      --slice-number=$(System.JobPositionInPhase)
-      --total-slices=$(System.TotalJobsInPhase)
-      --outfile="${{ parameters.testAssembly }}.runsettings"
-    displayName: Slice unit tests with filter
-    failOnStderr: true
-- ${{ else }}:
-  - pwsh: >-
-      dotnet-test-slicer slice
-      --test-assembly="${{ parameters.testAssembly }}"
-      --slice-number=$(System.JobPositionInPhase)
-      --total-slices=$(System.TotalJobsInPhase)
-      --outfile="${{ parameters.testAssembly }}.runsettings"
-    displayName: Slice unit tests
-    failOnStderr: true
+- pwsh: >-
+    dotnet-test-slicer slice
+    --test-assembly "${{ parameters.testAssembly }}"
+    --test-filter `"${{ parameters.testFilter }}`"
+    --slice-number $(System.JobPositionInPhase)
+    --total-slices $(System.TotalJobsInPhase)
+    --outfile "${{ parameters.testAssembly }}.runsettings"
+  displayName: Slice unit tests
+  failOnStderr: true
 
 - ${{ if eq(parameters.retryFailedTests, 'false') }}:
   # If we aren't using auto-retry logic, then this is just a simple template call
@@ -51,8 +41,8 @@ steps:
   - pwsh: |
       dotnet-test-slicer `
         retry `
-        --trx="$(Agent.TempDirectory)" `
-        --outfile="${{ parameters.testAssembly }}.runsettings"
+        --trx "$(Agent.TempDirectory)" `
+        --outfile "${{ parameters.testAssembly }}.runsettings"
     displayName: Look for failed tests
     workingDirectory: ${{ parameters.xaSourcePath }}
 


### PR DESCRIPTION
The `--test-filter` option for `dotnet-test-slicer` is supposed to be optional, however it apparently matters how you call it.

We were calling it in a way that `System.CommandLine` didn't like:
```
--test-filter=""

Required argument missing for option: '--test-filter'.
```

If we omit the equal sign it should work:
```
--test-filter ""
```

Additionally, it seems this works in `cmd` but not in PowerShell.  For PowerShell you also have to escape the quotation marks for it to pass the empty string to the executable: 🤦 
```
--test-filter `"`"
```

Update, apparently the fact that escaping the quotation marks works is a bug (it also doesn't work when the string isn't empty): https://github.com/PowerShell/PowerShell/issues/6280#issuecomment-390044956.

It looks like the root issue of empty strings not getting passed to the executable is fixed in PowerShell 7.3, so we can wait until that is the version available on our test agents:

https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing