### PR TITLE
[build] Include ThirdPartyNotices in workload packs

### DIFF
--- a/build-tools/create-packs/License.targets
+++ b/build-tools/create-packs/License.targets
@@ -18,6 +18,7 @@
     />
     <ItemGroup>
       <_PackageFiles Include="$(IntermediateOutputPath)$(PackageLicenseFile)" PackagePath="\" />
+      <_PackageFiles Include="$(XAInstallPrefix)THIRD-PARTY-NOTICES.TXT" PackagePath="\" />
     </ItemGroup>
   </Target>
 </Project>

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -61,7 +61,6 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\profiled-aot\dotnet.aotprofile" PackagePath="targets" />
       <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <_PackageFiles Include="$(MSBuildThisFileDirectory)\linux-README.md" PackagePath="\README.md" Condition=" '$(HostOS)' == 'Linux' " />
-      <_PackageFiles Include="@(ThirdPartyNotice)" PackagePath="\" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" PackagePath="data\$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)" />
       <_PackageFiles
           Include="$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\AndroidApiInfo.xml"

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -61,6 +61,7 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <_PackageFiles Include="$(XamarinAndroidSourcePath)src\profiled-aot\dotnet.aotprofile" PackagePath="targets" />
       <_PackageFiles Include="$(IntermediateOutputPath)UnixFilePermissions.xml" PackagePath="data" Condition=" '$(HostOS)' != 'Windows' " />
       <_PackageFiles Include="$(MSBuildThisFileDirectory)\linux-README.md" PackagePath="\README.md" Condition=" '$(HostOS)' == 'Linux' " />
+      <_PackageFiles Include="@(ThirdPartyNotice)" PackagePath="\" />
       <_PackageFiles Include="$(_MonoAndroidNETOutputRoot)$(AndroidLatestStableApiLevel)\AndroidApiInfo.xml" PackagePath="data\$(DotNetAndroidTargetFramework)$(AndroidLatestStableApiLevel)" />
       <_PackageFiles
           Include="$(_MonoAndroidNETOutputRoot)$(AndroidDefaultTargetDotnetApiLevel)\AndroidApiInfo.xml"

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -340,7 +340,7 @@
     <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-lib.zip" />
   </ItemGroup>
   <ItemGroup>
-    <ThirdPartyNotice Include="$(XAInstallPrefix)ThirdPartyNotices.txt" />
+    <ThirdPartyNotice Include="$(XAInstallPrefix)THIRD-PARTY-NOTICES.TXT" />
   </ItemGroup>
   <!-- monodroid -->
   <!-- new files to be included from monodroid should be added to the following projitems file in that repo. -->

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -201,7 +201,7 @@ namespace Xamarin.Android.Prepare
 			///   Used in rules.mk generator. Files to include in the XA bundle archives.
 			/// </summary>
 			public static readonly List <string> BundleZipsInclude = new List <string> {
-				"$(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt",
+				"$(ZIP_OUTPUT_BASENAME)/THIRD-PARTY-NOTICES.TXT",
 				"$(ZIP_OUTPUT_BASENAME)/bin/Debug",
 				"$(ZIP_OUTPUT_BASENAME)/bin/Release",
 			};

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 	class Scenario_ThirdPartyNotices : Scenario
 	{
 		public Scenario_ThirdPartyNotices ()
-			: base ("ThirdPartyNotices", "Generate the `ThirdPartyNotices.txt` files.")
+			: base ("ThirdPartyNotices", "Generate the `THIRD-PARTY-NOTICES.TXT` files.")
 		{
 			NeedsGitSubmodules = true;
 		}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyExtraResultFilesForCI.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Prepare
 		string[] xaRootDirBuildFiles = {
 			"Configuration.OperatingSystem.props",
 			"Configuration.Override.props",
-			"ThirdPartyNotices.txt",
+			"THIRD-PARTY-NOTICES.TXT",
 			"config.log",
 			"config.status",
 			"config.h",

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
@@ -60,12 +60,12 @@ implication, estoppel or otherwise."			}
 #pragma warning disable CS1998
 		protected override async Task<bool> Execute (Context context)
 		{
-			GenerateThirdPartyNotices (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "ThirdPartyNotices.txt"),
+			GenerateThirdPartyNotices (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "THIRD-PARTY-NOTICES.TXT"),
 			                           ThirdPartyLicenseType.Foundation,
 			                           includeExternalDeps: false,
 			                           includeBuildDeps: true);
 			Log.StatusLine ();
-			GenerateThirdPartyNotices (Path.Combine (context.XAInstallPrefix, "ThirdPartyNotices.txt"),
+			GenerateThirdPartyNotices (Path.Combine (context.XAInstallPrefix, "THIRD-PARTY-NOTICES.TXT"),
 			                           ThirdPartyLicenseType.MicrosoftOSS,
 			                           includeExternalDeps: true,
 			                           includeBuildDeps: false);


### PR DESCRIPTION
Adds the `THIRD-PARTY-NOTICES.TXT` file to all packs that contain a
license file.