### PR TITLE
[Xamarin.Android.Build.Tasks] improve net6.0 "out of support" message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
@@ -28,7 +28,7 @@ Things to note:
   </PropertyGroup>
   <ItemGroup>
     <SdkSupportedTargetPlatformVersion Include="21.0" />
-    <EolWorkload Include="android" Url="https://aka.ms/maui-support-policy" />
+    <EolWorkload Include="net6.0-android" Url="https://aka.ms/maui-support-policy" />
   </ItemGroup>
   <Target Name="_ClearMissingWorkloads">
     <!--


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8047#issuecomment-1692910565

The current error message:

    Microsoft.NET.EolTargetFrameworks.targets(35,5): error NETSDK1202:
    The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.

Doesn't say the problem is .NET 6, it sounds like all versions of the `android` workload are out of support.

To align with the xamarin-macios team, let's change it to be:

    The workload 'net6.0-android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.