### PR TITLE
[xaprepare] Prefer 7zip to p7zip-full on Debian/unstable

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -18,10 +18,12 @@ namespace Xamarin.Android.Prepare
 
 		static readonly List<DebianLinuxProgram> packagesPreTrixie = new List<DebianLinuxProgram> {
 			new DebianLinuxProgram ("libncurses5-dev"),
+			new DebianLinuxProgram ("p7zip-full", "7z"),
 		};
 
 		static readonly List<DebianLinuxProgram> packagesTrixieAndLater = new List<DebianLinuxProgram> {
 			new DebianLinuxProgram ("libncurses-dev"),
+			new DebianLinuxProgram ("7zip", "7z"),
 		};
 
 		// zulu-8 does NOT exist as official Debian package! We need it for our bots, but we have to figure out what to

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Android.Prepare
 			new DebianLinuxProgram ("make"),
 			new DebianLinuxProgram ("ninja-build", "ninja"),
 			new DebianLinuxProgram ("nuget"),
-			new DebianLinuxProgram ("p7zip-full", "7z"),
 			new DebianLinuxProgram ("sqlite3"),
 			new DebianLinuxProgram ("vim-common"),
 			new DebianLinuxProgram ("zlib1g-dev"),


### PR DESCRIPTION
Debian/unstable (trixie) now includes the "original" 7z upstream package,
which is newer than its port p7zip.

Use `7zip` package on Debian/unstable and newer.