### PR TITLE
[build] Bump arcade for latest SxS manifest fixes

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -471,6 +471,7 @@ stages:
         !*Darwin*
       propsArtifactName: $(NuGetArtifactName)
       signType: $(MicroBuildSignType)
+      arcadePackageVersion: 8.0.0-beta.23417.3
       postConvertSteps:
       - task: DownloadPipelineArtifact@2
         inputs:


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/commit/b6e1c2fd5fdada05c64e7f17e2a97fae240f9043

Updates the arcade version to bring in a fix for workload MSI generation
when side by side manifest support is enabled.  This should allow us to
avoid an issue that would occur when trying to insert a new workload
manifest with the same SDK band as the one already in VS.