### PR TITLE
[tests] update Microsoft.Intune.Maui.Essentials.android

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -594,7 +594,7 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Microsoft_Intune_Maui_Essentials_android = new Package {
 			Id = "Microsoft.Intune.Maui.Essentials.android",
-			Version = "10.0.0-beta",
+			Version = "10.0.0-beta2",
 		};
 	}
 }


### PR DESCRIPTION
Context: https://www.nuget.org/packages/Microsoft.Intune.Maui.Essentials.android/10.0.0-beta2

A `MicrosoftIntune(false)` test on xamarin-android/main can fail with:

    /Users/runner/.nuget/packages/microsoft.intune.maui.essentials.android/10.0.0-beta/build/netstandard2.0/Microsoft.Intune.Maui.Essentials.android.targets(203,9):
    error : /Users/runner/work/1/s/bin/Release/dotnet/packs/Microsoft.NETCore.App.Runtime.Mono.android-x64/8.0.0-rc.2.23466.4/runtimes/android-x64/native/libSystem.Security.Cryptography.Native.Android.jar doesn't contain /Users/runner/.nuget/packages/ and the mamified library won't be placed in the correct intune directory. This is not expected.

This is potentially fixed in the next release, let's try it.