### PR TITLE
[Microsoft.Android.Templates] docs link in binding project template

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
+++ b/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
@@ -5,5 +5,9 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidBinding1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      NOTE: you can simply add .aar or .jar files in this directory to be included in the project.
+      To learn more, see: https://learn.microsoft.com/dotnet/maui/migration/android-binding-projects
+    -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8411
Context: https://github.com/dotnet/docs-maui/pull/1916

We have a nice docs page that should eliminate some confusion if we linked to it with a comment in the project template.

I considered putting a commented out example of disabling the C# binding (ala `EmbeddedReferenceJar`):

    <ItemGroup>
      <AndroidLibrary Update="foo.jar" Bind="false">
    </ItemGroup

But I think this case is rare, and the docs page should be sufficient.