### PR TITLE
[ci] Install signing plugin after building

### DIFF
--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -45,20 +45,12 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - template: install-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
     - template: commercial-build.yaml
       parameters:
         installerArtifactName: ${{ parameters.installerArtifactName }}
         nugetArtifactName: ${{ parameters.nugetArtifactName }}
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         testAssembliesArtifactName: ${{ parameters.testAssembliesArtifactName }}
-
-    - template: remove-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - powershell: |
         [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -77,9 +77,14 @@ steps:
   displayName: CodeQL 3000 Finalize
   condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
+- template: install-microbuild-tooling.yaml
+  parameters:
+    condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
 - task: MSBuild@1
   displayName: msbuild /t:Restore sign-content.proj
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -87,6 +92,7 @@ steps:
 
 - task: MSBuild@1
   displayName: PKG signing - add entitlements and sign
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -98,6 +104,7 @@ steps:
 
 - task: MSBuild@1
   displayName: PKG signing - sign binutils libraries
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -109,6 +116,7 @@ steps:
 
 - task: MSBuild@1
   displayName: PKG signing - sign binutils executables
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -117,6 +125,10 @@ steps:
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-ex.binlog
+
+- template: remove-microbuild-tooling.yaml
+  parameters:
+    condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 
 - script: make create-installers CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
   workingDirectory: ${{ parameters.xaSourcePath }}


### PR DESCRIPTION
A few of the projects in our submodules are configured to sign output
files after build:

https://github.com/xamarin/xamarin-android-tools/blob/fa3711b7ddac7cea6850a9c1c67beda1996aafc0/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj#L36
https://github.com/xamarin/androidtools/blob/720fd4e7cc2f018c681843210edfc796c97c1dde/Xamarin.AndroidTools/Xamarin.AndroidTools.csproj#L21

We should skip these sign requests during our build as we perform post
build signing for all of our shipping artifacts.