### PR TITLE
[ci] Increase MSBuild Emulator Tests timeout.

### DIFF
--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -26,7 +26,7 @@ stages:
     displayName: "macOS > Tests > MSBuild+Emulator"
     pool:
       vmImage: $(HostedMacImage)
-    timeoutInMinutes: 90
+    timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all


### PR DESCRIPTION
Our MSBuild Emulator Tests are bumping up against the 90 minute timeout specified by CI, causing legitimate runs to fail.  Bump the timeout to 180 minutes like most of our other CI stages.

![image](https://github.com/xamarin/xamarin-android/assets/179295/533c4bf9-3171-42d3-8606-ce4658ca2f54)
