### PR TITLE
Bump NDK to r26b

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "26";
-		public const string AndroidNdkPkgRevision = "26.0.10792818";
+		public const string AndroidNdkVersion = "26b";
+		public const string AndroidNdkPkgRevision = "26.1.10909125";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r26#r26b

NDK r26 failed to update LLVM to v17.0.1 and instead shipped with 
an earlier beta build of the v17 toolchain.  r26b fixes this mistake 
and updates LLVM to:

   * 17.0.2 (based on r487747d)
   * https://github.com/llvm/llvm-project/commits/c4c5e79dd4b4c78eee7cffd9b0d7394b5bedcf12