### PR TITLE
[Xamarin.Android.Build.Tasks] Make manifestmerger.jar the default.

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -987,9 +987,12 @@ merging *AndroidManifest.xml* files. This is an enum-style property
 where `legacy` selects the original C# implementation
 and `manifestmerger.jar` selects Google's Java implementation.
 
-The default value is currently `legacy`. This will change to
-`manifestmerger.jar` in a future release to align behavior with
-Android Studio.
+The default value is currently `manifestmerger.jar`. If you want to 
+use the old version add the following to your csproj
+
+```
+<AndroidManifestMerger>legacy</AndroidManifestMerger>
+```
 
 Google's merger enables support for `xmlns:tools="http://schemas.android.com/tools"`
 as described in the [Android documentation][manifest-merger].

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -990,7 +990,7 @@ and `manifestmerger.jar` selects Google's Java implementation.
 The default value is currently `manifestmerger.jar`. If you want to 
 use the old version add the following to your csproj
 
-```
+```xml
 <AndroidManifestMerger>legacy</AndroidManifestMerger>
 ```
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -670,6 +670,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			if (Builder.UseDotNet) {
 				lib.RemoveProperty ("OutputType");
 			}
+			lib.AndroidManifest = lib.AndroidManifest.
+				Replace ("application android:label=\"${PROJECT_NAME}\"", "application android:label=\"com.test.foo\" ");
 
 			// Create an "app" that is basically empty and references the library
 			var app = new XamarinAndroidLibraryProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -755,6 +755,7 @@ namespace Bug12935
 					KnownPackages.SupportV7AppCompat_27_0_2_1,
 				},
 			};
+			proj.SetProperty ("AndroidManifestMerger", "legacy");
 			proj.Sources.Add (new BuildItem.Source ("TestActivity1.cs") {
 				TextContent = () => @"using System;
 using System.Collections.Generic;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -275,7 +275,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidCreatePackagePerAbi Condition=" '$(AndroidCreatePackagePerAbi)' == 'aab' ">False</AndroidCreatePackagePerAbi>
 	<AndroidApkSigningAlgorithm Condition=" '$(AndroidApkSigningAlgorithm)' == '' ">SHA256withRSA</AndroidApkSigningAlgorithm>
 	<AndroidApkDigestAlgorithm  Condition=" '$(AndroidApkDigestAlgorithm)' == '' ">SHA-256</AndroidApkDigestAlgorithm>
-	<AndroidManifestMerger      Condition=" '$(AndroidManifestMerger)' == '' ">legacy</AndroidManifestMerger>
+	<AndroidManifestMerger      Condition=" '$(AndroidManifestMerger)' == '' ">manifestmerger.jar</AndroidManifestMerger>
 
 	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
 	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/8387

The value for `AndroidManifestMerger` should be updated to be `manifestmerger.jar`. This allows users to make use of the new features like `AndroidManifestOverlay` out of the box.

The old system is still available, the users will need to add the following to their csproj.

```
<AndroidManifestMerger>legacy</AndroidManifestMerger>
```