### PR TITLE
[xaprepare] Fix dotnet-install script size check

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -488,10 +488,7 @@ namespace Xamarin.Android.Prepare
 				try {
 					using (HttpClient httpClient = CreateHttpClient ()) {
 						httpClient.Timeout = WebRequestTimeout;
-						var req = new HttpRequestMessage (HttpMethod.Head, url);
-						req.Headers.ConnectionClose = true;
-
-						HttpResponseMessage resp = await httpClient.SendAsync (req, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait (true);
+						HttpResponseMessage resp = await httpClient.GetAsync (url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait (true);
 						if (!resp.IsSuccessStatusCode || !resp.Content.Headers.ContentLength.HasValue)
 							return (false, 0, resp.StatusCode);
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Prepare
 			dotnetPath = dotnetPath.TrimEnd (new char [] { Path.DirectorySeparatorChar });
 
 			if (!await InstallDotNetAsync (context, dotnetPath, BuildToolVersion)) {
-				Log.ErrorLine ($"Installation of dotnet SDK {BuildToolVersion} failed.");
+				Log.ErrorLine ($"Installation of dotnet SDK '{BuildToolVersion}' failed.");
 				return false;
 			}
 
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Prepare
 				ProcessRunner.QuoteArgument ($"-bl:{logPath}"),
 			};
 			if (!Utilities.RunCommand (Configurables.Paths.DotNetPreviewTool, restoreArgs)) {
-				Log.ErrorLine ($"dotnet restore {packageDownloadProj} failed.");
+				Log.ErrorLine ($"Failed to restore runtime packs using '{packageDownloadProj}'.");
 				return false;
 			}
 
@@ -74,18 +74,19 @@ namespace Xamarin.Android.Prepare
 			string tempDotnetScriptPath = dotnetScriptPath + "-tmp";
 			Utilities.DeleteFile (tempDotnetScriptPath);
 
-			Log.StatusLine ("Downloading dotnet-install...");
+			Log.StatusLine ("Downloading dotnet-install script...");
 
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (dotnetScriptUrl);
 			if (!success) {
 				string message;
 				if (status == HttpStatusCode.NotFound) {
-					message = "dotnet-install URL not found";
+					message = $"dotnet-install URL '{dotnetScriptUrl}' not found.";
 				} else {
-					message = $"Failed to obtain dotnet-install size. HTTP status code: {status} ({(int)status})";
+					message = $"Failed to obtain dotnet-install script size from URL '{dotnetScriptUrl}'. HTTP status code: {status} ({(int)status})";
 				}
 
-				return ReportAndCheckCached (message, quietOnError: true);
+				if (ReportAndCheckCached (message, quietOnError: true))
+					return true;
 			}
 
 			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, size, context.InteractiveSession);
@@ -192,6 +193,7 @@ namespace Xamarin.Android.Prepare
 			string scriptFileName = Path.GetFileName (dotnetScriptUrl.LocalPath);
 			string cachedDotnetScriptPath = Path.Combine (cacheDir, scriptFileName);
 			if (!await DownloadDotNetInstallScript (context, cachedDotnetScriptPath, dotnetScriptUrl)) {
+				Log.ErrorLine ($"Failed to download dotnet-install script.");
 				return false;
 			}
 


### PR DESCRIPTION
CI builds have been failing frequently and quietly:

    Downloading dotnet-install...
      Error: Installation of dotnet SDK 8.0.100-rc.2.23422.31 failed.

    Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed

We were returning early when attempts to calculate the size of the
`dotnet-install` script failed, and a cached install script file was not
already on disk.  This has been fixed by ensuring that we still attempt
to download the script if the size calculation fails.

The size check failure has also been fixed by using a get request, and
logging around this prepare step has been improved.