### PR TITLE
[d17-5] [Xamarin.Android.Build.Tasks] allow JDK 17 usage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -9,7 +9,7 @@
 		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">11.0.99</LatestSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">17.0.99</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8309
Context: https://learn.microsoft.com/java/openjdk/download#openjdk-17

Classic Xamarin.Android apps appear to work with JDK-17, just by doing:

    msbuild -r -bl -t:SignAndroidPackage -p:JavaSdkDirectory="C:\Program Files\Microsoft\jdk-17.0.8.101-hotspot" -p:LatestSupportedJavaVersion=17.99

I see log messages calling a JDK 17 `javac` like:

    _CompileJava:
    C:\Program Files\Microsoft\jdk-17.0.8.101-hotspot\bin\javac.exe -J-Dfile.encoding=UTF8 "@C:\Users\jopepper\AppData\Local\Temp\tmp119C.tmp" -target 1.8 -source 1.8

Update `$(LatestSupportedJavaVersion)` to allow usage of JDK 17.