### PR TITLE
[release/8.0.1xx] stable 34.0.x branding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,8 +34,11 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>34.0.1</AndroidPackVersion>
+    <AndroidPackVersionPatchIndex>$(AndroidPackVersion.LastIndexOf("."))</AndroidPackVersionPatchIndex>
+    <AndroidPackVersionMajorMinor>$(AndroidPackVersion.Substring(0,$(AndroidPackVersionPatchIndex)))</AndroidPackVersionMajorMinor>
+    <AndroidPackVersionPatch>$(AndroidPackVersion.Substring($([MSBuild]::Add($(AndroidPackVersionPatchIndex), 1))))</AndroidPackVersionPatch>
+    <AndroidPackVersionSuffix>rtm</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -85,7 +85,7 @@
     <ReplaceFileContents
         SourceFile="vs-workload.in.props"
         DestinationFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\nuget-unsigned\vs-workload.props"
-        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidMSIVersion);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFramework)"
+        Replacements="@PACK_VERSION_LONG@=$(AndroidPackVersionLong);@PACK_VERSION_SHORT@=$(AndroidPackVersionLong);@WORKLOAD_VERSION@=$(AndroidMSIVersion);@VSMAN_VERSION@=$(DotNetTargetFramework)"
     />
   </Target>
 

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -82,8 +82,8 @@
       <_AndroidPackBranch>$([System.Text.RegularExpressions.Regex]::Replace('$(XAVersionBranch)', '[^a-zA-Z0-9-]', '-'))</_AndroidPackBranch>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' and ('$(XAVersionBranch)' == 'main' or $(XAVersionBranch.StartsWith('release/')))">$(AndroidPackVersionSuffix).$(PackVersionCommitCount)</_AndroidPackLabel>
       <_AndroidPackLabel Condition=" '$(_AndroidPackLabel)' == '' ">ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</_AndroidPackLabel>
-      <AndroidPackVersionLong>$(AndroidPackVersion)-$(_AndroidPackLabel)</AndroidPackVersionLong>
-      <AndroidMSIVersion>$(AndroidPackVersion).$(PackVersionCommitCount)</AndroidMSIVersion>
+      <AndroidPackVersionLong>$(AndroidPackVersionMajorMinor).$([MSBuild]::Add($(AndroidPackVersionPatch), $(PackVersionCommitCount)))</AndroidPackVersionLong>
+      <AndroidMSIVersion>$(AndroidPackVersionLong).0</AndroidMSIVersion>
     </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/e6002f84602ade59eccf95974ca6188875d3a79f

The `release/8.0.1xx` versioning will be stable with .NET 8 GA.

We will start out with 34.0.1, and each commit increments by 1.

We have to reset `$(AndroidPackVersion)` so it will "reset" the commit distance.