### PR TITLE
[ci] Run tests on JDK 17

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -114,6 +114,7 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
+        jdkTestFolder: $(JAVA_HOME_11_X64)
 
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:
@@ -121,9 +122,6 @@ stages:
         arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) -m:1 -v:n
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
-
-    - script: echo "##vso[task.setvariable variable=Java8SdkDirectory]$JAVA_HOME_8_X64"
-      displayName: set Java8SdkDirectory
 
     - template: yaml-templates/start-stop-emulator.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -350,9 +350,9 @@ stages:
         forceReinstallCredentialProvider: true
 
     - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_11_X64%
-        echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_11_X64%
-      displayName: set JI_JAVA_HOME, JAVA_HOME
+        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
+        echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_17_X64%
+      displayName: set JI_JAVA_HOME, JAVA_HOME to $(JAVA_HOME_17_X64)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -38,8 +38,8 @@ stages:
     - template: clean.yaml
 
     - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_11_X64%
-      displayName: set JI_JAVA_HOME
+        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
+      displayName: set JI_JAVA_HOME to $(JAVA_HOME_17_X64)
 
     - template: use-dot-net.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,7 +1,7 @@
 parameters:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
-  jdkTestFolder: $(JAVA_HOME_11_X64)
+  jdkTestFolder: $(JAVA_HOME_17_X64)
   remove_dotnet: false
   installTestSlicer: false
   installApkDiff: true
@@ -26,13 +26,13 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"
     echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}/bin/${{ parameters.configuration }}/dotnet/dotnet"
-  displayName: set JI_JAVA_HOME
+  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
   condition: and(succeeded(), ne(variables['agent.os'], 'Windows_NT'))
 
 - script: |
     echo ##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}
     echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}\bin\${{ parameters.configuration }}\dotnet\dotnet.exe
-  displayName: set JI_JAVA_HOME
+  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 # Install .NET 6 for legacy tests


### PR DESCRIPTION
Sets `$JI_JAVA_HOME` to JDK 17 for all test environments except for one
nightly test job that runs on JDK 11.