### PR TITLE
Bump to xamarin/Java.Interop/main@445ee6cd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = dev/jonp/jonp-use-package-net.dot.jni
+    branch = main
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = main
+    branch = dev/jonp/jonp-use-package-net.dot.jni
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git

--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -3,7 +3,7 @@
 -dontobfuscate
 
 -keep class android.support.multidex.MultiDexApplication { <init>(); }
--keep class com.xamarin.java_interop.** { *; <init>(); }
+-keep class net.dot.jni.** { *; <init>(); }
 -keep class mono.MonoRuntimeProvider* { *; <init>(...); }
 -keep class mono.MonoPackageManager { *; <init>(...); }
 -keep class mono.MonoPackageManager_Resources { *; <init>(...); }
@@ -14,7 +14,7 @@
 -keep class opentk.GameViewBase { *; <init>(...); }
 -keep class opentk_1_0.platform.android.AndroidGameView { *; <init>(...); }
 -keep class opentk_1_0.GameViewBase { *; <init>(...); }
--keep class com.xamarin.java_interop.ManagedPeer { *; <init>(...); }
+-keep class net.dot.jni.ManagedPeer { *; <init>(...); }
 -keep class xamarin.android.net.ServerCertificateCustomValidator_TrustManager { *; <init>(...); }
 -keep class xamarin.android.net.ServerCertificateCustomValidator_TrustManager_FakeSSLSession { *; <init>(...); }
 -keep class xamarin.android.net.ServerCertificateCustomValidator_AlwaysAcceptingHostnameVerifier { *; <init>(...); }

--- a/src/java-runtime/java-runtime.csproj
+++ b/src/java-runtime/java-runtime.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <AllRuntimeSource Include="java/mono/**/*.java" />
-    <AllRuntimeSource Include="..\..\src-ThirdParty\bazel\java\mono\**\*.java" />
-    <AllRuntimeSource Include="$(JavaInteropSourceDirectory)\src\Java.Interop\java\com\xamarin\**\*.java" />
+    <AllRuntimeSource Include="java/**/*.java" />
+    <AllRuntimeSource Include="..\..\src-ThirdParty\bazel\java\**\*.java" />
+    <AllRuntimeSource Include="$(JavaInteropSourceDirectory)\src\Java.Interop\java\**\*.java" />
   </ItemGroup>
   
   <Import Project="java-runtime.targets" />

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Remaps.xml
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Remaps.xml
@@ -1,10 +1,10 @@
 <replacements>
   <replace-type
-      from="com/xamarin/interop/RenameClassBase1"
-      to="com/xamarin/interop/RenameClassBase2" />
+      from="net/dot/jni/test/RenameClassBase1"
+      to="net/dot/jni/test/RenameClassBase2" />
   <replace-type
-      from="com/xamarin/interop/AndroidInterface"
-      to="com/xamarin/interop/DesugarAndroidInterface$_CC" />
+      from="net/dot/jni/test/AndroidInterface"
+      to="net/dot/jni/test/DesugarAndroidInterface$_CC" />
   <replace-method
       source-type="java/lang/Object"
       source-method-name="remappedToToString"
@@ -14,7 +14,7 @@
   <replace-method
       source-type="java/lang/Object"
       source-method-name="remappedToStaticHashCode"
-      target-type="com/xamarin/interop/ObjectHelper"
+      target-type="net/dot/jni/test/ObjectHelper"
       target-method-name="getHashCodeHelper" target-method-instance-to-static="true" />
   <replace-method
       source-type="java/lang/Runtime"
@@ -22,9 +22,9 @@
       target-type="java/lang/Runtime"
       target-method-name="getRuntime" target-method-instance-to-static="false" />
   <replace-method
-      source-type="com/xamarin/interop/RenameClassBase2"
+      source-type="net/dot/jni/test/RenameClassBase2"
       source-method-name="hashCode"
       source-method-signature="()"
-      target-type="com/xamarin/interop/RenameClassBase2"
+      target-type="net/dot/jni/test/RenameClassBase2"
       target-method-name="myNewHashCode" target-method-instance-to-static="false" />
 </replacements>

--- a/tests/Mono.Android-Tests/proguard.cfg
+++ b/tests/Mono.Android-Tests/proguard.cfg
@@ -1,3 +1,3 @@
 # Need to preserve the contents of Mono.Android-Test-classes.jar
 
--keep class com.xamarin.interop.** { *; <init>(); }
+-keep class net.dot.jni.test.** { *; <init>(); }


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/25850ba741b9e3d9dbda353c03b80f7ccb4def42...445ee6cdde696f771bb73c1694adacac56006b78
    
  * xamarin/java.interop@445ee6cd: Rename com.xamarin.java_interop package to net.dot.jni (xamarin/java.interop#1166)
