### PR TITLE
[installers] Let monodroid control which fast dev files are included in the installer

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@8908d6a1c4fdfa8d3cc391d1d78f23f88a8ce6fb
+xamarin/monodroid:main@c36049815ca04379194dd32f402f56beb5b992d3
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -20,6 +20,7 @@
     <IncludeMonoBundleComponents Condition="'$(IncludeMonoBundleComponents)' == ''">True</IncludeMonoBundleComponents>
     <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
     <_HasCommercialFiles Condition="Exists('$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Common.Debugging.targets')">True</_HasCommercialFiles>
+    <_MonoDroidPath Condition=" '$(_MonoDroidPath)' == '' ">..\..\external\monodroid</_MonoDroidPath>
   </PropertyGroup>
   <Target Name="_FindFrameworkDirs">
     <ItemGroup>
@@ -360,40 +361,9 @@
     <ThirdPartyNotice Include="$(XAInstallPrefix)ThirdPartyNotices.txt" />
   </ItemGroup>
   <!-- monodroid -->
-  <ItemGroup Condition=" '$(_HasCommercialFiles)' == 'True' ">
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)INIFileParser.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)jar2xml.jar" ExcludeFromAndroidNETSdk="true" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.AndroidTools.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Mono.AndroidTools.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Analysis.Compatibility.targets" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Analysis.targets" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Analysis.Tasks.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Analysis.Tasks.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Debugging.Tasks.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Build.Debugging.Tasks.pdb" />
-    <_MSBuildFiles Include="@(_LocalizationLanguages->'$(MicrosoftAndroidSdkOutDir)%(Identity)\Xamarin.Android.Build.Debugging.Tasks.resources.dll')" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Common.Debugging.props" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Common.Debugging.targets" />
-    <!-- The `installer` tool relies on protobuf-net.dll, listed above. -->
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)lib\arm64-v8a\installer" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)lib\armeabi-v7a\installer" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)lib\x86\installer" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)lib\x86_64\installer" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.AndroidTools.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.AndroidTools.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.AndroidSDK.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.AndroidSDK.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Build.Tasks.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Build.Tasks.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.dll" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.pdb" />
-    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Installer.Common.targets" />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.sync')" />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.find')" />
-    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MicrosoftAndroidSdkOutDir)lib\%(Identity)\xamarin.stat')" />
-    <LegacyTargetsFiles Include="$(XAInstallPrefix)xbuild\Novell\Xamarin.Android.Bindings.targets" />
-    <LegacyTargetsFiles Include="$(XAInstallPrefix)xbuild\Novell\Xamarin.Android.VisualBasic.targets" />
-  </ItemGroup>
+  <!-- new files to be included from monodroid should be added to the following projitems file in that repo. -->
+  <Import Project="$(_MonoDroidPath)\tools\scripts\installer-files.projitems" Condition=" '$(_HasCommercialFiles)' == 'True' And Exists ('$(_MonoDroidPath)\tools\scripts\installer-files.projitems') " />
+  <!-- end monodroid -->
   <Target Name="ConstructInstallerItems"
       DependsOnTargets="_FindFrameworkDirs;_WriteVersionFiles"
       Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(LegacyMSBuildItemsWin);@(MSBuildItemsUnix);@(LegacyMSBuildItemsUnix)">


### PR DESCRIPTION
Related https://github.com/xamarin/monodroid/commit/a2dbe752e40f25b39e22f0fac6b21f7980d73c1d.

Currently we control which files are included from the monodroid Fast Deployment in this repo. 
This can cause problems when we want to add new files (or remove them). Since we would need
to bump each repo multiple times to get everything to work. 

This PR moves that control over to monodroid, so new files can be included in one commit and then
one bump. 