### PR TITLE
[build] set `$(AllowSelfContainedWithoutRuntimeIdentifier)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -14,6 +14,7 @@
     <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidUseIntermediateDesignerFile>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseIntermediateDesignerFile>
+    <AllowSelfContainedWithoutRuntimeIdentifier Condition =" '$(AllowSelfContainedWithoutRuntimeIdentifier)' == '' ">true</AllowSelfContainedWithoutRuntimeIdentifier>
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' ">false</ComputeNETCoreBuildOutputFiles>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8366
Context: https://github.com/dotnet/sdk/commit/d21e6bf5c5a239892d771f409841ce856bddcd89

Rolf introduced an "escape hatch" in the .NET 9 SDK for emitting a build warning for a case that doesn't make sense on mobile. All mobile apps are self-contained, and we define RIDs by default, so the error is not needed.

It appears than when building `net8.0-android` apps on the .NET 9 SDK, we will also need to silence this warning. This property should not have any effect in the stable, .NET 8 SDK.

After this change goes in, we'll likely need the .NET 9 Android workload to depend on a newer .NET 8 Android workload with this change in place.