### PR TITLE
[Xamarin.Android.Build.Tasks] Fix APT2264 error on Windows.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -493,7 +493,7 @@ namespace Xamarin.Android.Tasks {
 			Tuple.Create ("APT2261", "file failed to compile"),
 			Tuple.Create ("APT2262", "unexpected element <activity> found in <manifest>"),
 			Tuple.Create ("APT2263", "found in <manifest>"),  // unexpected element <xxxxx> found in <manifest>
-			Tuple.Create ("APT2264", "The system cannot find the file specified. (2).") // Windows Long Path error from aapt2
+			Tuple.Create ("APT2264", "The system cannot find the file specified. (2)") // Windows Long Path error from aapt2
 		};
 	}
 }


### PR DESCRIPTION
We see users reporting the following error on Windows machines.

```
APT2000 The system cannot find the file specified. (2): foo.xml
```

This is odd because what it SHOULD be reporting is an APT2264 error. This provides additional feedback to check for Long File Paths. As a result users do not get the additional info.
It turns out we were trying to match
`The system cannot find the file specified. (2).`
with `The system cannot find the file specified. (2):`. On Windows the error message contains a `:` rather than `.` this stops the code matching and results in the APT2000 error. Lets fix that.