### PR TITLE
[build] Do not install build-tools 30.0.3

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -137,14 +137,6 @@
     <XABuildToolsPackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildToolsPackagePrefixWindows)</XABuildToolsPackagePrefix>
     <XABuildToolsVersion>34</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">34.0.0</XABuildToolsFolder>
-    <!-- build-tools 30, for DX tests -->
-    <XABuildTools30PackagePrefixMacOS>f6d24b187cc6bd534c6c37604205171784ac5621.</XABuildTools30PackagePrefixMacOS>
-    <XABuildTools30PackagePrefixWindows>91936d4ee3ccc839f0addd53c9ebf087b1e39251.</XABuildTools30PackagePrefixWindows>
-    <XABuildTools30PackagePrefixLinux></XABuildTools30PackagePrefixLinux>
-    <XABuildTools30PackagePrefix Condition=" '$(HostOS)' == 'Darwin' ">$(XABuildTools30PackagePrefixMacOS)</XABuildTools30PackagePrefix>
-    <XABuildTools30PackagePrefix Condition=" '$(HostOS)' == 'Windows' ">$(XABuildTools30PackagePrefixWindows)</XABuildTools30PackagePrefix>
-    <XABuildTools30Version>30.0.3</XABuildTools30Version>
-    <XABuildTools30Folder Condition="'$(XABuildTools30Folder)' == ''">30.0.3</XABuildTools30Folder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
     <XAPlatformToolsVersion>34.0.1</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -65,12 +65,6 @@ namespace Xamarin.Android.Prepare
 		public const string XABuildToolsPackagePrefixWindows    = "XABuildToolsPackagePrefixWindows";
 		public const string XABuildToolsPackagePrefixLinux      = "XABuildToolsPackagePrefixLinux";
 		public const string XABuildToolsPackagePrefix           = "XABuildToolsPackagePrefix";
-		public const string XABuildTools30Folder                = "XABuildTools30Folder";
-		public const string XABuildTools30Version               = "XABuildTools30Version";
-		public const string XABuildTools30PackagePrefixMacOS    = "XABuildTools30PackagePrefixMacOS";
-		public const string XABuildTools30PackagePrefixWindows  = "XABuildTools30PackagePrefixWindows";
-		public const string XABuildTools30PackagePrefixLinux    = "XABuildTools30PackagePrefixLinux";
-		public const string XABuildTools30PackagePrefix         = "XABuildTools30PackagePrefix";
 		public const string XABinRelativeInstallPrefix          = "XABinRelativeInstallPrefix";
 		public const string XAInstallPrefix                     = "XAInstallPrefix";
 		public const string XAPlatformToolsVersion              = "XAPlatformToolsVersion";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -69,12 +69,6 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.XABuildToolsPackagePrefixWindows,    StripQuotes ("@XABuildToolsPackagePrefixWindows@"));
 			properties.Add (KnownProperties.XABuildToolsPackagePrefixLinux,      StripQuotes ("@XABuildToolsPackagePrefixLinux@"));
 			properties.Add (KnownProperties.XABuildToolsPackagePrefix,           StripQuotes ("@XABuildToolsPackagePrefix@"));
-			properties.Add (KnownProperties.XABuildTools30Folder,                StripQuotes (@"@XABuildTools30Folder@"));
-			properties.Add (KnownProperties.XABuildTools30Version,               StripQuotes ("@XABuildTools30Version@"));
-			properties.Add (KnownProperties.XABuildTools30PackagePrefixMacOS,    StripQuotes ("@XABuildTools30PackagePrefixMacOS@"));
-			properties.Add (KnownProperties.XABuildTools30PackagePrefixWindows,  StripQuotes ("@XABuildTools30PackagePrefixWindows@"));
-			properties.Add (KnownProperties.XABuildTools30PackagePrefixLinux,    StripQuotes ("@XABuildTools30PackagePrefixLinux@"));
-			properties.Add (KnownProperties.XABuildTools30PackagePrefix,         StripQuotes ("@XABuildTools30PackagePrefix@"));
 			properties.Add (KnownProperties.XABinRelativeInstallPrefix,          StripQuotes (@"@XABinRelativeInstallPrefix@"));
 			properties.Add (KnownProperties.XAInstallPrefix,                     StripQuotes (@"@XAInstallPrefix@"));
 			properties.Add (KnownProperties.XAPlatformToolsVersion,              StripQuotes ("@XAPlatformToolsVersion@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -26,9 +26,6 @@ namespace Xamarin.Android.Prepare
 			string XABuildToolsFolder      = GetRequiredProperty (KnownProperties.XABuildToolsFolder);
 			string XABuildToolsVersion         = GetRequiredProperty (KnownProperties.XABuildToolsVersion);
 			string XABuildToolsPackagePrefix   = Context.Instance.Properties [KnownProperties.XABuildToolsPackagePrefix] ?? String.Empty;
-			string XABuildTools30Folder        = GetRequiredProperty (KnownProperties.XABuildTools30Folder);
-			string XABuildTools30Version       = GetRequiredProperty (KnownProperties.XABuildTools30Version);
-			string XABuildTools30PackagePrefix = Context.Instance.Properties [KnownProperties.XABuildTools30PackagePrefix] ?? String.Empty;
 			string XAPlatformToolsVersion  = GetRequiredProperty (KnownProperties.XAPlatformToolsVersion);
 			string XAPlatformToolsPackagePrefix = Context.Instance.Properties [KnownProperties.XAPlatformToolsPackagePrefix] ?? String.Empty;
 			bool isArm64Apple = Context.Instance.OS.Flavor == "macOS" && RuntimeInformation.OSArchitecture == Architecture.Arm64;
@@ -110,12 +107,6 @@ namespace Xamarin.Android.Prepare
 					isMultiVersion: true,
 					buildToolName: "android-sdk-build-tools",
 					buildToolVersion: $"{XABuildToolsVersion}"
-				),
-				new AndroidToolchainComponent ($"{XABuildTools30PackagePrefix}build-tools_r{XABuildTools30Version}-{altOsTag}",
-					destDir: Path.Combine ("build-tools", XABuildTools30Folder),
-					isMultiVersion: true,
-					buildToolName: "android-sdk-build-tools",
-					buildToolVersion: $"{XABuildTools30Version}"
 				),
 				new AndroidToolchainComponent ($"commandlinetools-{cltOsTag}-{CommandLineToolsVersion}",
 					destDir: Path.Combine ("cmdline-tools", CommandLineToolsFolder),

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Android_BuildTools.cs
@@ -21,17 +21,6 @@ namespace Xamarin.Android.Prepare
 			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-macosx.zip", prefix: XABuildToolsPackagePrefixMacOS));
 			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-windows.zip", prefix: XABuildToolsPackagePrefixWindows));
 			packages.Add ((package: $"build-tools_r{XABuildToolsVersion}-linux.zip", prefix: XABuildToolsPackagePrefixLinux));
-
-			// build-tools 30, for DX tests
-			string XABuildTools30Version     = Context.Instance.Properties [KnownProperties.XABuildTools30Version] ?? String.Empty;
-			string XABuildTools30PackagePrefixMacOS = Context.Instance.Properties [KnownProperties.XABuildTools30PackagePrefixMacOS] ?? string.Empty;
-			string XABuildTools30PackagePrefixWindows = Context.Instance.Properties [KnownProperties.XABuildTools30PackagePrefixWindows] ?? string.Empty;
-			string XABuildTools30PackagePrefixLinux = Context.Instance.Properties [KnownProperties.XABuildTools30PackagePrefixLinux] ?? string.Empty;
-			if (!string.IsNullOrEmpty (XABuildTools30Version)) {
-				packages.Add ((package: $"build-tools_r{XABuildTools30Version}-macosx.zip", prefix: XABuildTools30PackagePrefixMacOS));
-				packages.Add ((package: $"build-tools_r{XABuildTools30Version}-windows.zip", prefix: XABuildTools30PackagePrefixWindows));
-				packages.Add ((package: $"build-tools_r{XABuildTools30Version}-linux.zip", prefix: XABuildTools30PackagePrefixLinux));
-			}
 		}
 
 		protected override async Task<bool> Execute (Context context)

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -102,12 +102,6 @@
       <Replacement Include="@XABuildToolsPackagePrefixWindows@=$(XABuildToolsPackagePrefixWindows)" />
       <Replacement Include="@XABuildToolsPackagePrefixLinux@=$(XABuildToolsPackagePrefixLinux)" />
       <Replacement Include="@XABuildToolsPackagePrefix@=$(XABuildToolsPackagePrefix)" />
-      <Replacement Include="@XABuildTools30Folder@=$(XABuildTools30Folder)" />
-      <Replacement Include="@XABuildTools30Version@=$(XABuildTools30Version)" />
-      <Replacement Include="@XABuildTools30PackagePrefixMacOS@=$(XABuildTools30PackagePrefixMacOS)" />
-      <Replacement Include="@XABuildTools30PackagePrefixWindows@=$(XABuildTools30PackagePrefixWindows)" />
-      <Replacement Include="@XABuildTools30PackagePrefixLinux@=$(XABuildTools30PackagePrefixLinux)" />
-      <Replacement Include="@XABuildTools30PackagePrefix@=$(XABuildTools30PackagePrefix)" />
       <Replacement Include="@XAPlatformToolsVersion@=$(XAPlatformToolsVersion)" />
       <Replacement Include="@XAInstallPrefix@=$(XAInstallPrefix)" />
       <Replacement Include="@XABinRelativeInstallPrefix@=$(_XABinRelativeInstallPrefix)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/6eb11f159c692563200ffb88cddc7b69f761cace

We do not need to provision build-tools version 30.0.3 as `dx` is no
longer supported.