### PR TITLE
$(AndroidPackVersionSuffix)=preview.1; net9 is 34.99.0.preview.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,8 +34,8 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>34.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>rc.2</AndroidPackVersionSuffix>
+    <AndroidPackVersion>34.99.0</AndroidPackVersion>
+    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/8.0.1xx

We branched for .NET 8 from 791fedb5 into release/8.0.1xx; the main branch is now .NET 9.

Update xamarin-android/main's version number to 34.99.0-preview.1.