### PR TITLE
Bump monodroid to 2f07bd4a71f2d59d0d86caefedf61b9fd0795699

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@e57630bd3a790e5772ae030e517326d34f38431d
+xamarin/monodroid:main@2f07bd4a71f2d59d0d86caefedf61b9fd0795699
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@2f07bd4a71f2d59d0d86caefedf61b9fd0795699
+xamarin/monodroid:main@47bdaaa9b8ac16d6197a8982c8cc810d177c5cff
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d


### PR DESCRIPTION

Changes https://github.com/xamarin/monodroid/compare/e57630bd3...47bdaaa9b

https://github.com/xamarin/monodroid/commit/47bdaaa9b Bump to xamarin/androidtools/main@a9168743 (#1379)
https://github.com/xamarin/monodroid/commit/2f07bd4a7 Bump external/android-sdk-installer from `6f38560` to `3880589` (#1378)
https://github.com/xamarin/monodroid/commit/af9de6a1b Bump external/xamarin-android from `c6d5025` to `2b0761b` (#1377)
https://github.com/xamarin/monodroid/commit/05a18eedb [tools/msbuild] Dont raise XA0138 Warning if fast deployment hangs. (#1375)
https://github.com/xamarin/monodroid/commit/8dee1d4c8 Bump external/xamarin-android from `41aaf38` to `c6d5025` (#1374)
https://github.com/xamarin/monodroid/commit/fbb362b85 Bump external/xamarin-android from `547a157` to `41aaf38` (#1372)
https://github.com/xamarin/monodroid/commit/f3257cf75 Bump external/android-sdk-installer from `20b5b01` to `6f38560` (#1370)
https://github.com/xamarin/monodroid/commit/6e5ad72c3 Bump tools/msbuild/external/androidtools from `720fd4e` to `7b48571` (#1369)
https://github.com/xamarin/monodroid/commit/d0889c7be Bump external/xamarin-android from `fbbf984` to `547a157` (#1371)