### PR TITLE
[d17-5] [ci] Don't checkout monodroid's unneeded XA submodule

### DIFF
--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -30,9 +30,18 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make prepare-update-mono
 
-# Clone and prepare monodroid with submodules, but disregard the unused xamarin-android submodule.
+# Clone 'monodroid' without submodules
 - checkout: monodroid
   clean: true
+  path: s/xamarin-android/external/monodroid
+
+# Tell git to ignore the 'xamarin-android' submodule, which is large and unneeded
+- script: git config submodule."external/xamarin-android".update none
+  workingDirectory: xamarin-android/external/monodroid
+  displayName: Ignore XA submodule
+
+# Clone 'monodroid' with the rest of the submodules
+- checkout: monodroid
   submodules: recursive
   path: s/xamarin-android/external/monodroid
   persistCredentials: true


### PR DESCRIPTION
This is a backport of #8231, to see if we can fix CI on `d17-5` branch.

I might end up bringing over other changes.