### PR TITLE
[tests] set `$(DisableTransitiveFrameworkReferenceDownloads)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -95,6 +95,7 @@ namespace Xamarin.ProjectTools
 $@"<Project>
 	<PropertyGroup>
 		<Configuration>{Configuration}</Configuration>
+		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 	</PropertyGroup>
 </Project>"
 				});


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8360

MSBuild tests that use `net7.0-android` `TargetFrameworks` can fail on release branches with:

    (Restore target) ->
    error NU1102: Unable to find package Microsoft.AspNetCore.App.Ref with version (= 7.0.12)
    error NU1102:   - Found 1621 version(s) in dotnet7 [ Nearest version: 7.0.0-rtm.22513.3 ]
    error NU1102:   - Found 1537 version(s) in dotnet8 [ Nearest version: 8.0.0-alpha.1.22416.11 ]
    error NU1102:   - Found 87 version(s) in testsource1 [ Nearest version: 8.0.0-preview.1.23112.2 ]
    error NU1102:   - Found 87 version(s) in dotnet-public [ Nearest version: 8.0.0-preview.1.23112.2 ]
    error NU1102:   - Found 0 version(s) in darc-pub-dotnet-emsdk-9506882
    error NU1102:   - Found 0 version(s) in darc-pub-dotnet-runtime-26e0f82
    error NU1102:   - Found 0 version(s) in darc-pub-dotnet-runtime-301ba1e
    error NU1102:   - Found 0 version(s) in dotnet-eng
    error NU1102:   - Found 0 version(s) in dotnet8-transport
    error NU1102:   - Found 0 version(s) in xamarin.android util
        0 Warning(s)
        1 Error(s)

To solve this, we can set `$(DisableTransitiveFrameworkReferenceDownloads)` as we did in 2320e204 so it doesn't try to restore ASP.NET or Windows Desktop packs.

The MSBuild integration tests have their own `Directory.Build.props`, so this seems like a reasonable place to set this value.