### PR TITLE
[release/8.0.1xx] Bump Android SDK component versions

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:main@47bdaaa9b8ac16d6197a8982c8cc810d177c5cff
+xamarin/monodroid:dev/pjc/rel8-tools-34@2d96a249551b3142cf19fdeafbfe2d3977a8066a
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:dev/pjc/rel8-tools-34@2d96a249551b3142cf19fdeafbfe2d3977a8066a
+xamarin/monodroid:release/8.0.1xx@7b6faa349a2e8587b6e55357fcf007a5790f1555
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d

--- a/Configuration.props
+++ b/Configuration.props
@@ -146,7 +146,7 @@
     <XABuildTools30Version>30.0.3</XABuildTools30Version>
     <XABuildTools30Folder Condition="'$(XABuildTools30Folder)' == ''">30.0.3</XABuildTools30Folder>
     <XAPlatformToolsPackagePrefix Condition=" '$(HostOS)' == 'Darwin' "></XAPlatformToolsPackagePrefix>
-    <XAPlatformToolsVersion>34.0.1</XAPlatformToolsVersion>
+    <XAPlatformToolsVersion>34.0.5</XAPlatformToolsVersion>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">1.15.1</XABundleToolVersion>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
@@ -187,8 +187,8 @@
     <AvdManagerToolExe Condition=" '$(AvdManagerToolExe)' == '' and '$(HostOS)' == 'Windows' ">avdmanager.bat</AvdManagerToolExe>
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
-    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">7.0</CommandLineToolsFolder>
-    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">8512546_latest</CommandLineToolsVersion>
+    <CommandLineToolsFolder Condition=" '$(CommandLineToolsFolder)' == '' ">11.0</CommandLineToolsFolder>
+    <CommandLineToolsVersion Condition=" '$(CommandLineToolsVersion)' == '' ">10406996_latest</CommandLineToolsVersion>
     <CommandLineToolsBinPath Condition=" '$(CommandLineToolsBinPath)' == '' ">$(AndroidSdkFullPath)\cmdline-tools\$(CommandLineToolsFolder)\bin</CommandLineToolsBinPath>
     <!-- Version numbers and PkgVersion are found in https://dl-ssl.google.com/android/repository/repository2-3.xml -->
     <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">9364964</EmulatorVersion>

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -156,6 +156,7 @@ stages:
       emulatorMSBuildArgs: -p:TestAvdExtraBootArgs=-writable-system
       jobName: SystemApplicationTests
       jobTimeout: 120
+      jdkTestFolder: $HOME/android-toolchain/jdk-17
       testSteps:
       - template: run-nunit-tests.yaml
         parameters:
@@ -187,6 +188,10 @@ stages:
       clean: all
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
+
+    - script: |
+        echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
+      displayName: set JAVA_HOME to $HOME/android-toolchain/jdk-17
 
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -241,6 +246,10 @@ stages:
       clean: all
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
+
+    - script: |
+        echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/android-toolchain/jdk-17"
+      displayName: set JAVA_HOME to $HOME/android-toolchain/jdk-17
 
     - template: yaml-templates/setup-test-environment.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -118,6 +118,7 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
+        jdkTestFolder: $(JAVA_HOME_11_X64)
 
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:
@@ -125,9 +126,6 @@ stages:
         arguments: -t:PrepareJavaInterop -c $(XA.Build.Configuration) -m:1 -v:n
         displayName: prepare java.interop $(XA.Build.Configuration)
         continueOnError: false
-
-    - script: echo "##vso[task.setvariable variable=Java8SdkDirectory]$JAVA_HOME_8_X64"
-      displayName: set Java8SdkDirectory
 
     - template: yaml-templates/start-stop-emulator.yaml
       parameters:
@@ -197,6 +195,7 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
+        jdkTestFolder: $HOME/android-toolchain/jdk-17
 
     - task: DownloadPipelineArtifact@2
       inputs:
@@ -250,6 +249,7 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
+        jdkTestFolder: $HOME/android-toolchain/jdk-17
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -350,9 +350,9 @@ stages:
         forceReinstallCredentialProvider: true
 
     - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_11_X64%
-        echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_11_X64%
-      displayName: set JI_JAVA_HOME, JAVA_HOME
+        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
+        echo ##vso[task.setvariable variable=JAVA_HOME]%JAVA_HOME_17_X64%
+      displayName: set JI_JAVA_HOME, JAVA_HOME to $(JAVA_HOME_17_X64)
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -38,8 +38,8 @@ stages:
     - template: clean.yaml
 
     - script: |
-        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_11_X64%
-      displayName: set JI_JAVA_HOME
+        echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
+      displayName: set JI_JAVA_HOME to $(JAVA_HOME_17_X64)
 
     - template: use-dot-net.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/run-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-emulator-tests.yaml
@@ -4,6 +4,7 @@ parameters:
   emulatorMSBuildArgs: ''
   jobName: CheckTimeZoneInfoIsCorrectNode1
   jobTimeout: 360
+  jdkTestFolder: $(JAVA_HOME_17_X64)
   testSteps: []
 
 jobs:
@@ -20,12 +21,17 @@ jobs:
     steps:
     - template: agent-cleanser/v1.yml@yaml-templates
 
+    - script: |
+        echo "##vso[task.setvariable variable=JAVA_HOME]${{ parameters.jdkTestFolder }}"
+      displayName: set JAVA_HOME to ${{ parameters.jdkTestFolder }}
+
     - template: setup-test-environment.yaml
       parameters:
         installLegacyDotNet: false
         restoreNUnitConsole: false
         updateMono: false
         xaprepareScenario: EmulatorTestDependencies
+        jdkTestFolder: ${{ parameters.jdkTestFolder }}
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,7 +1,7 @@
 parameters:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
-  jdkTestFolder: $(JAVA_HOME_11_X64)
+  jdkTestFolder: $(JAVA_HOME_17_X64)
   remove_dotnet: false
   installTestSlicer: false
   installApkDiff: true
@@ -26,13 +26,13 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}"
     echo "##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}/bin/${{ parameters.configuration }}/dotnet/dotnet"
-  displayName: set JI_JAVA_HOME
+  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
   condition: and(succeeded(), ne(variables['agent.os'], 'Windows_NT'))
 
 - script: |
     echo ##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkTestFolder }}
     echo ##vso[task.setvariable variable=DOTNET_TOOL_PATH]${{ parameters.xaSourcePath }}\bin\${{ parameters.configuration }}\dotnet\dotnet.exe
-  displayName: set JI_JAVA_HOME
+  displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 # Install .NET 6 for legacy tests

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -371,7 +371,6 @@
     <!-- SDK component installation can be frail, try a few times. -->
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
     </Exec>
@@ -381,7 +380,6 @@
     />
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />
@@ -392,7 +390,6 @@
     />
     <Exec
         Command="&quot;$(CommandLineToolsBinPath)\sdkmanager&quot; &quot;$(SdkManagerImageName)&quot;"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
         ContinueOnError="true"
         Condition=" '$(_SdkManagerExitCode)' != '0' ">
       <Output TaskParameter="ExitCode" PropertyName="_SdkManagerExitCode" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android-tools/pull/218

Changes:
 * xamarin/monodroid@7b6faa349: Bump to xamarin/android-sdk-installer@ac2bd9a, xamarin/androidtools@352675a
 * xamarin/monodroid@7a85ac569: [ci] Stop provisioning Xcode on macOS agents

Changes:
 * xamarin/xamarin-android-tools@08a6990 Bump android-sdk NDK version to 26.1.10909125
 * xamarin/xamarin-android-tools@6ae1f2a Bump android-sdk build-tool version to 34.0.0
 * xamarin/xamarin-android-tools@184b6b3 Bump android-sdk cmdline-tools to version 11.0
 * xamarin/xamarin-android-tools@1365e33 Bump android-sdk platforms-tools to version 34.0.5
 * xamarin/xamarin-android-tools@8d38281 Update the maximum NDK version to 26

Updates our recommended Android SDK component versions to the following:

 * build-tools 34.0.0
 * cmdline-tools 11.0
 * platform-tools 34.0.5
 * android-ndk 26.1.10909125

All PR test jobs have been updated to use JDK 17, while one nightly test job will remain on JDK 11.