### PR TITLE
[ci] Fix builds from forks

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -112,6 +112,8 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
+    - script: echo hello world
+
     # Set up dependencies to run tests in both debug and release configurations
     - task: DotNetCoreCLI@2
       displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -112,8 +112,6 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - script: echo hello world
-
     # Set up dependencies to run tests in both debug and release configurations
     - task: DotNetCoreCLI@2
       displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -40,6 +40,10 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
+    # Always checkout a second resource to ensure we are using multi-repo checkout behavior
+    #  https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
+    - checkout: maui
+
     - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
       - checkout: monodroid
         clean: true

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -40,15 +40,20 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - checkout: monodroid
-      clean: true
-      submodules: recursive
-      path: s/xamarin-android/external/monodroid
-      persistCredentials: true
+    - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
+      - checkout: monodroid
+        clean: true
+        submodules: recursive
+        path: s/xamarin-android/external/monodroid
+        persistCredentials: true
 
-    - script: rm -rf external/monodroid/external/xamarin-android
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: delete external xamarin-android submodule
+      - script: rm -rf external/monodroid/external/xamarin-android
+        workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+        displayName: delete external xamarin-android submodule
+
+      - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
+        workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+        displayName: make prepare-external-git-dependencies
 
     - template: setup-ubuntu.yaml
 
@@ -56,10 +61,6 @@ stages:
       displayName: authenticate with azure artifacts
       inputs:
         forceReinstallCredentialProvider: true
-
-    - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: make prepare-external-git-dependencies
 
     - script: make jenkins PREPARE_CI=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -24,7 +24,7 @@ steps:
 
 # Always checkout a second resource to ensure we are using multi-repo checkout behavior
 #  https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path
-- checkout: yaml-templates
+- checkout: maui
 
 - script: >
     ls -l /Applications &&


### PR DESCRIPTION
The Xamarin.Android-PR pipeline has been updated to restrict builds from 
forks, which surfaced a few issues that were missed in commit b1bb67b3.

The Linux build and the repo used to preserve multi-repo checkout
behavior have been updated to fix these issues.