### PR TITLE
[Tests] Remove Builder.UseDotNet

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -133,9 +133,7 @@ namespace Xamarin.Android.Build.Tests
 			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				TargetFrameworkVersion = "v8.0",
 				TargetSdkVersion = "26",
-				UseLatestPlatformSdk = false,
 			};
 			var parameters = new string [] {
 				$"TargetFrameworkRootPath={referencesPath}",
@@ -147,7 +145,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Target = "GetAndroidDependencies";
 				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
-				int apiLevel = Builder.UseDotNet ? XABuildConfig.AndroidDefaultTargetDotnetApiLevel : 26;
+				int apiLevel = XABuildConfig.AndroidDefaultTargetDotnetApiLevel;
 				StringAssertEx.Contains ($"platforms/android-{apiLevel}", builder.LastBuildOutput, $"platforms/android-{apiLevel} should be a dependency.");
 				StringAssertEx.Contains ($"build-tools/{buildToolsVersion}", builder.LastBuildOutput, $"build-tools/{buildToolsVersion} should be a dependency.");
 				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");
@@ -168,9 +166,7 @@ namespace Xamarin.Android.Build.Tests
 			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				TargetFrameworkVersion = "v8.0",
 				TargetSdkVersion = "26",
-				UseLatestPlatformSdk = false,
 			};
 			var parameters = new string [] {
 				$"TargetFrameworkRootPath={referencesPath}",
@@ -183,7 +179,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Target = "GetAndroidDependencies";
 				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
-				int apiLevel = Builder.UseDotNet ? XABuildConfig.AndroidDefaultTargetDotnetApiLevel : 26;
+				int apiLevel = XABuildConfig.AndroidDefaultTargetDotnetApiLevel;
 				StringAssertEx.Contains ($"platforms/android-{apiLevel}", builder.LastBuildOutput, $"platforms/android-{apiLevel} should be a dependency.");
 				StringAssertEx.Contains ($"build-tools/{buildToolsVersion}", builder.LastBuildOutput, $"build-tools/{buildToolsVersion} should be a dependency.");
 				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
@@ -58,9 +58,8 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void CheckAssetsAreIncludedInAPK ([Values (true, false)] bool useAapt2)
+		public void CheckAssetsAreIncludedInAPK ()
 		{
-			AssertAaptSupported (useAapt2);
 			var projectPath = Path.Combine ("temp", TestName);
 			var libproj = new XamarinAndroidLibraryProject () {
 				ProjectName = "Library1",
@@ -106,7 +105,6 @@ namespace Xamarin.Android.Build.Tests
 					},
 				}
 			};
-			proj.AndroidUseAapt2 = useAapt2;
 			proj.References.Add (new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj"));
 			using (var libb = CreateDllBuilder (Path.Combine (projectPath, libproj.ProjectName))) {
 				Assert.IsTrue (libb.Build (libproj), "{0} should have built successfully.", libproj.ProjectName);
@@ -151,19 +149,12 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName, "SubDir"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var libraryProjectImports = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "__AndroidLibraryProjects__.zip");
-				if (Builder.UseDotNet) {
-					var aarPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.aar");
-					FileAssert.Exists (aarPath);
-					using (var aar = ZipHelper.OpenZip (aarPath)) {
-						aar.AssertEntryContents (aarPath, "assets/foo.txt", contents: "bar");
-					}
-					FileAssert.DoesNotExist (libraryProjectImports);
-				} else {
-					FileAssert.Exists (libraryProjectImports);
-					using (var zip = ZipHelper.OpenZip (libraryProjectImports)) {
-						zip.AssertEntryContents (libraryProjectImports, "library_project_imports/assets/foo.txt", contents: "bar");
-					}
+				var aarPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, $"{proj.ProjectName}.aar");
+				FileAssert.Exists (aarPath);
+				using (var aar = ZipHelper.OpenZip (aarPath)) {
+					aar.AssertEntryContents (aarPath, "assets/foo.txt", contents: "bar");
 				}
+				FileAssert.DoesNotExist (libraryProjectImports);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/CodeBehindTests.cs
@@ -153,9 +153,7 @@ namespace Xamarin.Android.Build.Tests
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", "BuildTests"));
 			CommonSampleLibraryRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", CommonSampleLibraryName));
 			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "CodeBehind");
-			if (Builder.UseDotNet) {
-				ProjectName += ".NET";
-			}
+			ProjectName += ".NET";
 
 			generated_sources = new List <SourceFile> {
 				new SourceFile ("Binding.Main.g.cs") {
@@ -272,14 +270,9 @@ namespace Xamarin.Android.Build.Tests
 				$"{ProjectName}.dll",
 				"CommonSampleLibrary.dll",
 				$"{PackageName}-Signed.apk",
+				$"{PackageName}.aab",
+				$"{PackageName}-Signed.aab",
 			};
-
-			if (!Builder.UseDotNet) {
-				produced_binaries.Add ($"{PackageName}.apk");
-			} else {
-				produced_binaries.Add ($"{PackageName}.aab");
-				produced_binaries.Add ($"{PackageName}-Signed.aab");
-			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -152,8 +152,7 @@ namespace UnnamedProject
 				var resourcepathscache = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
 				FileAssert.Exists (resourcepathscache);
 				var doc = XDocument.Load (resourcepathscache);
-				var expected = Builder.UseDotNet ? 37 : 40;
-				Assert.AreEqual (expected, doc.Root.Element ("Jars").Elements ("Jar").Count (), "libraryprojectimports.cache did not contain expected jar files");
+				Assert.AreEqual (37, doc.Root.Element ("Jars").Elements ("Jar").Count (), "libraryprojectimports.cache did not contain expected jar files");
 			}
 		}
 
@@ -326,9 +325,6 @@ namespace UnnamedProject
 
 				var packageManagerPath = Path.Combine (Root, appb.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "mono", "MonoPackageManager_Resources.java");
 				var before = GetAssembliesFromPackageManager (packageManagerPath);
-				if (!Builder.UseDotNet) {
-					Assert.AreEqual ("\"App1.dll\",", before, $"After first `{appb.Target}`, assemblies list should only have main App dll.");
-				}
 
 				// NuGet restore, either with /t:Restore in a separate MSBuild call or /restore in a single call
 				if (restoreInSingleCall) {
@@ -341,9 +337,6 @@ namespace UnnamedProject
 				Assert.IsTrue (appb.Build (proj, parameters: DesignerParameters), "second build should have succeeded");
 
 				var after = GetAssembliesFromPackageManager (packageManagerPath);
-				if (!Builder.UseDotNet) {
-					Assert.AreNotEqual (before, after, $"After second `{appb.Target}`, assemblies list should *not* be empty.");
-				}
 				foreach (var assembly in new [] { "Xamarin.Forms.Core.dll", "Xamarin.Forms.Platform.Android.dll" }) {
 					StringAssert.Contains (assembly, after);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -43,10 +43,6 @@ namespace Xamarin.Android.Build.Tests
 			using (var appb = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
 				Assert.IsTrue (libb.Build (lib), "Library build should have succeeded.");
 				Assert.IsTrue (appb.Build (app), "App should have succeeded.");
-				if (!Builder.UseDotNet) {
-					//TODO: $(AndroidLinkSkip) is not yet implemented
-					Assert.IsTrue (StringAssertEx.ContainsText (appb.LastBuildOutput, $"Save assembly: {linkSkip}"), $"{linkSkip} should be saved, and not linked!");
-				}
 
 				string intermediateOutputDir = Path.Combine (Root, appb.ProjectDirectory, app.IntermediateOutputPath);
 				List<EnvironmentHelper.EnvironmentFile> envFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediateOutputDir, supportedAbis, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -70,18 +70,15 @@ namespace Bug12935
 ";
 
 		[Test]
-		public void Bug12935 ([Values (true, false)] bool useAapt2)
+		public void Bug12935 ()
 		{
-			AssertAaptSupported (useAapt2);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
 			proj.MainActivity = ScreenOrientationActivity;
-			proj.AndroidUseAapt2 = useAapt2;
-			var directory = $"temp/Bug12935_{useAapt2}";
+			var directory = $"temp/Bug12935";
 			using (var builder = CreateApkBuilder (directory)) {
 
-				proj.TargetFrameworkVersion = "v4.2";
 				proj.AndroidManifest = string.Format (TargetSdkManifest, "17");
 				Assert.IsTrue (builder.Build (proj), "Build for TargetFrameworkVersion 17 should have succeeded");
 				var manifestFile = Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
@@ -103,7 +100,6 @@ namespace Bug12935
 				Assert.AreEqual ("sensorPortrait", screenOrientation.Value, "screenOrientation should have been sensorPortrait");
 
 				builder.Cleanup ();
-				proj.TargetFrameworkVersion = "v4.1";
 				proj.AndroidManifest = string.Format (TargetSdkManifest, "16");
 				Assert.IsTrue (builder.Build (proj), "Build for TargetFrameworkVersion 16 should have succeeded");
 
@@ -119,25 +115,22 @@ namespace Bug12935
 
 				builder.Cleanup ();
 				builder.ThrowOnBuildFailure = false;
-				proj.TargetFrameworkVersion = "v4.0.3";
 				proj.AndroidManifest = string.Format (TargetSdkManifest, "15");
 				Assert.IsFalse (builder.Build (proj), "Build for TargetFrameworkVersion 15 should have failed");
-				StringAssertEx.Contains (useAapt2 ? "APT2259: " : "APT1134: ", builder.LastBuildOutput);
-				StringAssertEx.Contains (useAapt2 ? "APT2067" : "", builder.LastBuildOutput);
+				StringAssertEx.Contains ("APT2259: ", builder.LastBuildOutput);
+				StringAssertEx.Contains ("APT2067", builder.LastBuildOutput);
 				StringAssertEx.Contains (Path.Combine ("Properties", "AndroidManifest.xml"), builder.LastBuildOutput);
-				StringAssertEx.Contains ($"{(useAapt2 ? "2" : "1")} Error(s)", builder.LastBuildOutput);
+				StringAssertEx.Contains ("2 Error(s)", builder.LastBuildOutput);
 			}
 		}
 
 		[Test]
-		public void CheckElementReOrdering ([Values (true, false)] bool useAapt2)
+		public void CheckElementReOrdering ()
 		{
-			AssertAaptSupported (useAapt2);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
 			proj.MainActivity = ScreenOrientationActivity;
-			proj.AndroidUseAapt2 = useAapt2;
 			using (var builder = CreateApkBuilder ()) {
 				proj.AndroidManifest = ElementOrderManifest;
 				Assert.IsTrue (builder.Build (proj), "first build should have succeeded");
@@ -305,7 +298,6 @@ namespace Bug12935
 		public void LayoutAttributeElement ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
-				TargetFrameworkVersion = "v7.0",
 				IsRelease = true,
 			};
 			string declHead = "public class MainActivity";
@@ -328,7 +320,6 @@ namespace Bug12935
 		public void DirectBootAwareAttribute ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
-				TargetFrameworkVersion = "v7.0",
 				IsRelease = true,
 			};
 			string attrHead = ", Activity (";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/SingleProjectTest.cs
@@ -47,9 +47,7 @@ namespace Xamarin.Android.Build.Tests
 				.Replace ("android:label=\"${PROJECT_NAME}\"", "")
 				.Replace ("android:versionName=\"1.0\"", "")
 				.Replace ("android:versionCode=\"1\"", "");
-			if (!Builder.UseDotNet) {
-				proj.SetProperty ("GenerateApplicationManifest", "true");
-			}
+
 			proj.SetProperty ("ApplicationId", packageName);
 			proj.SetProperty ("ApplicationTitle", applicationLabel);
 			proj.SetProperty ("ApplicationVersion", versionCode);
@@ -78,9 +76,6 @@ namespace Xamarin.Android.Build.Tests
 				var apk = b.Output.GetIntermediaryPath ($"android/bin/{packageName}.apk");
 				FileAssert.Exists (apk);
 
-				// NOTE: the $(Version) setting is only implemented in .NET 6
-				if (!Builder.UseDotNet)
-					return;
 				// If not valid version, skip
 				if (!Version.TryParse (versionName, out _))
 					return;
@@ -121,9 +116,7 @@ namespace Xamarin.Android.Build.Tests
 				.Replace ("android:label=\"${PROJECT_NAME}\"", $"android:label=\"{applicationLabel}\"")
 				.Replace ("android:versionName=\"1.0\"", $"android:versionName=\"{versionName}\"")
 				.Replace ("android:versionCode=\"1\"", $"android:versionCode=\"{versionCode}\"");
-			if (!Builder.UseDotNet) {
-				proj.SetProperty ("GenerateApplicationManifest", "true");
-			}
+
 			proj.SetProperty ("ApplicationId", "com.i.should.not.be.used");
 			proj.SetProperty ("ApplicationTitle", "I should not be used");
 			proj.SetProperty ("ApplicationVersion", "21");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -435,20 +435,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void Aapt2Disabled ()
-		{
-			AssertAaptSupported (useAapt2: false);
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.AndroidUseAapt2 = false;
-			using (var b = CreateApkBuilder ()) {
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Aapt2Link"), "Aapt2Link task should not run!");
-				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Aapt2Compile"), "Aapt2Compile task should not run!");
-				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "_CreateAapt2VersionCache"), "_CreateAapt2VersionCache target should not run!");
-			}
-		}
-
-		[Test]
 		public void Aapt2AndroidResgenExtraArgsAreInvalid ()
 		{
 			var path = Path.Combine (Root, "temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidDotnetToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidDotnetToolTests.cs
@@ -37,12 +37,11 @@ namespace Xamarin.Android.Build.Tests
 				BuildEngine = engine,
 				NetCoreRoot = dotnetDir,
 				ToolPath = TestEnvironment.AndroidMSBuildDirectory,
-				ToolExe = Builder.UseDotNet ? "class-parse.dll" : "class-parse.exe",
+				ToolExe = "class-parse.dll",
 			};
 
 			Assert.True (classParseTask.Execute (), "Task should have succeeded.");
-			var expectedTool = Builder.UseDotNet ? dotnetPath : Path.Combine (TestEnvironment.AndroidMSBuildDirectory, "class-parse.exe");
-			Assert.IsTrue (messages.Any (m => m.Message.StartsWith (expectedTool)), "Task did not use expected tool path.");
+			Assert.IsTrue (messages.Any (m => m.Message.StartsWith (dotnetPath)), "Task did not use expected tool path.");
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -174,15 +174,10 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void PreserveCustomHttpClientHandlers ()
 		{
-			if (Builder.UseDotNet) {
-				PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidMessageHandler", "",
-					"temp/PreserveAndroidMessageHandler", "android-arm64/linked/Mono.Android.dll");
-				PreserveCustomHttpClientHandler ("System.Net.Http.SocketsHttpHandler", "System.Net.Http",
-					"temp/PreserveSocketsHttpHandler", "android-arm64/linked/System.Net.Http.dll");
-			} else {
-				PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidClientHandler", "",
-					"temp/PreserveAndroidHttpClientHandler", "android/assets/Mono.Android.dll");
-			}
+			PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidMessageHandler", "",
+				"temp/PreserveAndroidMessageHandler", "android-arm64/linked/Mono.Android.dll");
+			PreserveCustomHttpClientHandler ("System.Net.Http.SocketsHttpHandler", "System.Net.Http",
+				"temp/PreserveSocketsHttpHandler", "android-arm64/linked/System.Net.Http.dll");
 		}
 
 		[Test]
@@ -216,8 +211,8 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (appBuilder.Build (app), "app build should have succeeded.");
 
 			// NOTE: in .NET 6, we only emit IL6200 for Release builds
-			if (!Builder.UseDotNet || isRelease) {
-				string code = Builder.UseDotNet ? "IL6200" : "XA2000";
+			if (isRelease) {
+				string code = "IL6200";
 				Assert.IsTrue (StringAssertEx.ContainsText (appBuilder.LastBuildOutput, "1 Warning(s)"), "MSBuild should count 1 warnings.");
 				Assert.IsTrue (StringAssertEx.ContainsText (appBuilder.LastBuildOutput, $"warning {code}: Use of AppDomain.CreateDomain()"), $"Should warn {code} about creating AppDomain.");
 			}
@@ -260,7 +255,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void LinkDescription ([Values (true, false)] bool useAssemblyStore)
 		{
-			string assembly_name = Builder.UseDotNet ? "System.Console" : "mscorlib";
+			string assembly_name = "System.Console";
 			string linker_xml = "<linker/>";
 
 			var proj = new XamarinAndroidApplicationProject {
@@ -428,7 +423,7 @@ namespace UnnamedProject {
 				Assert.IsTrue (b.Build (proj), "Building a project should have succeded.");
 
 				var assemblyFile = "UnnamedProject.dll";
-				var assemblyPath = (Builder.UseDotNet && (!isRelease || setLinkModeNone)) ? b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", assemblyFile)) : BuildTest.GetLinkedPath (b,  true, assemblyFile);
+				var assemblyPath = (!isRelease || setLinkModeNone) ? b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", assemblyFile)) : BuildTest.GetLinkedPath (b,  true, assemblyFile);
 				using (var assembly = AssemblyDefinition.ReadAssembly (assemblyPath)) {
 					Assert.IsTrue (assembly != null);
 
@@ -461,9 +456,6 @@ namespace UnnamedProject {
 		[Test]
 		public void TypeRegistrationsFallback ([Values (true, false)] bool enabled)
 		{
-			if (!Builder.UseDotNet)
-				Assert.Ignore ("Test only valid on .NET 6");
-
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			if (enabled)
 				proj.SetProperty (proj.ActiveConfigurationProperties, "VSAndroidDesigner", "true");
@@ -484,9 +476,6 @@ namespace UnnamedProject {
 		[Test]
 		public void AndroidUseNegotiateAuthentication ([Values (true, false, null)] bool? useNegotiateAuthentication)
 		{
-			if (!Builder.UseDotNet)
-				Assert.Ignore ("Test only valid on .NET");
-
 			var proj = new XamarinAndroidApplicationProject { IsRelease = true };
 			proj.AddReferences ("System.Net.Http");
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
@@ -519,9 +508,6 @@ namespace UnnamedProject {
 		[Test]
 		public void DoNotErrorOnPerArchJavaTypeDuplicates ([Values(true, false)] bool enableMarshalMethods)
 		{
-			if (!Builder.UseDotNet)
-				Assert.Ignore ("Test only valid on .NET");
-
 			var path = Path.Combine (Root, "temp", TestName);
 			var lib = new XamarinAndroidLibraryProject { IsRelease = true, ProjectName = "Lib1" };
 			lib.SetProperty ("IsTrimmable", "true");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveSdksTaskTests.cs
@@ -436,17 +436,5 @@ namespace Xamarin.Android.Build.Tests {
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
-		[Test]
-		public void LatestTFV_OldTargetSdkVersion ()
-		{
-			var proj = new XamarinAndroidApplicationProject {
-				UseLatestPlatformSdk = false,
-			};
-			proj.TargetSdkVersion = "19";
-			using (var b = CreateApkBuilder ()) {
-				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-			}
-		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -73,13 +73,6 @@ namespace Xamarin.Android.Build.Tests
 		/// </summary>
 		public const int MaxFileName = 255;
 
-		protected static void AssertAaptSupported (bool useAapt2)
-		{
-			if (Builder.UseDotNet && !useAapt2) {
-				Assert.Ignore ("aapt(1) is not supported in .NET 5+");
-			}
-		}
-
 		protected static void WaitFor(int milliseconds)
 		{
 			var pause = new ManualResetEvent(false);
@@ -452,36 +445,28 @@ namespace Xamarin.Android.Build.Tests
 
 		protected string GetResourceDesignerPath (ProjectBuilder builder, XamarinAndroidProject project)
 		{
-			string path;
-			if (Builder.UseDotNet) {
-				path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
-				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
-					return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
-				}
-			} else {
-				path = Path.Combine (Root, builder.ProjectDirectory, "Resources");
+			string path = Path.Combine (Root, builder.ProjectDirectory, project.IntermediateOutputPath);
+			if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "False", ignoreCase: true) != 0) {
+				return Path.Combine (path, "_Microsoft.Android.Resource.Designer.dll");
 			}
 			return Path.Combine (path, "Resource.designer" + project.Language.DefaultDesignerExtension);
 		}
 
 		protected string GetResourceDesignerText (XamarinAndroidProject project, string path)
 		{
-			if (Builder.UseDotNet) {
-				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
-					var decompiler = new CSharpDecompiler (path, new DecompilerSettings () { });
-					return decompiler.DecompileWholeModuleAsString ();
-				}
+			if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "False", ignoreCase: true) != 0) {
+				var decompiler = new CSharpDecompiler (path, new DecompilerSettings () { });
+				return decompiler.DecompileWholeModuleAsString ();
 			}
+
 			return File.ReadAllText (path);
 		}
 
 		protected string[] GetResourceDesignerLines (XamarinAndroidProject project, string path)
 		{
-			if (Builder.UseDotNet) {
-				if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "True", ignoreCase: true) == 0) {
-					var decompiler = new CSharpDecompiler (path, new DecompilerSettings () { });
-					return decompiler.DecompileWholeModuleAsString ().Split (Environment.NewLine[0]);
-				}
+			if (string.Compare (project.GetProperty ("AndroidUseDesignerAssembly"), "False", ignoreCase: true) != 0) {
+				var decompiler = new CSharpDecompiler (path, new DecompilerSettings () { });
+				return decompiler.DecompileWholeModuleAsString ().Split (Environment.NewLine[0]);
 			}
 			return File.ReadAllLines (path);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -190,7 +190,12 @@ namespace Xamarin.Android.Build.Tests
 
 		protected static string ClearDebugProperty ()
 		{
-			return RunAdbCommand ("shell setprop debug.mono.extra \"\"");
+			return ClearShellProp ("debug.mono.extra");
+		}
+
+		protected static string ClearShellProp (string propName)
+		{
+			return RunAdbCommand ($"shell setprop {propName} \"''\"");
 		}
 
 		protected static string AdbStartActivity (string activity)
@@ -200,15 +205,8 @@ namespace Xamarin.Android.Build.Tests
 
 		protected static void RunProjectAndAssert (XamarinAndroidApplicationProject proj, ProjectBuilder builder, string logName = "run.log", bool doNotCleanupOnUpdate = false, string [] parameters = null)
 		{
-			if (Builder.UseDotNet) {
-				builder.BuildLogFile = logName;
-				Assert.True (builder.RunTarget (proj, "Run", doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters), "Project should have run.");
-			} else if (TestEnvironment.CommercialBuildAvailable) {
-				builder.BuildLogFile = logName;
-				Assert.True (builder.RunTarget (proj, "_Run", doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters), "Project should have run.");
-			} else {
-				StartActivityAndAssert (proj);
-			}
+			builder.BuildLogFile = logName;
+			Assert.True (builder.RunTarget (proj, "Run", doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters), "Project should have run.");
 		}
 
 		protected static void StartActivityAndAssert (XamarinAndroidApplicationProject proj)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
@@ -58,32 +58,9 @@ namespace Xamarin.Android.Build.Tests
 			using (var wearBuilder = CreateDllBuilder (Path.Combine (path, wear.ProjectName)))
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.IsTrue (wearBuilder.Build (wear), "first wear build should have succeeded.");
-				// In .NET 5+, just check for a build error
-				if (Builder.UseDotNet) {
-					appBuilder.ThrowOnBuildFailure = false;
-					Assert.IsFalse (appBuilder.Build (app), "'dotnet' app build should have failed.");
-					StringAssertEx.Contains ($"error XA4312", appBuilder.LastBuildOutput, "Error should be XA4312");
-					return;
-				}
-				Assert.IsTrue (appBuilder.Build (app), "first app build should have succeeded.");
-				StringAssertEx.Contains ($"warning XA4312", appBuilder.LastBuildOutput, "Warning should be XA4312");
-				// Build with no changes
-				Assert.IsTrue (wearBuilder.Build (wear, doNotCleanupOnUpdate: true), "second wear build should have succeeded.");
-				Assert.IsTrue (wearBuilder.Output.IsTargetSkipped (target), $"`{target}` in wear build should be skipped!");
-				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true), "second app build should have succeeded.");
-				Assert.IsTrue (appBuilder.LastBuildOutput.ContainsOccurances ($"Skipping target \"{target}\"", 2), $"`{target}` in app build should be skipped!");
-				// Check the APK for the special Android Wear files
-				var files = new [] {
-					"res/raw/wearable_app.apk",
-					"res/xml/wearable_app_desc.xml"
-				};
-				var apk = Path.Combine (Root, appBuilder.ProjectDirectory, app.OutputPath, $"{app.PackageName}.apk");
-				FileAssert.Exists (apk);
-				using (var zipFile = ZipHelper.OpenZip (apk)) {
-					foreach (var file in files) {
-						Assert.IsTrue (zipFile.ContainsEntry (file, caseSensitive: true), $"{file} should be in the apk!");
-					}
-				}
+				appBuilder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (appBuilder.Build (app), "'dotnet' app build should have failed.");
+				StringAssertEx.Contains ($"error XA4312", appBuilder.LastBuildOutput, "Error should be XA4312");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -9,7 +9,6 @@ namespace Xamarin.ProjectTools
 
 		public const string AndroidLinkMode = "AndroidLinkMode";
 		public const string EmbedAssembliesIntoApk = "EmbedAssembliesIntoApk";
-		public const string AndroidUseLatestPlatformSdk = "AndroidUseLatestPlatformSdk";
 		public const string AndroidUseAapt2 = "AndroidUseAapt2";
 		public const string AndroidCreatePackagePerAbi = "AndroidCreatePackagePerAbi";
 		public const string AndroidEnableMarshalMethods = "AndroidEnableMarshalMethods";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownTargets.cs
@@ -7,6 +7,6 @@ namespace Xamarin.ProjectTools
 		public const string LinkAssembliesNoShrink = "_LinkAssembliesNoShrink";
 
 		// _RunILLink is found at: https://github.com/dotnet/sdk/blob/1ed51bc8f9cb06760c5b2f26798ee0278bd75f54/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L69-L72
-		public static string LinkAssembliesShrink => Builder.UseDotNet ? "_RunILLink" : "_LinkAssembliesShrink";
+		public const string LinkAssembliesShrink = "_RunILLink";
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -25,8 +25,7 @@ namespace Xamarin.ProjectTools
 
 		static XamarinAndroidApplicationProject ()
 		{
-			var folder = Builder.UseDotNet ? "DotNet" : "Base";
-			using (var sr = new StreamReader (typeof(XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ($"Xamarin.ProjectTools.Resources.{folder}.MainActivity.cs")))
+			using (var sr = new StreamReader (typeof(XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ($"Xamarin.ProjectTools.Resources.DotNet.MainActivity.cs")))
 				default_main_activity_cs = sr.ReadToEnd ();
 			using (var sr = new StreamReader (typeof(XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.MainActivity.fs")))
 				default_main_activity_fs = sr.ReadToEnd ();
@@ -40,39 +39,24 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release", [CallerMemberName] string packageName = "")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			if (Builder.UseDotNet) {
-				SetProperty (KnownProperties.OutputType, "Exe");
-				SetProperty (KnownProperties.Nullable, "enable");
-				SetProperty (KnownProperties.ImplicitUsings, "enable");
-				SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
-				SetProperty ("_FastDeploymentDiagnosticLogging", "True");
-				SupportedOSPlatformVersion = "21.0";
+			SetProperty (KnownProperties.OutputType, "Exe");
+			SetProperty (KnownProperties.Nullable, "enable");
+			SetProperty (KnownProperties.ImplicitUsings, "enable");
+			SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
+			SetProperty ("_FastDeploymentDiagnosticLogging", "True");
+			SupportedOSPlatformVersion = "21.0";
 
-				// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
-				Imports.Add (new Import (() => "Directory.Build.targets") {
-					TextContent = () =>
-						@"<Project>
-							<PropertyGroup>
-								<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
-							</PropertyGroup>
-						</Project>"
-				});
-			} else {
-				SetProperty ("_FastDeploymentDiagnosticLogging", "True");
-				SetProperty ("AndroidApplication", "True");
-				SetProperty ("AndroidResgenClass", "Resource");
-				SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);
-				SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
-				SetProperty (DebugProperties, "AndroidLinkMode", "None");
-				SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");
-				SetProperty (DebugProperties, KnownProperties.EmbedAssembliesIntoApk, "False", "'$(EmbedAssembliesIntoApk)' == ''");
-				SetProperty (ReleaseProperties, KnownProperties.EmbedAssembliesIntoApk, "True", "'$(EmbedAssembliesIntoApk)' == ''");
-				MinSdkVersion = "19";
-			}
+			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
+			Imports.Add (new Import (() => "Directory.Build.targets") {
+				TextContent = () =>
+					@"<Project>
+						<PropertyGroup>
+							<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
+						</PropertyGroup>
+					</Project>"
+			});
+
 			AndroidManifest = default_android_manifest;
-			if (!Builder.UseDotNet) {
-				TargetSdkVersion = AndroidSdkResolver.GetMaxInstalledPlatform ().ToString ();
-			}
 			LayoutMain = default_layout_main;
 			StringsXml = default_strings_xml;
 			PackageName = $"com.xamarin.{(packageName ?? ProjectName).ToLower ()}";
@@ -110,11 +94,9 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.SupportedOSPlatformVersion, value); }
 		}
 
-		string AotAssembliesPropertyName => Builder.UseDotNet ? KnownProperties.RunAOTCompilation : KnownProperties.AotAssemblies;
-
 		public bool AotAssemblies {
-			get { return string.Equals (GetProperty (AotAssembliesPropertyName), "True", StringComparison.OrdinalIgnoreCase); }
-			set { SetProperty (AotAssembliesPropertyName, value.ToString ()); }
+			get { return string.Equals (GetProperty (KnownProperties.RunAOTCompilation), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.RunAOTCompilation, value.ToString ()); }
 		}
 
 		public bool AndroidEnableProfiledAot {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -54,10 +54,6 @@ namespace Xamarin.ProjectTools
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable-xxhdpi\\Icon.png") { BinaryContent = () => icon_binary_xxhdpi });
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable-xxxhdpi\\Icon.png") { BinaryContent = () => icon_binary_xxxhdpi });
 			//AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable-nodpi\\Icon.png") { BinaryContent = () => icon_binary });
-			if (Builder.UseDotNet) {
-				// set our default
-				SetProperty ("AndroidUseDesignerAssembly", "True");
-			}
 		}
 
 		public override string ProjectTypeGuid {
@@ -90,10 +86,8 @@ namespace Xamarin.ProjectTools
 					Sources.Remove (resourceDesigner);
 					OtherBuildItems.Add (new BuildItem.NoActionResource (() => "Resources\\Resource.designer" + Language.DefaultDesignerExtension) { TextContent = () => string.Empty });
 
-					if (Builder.UseDotNet) {
-						// Use KnownPackages.FSharp_Core_Latest for FSharp.Core
-						SetProperty ("DisableImplicitFSharpCoreReference", "true");
-					}
+					// Use KnownPackages.FSharp_Core_Latest for FSharp.Core
+					SetProperty ("DisableImplicitFSharpCoreReference", "true");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
@@ -14,14 +14,8 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidLibraryProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			if (Builder.UseDotNet) {
-				SetProperty (KnownProperties.Nullable, "enable");
-				SetProperty (KnownProperties.ImplicitUsings, "enable");
-			} else {
-				SetProperty ("AndroidApplication", "False");
-				SetProperty ("AndroidResgenFile", Path.Combine ("Resources", "Resource.designer.cs"));
-			}
-
+			SetProperty (KnownProperties.Nullable, "enable");
+			SetProperty (KnownProperties.ImplicitUsings, "enable");
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\Strings.xml") { TextContent = () => StringsXml.Replace ("${PROJECT_NAME}", ProjectName) });
 			StringsXml = default_strings_xml;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -13,45 +13,12 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			Language = XamarinAndroidProjectLanguage.CSharp;
-
-			if (!Builder.UseDotNet) {
-				TargetFrameworkVersion = Versions.Android11;
-				UseLatestPlatformSdk = true;
-				AddReferences ("System.Core", "System.Xml", "Mono.Android");
-				ProjectGuid = Guid.NewGuid ().ToString ();
-				SetProperty ("ProjectTypeGuids", () => "{" + Language.ProjectTypeGuid + "};{" + ProjectTypeGuid + "}");
-				SetProperty ("ProjectGuid", () => "{" + ProjectGuid + "}");
-				SetProperty ("MonoAndroidAssetsPrefix", "Assets");
-				SetProperty ("MonoAndroidResourcePrefix", "Resources");
-				SetProperty (KnownProperties.AndroidUseLatestPlatformSdk, () => UseLatestPlatformSdk ? "True" : "False");
-				SetProperty (KnownProperties.TargetFrameworkVersion, () => TargetFrameworkVersion);
-			}
-
 			SetProperty (KnownProperties.OutputType, "Library");
 		}
 
 
 		public XamarinAndroidProjectLanguage XamarinAndroidLanguage {
 			get { return (XamarinAndroidProjectLanguage) Language; }
-		}
-
-		public bool UseLatestPlatformSdk { get; set; }
-
-		public string TargetFrameworkVersion { get; set; }
-
-		/// <summary>
-		/// TargetFrameworkVersion=v8.1 -> 81
-		/// </summary>
-		public string TargetFrameworkAbbreviated => TargetFrameworkVersion?.TrimStart ('v').Replace (".", "");
-
-		/// <summary>
-		/// TargetFrameworkVersion=v8.1 -> MonoAndroid81
-		/// </summary>
-		public string TargetFrameworkMoniker => "MonoAndroid" + TargetFrameworkAbbreviated;
-
-		public bool AndroidUseAapt2 {
-			get { return string.Equals (GetProperty (KnownProperties.AndroidUseAapt2), "True", StringComparison.OrdinalIgnoreCase); }
-			set { SetProperty (KnownProperties.AndroidUseAapt2, value.ToString ()); }
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProjectLanguage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProjectLanguage.cs
@@ -34,7 +34,7 @@ namespace Xamarin.ProjectTools
 				get { return ".fs"; }
 			}
 			public override string DefaultDesignerExtension {
-				get { return Builder.UseDotNet ? ".fs" : ".cs"; }
+				get { return ".fs"; }
 			}
 			public override string DefaultProjectExtension {
 				get { return ".fsproj"; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -28,8 +28,6 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidWearApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release", [CallerMemberName] string packageName = "")
 			: base (debugConfigurationName, releaseConfigurationName, packageName)
 		{
-			TargetFrameworkVersion = Versions.KitkatWatch;
-			UseLatestPlatformSdk = true;
 			PackageReferences.Add (KnownPackages.AndroidWear_2_2_0);
 
 			MainActivity = default_main_activity;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -41,13 +41,9 @@ namespace Xamarin.ProjectTools
 		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release", [CallerMemberName] string packageName = "")
 			: base (debugConfigurationName, releaseConfigurationName, packageName)
 		{
-			if (Builder.UseDotNet) {
-				// Don't opt into ImplicitUsings
-				RemoveProperty (KnownProperties.ImplicitUsings);
-				PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
-			} else {
-				PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
-			}
+			// Don't opt into ImplicitUsings
+			RemoveProperty (KnownProperties.ImplicitUsings);
+			PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
 				TextContent = () => colors_xml,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -17,19 +17,13 @@ namespace Xamarin.ProjectTools
 		public XamarinFormsMapsApplicationProject ([CallerMemberName] string packageName = "")
 			: base (packageName: packageName)
 		{
-			if (Builder.UseDotNet) {
-				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_7_0_1142);
-				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
-				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
-				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Maps);
-				PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
-				PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
+			PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_7_0_1142);
+			PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
+			PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
+			PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Maps);
+			PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
+			PackageReferences.Add (KnownPackages.Xamarin_Build_Download);
 
-				//TODO: temporary fix for <Import/> ordering breakage and workloads
-				SetProperty ("AndroidApplication", "True");
-			} else {
-				PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_0_0_425677);
-			}
 			MainActivity = MainActivity.Replace ("//${AFTER_FORMS_INIT}", "Xamarin.FormsMaps.Init (this, savedInstanceState);");
 			//NOTE: API_KEY metadata just has to *exist*
 			AndroidManifest = AndroidManifest.Replace ("</application>", "<meta-data android:name=\"com.google.android.maps.v2.API_KEY\" android:value=\"\" /></application>");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -18,13 +18,6 @@ namespace Xamarin.ProjectTools
 		const string ConsoleLoggerError = "[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative";
 		const int DefaultBuildTimeOut = 30;
 
-		string Arm32AbiDir => UseDotNet ? "android-arm" : "armeabi-v7a";
-
-		/// <summary>
-		/// If true, use `dotnet build` and IShortFormProject throughout the tests
-		/// </summary>
-		public static bool UseDotNet => Environment.Version.Major >= 5;
-
 		string root;
 		string buildLogFullPath;
 		public bool IsUnix { get; set; }
@@ -182,21 +175,18 @@ namespace Xamarin.ProjectTools
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (Path.Combine (TestEnvironment.DotNetPreviewDirectory, "dotnet"));
 			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "project.rsp");
-			if (UseDotNet) {
-				args.Append ("build ");
-				if (TestEnvironment.UseLocalBuildOutput) {
-					psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", TestEnvironment.WorkloadManifestOverridePath);
-					psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
-				}
+			args.Append ("build ");
+
+			if (TestEnvironment.UseLocalBuildOutput) {
+				psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", TestEnvironment.WorkloadManifestOverridePath);
+				psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
 			}
+
 			args.AppendFormat ("{0} /t:{1} {2}",
 					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
-			if (UseDotNet) {
-				if (!AutomaticNuGetRestore) {
-					args.Append (" --no-restore");
-				}
-			} else if (AutomaticNuGetRestore && restore) {
-				args.Append (" /restore");
+
+			if (!AutomaticNuGetRestore) {
+				args.Append (" --no-restore");
 			}
 
 			args.Append (" -nodeReuse:false"); // Disable the MSBuild daemon everywhere!
@@ -248,13 +238,8 @@ namespace Xamarin.ProjectTools
 			psi.SetEnvironmentVariable ("BUILD_SOURCEVERSIONMESSAGE", "");
 
 			// Ensure any variable alteration from DotNetXamarinProject.Construct is cleared.
-			if (!Builder.UseDotNet && !TestEnvironment.IsWindows) {
-				psi.SetEnvironmentVariable ("MSBUILD_EXE_PATH", null);
-			}
-			if (Builder.UseDotNet) {
-				psi.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
-				psi.SetEnvironmentVariable ("PATH", TestEnvironment.DotNetPreviewDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable ("PATH"));
-			}
+			psi.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
+			psi.SetEnvironmentVariable ("PATH", TestEnvironment.DotNetPreviewDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable ("PATH"));
 
 			psi.Arguments = args.ToString ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -53,11 +53,6 @@ namespace Xamarin.ProjectTools
 					p.StartInfo.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_PACK_ROOTS", TestEnvironment.WorkloadPackOverridePath);
 				}
 
-				// Ensure any variable alteration from DotNetXamarinProject.Construct is cleared.
-				if (!Builder.UseDotNet && !TestEnvironment.IsWindows) {
-					p.StartInfo.SetEnvironmentVariable ("MSBUILD_EXE_PATH", null);
-				}
-
 				p.ErrorDataReceived += (sender, e) => {
 					if (e.Data != null) {
 						procOutput.AppendLine (e.Data);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -42,9 +42,5 @@ namespace Xamarin.ProjectTools
 		{
 			return XmlUtils.ToXml (this);
 		}
-
-		public override void NuGetRestore (string directory, string packagesDirectory = null)
-		{
-		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -21,7 +21,6 @@ namespace Xamarin.ProjectTools
 
 		public bool CleanupOnDispose { get; set; }
 		public bool CleanupAfterSuccessfulBuild { get; set; }
-		public string PackagesDirectory { get; set; }
 		public string ProjectDirectory { get; set; }
 		public string Target { get; set; }
 
@@ -49,9 +48,6 @@ namespace Xamarin.ProjectTools
 						FileSystemUtils.SetDirectoryWriteable (ProjectDirectory);
 						Directory.Delete (ProjectDirectory, true);
 					}
-					if (Directory.Exists (PackagesDirectory)) {
-						Directory.Delete (PackagesDirectory, true);
-					}
 					project.Populate (ProjectDirectory, files);
 				}
 
@@ -66,10 +62,6 @@ namespace Xamarin.ProjectTools
 			Save (project, doNotCleanupOnUpdate, saveProject);
 
 			Output = project.CreateBuildOutput (this);
-
-			if (AutomaticNuGetRestore) {
-				project.NuGetRestore (Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory), PackagesDirectory);
-			}
 
 			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, restore: project.ShouldRestorePackageReferences, binlogName: Path.GetFileNameWithoutExtension (BuildLogFile));
 			built_before = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -24,8 +24,6 @@ namespace Xamarin.ProjectTools
 			foreach (var p in Projects) {
 				using (var pb = new ProjectBuilder (Path.Combine (SolutionPath, p.ProjectName))) {
 					pb.Save (p);
-					if (AutomaticNuGetRestore)
-						p.NuGetRestore (Path.Combine (SolutionPath, p.ProjectName), Path.Combine (SolutionPath, "packages"));
 				}
 			}
 			// write a sln.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -27,7 +27,6 @@ namespace Xamarin.ProjectTools
 		public IList<Property> CommonProperties { get; private set; }
 		public IList<IList<BuildItem>> ItemGroupList { get; private set; }
 		public IList<PropertyGroup> PropertyGroups { get; private set; }
-		public IList<Package> Packages { get; private set; }
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
 		public string GlobalPackagesFolder { get; set; } = FileSystemUtils.FindNugetGlobalPackageFolder ();
@@ -51,10 +50,7 @@ namespace Xamarin.ProjectTools
 			get => isRelease;
 			set {
 				isRelease = value;
-
-				if (Builder.UseDotNet) {
-					Touch ("Directory.Build.props");
-				}
+				Touch ("Directory.Build.props");
 			}
 		}
 
@@ -73,35 +69,23 @@ namespace Xamarin.ProjectTools
 			common = new PropertyGroup (null, CommonProperties);
 			DebugProperties = new List<Property> ();
 			ReleaseProperties = new List<Property> ();
-			if (Builder.UseDotNet) {
-				debug = new PropertyGroup ($"'$(Configuration)' == '{debugConfigurationName}'", DebugProperties);
-				release = new PropertyGroup ($"'$(Configuration)' == '{releaseConfigurationName}'", ReleaseProperties);
-			} else {
-				debug = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{debugConfigurationName}|AnyCPU'", DebugProperties);
-				release = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{releaseConfigurationName}|AnyCPU'", ReleaseProperties);
-			}
-
+			debug = new PropertyGroup ($"'$(Configuration)' == '{debugConfigurationName}'", DebugProperties);
+			release = new PropertyGroup ($"'$(Configuration)' == '{releaseConfigurationName}'", ReleaseProperties);
 			PropertyGroups.Add (common);
 			PropertyGroups.Add (debug);
 			PropertyGroups.Add (release);
-
-			Packages = new List<Package> ();
 			Imports = new List<Import> ();
 
-			if (Builder.UseDotNet) {
-				//NOTE: for SDK-style projects, we need $(Configuration) set before Microsoft.NET.Sdk.targets
-				Imports.Add (new Import ("Directory.Build.props") {
-					TextContent = () =>
+			//NOTE: for SDK-style projects, we need $(Configuration) set before Microsoft.NET.Sdk.targets
+			Imports.Add (new Import ("Directory.Build.props") {
+				TextContent = () =>
 $@"<Project>
 	<PropertyGroup>
 		<Configuration>{Configuration}</Configuration>
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 	</PropertyGroup>
 </Project>"
-				});
-			} else {
-				SetProperty (KnownProperties.Configuration, () => Configuration);
-			}
+			});
 		}
 
 		/// <summary>
@@ -228,7 +212,6 @@ $@"<Project>
 		}
 
 		ProjectResource project;
-		string packages_config_contents;
 
 		public virtual List<ProjectResource> Save (bool saveProject = true)
 		{
@@ -247,19 +230,6 @@ $@"<Project>
 					project.Content = contents;
 				}
 				list.Add (project);
-			}
-
-			if (Packages.Any ()) {
-				var contents = "<packages>\n" + string.Concat (Packages.Select (p => string.Format ("  <package id='{0}' version='{1}' targetFramework='{2}' />\n",
-					p.Id, p.Version, p.TargetFramework))) + "</packages>";
-				var timestamp = contents != packages_config_contents ? default (DateTimeOffset?) : DateTimeOffset.MinValue;
-				list.Add (new ProjectResource () {
-					Timestamp = timestamp,
-					Path = "packages.config",
-					Content = packages_config_contents = contents,
-				});
-			} else {
-				packages_config_contents = null;
 			}
 
 			foreach (var ig in ItemGroupList)
@@ -380,34 +350,6 @@ $@"<Project>
 				}
 			}
 
-		}
-
-		public virtual void NuGetRestore (string directory, string packagesDirectory = null)
-		{
-			if (!Packages.Any ())
-				return;
-
-			var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
-			var nuget = Path.Combine (XABuildPaths.TestAssemblyOutputDirectory, "nuget", "NuGet.exe");
-			var psi = new ProcessStartInfo (isWindows ? nuget : "mono") {
-				Arguments = $"{(isWindows ? "" : "\"" + nuget + "\"")} restore -Verbosity Detailed -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
-				CreateNoWindow = true,
-				UseShellExecute = false,
-				WindowStyle = ProcessWindowStyle.Hidden,
-				RedirectStandardError = true,
-				RedirectStandardOutput = true,
-			};
-			Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
-			using (var process = new Process {
-				StartInfo = psi,
-			}) {
-				process.OutputDataReceived += (sender, e) => Console.WriteLine (e.Data);
-				process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine (e.Data);
-				process.Start ();
-				process.BeginOutputReadLine ();
-				process.BeginErrorReadLine ();
-				process.WaitForExit ();
-			}
 		}
 
 		public virtual string ProcessSourceTemplate (string source)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/ProjectExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Xamarin.ProjectTools
@@ -7,26 +8,20 @@ namespace Xamarin.ProjectTools
 		/// <summary>
 		/// Sets $(AndroidSupportedAbis) or $(RuntimeIdentifiers) depending if running under dotnet
 		/// </summary>
+		[Obsolete ("SetAndroidSupportedAbis is deprecated, please use SetRuntimeIdentifiers instead.")]
 		public static void SetAndroidSupportedAbis (this IShortFormProject project, params string [] abis)
 		{
-			if (Builder.UseDotNet) {
-				project.SetRuntimeIdentifiers (abis);
-			} else {
-				project.SetAndroidSupportedAbis (string.Join (";", abis));
-			}
+			project.SetRuntimeIdentifiers (abis);
 		}
 
 		/// <summary>
 		/// Sets $(AndroidSupportedAbis) or $(RuntimeIdentifiers) depending if running under dotnet
 		/// </summary>
-		/// <param name="abis">A semi-colon-delimited list of ABIs</param>
+		/// <param name="abis">A semi-colon-delimited list of ABIs</param> 
+		[Obsolete ("SetAndroidSupportedAbis is deprecated, please use SetRuntimeIdentifiers instead.")]
 		public static void SetAndroidSupportedAbis (this IShortFormProject project, string abis)
 		{
-			if (Builder.UseDotNet) {
-				project.SetRuntimeIdentifiers (abis.Split (';'));
-			} else {
-				project.SetProperty (KnownProperties.AndroidSupportedAbis, abis);
-			}
+			project.SetRuntimeIdentifiers (abis.Split (';'));
 		}
 
 		public static void SetRuntimeIdentifier (this IShortFormProject project, string androidAbi)

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -9,6 +9,11 @@ namespace Xamarin.Android.Build.Tests
 	[Category ("UsesDevice"), Category ("AOT"), Category ("ProfiledAOT")]
 	public class AotProfileTests : DeviceTest
 	{
+		[TearDown]
+		protected void ClearProp ()
+		{
+			ClearShellProp ("debug.mono.profile");
+		}
 
 		readonly string PermissionManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{0}"">
@@ -19,6 +24,7 @@ namespace Xamarin.Android.Build.Tests
 </manifest>";
 
 		[Test]
+		[NonParallelizable]
 		public void BuildBasicApplicationAndAotProfileIt ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -26,12 +32,10 @@ namespace Xamarin.Android.Build.Tests
 				AotAssemblies = false,
 			};
 			proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
-			
-			if (Builder.UseDotNet) {
-				// TODO: only needed in .NET 6+
-				// See https://github.com/dotnet/runtime/issues/56989
-				proj.PackageReferences.Add (KnownPackages.Mono_AotProfiler_Android);
-			}
+
+			// TODO: only needed in .NET 6+
+			// See https://github.com/dotnet/runtime/issues/56989
+			proj.PackageReferences.Add (KnownPackages.Mono_AotProfiler_Android);
 
 			var port = 9000 + new Random ().Next (1000);
 			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());
@@ -44,7 +48,7 @@ namespace Xamarin.Android.Build.Tests
 				b.BuildLogFile = "build2.log";
 
 				// Need execute permission
-				if (Builder.UseDotNet && !IsWindows) {
+				if (!IsWindows) {
 					var aprofutil = Path.Combine (Root, b.ProjectDirectory, "aprofutil");
 					RunProcess ("chmod", $"u+x {aprofutil}");
 				}

--- a/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BundleToolTests.cs
@@ -167,47 +167,23 @@ namespace Xamarin.Android.Build.Tests
 				expectedFiles.Add ("root/assemblies/UnnamedProject.dll");
 			}
 
-			if (Builder.UseDotNet) {
-				//These are random files from Google Play Services .aar files
-				expectedFiles.Add ("root/play-services-base.properties");
-				expectedFiles.Add ("root/play-services-basement.properties");
-				expectedFiles.Add ("root/play-services-maps.properties");
-				expectedFiles.Add ("root/play-services-tasks.properties");
-			} else {
-				if (usesAssemblyBlobs) {
-					expectedFiles.Add ($"{blobEntryPrefix}mscorlib.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Core.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Runtime.Serialization.dll");
-				} else {
-					expectedFiles.Add ("root/assemblies/mscorlib.dll");
-					expectedFiles.Add ("root/assemblies/System.Core.dll");
-					expectedFiles.Add ("root/assemblies/System.dll");
-					expectedFiles.Add ("root/assemblies/System.Runtime.Serialization.dll");
-				}
+			//These are random files from Google Play Services .aar files
+			expectedFiles.Add ("root/play-services-base.properties");
+			expectedFiles.Add ("root/play-services-basement.properties");
+			expectedFiles.Add ("root/play-services-maps.properties");
+			expectedFiles.Add ("root/play-services-tasks.properties");
 
-				//These are random files from Google Play Services .aar files
-				expectedFiles.Add ("root/build-data.properties");
-				expectedFiles.Add ("root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt");
-				expectedFiles.Add ("root/error_prone/Annotations.gwt.xml");
-				expectedFiles.Add ("root/protobuf.meta");
-			}
 			foreach (var abi in Abis) {
 				expectedFiles.Add ($"lib/{abi}/libmonodroid.so");
 				expectedFiles.Add ($"lib/{abi}/libmonosgen-2.0.so");
 				expectedFiles.Add ($"lib/{abi}/libxamarin-app.so");
-				if (Builder.UseDotNet) {
-					if (usesAssemblyBlobs) {
-						expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
-					} else {
-						expectedFiles.Add ($"root/assemblies/{abi}/System.Private.CoreLib.dll");
-					}
-					expectedFiles.Add ($"lib/{abi}/libSystem.IO.Compression.Native.so");
-					expectedFiles.Add ($"lib/{abi}/libSystem.Native.so");
+				if (usesAssemblyBlobs) {
+					expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
 				} else {
-					expectedFiles.Add ($"lib/{abi}/libmono-native.so");
-					expectedFiles.Add ($"lib/{abi}/libmono-btls-shared.so");
+					expectedFiles.Add ($"root/assemblies/{abi}/System.Private.CoreLib.dll");
 				}
+				expectedFiles.Add ($"lib/{abi}/libSystem.IO.Compression.Native.so");
+				expectedFiles.Add ($"lib/{abi}/libSystem.Native.so");
 			}
 			foreach (var expected in expectedFiles) {
 				CollectionAssert.Contains (contents, expected, $"`{baseZip}` did not contain `{expected}`");
@@ -249,47 +225,23 @@ namespace Xamarin.Android.Build.Tests
 				expectedFiles.Add ("base/root/assemblies/UnnamedProject.dll");
 			}
 
-			if (Builder.UseDotNet) {
-				//These are random files from Google Play Services .aar files
-				expectedFiles.Add ("base/root/play-services-base.properties");
-				expectedFiles.Add ("base/root/play-services-basement.properties");
-				expectedFiles.Add ("base/root/play-services-maps.properties");
-				expectedFiles.Add ("base/root/play-services-tasks.properties");
-			} else {
-				if (usesAssemblyBlobs) {
-					expectedFiles.Add ($"{blobEntryPrefix}mscorlib.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Core.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.dll");
-					expectedFiles.Add ($"{blobEntryPrefix}System.Runtime.Serialization.dll");
-				} else {
-					expectedFiles.Add ("base/root/assemblies/mscorlib.dll");
-					expectedFiles.Add ("base/root/assemblies/System.Core.dll");
-					expectedFiles.Add ("base/root/assemblies/System.dll");
-					expectedFiles.Add ("base/root/assemblies/System.Runtime.Serialization.dll");
-				}
+			//These are random files from Google Play Services .aar files
+			expectedFiles.Add ("base/root/play-services-base.properties");
+			expectedFiles.Add ("base/root/play-services-basement.properties");
+			expectedFiles.Add ("base/root/play-services-maps.properties");
+			expectedFiles.Add ("base/root/play-services-tasks.properties");
 
-				//These are random files from Google Play Services .aar files
-				expectedFiles.Add ("base/root/build-data.properties");
-				expectedFiles.Add ("base/root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt");
-				expectedFiles.Add ("base/root/error_prone/Annotations.gwt.xml");
-				expectedFiles.Add ("base/root/protobuf.meta");
-			}
 			foreach (var abi in Abis) {
 				expectedFiles.Add ($"base/lib/{abi}/libmonodroid.so");
 				expectedFiles.Add ($"base/lib/{abi}/libmonosgen-2.0.so");
 				expectedFiles.Add ($"base/lib/{abi}/libxamarin-app.so");
-				if (Builder.UseDotNet) {
-					if (usesAssemblyBlobs) {
-						expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
-					} else {
-						expectedFiles.Add ($"base/root/assemblies/{abi}/System.Private.CoreLib.dll");
-					}
-					expectedFiles.Add ($"base/lib/{abi}/libSystem.IO.Compression.Native.so");
-					expectedFiles.Add ($"base/lib/{abi}/libSystem.Native.so");
+				if (usesAssemblyBlobs) {
+					expectedFiles.Add ($"{blobEntryPrefix}System.Private.CoreLib.dll");
 				} else {
-					expectedFiles.Add ($"base/lib/{abi}/libmono-native.so");
-					expectedFiles.Add ($"base/lib/{abi}/libmono-btls-shared.so");
+					expectedFiles.Add ($"base/root/assemblies/{abi}/System.Private.CoreLib.dll");
 				}
+				expectedFiles.Add ($"base/lib/{abi}/libSystem.IO.Compression.Native.so");
+				expectedFiles.Add ($"base/lib/{abi}/libSystem.Native.so");
 			}
 			foreach (var expected in expectedFiles) {
 				CollectionAssert.Contains (contents, expected, $"`{aab}` did not contain `{expected}`");

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Build.Tests
 				proj.SetAndroidSupportedAbis ("armeabi-v7a", "x86", "x86_64");
 			}
 			proj.SetDefaultTargetDevice ();
-			if (Builder.UseDotNet && isRelease) {
+			if (isRelease) {
 				// bundle tool does NOT support embeddedDex files it seems.
 				useEmbeddedDex = false;
 			}

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -17,7 +17,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinFormsAndroidApplicationProject {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			var b = CreateApkBuilder (Path.Combine ("temp", TestName));
 			Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
@@ -51,7 +50,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedResourceGenerator.ToString ());
 			proj.SetProperty ("AndroidUseDesignerAssembly", "False");
@@ -127,7 +125,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			var b = CreateApkBuilder (Path.Combine ("temp", TestName));
@@ -143,7 +140,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
@@ -182,7 +178,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			foreach (var pkg in packages)
@@ -212,7 +207,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
@@ -244,7 +238,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
@@ -273,15 +266,12 @@ namespace Xamarin.Android.Build.Tests
 			};
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 				OtherBuildItems = {
 					nativeLib,
 				},
 			};
-			if (Builder.UseDotNet) {
-				//NOTE: in .NET 6 by default an x86_64 emulator would fall back to x86 if we don't set this.
-				proj.SetAndroidSupportedAbis (DeviceAbi);
-			}
+			//NOTE: in .NET 6 by default an x86_64 emulator would fall back to x86 if we don't set this.
+			proj.SetAndroidSupportedAbis (DeviceAbi);
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Install (proj), "install should have succeeded. 0");
@@ -311,7 +301,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidFastDeploymentType = "Assemblies:Dexes",
-				UseLatestPlatformSdk = true,
 			};
 			proj.SetDefaultTargetDevice ();
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("<application ", $"<application android:useEmbeddedDex=\"{useEmbeddedDex.ToString ().ToLowerInvariant ()}\" ");

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -108,8 +108,7 @@ namespace UnnamedProject
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				string apiLevel;
-				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
+				b.LatestTargetFrameworkVersion (out string apiLevel);
 				proj.SupportedOSPlatformVersion = "24.0";
 				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""${proj.PackageName}"">

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -50,10 +50,8 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Fail ($"No timeout value found for a key of {caller}");
 			}
 
-			if (Builder.UseDotNet) {
-				//TODO: there is currently a slight performance regression in .NET 6
-				expected += 500;
-			}
+			//TODO: Update baselines in MSBuildDeviceIntegration.csv, there is currently a slight performance regression in .NET 6
+			expected += 500;
 
 			action (builder);
 			var actual = GetDurationFromBinLog (builder);


### PR DESCRIPTION
The .NET versus Classic switches have been removed from the MSBuild
tests.  Tests / asserts that only applied to classic have been removed.
Test parameters that only applied to classic (`aapt` vs `aapt2`) have
been removed.  Some project properties that only applied to classic
(`UseLatestPlatformSdk`) have been removed.