### PR TITLE
[Performance] Simplify `AddKeepAlivesStep` to not add all assembly types in a list

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -58,7 +58,7 @@ namespace MonoDroid.Tuner
 			return changed;
 		}
 
-		static bool ProcessType (TypeDefinition type)
+		bool ProcessType (TypeDefinition type)
 		{
   			bool changed = false;
 			if (MightNeedFix (type))

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AddKeepAlivesStep.cs
@@ -52,27 +52,25 @@ namespace MonoDroid.Tuner
 				return false;
 
 			bool changed = false;
-			List<TypeDefinition> types = assembly.MainModule.Types.ToList ();
 			foreach (TypeDefinition type in assembly.MainModule.Types)
-				AddNestedTypes (types, type);
-
-			foreach (TypeDefinition type in types)
-				if (MightNeedFix (type))
-					changed |= AddKeepAlives (type);
+				changed |= ProcessType (type);
 
 			return changed;
 		}
 
-		// Adapted from `MarkJavaObjects`
-		static void AddNestedTypes (List<TypeDefinition> types, TypeDefinition type)
+		static bool ProcessType (TypeDefinition type)
 		{
-			if (!type.HasNestedTypes)
-				return;
+  			bool changed = false;
+			if (MightNeedFix (type))
+				changed |= AddKeepAlives (type);
 
-			foreach (var t in type.NestedTypes) {
-				types.Add (t);
-				AddNestedTypes (types, t);
+			if (type.HasNestedTypes) {
+				foreach (var t in type.NestedTypes) {
+					changed |= ProcessType (t);
+				}
 			}
+
+			return changed;
 		}
 
 		bool MightNeedFix (TypeDefinition type)


### PR DESCRIPTION
Adding all types to a list first, then processing that list is not necessary and has unnecessary overhead. The code is now modified to process types directly