### PR TITLE
[build] Use Microsoft OpenJDK 17.0.8

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -59,7 +59,7 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-11"
+    - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
       displayName: set JI_JAVA_HOME
 
     # Set MSBuild property overrides if parameters are set

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -7,7 +7,7 @@ parameters:
   testAssembliesArtifactName: $(TestAssembliesArtifactName)
 
 steps:
-- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-11"
+- script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
   displayName: set JI_JAVA_HOME
 
 - template: use-dot-net.yaml

--- a/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -17,9 +17,9 @@ namespace Xamarin.Android.Prepare
 	{
 		const string BinutilsVersion                = "L_16.0.6-6.0.0";
 
-		const string MicrosoftOpenJDK11Version      = "11.0.16";
-		const string MicrosoftOpenJDK11Release      = "8.1";
-		const string MicrosoftOpenJDK11RootDirName  = "jdk-11.0.16+8";
+		const string MicrosoftOpenJDK17Version      = "17.0.8";
+		const string MicrosoftOpenJDK17Release      = "17.0.8.7";
+		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.8+7";
 
 		const string AdoptOpenJDKRelease = "8.0"; // build_number.0
 		static readonly string AdoptOpenJDKUrlVersion = $"8u{AdoptOpenJDKUpdate}{AdoptOpenJDKBuild}";
@@ -35,10 +35,10 @@ namespace Xamarin.Android.Prepare
 			// https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01.zip
 			public static readonly Uri AdoptOpenJDK8 = new Uri ($"https://github.com/adoptium/temurin8-binaries/releases/download/{AdoptOpenJDKTag}/OpenJDK8U-jdk_{AdoptOpenJDKOperatingSystem}_hotspot_{AdoptOpenJDKUrlVersion}.{AdoptOpenJDKArchiveExtension}");
 
-			// https://aka.ms/download-jdk/microsoft-jdk-11.0.16-linux-x64.tar.gz
-			// https://aka.ms/download-jdk/microsoft-jdk-11.0.16-macOS-x64.tar.gz
-			// https://aka.ms/download-jdk/microsoft-jdk-11.0.16-windows-x64.zip
-			public static readonly Uri MicrosoftOpenJDK11 = new Uri ($"https://aka.ms/download-jdk/microsoft-jdk-{MicrosoftOpenJDK11Version}-{MicrosoftOpenJDKOperatingSystem}.{MicrosoftOpenJDKFileExtension}");
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-linux-x64.tar.gz
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-macOS-x64.tar.gz
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.zip
+			public static readonly Uri MicrosoftOpenJDK17 = new Uri ($"https://aka.ms/download-jdk/microsoft-jdk-{MicrosoftOpenJDK17Version}-{MicrosoftOpenJDKOperatingSystem}.{MicrosoftOpenJDKFileExtension}");
 
 			/// <summary>
 			///   Base URL for all Android SDK and NDK downloads. Used in <see cref="AndroidToolchain"/>
@@ -57,11 +57,11 @@ namespace Xamarin.Android.Prepare
 			public static readonly string BinutilsVersion            = Configurables.BinutilsVersion;
 			public static readonly char[] PropertyListSeparator            = new [] { ':' };
 
-			public static readonly string JdkFolder                        = "jdk-11";
+			public static readonly string JdkFolder                        = "jdk-17";
 
-			public static readonly Version MicrosoftOpenJDK11Version = new Version (Configurables.MicrosoftOpenJDK11Version);
-			public static readonly Version MicrosoftOpenJDK11Release = new Version (Configurables.MicrosoftOpenJDK11Release);
-			public static readonly string  MicrosoftOpenJDK11RootDirName   = Configurables.MicrosoftOpenJDK11RootDirName;
+			public static readonly Version MicrosoftOpenJDK17Version       = new Version (Configurables.MicrosoftOpenJDK17Version);
+			public static readonly Version MicrosoftOpenJDK17Release       = new Version (Configurables.MicrosoftOpenJDK17Release);
+			public static readonly string  MicrosoftOpenJDK17RootDirName   = Configurables.MicrosoftOpenJDK17RootDirName;
 
 			public static readonly Version AdoptOpenJDK8Version     = new Version (Configurables.AdoptOpenJDKVersion);
 			public static readonly Version AdoptOpenJDK8Release     = new Version (Configurables.AdoptOpenJDKRelease);
@@ -307,8 +307,8 @@ namespace Xamarin.Android.Prepare
 			public static string OpenJDK8InstallDir                  => GetCachedPath (ref openJDK8InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-1.8"));
 			public static string OpenJDK8CacheDir                    => GetCachedPath (ref openJDK8CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
 
-			public static string OpenJDK11InstallDir                 => GetCachedPath (ref openJDK11InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-11"));
-			public static string OpenJDK11CacheDir                   => GetCachedPath (ref openJDK11CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
+			public static string OpenJDK17InstallDir                 => GetCachedPath (ref openJDK17InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-17"));
+			public static string OpenJDK17CacheDir                   => GetCachedPath (ref openJDK17CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
 			// bundle
 			public static string BCLTestsArchiveName                 = "bcl-tests.zip";
 
@@ -448,8 +448,8 @@ namespace Xamarin.Android.Prepare
 			static string? monoSdksTpnExternalPath;
 			static string? monoSDKSIncludeDestDir;
 			static string? monoLlvmTpnPath;
-			static string? openJDK8InstallDir,  openJDK11InstallDir;
-			static string? openJDK8CacheDir,    openJDK11CacheDir;
+			static string? openJDK8InstallDir,  openJDK17InstallDir;
+			static string? openJDK8CacheDir,    openJDK17CacheDir;
 			static string? oldOpenJDKInstallDir;
 			static string? configurationPropsGeneratedPath;
 			static string? windowsBinutilsInstallDir;

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
@@ -295,11 +295,11 @@ namespace Xamarin.Android.Prepare
 		}
 
 		protected   override    string  ProductName      => _ProductName;
-		protected   override    string  JdkInstallDir    => Configurables.Paths.OpenJDK11InstallDir;
-		protected   override    Version JdkVersion       => Configurables.Defaults.MicrosoftOpenJDK11Version;
-		protected   override    Version JdkRelease       => Configurables.Defaults.MicrosoftOpenJDK11Release;
-		protected   override    Uri     JdkUrl           => Configurables.Urls.MicrosoftOpenJDK11;
-		protected   override    string  JdkCacheDir      => Configurables.Paths.OpenJDK11CacheDir;
-		protected   override    string  RootDirName      => Configurables.Defaults.MicrosoftOpenJDK11RootDirName;
+		protected   override    string  JdkInstallDir    => Configurables.Paths.OpenJDK17InstallDir;
+		protected   override    Version JdkVersion       => Configurables.Defaults.MicrosoftOpenJDK17Version;
+		protected   override    Version JdkRelease       => Configurables.Defaults.MicrosoftOpenJDK17Release;
+		protected   override    Uri     JdkUrl           => Configurables.Urls.MicrosoftOpenJDK17;
+		protected   override    string  JdkCacheDir      => Configurables.Paths.OpenJDK17CacheDir;
+		protected   override    string  RootDirName      => Configurables.Defaults.MicrosoftOpenJDK17RootDirName;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -9,7 +9,7 @@
 		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0.99</LatestSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">17.0.99</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>

--- a/src/manifestmerger/build.gradle
+++ b/src/manifestmerger/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/com.android.tools.build/manifest-merger
-    compile group: 'com.android.tools.build', name: 'manifest-merger', version: '30.3.1'
+    implementation 'com.android.tools.build:manifest-merger:30.3.1'
 }
 
 sourceSets {
@@ -36,10 +36,10 @@ jar {
         attributes 'Main-Class': 'com.xamarin.manifestmerger.Main'
     }
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     } {
         // Exclude native jnidispatch content to simplify installer signing and notarization
         exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'com/sun/jna/**/*jnidispatch*'
     }
-    archiveName 'manifestmerger.jar'
+    archiveFileName.set('manifestmerger.jar')
 }

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '8.1.56'
+    implementation 'com.android.tools:r8:8.1.56'
 }
 
 jar {
@@ -24,7 +24,7 @@ jar {
         attributes 'Main-Class': 'com.android.tools.r8.R8'
     }
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    archiveName 'r8.jar'
+    archiveFileName.set('r8.jar')
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8304
Context: https://github.com/xamarin/xamarin-android/pull/8029
Context: https://web.archive.org/web/20230507035529/https://developer.android.com/studio/releases/#jdk-17

> Starting from Android Studio Flamingo Canary 3, the Studio IDE is
> bundled with JDK 17.

Context: https://github.com/xamarin/java.interop/pull/1141

> Does It Build™?

Because of xamarin/xamarin-android#8029 we know we *can* use JDK 17.

Because of xamarin/xamarin-android#8304 we know we *should* use JDK 17.

Update `xaprepare` so that Microsoft OpenJDK 17.0.8 is provisioned for the build.  Note: `$(_JavacSourceVersion)` and `$(_JavacTargetVersion)` are *not* changed, so that our built `.jar` tooling can still *run* on JDK-11.

Update to use Gradle 8.1.1.  This is needed for JDK-17 support.

Update `$(LatestSupportedJavaVersion)` to 17.0.99 so that JDK 17 can be used by .NET Android projects by default.