### PR TITLE
[tests] fix `UpdateLayoutIdIsIncludedInDesigner`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -361,9 +361,9 @@ namespace Foo.Foo
 		public partial class Styleable
 		{
 			
-			// aapt resource value: { 0x10100D2,0x7F040000,0x7F040000,0x7F040001 }
+			// aapt resource value: { 0x0,0x7F040000,0x7F040000,0x7F040001 }
 			public static int[] CustomFonts = new int[] {
-					16842962,
+					0,
 					2130968576,
 					2130968576,
 					2130968577};
@@ -377,10 +377,10 @@ namespace Foo.Foo
 			// aapt resource value: 3
 			public const int CustomFonts_customFont1 = 3;
 			
-			// aapt resource value: { 0x10100B2,0x10101F8,0x7F040002,0x7F040003 }
+			// aapt resource value: { 0x0,0x0,0x7F040002,0x7F040003 }
 			public static int[] MultiSelectListPreference = new int[] {
-					16842930,
-					16843256,
+					0,
+					0,
 					2130968578,
 					2130968579};
 			


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8509

Seeing a test failure:

    UpdateLayoutIdIsIncludedInDesigner(False)
    /Users/runner/work/1/a/TestRelease/11-27_15.45.30/temp/UpdateLayoutIdIsIncludedInDesignerFalse Some Space/Resource.designer.cs and /Users/runner/work/1/s/bin/TestRelease/Expected/GenerateDesignerFileExpected.cs do not match.

It appears the files do indeed have changes, that maybe could be caused by a newer `aapt2` version?

Let's see if the tests fail on a fresh pull request.