### PR TITLE
[ci] Install signing plugin after building

### DIFF
--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -46,10 +46,6 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - template: install-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
-
     - template: commercial-build.yaml
       parameters:
         installerArtifactName: ${{ parameters.installerArtifactName }}
@@ -57,10 +53,6 @@ stages:
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         signClassicPkgContent: ${{ parameters.signClassicPkgContent }}
         testAssembliesArtifactName: ${{ parameters.testAssembliesArtifactName }}
-
-    - template: remove-microbuild-tooling.yaml
-      parameters:
-        condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 
     - script: >
         mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -58,16 +58,22 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make all-tests
 
+- template: install-microbuild-tooling.yaml
+  parameters:
+    condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+
 # Restore needs to be executed first or MicroBuild targets won't be imported in time
 - task: MSBuild@1
   displayName: msbuild /t:Restore sign-content.proj
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
     msbuildArguments: /t:Restore /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/restore-sign-content.binlog
 
 - task: MSBuild@1
-  displayName: PKG signing - add entitlements and sign classic libraries
+  displayName: PKG signing - add entitlements and sign
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -76,22 +82,10 @@ steps:
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
-  condition: and(succeeded(), eq('${{ parameters.signClassicPkgContent }}', 'true'))
-
-- task: MSBuild@1
-  displayName: PKG signing - sign classic executables
-  inputs:
-    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
-    configuration: $(XA.Build.Configuration)
-    msbuildArguments: >-
-      /t:AddMSBuildFilesUnixSignAndHarden;Build
-      /p:SignType=$(MicroBuildSignType)
-      /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
-      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
-  condition: and(succeeded(), eq('${{ parameters.signClassicPkgContent }}', 'true'))
 
 - task: MSBuild@1
   displayName: PKG signing - sign binutils libraries
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -99,11 +93,11 @@ steps:
       /t:AddBinUtilsFilesUnixSign;Build
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
-      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
-  condition: and(succeeded(), eq('${{ parameters.signClassicPkgContent }}', 'true'))
+      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-lib.binlog
 
 - task: MSBuild@1
   displayName: PKG signing - sign binutils executables
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
   inputs:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
@@ -111,8 +105,11 @@ steps:
       /t:AddBinUtilsFilesUnixSignAndHarden;Build
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
-      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
-  condition: and(succeeded(), eq('${{ parameters.signClassicPkgContent }}', 'true'))
+      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-ex.binlog
+
+- template: remove-microbuild-tooling.yaml
+  parameters:
+    condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 
 - script: make create-installers CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
   workingDirectory: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -78,7 +78,7 @@ steps:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
     msbuildArguments: >-
-      /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;Build
+      /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;AddMSBuildFilesUnixSignAndHarden;Build
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -78,10 +78,22 @@ steps:
     solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
     configuration: $(XA.Build.Configuration)
     msbuildArguments: >-
-      /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;AddMSBuildFilesUnixSignAndHarden;Build
+      /t:AddMachOEntitlements;AddMSBuildFilesUnixSign;Build
       /p:SignType=$(MicroBuildSignType)
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-content.binlog
+
+- task: MSBuild@1
+  displayName: PKG signing - sign classic executables
+  condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
+  inputs:
+    solution: ${{ parameters.xaSourcePath }}/build-tools/installers/sign-content.proj
+    configuration: $(XA.Build.Configuration)
+    msbuildArguments: >-
+      /t:AddMSBuildFilesUnixSignAndHarden;Build
+      /p:SignType=$(MicroBuildSignType)
+      /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
+      /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-classic.binlog
 
 - task: MSBuild@1
   displayName: PKG signing - sign binutils libraries

--- a/build-tools/installers/sign-content.proj
+++ b/build-tools/installers/sign-content.proj
@@ -37,7 +37,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
 
   <Target Name="AddMSBuildFilesUnixSign" >
     <ItemGroup>
-      <FilesToSign Include="@(_MSBuildFilesUnixSign)" Condition=" '%(_MSBuildFilesUnixSign.ExcludeFromAndroidNETSdk)' != 'true' ">
+      <FilesToSign Include="@(_MSBuildFilesUnixSign)">
         <Authenticode>MacDeveloperVNext</Authenticode>
         <Zip>true</Zip>
       </FilesToSign>
@@ -46,7 +46,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
 
   <Target Name="AddMSBuildFilesUnixSignAndHarden" >
     <ItemGroup>
-      <FilesToSign Include="@(_MSBuildFilesUnixSignAndHarden)" Condition=" '%(_MSBuildFilesUnixSignAndHarden.ExcludeFromAndroidNETSdk)' != 'true' ">
+      <FilesToSign Include="@(_MSBuildFilesUnixSignAndHarden)">
         <Authenticode>MacDeveloperVNextHarden</Authenticode>
         <Zip>true</Zip>
       </FilesToSign>

--- a/build-tools/installers/sign-content.proj
+++ b/build-tools/installers/sign-content.proj
@@ -37,7 +37,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
 
   <Target Name="AddMSBuildFilesUnixSign" >
     <ItemGroup>
-      <FilesToSign Include="@(_MSBuildFilesUnixSign)">
+      <FilesToSign Include="@(_MSBuildFilesUnixSign)" Condition=" '%(_MSBuildFilesUnixSign.ExcludeFromAndroidNETSdk)' != 'true' ">
         <Authenticode>MacDeveloperVNext</Authenticode>
         <Zip>true</Zip>
       </FilesToSign>
@@ -46,7 +46,7 @@ ourself (using an empty signing identity) before passing these files to ESRP.
 
   <Target Name="AddMSBuildFilesUnixSignAndHarden" >
     <ItemGroup>
-      <FilesToSign Include="@(_MSBuildFilesUnixSignAndHarden)">
+      <FilesToSign Include="@(_MSBuildFilesUnixSignAndHarden)" Condition=" '%(_MSBuildFilesUnixSignAndHarden.ExcludeFromAndroidNETSdk)' != 'true' ">
         <Authenticode>MacDeveloperVNextHarden</Authenticode>
         <Zip>true</Zip>
       </FilesToSign>


### PR DESCRIPTION
A few of the projects in our submodules are configured to sign output
files after build:

https://github.com/xamarin/xamarin-android-tools/blob/fa3711b7ddac7cea6850a9c1c67beda1996aafc0/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj#L36
https://github.com/xamarin/androidtools/blob/720fd4e7cc2f018c681843210edfc796c97c1dde/Xamarin.AndroidTools/Xamarin.AndroidTools.csproj#L21

We should skip these sign requests during our build as we perform post
build signing for all of our shipping artifacts.