### PR TITLE
[tests] Skip sign check when installing MAUI

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -109,6 +109,7 @@
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
       <_NuGetSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
       <_InstallArguments Include="--skip-manifest-update" />
+      <_InstallArguments Include="--skip-sign-check" />
       <_InstallArguments Include="--verbosity diag" />
       <_InstallArguments Include="--source &quot;%(_NuGetSources.Identity)&quot;" />
       <_InstallArguments Include="--temp-dir &quot;$(_TempDirectory)&quot;" />


### PR DESCRIPTION
The MAUI integration test job has been failing with:

    EXEC(0,0): Error : NU3004: The package is not signed.

Our upstream dependencies will not always be signed, and the packages
we are building for testing purposes are not signed.  We can avoid this
error by adding `--skip-sign-check` to the workload install command.