### PR TITLE
Bump to xamarin/java.interop/main@ed63d890

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1136,6 +1136,7 @@ namespace UnamedProject
 				FileAssert.Exists (dexFile);
 				var classes = new [] {
 					"Lmono/MonoRuntimeProvider;",
+					"Lmono/android/view/View_OnClickListenerImplementor;",
 					"Landroid/runtime/JavaProxyThrowable;",
 					$"L{toolbar_class.Replace ('.', '/')};"
 				};


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/8e63cc8d...ed63d890

* [generator] restore `[RegisterAttribute]` for *Implementor types