### PR TITLE
Fix up ForegroundService.ToString()

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -909,6 +909,33 @@ class TestActivity : Activity { }"
 		}
 
 		[Test]
+		[TestCase ("Android.Content.PM.ForegroundService.TypeSpecialUse", "specialUse")]
+		[TestCase ("Android.Content.PM.ForegroundService.TypeConnectedDevice", "connectedDevice")]
+		[TestCase ("Android.Content.PM.ForegroundService.TypeCamera|Android.Content.PM.ForegroundService.TypeMicrophone", "camera|microphone")]
+		public void AllForegroundServiceTypes (string serviceType, string expected)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+			};
+
+ 			proj.Sources.Add (new BuildItem.Source ("TestActivity.cs") {
+ 				TextContent = () => $@"using Android.App;
+ using Android.Content.PM;
+ using Android.Views;
+ [Service (ForegroundServiceType      = {serviceType})]
+ class TestService : Service {{ public override Android.OS.IBinder OnBind (Android.Content.Intent intent) {{ return null; }} }}"
+ 			});
+			using (ProjectBuilder builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+ 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+				string manifest = builder.Output.GetIntermediaryAsText (Path.Combine ("android", "AndroidManifest.xml"));
+ 				var doc = XDocument.Parse (manifest);
+ 				var ns = XNamespace.Get ("http://schemas.android.com/apk/res/android");
+ 				IEnumerable<XElement> services = doc.Element ("manifest")?.Element ("application")?.Elements ("service");
+ 				XElement e = services.FirstOrDefault (x => x.Attribute (ns.GetName ("foregroundServiceType"))?.Value == expected);
+ 				Assert.IsNotNull (e, $"Manifest should contain an service with a foregroundServiceType of {expected}");
+			}
+		}
+
+		[Test]
  		public void AllServiceAttributeProperties ([Values ("legacy", "manifestmerger.jar")] string manifestMerger)
  		{
  			string expectedOutput = manifestMerger == "legacy" ?

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		char [] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=' };
+		char [] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=', '|' };
 
 		public string TestName {
 			get {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -401,7 +401,7 @@ namespace Xamarin.Android.Manifest {
 			// When including a non-stable value you can cast the integer value
 			// to ForegroundService. We need to do this because the Build.Tasks
 			// only build against the latest STABLE api.
-			//if (value.HasFlag (ForegroundService()128))
+			//if (value.HasFlag ((ForegroundService)128))
 			//	values.Add ("newValue");
 
 			return string.Join ("|", values.ToArray ());

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -383,12 +383,26 @@ namespace Xamarin.Android.Manifest {
 				values.Add ("mediaProjection");
 			if (value.HasFlag (ForegroundService.TypePhoneCall))
 				values.Add ("phoneCall");
-
-			// These can be changed to enum members when API-R is the stable binding.
-			if (value.HasFlag ((ForegroundService)64))
+			if (value.HasFlag (ForegroundService.TypeCamera))
 				values.Add ("camera");
-			if (value.HasFlag ((ForegroundService)128))
+			if (value.HasFlag (ForegroundService.TypeMicrophone))
 				values.Add ("microphone");
+			if (value.HasFlag (ForegroundService.TypeHealth))
+				values.Add ("health");
+			if (value.HasFlag (ForegroundService.TypeRemoteMessaging))
+				values.Add ("remoteMessaging");
+			if (value.HasFlag (ForegroundService.TypeSystemExempted))
+				values.Add ("systemExempted");
+			if (value.HasFlag (ForegroundService.TypeShortService))
+				values.Add ("shortService");
+			if (value.HasFlag (ForegroundService.TypeSpecialUse))
+				values.Add ("specialUse");
+
+			// When including a non-stable value you can cast the integer value
+			// to ForegroundService. We need to do this because the Build.Tasks
+			// only build against the latest STABLE api.
+			//if (value.HasFlag (ForegroundService()128))
+			//	values.Add ("newValue");
 
 			return string.Join ("|", values.ToArray ());
 		}


### PR DESCRIPTION
Fixes #8409

There were a number of missing `ForegroundService` types missing in the last few releases. As a result users were not able to make use of them via the `Service` attribute. If they tried it would result in an empty `foregroundService` attribute.

```
<service android:foregroundServiceType="" android:name="crc64cd18cf298594e84d.MyService " />
```

Lets fill in the missing types. We should address this in the future by using some form of code generation as outlined in #8272 