### PR TITLE
Add Unit test to make sure Designer Assembly is not packaged.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -141,6 +141,7 @@ public class JavaSourceTest {
 			nupkg.AssertDoesNotContainEntry (nupkgPath, "content/nopack.aar");
 			nupkg.AssertDoesNotContainEntry (nupkgPath, $"contentFiles/any/{dotnetVersion}-android{apiLevel}.0/nopack.aar");
 			nupkg.AssertContainsEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/baz.aar");
+			nupkg.AssertDoesNotContainEntry (nupkgPath, $"lib/{dotnetVersion}-android{apiLevel}.0/_Microsoft.Android.Resource.Designer.dll");
 		}
 
 		static readonly object[] DotNetTargetFrameworks = new object[] {


### PR DESCRIPTION
We had a worry that the `_Microsoft.Android.Resource.Designer.dll` was being auto included in NuGet packages. So lets add a test to make sure it is not.





Spoiler... turns out it wasn't :D