### PR TITLE
[ci] Skip Linux apt upgrade step

### DIFF
--- a/build-tools/automation/yaml-templates/setup-ubuntu.yaml
+++ b/build-tools/automation/yaml-templates/setup-ubuntu.yaml
@@ -13,9 +13,6 @@ steps:
     sudo apt install -y --no-install-recommends mono-complete nuget msbuild
   displayName: install mono preview
 
-- script: sudo apt upgrade
-  displayName: update packages
-
 - template: use-dot-net.yaml
   parameters:
     remove_dotnet: true


### PR DESCRIPTION
Package update attempts started failing recently on our Linux lane:

    Setting up grub-efi-amd64-signed (1.187.6~20.04.1+2.06-2ubuntu14.4) ...
    mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-14d5346542020202075f68e4df928b946a6a92fab5bc044c1-part15 does not exist.
    dpkg: error processing package grub-efi-amd64-signed (--configure):
     installed grub-efi-amd64-signed package post-installation script subprocess returned error exit status 32

Our base Linux OS image is updated regularly by 1ES, so we shouldn't
need to update during every CI run.