### PR TITLE
[Mono.Android] Generate API docs for android-34

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -75,11 +75,11 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-33_r02",   apiLevel: "33", pkgRevision: "2"),
 				new AndroidPlatformComponent ("platform-34-ext7_r01",   apiLevel: "34", pkgRevision: "1"),
 
-				new AndroidToolchainComponent ("sources-33_r01",
-					destDir: Path.Combine ("sources", "android-33"),
+				new AndroidToolchainComponent ("sources-34_r01",
+					destDir: Path.Combine ("sources", "android-34"),
 					pkgRevision: "1",
 					dependencyType: AndroidToolchainComponentType.BuildDependency,
-					buildToolVersion: "33.1"
+					buildToolVersion: "34.1"
 				),
 				new AndroidToolchainComponent ("docs-24_r01",
 					destDir: "docs",

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -238,9 +238,9 @@
 
   <PropertyGroup>
     <!-- Override these properties to generate docs against a specific API level -->
-    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">33</DocsApiLevel>
-    <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">33</DocsPlatformId>
-    <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">xamarin-android-sdk-13</DocsFxMoniker>
+    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">34</DocsApiLevel>
+    <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">$(DocsApiLevel)</DocsPlatformId>
+    <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">net-android-$(DocsApiLevel).0</DocsFxMoniker>
     <_LogPrefix>$(MSBuildThisFileDirectory)../../bin/Build$(Configuration)/UpdateApiDocs-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))</_LogPrefix>
     <_Mdoc Condition=" '$(Pkgmdoc)' != '' ">"$(Pkgmdoc)/tools/mdoc.exe"</_Mdoc>
     <_Mdoc Condition=" '$(Pkgmdoc)' == '' ">"$(XAPackagesDir)/mdoc/$(MdocPackageVersion)/tools/mdoc.exe"</_Mdoc>


### PR DESCRIPTION
Updates xaprepare to install the `sources-34_r01` Android SDK package,
allowing our API docs generation tasks to use the latest sources.