### PR TITLE
[Build Tasks] Update CheckClientHandlerType errors

### DIFF
--- a/Documentation/guides/messages/xa1031.md
+++ b/Documentation/guides/messages/xa1031.md
@@ -12,6 +12,11 @@ The 'AndroidHttpClientHandlerType' property value 'Foo.Bar.HttpHander, MyApp' mu
 Please change the value to an assembly-qualifed type name which inherits from '{1}' or remove the property completely.
 ```
 
+```
+The 'AndroidHttpClientHandlerType' property value 'Xamarin.Android.Net.AndroidClientHandler' must not derive from 'System.Net.Htt.HttpClientHandler'.
+Please change the value to an assembly-qualifed type name which inherits from 'System.Net.Http.HttpMessageHandler' or remove the property completely.
+```
+
 ## Solution
 
 Edit your csproj directly and change the 'AndroidHttpClientHandlerType' to

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1478,11 +1478,22 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Two processes may be building this project at once. Lock file exists at path: {0}.
+        ///   Looks up a localized string similar to The 'AndroidHttpClientHandlerType' property value '{0}' must derive from '{1}'.
+        ///Please change the value to an assembly-qualifed type name which inherits from '{1}' or remove the property completely.
         /// </summary>
         public static string XA1031 {
             get {
                 return ResourceManager.GetString("XA1031", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The 'AndroidHttpClientHandlerType' property value '{0}' must not derive from 'System.Net.Htt.HttpClientHandler'.
+        ///Please change the value to an assembly-qualifed type name which inherits from 'System.Net.Http.HttpMessageHandler' or remove the property completely.
+        /// </summary>
+        public static string XA1031_HCH {
+            get {
+                return ResourceManager.GetString("XA1031_HCH", resourceCulture);
             }
         }
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -477,6 +477,12 @@ Please change the value to an assembly-qualifed type name which inherits from '{
 {0} - The value of the property.
 {1} - A type from which the AndroidHttpClientHandlerType should derive .</comment>
   </data>
+  <data name="XA1031_HCH" xml:space="preserve">
+    <value>The 'AndroidHttpClientHandlerType' property value '{0}' must not derive from 'System.Net.Htt.HttpClientHandler'.
+Please change the value to an assembly-qualifed type name which inherits from 'System.Net.Http.HttpMessageHandler' or remove the property completely.</value>
+    <comment>The following are literal names and should not be translated: 'AndroidHttpClientHandlerType', 'System.Net.Htt.HttpClientHandler', 'System.Net.Http.HttpMessageHandler',
+{0} - The value of the property.</comment>
+  </data>
   <data name="XA1032" xml:space="preserve">
     <value>Failed to resolve '{0}' from '{1}'. Please check your `AndroidHttpClientHandlerType` setting.</value>
     <comment>The following are literal names and should not be translated: 'AndroidHttpClientHandlerType',

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckClientHandlerType.cs
@@ -16,23 +16,12 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string ClientHandlerType { get; set; }
-		[Required]
-		public string ValidHandlerType { get; set; }
+
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
-		public bool UsingAndroidNETSdk { get; set; }
 
 		public override bool RunTask ()
 		{
-			// Fast path for known types
-			if (UsingAndroidNETSdk) {
-				if (ClientHandlerType == "Xamarin.Android.Net.AndroidMessageHandler")
-					return !Log.HasLoggedErrors;
-			} else {
-				if (ClientHandlerType == "Xamarin.Android.Net.AndroidClientHandler")
-					return !Log.HasLoggedErrors;
-			}
-
 			string[] types = ClientHandlerType.Split (',');
 			string type = types[0].Trim ();
 			string assembly = "Mono.Android";
@@ -77,9 +66,12 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 
-				string[] valueHandlerTypes = ValidHandlerType.Split (',');
-				if (!Extends (handlerType, valueHandlerTypes [0].Trim ())) {
-					Log.LogCodedError ("XA1031", Xamarin.Android.Tasks.Properties.Resources.XA1031, type, valueHandlerTypes [0]);
+				if (Extends (handlerType, "System.Net.Http.HttpClientHandler")) {
+					Log.LogCodedError ("XA1031", Xamarin.Android.Tasks.Properties.Resources.XA1031_HCH, type);
+				}
+
+				if (!Extends (handlerType, "System.Net.Http.HttpMessageHandler")) {
+					Log.LogCodedError ("XA1031", Xamarin.Android.Tasks.Properties.Resources.XA1031, type, "System.Net.Http.HttpMessageHandler");
 				}
 
 				return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -161,12 +161,8 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			var httpClientHandlerVarName = "XA_HTTP_CLIENT_HANDLER_TYPE";
-			var expectedDefaultValue = "System.Net.Http.HttpClientHandler, System.Net.Http";
-			var expectedUpdatedValue = "Xamarin.Android.Net.AndroidClientHandler";
-			if (Builder.UseDotNet) {
-				expectedDefaultValue = "System.Net.Http.SocketsHttpHandler, System.Net.Http";
-				expectedUpdatedValue = "Xamarin.Android.Net.AndroidMessageHandler";
-			}
+			var expectedDefaultValue = "System.Net.Http.SocketsHttpHandler, System.Net.Http";
+			var expectedUpdatedValue = "Xamarin.Android.Net.AndroidMessageHandler";
 
 			var supportedAbis = "armeabi-v7a;arm64-v8a";
 			proj.SetAndroidSupportedAbis (supportedAbis);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckClientHandlerTypeTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckClientHandlerTypeTests.cs
@@ -15,10 +15,9 @@ namespace Xamarin.Android.Build.Tests
 	public class CheckClientHandlerTypeTests : BaseTest
 	{
 		[Test]
-		[TestCase ("Xamarin.Android.Net.AndroidMessageHandler", "System.Net.Http.HttpMessageHandler, System.Net.Http")]
-		[TestCase ("Xamarin.Android.Net.AndroidClientHandler", "System.Net.Http.HttpClientHandler, System.Net.Http")]
-		[TestCase ("System.Net.Http.SocketsHttpHandler, System.Net.Http", "System.Net.Http.HttpMessageHandler, System.Net.Http")]
-		public void ErrorIsNotRaised (string handler, string validBaseType)
+		[TestCase ("Xamarin.Android.Net.AndroidMessageHandler")]
+		[TestCase ("System.Net.Http.SocketsHttpHandler, System.Net.Http")]
+		public void ErrorIsNotRaised (string handler)
 		{
 			string path = Path.Combine (Root, "temp", TestName);
 			Directory.CreateDirectory (path);
@@ -36,7 +35,7 @@ namespace Xamarin.Android.Build.Tests
 			var errors = new List<BuildErrorEventArgs> ();
 			var warnings = new List<BuildWarningEventArgs> ();
 			List<ITaskItem> assemblies = new List<ITaskItem> ();
-			string[] files = Directory.GetFiles (asmPath, "*.dll");
+			string[] files = Directory.GetFiles (asmPath, "*.dll", SearchOption.AllDirectories);
 			foreach (var file in files)
 				assemblies.Add (new TaskItem (file));
 			IBuildEngine4 engine = new MockBuildEngine (System.Console.Out, errors, warnings);
@@ -44,18 +43,13 @@ namespace Xamarin.Android.Build.Tests
 				BuildEngine = engine,
 				ClientHandlerType = handler,
 				ResolvedAssemblies = assemblies.ToArray (),
-				ValidHandlerType = validBaseType,
 			};
 			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
 		}
 
 		[Test]
-#if !NET_6
-		[TestCase ("Xamarin.Android.Net.AndroidMessageHandler", "System.Net.Http.HttpClientHandler, System.Net.Http")]
-#else
-		[TestCase ("Xamarin.Android.Net.AndroidClientHandler", "System.Net.Http.HttpMessageHandler, System.Net.Http")]
-#endif
-		public void ErrorIsRaised (string handler, string validBaseType)
+		[TestCase ("Xamarin.Android.Net.AndroidClientHandler")]
+		public void ErrorIsRaised (string handler)
 		{
 			var path = Path.Combine (Root, "temp", TestName);
 			Directory.CreateDirectory (path);
@@ -73,7 +67,7 @@ namespace Xamarin.Android.Build.Tests
 			var errors = new List<BuildErrorEventArgs> ();
 			var warnings = new List<BuildWarningEventArgs> ();
 			List<ITaskItem> assemblies = new List<ITaskItem> ();
-			string[] files = Directory.GetFiles (asmPath, "*.dll");
+			string[] files = Directory.GetFiles (asmPath, "*.dll", SearchOption.AllDirectories);
 			foreach (var file in files)
 				assemblies.Add (new TaskItem (file));
 			IBuildEngine4 engine = new MockBuildEngine (System.Console.Out, errors, warnings);
@@ -81,10 +75,10 @@ namespace Xamarin.Android.Build.Tests
 				BuildEngine = engine,
 				ClientHandlerType = handler,
 				ResolvedAssemblies = assemblies.ToArray (),
-				ValidHandlerType = validBaseType,
 			};
 			Assert.False (task.Execute (), $"task should have failed.");
-			Assert.AreEqual (1, errors.Count, $"An Error should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
+			Assert.AreEqual (1, errors.Count, $"One error should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
+			Assert.AreEqual ("XA1031", errors [0].Code, "Error code should have been XA1031.");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckClientHandlerTypeTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckClientHandlerTypeTests.cs
@@ -22,15 +22,22 @@ namespace Xamarin.Android.Build.Tests
 			string path = Path.Combine (Root, "temp", TestName);
 			Directory.CreateDirectory (path);
 			string intermediatePath;
+			bool targetSkipped;
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
 			};
-			proj.PackageReferences.Add (new Package() { Id = "System.Net.Http", Version = "*" });
+			proj.SetProperty ("AndroidHttpClientHandlerType", handler);
 			using (var b = CreateApkBuilder (path)) {
-				b.ThrowOnBuildFailure = false;
-				b.Build (proj); // we don't care it might error.
+				b.Build (proj);
 				intermediatePath = Path.Combine (path,proj.IntermediateOutputPath);
+				targetSkipped = b.Output.IsTargetSkipped ("_CheckAndroidHttpClientHandlerType");
 			}
+
+			if (handler.Contains ("Xamarin.Android.Net.AndroidMessageHandler"))
+				Assert.IsTrue (targetSkipped, "_CheckAndroidHttpClientHandlerType should not have run.");
+			else
+				Assert.IsFalse (targetSkipped, "_CheckAndroidHttpClientHandlerType should have run.");
+
 			string asmPath = Path.GetFullPath (Path.Combine (intermediatePath, "android", "assets"));
 			var errors = new List<BuildErrorEventArgs> ();
 			var warnings = new List<BuildWarningEventArgs> ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -486,15 +486,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_CheckAndroidHttpClientHandlerType"
-    Condition=" '$(AndroidHttpClientHandlerType)' != '' And  '$(AndroidApplication)' == 'True' ">
-  <PropertyGroup>
-    <ValidAndroidHttpClientHandlerBaseType Condition="'$(UsingAndroidNETSdk)' != 'true'">System.Net.Http.HttpClientHandler, System.Net.Http</ValidAndroidHttpClientHandlerBaseType>
-    <ValidAndroidHttpClientHandlerBaseType Condition="'$(UsingAndroidNETSdk)' == 'true'">System.Net.Http.HttpMessageHandler, System.Net.Http</ValidAndroidHttpClientHandlerBaseType>
-  </PropertyGroup>
+    Condition=" '$(AndroidHttpClientHandlerType)' != '' And '$(AndroidHttpClientHandlerType)' != 'Xamarin.Android.Net.AndroidMessageHandler' And '$(AndroidApplication)' == 'True' ">
   <CheckClientHandlerType
     ClientHandlerType="$(AndroidHttpClientHandlerType)"
-    ValidHandlerType="$(ValidAndroidHttpClientHandlerBaseType)"
-    UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
     ResolvedAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
   />
 </Target>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/d3e87674187fca4ce136f5c4b460c488044e1bec
Context: https://github.com/xamarin/xamarin-android/commit/311b41e864a0162895d079477cb9398fbec5ca6e

Updates the `CheckClientHandlerType` task to throw an XA1031 error when
`$(AndroidHttpClientHandlerType)` is set to a value that inherits from
`System.Net.Http.HttpClientHandler`.