### PR TITLE
Add `SkipAndroidAPK` property to allow skipping producing an APK

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -34,7 +34,7 @@ properties that determine build ordering.
       Outside IDEs: we need to produce an .apk/.aab and sign
       Inside IDEs: the Install target produces .apk/.aab files & signs
     -->
-    <BuildDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+    <BuildDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'true' AND '$(SkipAndroidAPK)' != 'true'">
       $(BuildDependsOn);
       _CopyPackage;
       _Sign;


### PR DESCRIPTION
Sometimes, all a CI build needs is verifying that a project builds without errors. In those cases, producing an APK is a waste of time. This PR adds an option for that. Note that `BuildingInsideVisualStudio` can't be used because it can have too many other side effects.