### PR TITLE
Import proguard rules from proguard-android.txt

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -38,3 +38,53 @@
    <init>(android.content.Context,android.util.AttributeSet);
    <init>(android.content.Context,android.util.AttributeSet,int);
 }
+
+# Import from https://android.googlesource.com/platform/sdk/+/refs/heads/main/files/proguard-android.txt
+
+# This is a configuration file for ProGuard.
+# http://proguard.sourceforge.net/index.html#manual/usage.html
+-dontusemixedcaseclassnames
+-dontskipnonpubliclibraryclasses
+-verbose
+# Optimization is turned off by default. Dex does not like code run
+# through the ProGuard optimize and preverify steps (and performs some
+# of these optimizations on its own).
+-dontoptimize
+-dontpreverify
+# Note that if you want to enable optimization, you cannot just
+# include optimization flags in your own project configuration file;
+# instead you will need to point to the
+# "proguard-android-optimize.txt" file instead of this one from your
+# project.properties file.
+-keepattributes *Annotation*
+-keep public class com.google.vending.licensing.ILicensingService
+-keep public class com.android.vending.licensing.ILicensingService
+# For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+# keep setters in Views so that animations can still work.
+# see http://proguard.sourceforge.net/manual/examples.html#beans
+-keepclassmembers public class * extends android.view.View {
+   void set*(***);
+   *** get*();
+}
+# We want to keep methods in Activity that could be used in the XML attribute onClick
+-keepclassmembers class * extends android.app.Activity {
+   public void *(android.view.View);
+}
+# For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+-keepclassmembers class * implements android.os.Parcelable {
+  public static final android.os.Parcelable$Creator CREATOR;
+}
+-keepclassmembers class **.R$* {
+    public static <fields>;
+}
+# The support library contains references to newer platform versions.
+# Don't warn about those in case this app is linking against an older
+# platform version.  We know about them, and they are safe.
+-dontwarn android.support.**

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1934,7 +1934,6 @@ because xbuild doesn't support framework reference assemblies.
     <_ProguardConfiguration Include="$(ProguardConfigFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProguardConfigFiles)' == '' ">
-    <_ProguardConfiguration Include="$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt" />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"         Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(_ProguardProjectConfiguration)"                               Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg" Condition=" '$(AndroidLinkTool)' != '' " />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8337
Fixes: https://github.com/xamarin/xamarin-android/issues/8397

The latest Android sdk no longer ships with `proguard` as a result the file in proguard-android.txt [1] is missing. As a result customers are reporting errors such as

```
Unhandled Exception from source=AndroidEnvironment

Java.Lang.Exception: android.view.View_IOnClickListenerImplementor
    at Java.Interop.JniEnvironment.Types.TryFindClass(String , Boolean )
    at Java.Interop.JniEnvironment.Types.FindClass(String )
    at Java.Interop.JniType..ctor(String )
    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type )
    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type )
    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String , Type , JniArgumentValue* )
    at Android.Views.View.IOnClickListenerImplementor..ctor()
    at Android.Views.View.__CreateIOnClickListenerImplementor()
    at Java.Interop.EventHelper.AddEventHandler[IOnClickListener,IOnClickListenerImplementor](WeakReference& , Func`1 , Action`1 , Action`1 )
    at Android.Views.View.add_Click(EventHandler )
    at com.glmsoftware.obdnowpros.Fragments.SubscriptionFragment.OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
    at AndroidX.Fragment.App.Fragment.n_OnCreateView_Landroid_view_LayoutInflater_Landroid_view_ViewGroup_Landroid_os_Bundle_(IntPtr jnienv, IntPtr native__this, IntPtr native_inflater, IntPtr native_container, IntPtr native_savedInstanceState)
    at Android.Runtime.JNINativeWrapper.Wrap_JniMarshal_PPLLL_L(_JniMarshal_PPLLL_L callback, IntPtr jnienv, IntPtr klazz, IntPtr p0, IntPtr p1, IntPtr p2)
    --- End of managed Java.Lang.Exception stack trace ---
```

This is probably because certain code is removed that in the latest version of R8 that used to be left in place.
We should include the contents of this removed file in our own proguard_xamarin.cfg file.

[1] https://android.googlesource.com/platform/sdk/+/refs/heads/main/files/proguard-android.txt