### PR TITLE
$(AndroidPackVersionSuffix)=rc.2; net8 is 34.0.0-rc.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx-rc1

We branched for .NET 8 RC 1 from 3cca3d9d into `release/8.0.1xx-rc1`.

Update xamarin-android/main's version number to 34.0.0-rc.2 for .NET 8 RC 2.