### PR TITLE
[Xamarin.Android.Build.Tasks] fix `InstallAndroidDependencies` in .NET 8

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -178,7 +178,6 @@ properties that determine build ordering.
       _BeforeGetAndroidDependencies;
       _SetLatestTargetFrameworkVersion;
       _ResolveSdks;
-      _ResolveMonoAndroidSdks;
       _ResolveAndroidTooling;
       $(GetAndroidDependenciesDependsOn);
     </GetAndroidDependenciesDependsOn>


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1837913

Testing on a DevBox with only the .NET 8 RC 1 SDK and `dotnet workload install maui`:

    > dotnet new android
    > dotnet build -t:InstallAndroidDependencies -p:AndroidSdkDirectory=C:\tools\android-sdk -p:JavaSdkDirectory=C:\tools\jdk -bl
    Microsoft.Android.Sdk.Windows\34.0.0-rc.1.432\tools\Xamarin.Android.Common.Debugging.targets(110,2):
    error XA5300:  The Android SDK directory could not be found. Check that the Android SDK Manager in Visual Studio shows a valid installation. To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path.

Ok, that's completely broken... So let's try `-c Release`, as this target is related to Fast Deployment:

    Microsoft.Android.Sdk.Windows\34.0.0-rc.1.432\tools\Xamarin.Android.Common.targets(664,2):
    error : Could not locate Java 6 or 7 SDK.

I tested .NET 7 and it worked fine?!?

It turns out to be due to an additional `_ResolveMonoAndroidSdks` target running in .NET 8 that *doesn't* run in .NET 7:

https://github.com/xamarin/xamarin-android/blob/547a157a7aeae930e4fc6092636fa20771ff1ef6/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets#L181

This was introduced in dc3ccf28, but I don't think it is actually needed.

The `GetAndroidDependencies` target doesn't run during a normal build, so it doesn't seem like `$(GetAndroidDependenciesDependsOn)` should need to run anything extra either.

Let's see what CI says, but maybe we can just delete this line?

With this change in place, `InstallAndroidDependencies` works on my DevBox, and I'm also able to build apps in `Debug` and `Release` mode.