### PR TITLE
[ci] Use Python 3 for signing tasks

### DIFF
--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -9,6 +9,10 @@ steps:
     forceReinstallCredentialProvider: true
   condition: ${{ parameters.condition }}
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.x
+
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates
   parameters:


### PR DESCRIPTION
Authenticode signing attempts started failing recently with:

    ERROR: 'xsign' is misspelled or not recognized by the system.

Updating to Python 3 is the suggested fix for this issue.