### PR TITLE
[build] don't pass `$(RestoreAdditionalProjectSources)` as a global property

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -8,12 +8,6 @@
     <MauiWorkloadToInstall Condition=" '$(MauiWorkloadToInstall)' == '' ">maui-android</MauiWorkloadToInstall>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Feeds for dotnet/runtime, to be passed to external/java.interop/external/xamarin-android-tools -->
-    <_RestoreAdditionalProjectSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-26e0f822/nuget/v3/index.json" />
-    <_RestoreAdditionalProjectSources Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-301ba1ee/nuget/v3/index.json" />
-  </ItemGroup>
-
   <Target Name="BuildExternal">
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; build monodroid.proj -c $(Configuration) -p:XamarinAndroidSourcePath=$(_Root) -p:DebuggingToolsOutputDirectory=$(MicrosoftAndroidSdkOutDir) -p:CompatTargetsOutputDirectory=$(XAInstallPrefix)xbuild/Novell -bl:$(_BinlogPathPrefix)-build-monodroid.binlog"
@@ -22,17 +16,8 @@
   </Target>
 
   <Target Name="PrepareJavaInterop">
-    <!-- See: https://github.com/dotnet/sdk/issues/8792#issuecomment-393756980 -->
-    <PropertyGroup Condition="'$(HostOS)' == 'Windows'">
-      <_Begin>\&quot;</_Begin>
-      <_End>\&quot;</_End>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(HostOS)' != 'Windows'">
-      <_Begin>&apos;&quot;</_Begin>
-      <_End>&quot;&apos;</_End>
-    </PropertyGroup>
     <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -p:RestoreAdditionalProjectSources=$(_Begin)@(_RestoreAdditionalProjectSources)$(_End) -bl:$(_BinlogPathPrefix)-prepare-java-interop.binlog"
+        Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_BinlogPathPrefix)-prepare-java-interop.binlog"
         WorkingDirectory="$(_Root)external\Java.Interop"
     />
   </Target>


### PR DESCRIPTION
This partially reverts 4c7b6455.

Opening this to test how we can fix this with a change in java.interop.

Ran:

    git checkout 4c7b6455b7bbf60268520e8d55996133210d1a37~1 build-tools\scripts\DotNet.targets