### PR TITLE
[Tests] Fix TestResolveToolsExists on .NET

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -29,29 +29,11 @@
       <_EarlierFrameworkDir Include="@(_FrameworkDirsThatExist)" Exclude="$(_LatestStableFrameworkDir)" />
     </ItemGroup>
   </Target>
-  <Target Name="_WriteVersionFiles"
-      DependsOnTargets="GetXAVersionInfo" >
-    <WriteLinesToFile
-        File="$(MicrosoftAndroidSdkOutDir)Version"
-        Lines="$(ProductVersion)"
-        Overwrite="True"
-    />
-    <WriteLinesToFile
-        File="$(MicrosoftAndroidSdkOutDir)Version.commit"
-        Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
-        Overwrite="True"
-    />
-    <WriteLinesToFile
-        File="$(MicrosoftAndroidSdkOutDir)Version.rev"
-        Lines="$(XAVersionCommitCount)"
-        Overwrite="True"
-    />
-    <ItemGroup>
-      <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version" />
-      <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.commit" />
-      <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.rev" />
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version" />
+    <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.commit" />
+    <VersionFiles Include="$(MicrosoftAndroidSdkOutDir)Version.rev" />
+  </ItemGroup>
   <ItemGroup>
     <_DesignerFilesUnix Include="$(LegacyMSBuildSrcDir)$(HostOS)\bcl\**\*" />
     <_DesignerFilesWin Include="$(LegacyMSBuildSrcDir)bcl\**\* "/>
@@ -365,7 +347,7 @@
   <Import Project="$(_MonoDroidPath)\tools\scripts\installer-files.projitems" Condition=" '$(_HasCommercialFiles)' == 'True' And Exists ('$(_MonoDroidPath)\tools\scripts\installer-files.projitems') " />
   <!-- end monodroid -->
   <Target Name="ConstructInstallerItems"
-      DependsOnTargets="_FindFrameworkDirs;_WriteVersionFiles"
+      DependsOnTargets="_FindFrameworkDirs"
       Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(LegacyMSBuildItemsWin);@(MSBuildItemsUnix);@(LegacyMSBuildItemsUnix)">
     <ItemGroup>
       <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\AndroidApiInfo.xml')" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -34,7 +34,9 @@ namespace Xamarin.Android.Build.Tests
 				Directory.Delete (Path.Combine (Root, path), recursive: true);
 
 			var engine = new MockBuildEngine (TestContext.Out, errors: errors, messages: messages);
-			var frameworksPath = Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, "v1.0");
+			var frameworksRoot = Path.Combine (TestEnvironment.DotNetPreviewDirectory, "packs", "Microsoft.NETCore.App.Ref");
+			var mscorlibDll = Directory.GetFiles (frameworksRoot, "mscorlib.dll", SearchOption.AllDirectories).LastOrDefault ();
+			var frameworksPath = Path.GetDirectoryName (mscorlibDll);
 			var androidSdk = CreateFauxAndroidSdkDirectory (Path.Combine (path, "Sdk"), "24.0.1", new[]
 			{
 				new ApiInfo { Id = "23", Level = 23, Name = "Marshmallow", FrameworkVersion = "v6.0", Stable = true },
@@ -52,6 +54,7 @@ namespace Xamarin.Android.Build.Tests
 				MonoAndroidToolsPath = TestEnvironment.AndroidMSBuildDirectory,
 				ReferenceAssemblyPaths = new string[] {
 					frameworksPath,
+					TestEnvironment.MonoAndroidFrameworkDirectory,
 				},
 			};
 			Assert.True (task.Execute (), "Task should have completed successfully.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -105,7 +105,7 @@ namespace Xamarin.ProjectTools
 			Version lastVersion     = null;
 			List<string> allTFVs    = new List<string> ();
 
-			var searchDir = UseDotNet ? Path.Combine (TestEnvironment.DotNetPreviewAndroidSdkDirectory, "data") : TestEnvironment.MonoAndroidFrameworkDirectory;
+			var searchDir = Path.Combine (TestEnvironment.DotNetPreviewAndroidSdkDirectory, "data");
 			foreach (var apiInfoFile in Directory.EnumerateFiles (searchDir, "AndroidApiInfo.xml", SearchOption.AllDirectories)) {
 				string frameworkVersion = GetApiInfoElementValue (apiInfoFile, "/AndroidApiInfo/Version");
 				string apiLevel         = GetApiInfoElementValue (apiInfoFile, "/AndroidApiInfo/Level");
@@ -135,16 +135,6 @@ namespace Xamarin.ProjectTools
 			var doc = XDocument.Load (androidApiInfo);
 			return doc.XPathSelectElement (elementPath)?.Value;
 		}
-
-		public bool TargetFrameworkExists (string targetFramework)
-		{
-			var path = Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, targetFramework);
-			if (!Directory.Exists (path)) {
-				return false;
-			}
-			return true;
-		}
-
 
 		public string Root {
 			get {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Xamarin.Android.Tools.VSWhere;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.ProjectTools
 {
@@ -47,69 +47,40 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		static readonly string LocalMonoAndroidToolsDirectory = Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
-
-		public static readonly string MacOSInstallationRoot = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
-
-		static VisualStudioInstance visualStudioInstance;
-		public static VisualStudioInstance GetVisualStudioInstance ()
-		{
-			//We should cache and reuse this value, so we don't run vswhere.exe so much
-			if (visualStudioInstance != null && !string.IsNullOrEmpty (visualStudioInstance.VisualStudioRootPath))
-				return visualStudioInstance;
-
-			return visualStudioInstance = MSBuildLocator.QueryLatest ();
-		}
-
 		/// <summary>
-		/// The MonoAndroid framework (and other reference assemblies) directory within a local build tree. Contains v1.0, v9.0, etc,
-		/// e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid.<br/>
+		/// The MonoAndroid reference assemblies directory within a local build tree, e.g. bin/Debug/lib/packs/Microsoft.Android.Ref.34/34.99.0/ref/net8.0/<br/>
 		/// If a local build tree can not be found, or if it is empty, this will return the system installation location instead:<br/>
-		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid <br/>
-		///	macOS:    Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild-frameworks/MonoAndroid
+		///    bin/Debug/dotnet/packs/Microsoft.Android.Ref.34/$(Latest)/ref/net$(Latest)/
 		/// </summary>
 		public static string MonoAndroidFrameworkDirectory {
 			get {
-				var frameworkLibDir = Path.Combine (XABuildPaths.PrefixDirectory, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");
-				if (Directory.Exists (frameworkLibDir) && Directory.EnumerateDirectories (frameworkLibDir, "v*", SearchOption.TopDirectoryOnly).Any ())
-					return frameworkLibDir;
-
-				if (IsWindows) {
-					VisualStudioInstance vs = GetVisualStudioInstance ();
-					return Path.Combine (vs.VisualStudioRootPath, "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework", "MonoAndroid");
-				} else {
-					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");
+				var rootRefDir = Directory.GetDirectories (Path.Combine (DotNetPreviewPacksDirectory, $"Microsoft.Android.Ref.{XABuildConfig.AndroidDefaultTargetDotnetApiLevel}")).LastOrDefault ();
+				if (!Directory.Exists (rootRefDir)) {
+					throw new DirectoryNotFoundException ($"Unable to locate Microsoft.Android.Ref.");
 				}
+
+				var maDll = Directory.GetFiles (rootRefDir, "Mono.Android.dll", SearchOption.AllDirectories).LastOrDefault ();
+				var refDir = Path.GetDirectoryName(maDll);
+				if (!Directory.Exists (refDir)) {
+					throw new DirectoryNotFoundException ($"Unable to locate Mono.Android.dll inside Microsoft.Android.Ref.");
+				}
+
+				return refDir;
 			}
 		}
 
 		/// <summary>
-		/// The MonoAndroidTools directory within a local build tree, e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android.<br/>
-		/// If a local build tree can not be found, or if it is empty, this will return the system installation or .NET sandbox location instead:<br/>
-		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android <br/>
-		///	macOS:    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android<br/>
-		///	Windows (dotnet):  bin\Debug\dotnet\packs\Microsoft.Android.Sdk.Windows\$(Latest)\tools<br/>
-		///	macOS (dotnet):    bin/Debug/dotnet/packs/Microsoft.Android.Sdk.Darwin/$(Latest)/tools
+		/// The MonoAndroidTools directory within a local build tree, e.g. bin/Debug/lib/packs/Microsoft.Android.Sdk.Darwin/34.99.0/tools/<br/>
+		/// If a local build tree can not be found, or if it is empty, this will return the .NET sandbox location instead:<br/>
+		///	Windows:  bin\Debug\dotnet\packs\Microsoft.Android.Sdk.Windows\$(Latest)\tools<br/>
+		///	macOS:    bin/Debug/dotnet/packs/Microsoft.Android.Sdk.Darwin/$(Latest)/tools
 		/// </summary>
 		public static string AndroidMSBuildDirectory {
 			get {
-				if (Builder.UseDotNet) {
-					if (!Directory.Exists (DotNetPreviewAndroidSdkDirectory)) {
-						throw new DirectoryNotFoundException ($"Unable to locate a Microsoft.Android.Sdk in either '{DefaultPacksDir}' or '{LocalPacksDir}'.");
-					}
-					return Path.Combine (DotNetPreviewAndroidSdkDirectory, "tools");
+				if (!Directory.Exists (DotNetPreviewAndroidSdkDirectory)) {
+					throw new DirectoryNotFoundException ($"Unable to locate a Microsoft.Android.Sdk in either '{DefaultPacksDir}' or '{LocalPacksDir}'.");
 				}
-
-				if (UseLocalBuildOutput) {
-					return LocalMonoAndroidToolsDirectory;
-				} else {
-					if (IsWindows) {
-						VisualStudioInstance vs = GetVisualStudioInstance ();
-						return Path.Combine (vs.VisualStudioRootPath, "MSBuild", "Xamarin", "Android");
-					} else {
-						return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
-					}
-				}
+				return Path.Combine (DotNetPreviewAndroidSdkDirectory, "tools");
 			}
 		}
 
@@ -167,12 +138,12 @@ namespace Xamarin.ProjectTools
 
 		/// <summary>
 		/// Tests will attempt to run against local build output directories by default,
-		///  and fall back to `dotnet/packs` or a legacy system install location if a local build does not exist.
+		///  and fall back to `dotnet/packs` if a local build does not exist.
 		/// This will always return false for our tests running in CI.
 		/// </summary>
 		public static bool UseLocalBuildOutput {
 			get {
-				var msbuildDir = Builder.UseDotNet ? Path.Combine (LocalDotNetAndroidSdkDirectory, "tools") : LocalMonoAndroidToolsDirectory;
+				var msbuildDir = Path.Combine (LocalDotNetAndroidSdkDirectory, "tools");
 				return Directory.Exists (msbuildDir) && File.Exists (Path.Combine (msbuildDir, "Xamarin.Android.Build.Tasks.dll"));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -22,6 +22,7 @@
       _GenerateBundledVersions;
       _CopyNetSdkTargets;
       _CopyVSExtensionTargets;
+      _WriteVersionFiles;
     </BuildDependsOn>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidSdkDirectory)</_AndroidSdkLocation>
     <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
@@ -379,6 +380,25 @@
         SourceFiles="@(_VSExtensionTargets)"
         DestinationFiles="@(_VSExtensionTargets->'$(XAInstallPrefix)xbuild\Xamarin\%(FileName)%(Extension)')"
         SkipUnchangedFiles="True"
+    />
+  </Target>
+
+  <Target Name="_WriteVersionFiles"
+      DependsOnTargets="GetXAVersionInfo" >
+    <WriteLinesToFile
+        File="$(MicrosoftAndroidSdkOutDir)Version"
+        Lines="$(ProductVersion)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
+        File="$(MicrosoftAndroidSdkOutDir)Version.commit"
+        Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
+        File="$(MicrosoftAndroidSdkOutDir)Version.rev"
+        Lines="$(XAVersionCommitCount)"
+        Overwrite="True"
     />
   </Target>
 </Project>


### PR DESCRIPTION
The `TestResolveToolsExists` test currently requires a Xamarin.Android
installation on disk to pass.  The test has been fixed by passing the
.NET reference assembly paths to the `ResolveXamarinAndroidTools` task.

The build has also been updated to allow this test to pass against a
local build tree, as it requires product `Version` files in the SDK
output directory.