### PR TITLE
Bump `xamarin-android-tools` from `bde49e6` to `4889bf0`.

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>$(TargetFrameworkNETStandard)</TargetFramework>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <OutputPath>$(BootstrapOutputDirectory)</OutputPath>
+    <_IncludeMicrosoftBuildPackage>true</_IncludeMicrosoftBuildPackage>
   </PropertyGroup>
 
   <Import Project="..\..\Configuration.props" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <ProjectGuid>{2DD1EE75-6D8D-4653-A800-0A24367F7F38}</ProjectGuid>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\product.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <_IncludeMicrosoftBuildPackage>true</_IncludeMicrosoftBuildPackage>
   </PropertyGroup>
   <Import Project="..\..\..\..\Configuration.props" />
   <Import Project="..\..\..\..\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\MSBuildReferences.projitems" />


### PR DESCRIPTION
Bump `xamarin-android-tools` from `bde49e6` to `4889bf0`.

With https://github.com/xamarin/xamarin-android-tools/pull/220, we now need to set `$(_IncludeMicrosoftBuildPackage)` for projects that need a `Microsoft.Build` reference.

This bump fixes 226 CI reported warnings (390 -> 164).