### PR TITLE
[Xamarin.Android.Build.Tasks] Try a case insensitive lookup as a backup for Legacy Designer fixup

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixLegacyResourceDesignerStep.cs
@@ -121,7 +121,7 @@ namespace MonoDroid.Tuner
 					} else {
 						LogMessage ($"          Adding {key}");
 						output.Add (key, property.GetMethod);
-						caseInsensitiveLookup.Add (key, property.GetMethod);
+						caseInsensitiveLookup [key] = property.GetMethod;
 					}
 				}
 			}


### PR DESCRIPTION
We have a very odd situation regarding the NuGet `Xamarin.CommunityToolkit.MauiCompat`. 

The NuGet package ships with a file `.net/__res_name_case_map.txt` in the 
`Xamarin.CommunityToolkit.MauiCompat.aar` which contains the 
case map changes for the `AndroidResource` items. The purpose of this file is to allow
the user to use Camel case (or any case) names in C# code, while the android resource
compilation is left as all lowercase. This is because android requires lowercase resource 
items. 

The contents of this file are as follows

```
Resources/Layout/CameraFragment.axml;layout/camerafragment.xml
```

As you can see from this `camerafragment` is remaped to `CameraFragment`. With this 
change we would expect to see code in C# which uses `CameraFragment`. This is true
as per https://github.com/xamarin/XamarinCommunityToolkit/blob/5a6062f3c3543acda3c36ca4683cd8fc7fe86ba7/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs#L129.

We can see that the code in the NuGet is using the `CameraFragment` casing. 
However when we look at the IL that comes from the NuGet package we see the following

```
ikdasm ~/.nuget/packages/xamarin.communitytoolkit.mauicompat/2.0.2-preview1013/lib/net6.0-android31.0/Xamarin.CommunityToolkit.MauiCompat.dll| grep Layout::camerafragment
      IL_0131:  stsfld     int32 Xamarin.CommunityToolkit.MauiCompat.Resource/Layout::camerafragment
    IL_0001:  ldsfld     int32 Xamarin.CommunityToolkit.MauiCompat.Resource/Layout::camerafragment
```
For some reason as part of the maui release the following script was run on the code
https://github.com/xamarin/XamarinCommunityToolkit/blob/5a6062f3c3543acda3c36ca4683cd8fc7fe86ba7/MauiCompat.sh#L561.

This force changes the case of the `CameraFragment` to `camerafragment` across the whole project. 
But the NuGet still includes the .aar with the case map changes (which are no longer needed). 
I'm not sure why this happens but it results in the following build error when trying to consume this package
under .net8.0-android with the new Resource Designer. 

```
XA8000
Could not find Android Resource ‘@layout/camerafragment’. Please update @(AndroidResource) to add the missing resource.
```

This is because we are looking for the lowercase version of the resource in the Designer assembly property list, but because 
of the remap file. We only have the Camel case version. 

The current workaround is to fallback to a case insensitive lookup... My first thought was to always use a case insensitive
lookup. But there are cases where users have two files with different cases. This is possible on systems like Linux and MacOS. 
