### PR TITLE
Hush some messages logged by default on startup

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -669,7 +669,7 @@ AndroidSystem::setup_environment ()
 		}
 
 		if (aotMode != MonoAotMode::MONO_AOT_MODE_LAST) {
-			log_info (LOG_DEFAULT, "Mono AOT mode: %s", mono_aot_mode_name);
+			log_debug (LOG_DEFAULT, "Mono AOT mode: %s", mono_aot_mode_name);
 		} else {
 			if (!is_interpreter_enabled ()) {
 				log_warn (LOG_DEFAULT, "Unknown Mono AOT mode: %s", mono_aot_mode_name);

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -31,13 +31,13 @@ void
 BasicAndroidSystem::setup_app_library_directories (jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, bool have_split_apks)
 {
 	if (!is_embedded_dso_mode_enabled ()) {
-		log_info (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
+		log_debug (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
 		BasicAndroidSystem::app_lib_directories_size = 1;
 		BasicAndroidSystem::app_lib_directories = new const char*[app_lib_directories_size]();
 		BasicAndroidSystem::app_lib_directories [0] = utils.strdup_new (appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 		log_debug (LOG_ASSEMBLY, "Added filesystem DSO lookup location: %s", appDirs[SharedConstants::APP_DIRS_DATA_DIR_INDEX].get_cstr ());
 	} else {
-		log_info (LOG_DEFAULT, "Setting up for DSO lookup directly in the APK");
+		log_debug (LOG_DEFAULT, "Setting up for DSO lookup directly in the APK");
 		BasicAndroidSystem::app_lib_directories_size = runtimeApks.get_length ();
 		BasicAndroidSystem::app_lib_directories = new const char*[app_lib_directories_size]();
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1026,7 +1026,7 @@ MonodroidRuntime::init_android_runtime (
 	// GC threshold is 90% of the max GREF count
 	init.grefGcThreshold        = static_cast<int>(androidSystem.get_gref_gc_threshold ());
 
-	log_warn (LOG_GC, "GREF GC Threshold: %i", init.grefGcThreshold);
+	log_info (LOG_GC, "GREF GC Threshold: %i", init.grefGcThreshold);
 
 	init.grefClass = utils.get_class_from_runtime_field (env, runtimeClass, "java_lang_Class", true);
 	Class_getName  = env->GetMethodID (init.grefClass, "getName", "()Ljava/lang/String;");
@@ -1536,7 +1536,7 @@ MonodroidRuntime::create_xdg_directory (jstring_wrapper& home, size_t home_len, 
 {
 	static_local_string<SENSIBLE_PATH_MAX> dir (home_len + relative_path_len);
 	utils.path_combine (dir, home.get_cstr (), home_len, relativePath, relative_path_len);
-	log_info (LOG_DEFAULT, "Creating XDG directory: %s", dir.get ());
+	log_debug (LOG_DEFAULT, "Creating XDG directory: %s", dir.get ());
 	int rv = utils.create_directory (dir.get (), DEFAULT_DIRECTORY_MODE);
 	if (rv < 0 && errno != EEXIST)
 		log_warn (LOG_DEFAULT, "Failed to create XDG directory %s. %s", dir.get (), strerror (errno));
@@ -2205,7 +2205,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	if (runtimeNativeLibDir != nullptr) {
 		jstr = runtimeNativeLibDir;
 		androidSystem.set_runtime_libdir (strdup (jstr.get_cstr ()));
-		log_info (LOG_DEFAULT, "Using runtime path: %s", androidSystem.get_runtime_libdir ());
+		log_debug (LOG_DEFAULT, "Using runtime path: %s", androidSystem.get_runtime_libdir ());
 	}
 
 	androidSystem.setup_process_args (runtimeApks);
@@ -2259,7 +2259,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	mono_config_parse_memory (reinterpret_cast<const char*> (monodroid_config));
 	mono_register_machine_config (reinterpret_cast<const char*> (monodroid_machine_config));
 #endif // ndef NET
-	log_info (LOG_DEFAULT, "Probing for Mono AOT mode\n");
+	log_debug (LOG_DEFAULT, "Probing for Mono AOT mode\n");
 
 	MonoAotMode mode = MonoAotMode::MONO_AOT_MODE_NONE;
 	if (androidSystem.is_mono_aot_enabled ()) {
@@ -2281,20 +2281,20 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		}
 #else   // defined (NET)
 		if (mode != MonoAotMode::MONO_AOT_MODE_INTERP_ONLY) {
-			log_info (LOG_DEFAULT, "Enabling AOT mode in Mono");
+			log_debug (LOG_DEFAULT, "Enabling AOT mode in Mono");
 		} else {
-			log_info (LOG_DEFAULT, "Enabling Mono Interpreter");
+			log_debug (LOG_DEFAULT, "Enabling Mono Interpreter");
 		}
 #endif  // !defined (NET)
 	}
 	mono_jit_set_aot_mode (mode);
 
-	log_info (LOG_DEFAULT, "Probing if we should use LLVM\n");
+	log_debug (LOG_DEFAULT, "Probing if we should use LLVM\n");
 
 	if (androidSystem.is_mono_llvm_enabled ()) {
 		char *args [1];
 		args[0] = const_cast<char*> ("--llvm");
-		log_info (LOG_DEFAULT, "Enabling LLVM mode in Mono\n");
+		log_debug (LOG_DEFAULT, "Enabling LLVM mode in Mono\n");
 		mono_jit_parse_options (1,  args);
 		mono_set_use_llvm (true);
 	}
@@ -2336,17 +2336,15 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	if (XA_UNLIKELY (utils.should_log (LOG_DEFAULT))) {
 		log_info_nocheck (
 			LOG_DEFAULT,
-			"Xamarin.Android version: %s (%s; %s); built on %s",
+			"Xamarin.Android version: %s (%s; %s); built on %s; NDK version: %s; API level: %s; MonoVM version: %s",
 			BuildInfo::xa_version,
 			BuildInfo::architecture,
 			BuildInfo::kind,
-			BuildInfo::date
+			BuildInfo::date,
+			BuildInfo::ndk_version,
+			BuildInfo::ndk_api_level,
+			mono_get_runtime_build_info ()
 		);
-
-#if defined (ANDROID)
-		log_info_nocheck (LOG_DEFAULT, "NDK version: %s; API level: %s", BuildInfo::ndk_version, BuildInfo::ndk_api_level);
-		log_info_nocheck (LOG_DEFAULT, "MonoVM version: %s", mono_get_runtime_build_info ());
-#endif // def ANDROID
 	}
 
 	if (XA_UNLIKELY (FastTiming::enabled ())) {

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2336,7 +2336,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	if (XA_UNLIKELY (utils.should_log (LOG_DEFAULT))) {
 		log_info_nocheck (
 			LOG_DEFAULT,
-			"Xamarin.Android version: %s (%s; %s); built on %s; NDK version: %s; API level: %s; MonoVM version: %s",
+			".NET Android version: %s (%s; %s); built on %s; NDK version: %s; API level: %s; MonoVM version: %s",
 			BuildInfo::xa_version,
 			BuildInfo::architecture,
 			BuildInfo::kind,

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -143,7 +143,7 @@ Util::monodroid_store_package_name (const char *name)
 	// And yes, I know it could be done in a simple loop or in even simpler 8 lines of code, but
 	// that would be boring, wouldn't it? :)
 	package_hash_to_hex (hash, 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u);
-	log_info (LOG_DEFAULT, "Generated hash 0x%s for package name %s", package_property_suffix, name);
+	log_debug (LOG_DEFAULT, "Generated hash 0x%s for package name %s", package_property_suffix, name);
 }
 
 #if defined (NET)


### PR DESCRIPTION
We log a number of messages during startup, whether or not logging is
enabled.  However, logcat messages take non-trivial (and not entirely
predictable) amount of time to process, so we should limit their number
by default in order to speed up startup.

Tests show the following improvements resulting from this change:

  * Displayed: 6.28% faster
  * Native-to-managed transition: 6.11% faster
  * Total native init time: 13.95% faster