### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for $(AndroidEnableObsoleteOverrideInheritance).

### DIFF
--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -469,6 +469,15 @@ Support for this property was added in Xamarin.Android 5.1.
 
 This property is `False` by default.
 
+## AndroidEnableObsoleteOverrideInheritance
+
+A boolean property that determines if bound methods automatically inherit `[Obsolete]`
+attributes from methods they override.
+
+Support for this property was added in .NET 8.
+
+This property is `True` by default.
+
 ## AndroidEnablePreloadAssemblies
 
 A boolean property that controls

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -99,6 +99,7 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         EnableBindingNestedInterfaceTypes="$(AndroidBoundInterfacesContainTypes)"
         EnableBindingInterfaceConstants="$(AndroidBoundInterfacesContainConstants)"
         EnableRestrictToAttributes="$(AndroidEnableRestrictToAttributes)"
+        EnableObsoleteOverrideInheritance="$(AndroidEnableObsoleteOverrideInheritance)"
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
         NamespaceTransforms="@(AndroidNamespaceReplacement)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -39,6 +39,7 @@
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods Condition=" '$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)' == '' ">true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     <AndroidBoundInterfacesContainTypes Condition=" '$(AndroidBoundInterfacesContainTypes)' == '' ">true</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainConstants Condition=" '$(AndroidBoundInterfacesContainConstants)' == '' ">true</AndroidBoundInterfacesContainConstants>
+    <AndroidEnableObsoleteOverrideInheritance Condition=" '$(AndroidEnableObsoleteOverrideInheritance)' == '' ">true</AndroidEnableObsoleteOverrideInheritance>
     <AndroidEnableRestrictToAttributes Condition=" '$(AndroidEnableRestrictToAttributes)' == '' ">obsolete</AndroidEnableRestrictToAttributes>
 
     <!-- Mono components -->

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Android.Tasks
 		public bool EnableBindingNestedInterfaceTypes { get; set; }
 		public bool EnableBindingInterfaceConstants { get; set; }
 		public string EnableRestrictToAttributes { get; set; }
+		public bool EnableObsoleteOverrideInheritance { get; set; }
 		public string Nullable { get; set; }
 
 		public ITaskItem[] TransformFiles { get; set; }
@@ -216,6 +217,9 @@ namespace Xamarin.Android.Tasks
 
 					if (EnableBindingStaticAndDefaultInterfaceMethods)
 						features.Add ("default-interface-methods");
+
+					if (!EnableObsoleteOverrideInheritance)
+						features.Add ("do-not-fix-obsolete-overrides");
 
 					if (string.Equals (EnableRestrictToAttributes, "obsolete", StringComparison.OrdinalIgnoreCase))
 						features.Add ("restrict-to-attributes");


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1143
Context: https://github.com/xamarin/java.interop/pull/1130

In https://github.com/xamarin/java.interop/pull/1143, we added the ability to globally opt-out of the new `generator` [feature](https://github.com/xamarin/java.interop/pull/1130) that automatically applies `[Obsolete]` attributes to methods that override `[Obsolete]` methods.  (Preventing a C# compiler warning.)

This adds support for a new `$(AndroidEnableObsoleteOverrideInheritance)` boolean MSBuild property for users to opt-out.  The default is `true`.