### PR TITLE
[ci] Fix nightly build

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -20,6 +20,10 @@ resources:
     type: github
     name: xamarin/monodroid
     endpoint: xamarin
+  - repository: maui
+    type: github
+    name: dotnet/maui
+    endpoint: xamarin
 
 # Global variables
 variables:


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-android/commit/204225b8ca3d94842f82e6fed60d350776191c23 broke the nightly build, as it added a `maui` checkout
to the main build and the maui resource was night defined in the nightly
pipeline.  This checkout was added as a sort of workaround to make sure
we are always checking out at least 2 repos, so that our sources are
placed into consistent locations.