### PR TITLE
Bump to 33.0.95 `$(AndroidNet7Version)`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -42,7 +42,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.68</AndroidNet7Version>
+    <AndroidNet7Version Condition=" '$(AndroidNet7Version)' == '' ">33.0.95</AndroidNet7Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android/compare/a7e0eff1...6678e021

These changes are going out in a future servicing release.