### PR TITLE
Add a handful of compiler options to harden code

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -217,6 +217,7 @@ function(xa_common_prepare)
     LINKER:-z,relro
     LINKER:-z,noexecstack
     LINKER:--no-undefined
+    LINKER:-z,nodlopen
     PARENT_SCOPE
     )
 

--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -217,7 +217,6 @@ function(xa_common_prepare)
     LINKER:-z,relro
     LINKER:-z,noexecstack
     LINKER:--no-undefined
-    LINKER:-z,nodlopen
     PARENT_SCOPE
     )
 

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -331,15 +331,36 @@ set(LOCAL_COMMON_COMPILER_ARGS
   -Werror=format-security
   -Werror=return-type
   -Wextra
-  -Wformat
   -Wformat-security
+  -Wformat=2
+  -Wimplicit-fallthrough
   -Wmisleading-indentation
   -Wnull-dereference
   -Wpointer-arith
   -Wshadow
   -Wsign-compare
+  -Wtrampolines
   -Wuninitialized
+  -fstack-clash-protection
+  -fstrict-flex-arrays=3
   )
+
+# Add some options to increase security. They may mildly affect performance but they won't be big, because the features are
+# assisted by the hardware.
+if((CMAKE_ANDROID_ARCH_ABI STREQUAL "x86") OR (CMAKE_ANDROID_ARCH_ABI STREQUAL "x86_64"))
+  # -fcf-protection=full: Enable control flow protection to counter Return Oriented Programming (ROP) and Jump Oriented Programming (JOP) attacks on many x86 architectures
+  list(APPEND LOCAL_COMMON_COMPILER_ARGS
+    -fcf-protection=full
+  )
+endif()
+
+if(CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
+  # -mbranch-protection=standard: Enable branch protection to counter Return Oriented Programming (ROP) and Jump Oriented Programming (JOP) attacks on AArch64
+  # In clang -mbranch-protection=standard is equivalent to -mbranch-protection=bti+pac-ret and invokes the AArch64 Branch Target Identification (BTI) and Pointer Authentication using key A (pac-ret)
+  list(APPEND LOCAL_COMMON_COMPILER_ARGS
+    -mbranch-protection=standard
+  )
+endif()
 
 if(COMPILER_DIAG_COLOR)
   list(APPEND LOCAL_COMMON_COMPILER_ARGS


### PR DESCRIPTION
The following compile-time warning options are added:

  * -Wformat=2
    Enable additional format function warnings. The `2` form of the
    option enables more extensive checks in calls to `printf`, `scanf`
    etc. These are compile-time only checks, no effect on runtime
    performance.
  * -Wimplicit-fallthrough
    Warn when a switch case falls through. If this is an intended
    -action, it can be marked with the `[[fallthrough]]` attribute
  * -Wtrampolines
    Enable warnings about trampolines that require executable stacks.
  
The following options which affect the generated code are added:

  * -fstack-clash-protection
    Enable run-time checks for variable-size stack allocation validity.
    This may affect performance if code allocates a lot of memory on the
    stack, but since we don't do that, we should be fine.
  * -fstrict-flex-arrays=3
    Consider trailing array (at the end of struct) as flexible array
    only if declared as `[]`
  * (x86) -fcf-protection=full
    Enable control flow protection to counter Return Oriented
    Programming (ROP) and Jump Oriented Programming (JOP) attacks on
    many x86 architectures
  * (arm64) -mbranch-protection=standard
    Enable branch protection to counter Return Oriented
    Programming (ROP) and Jump Oriented Programming (JOP) attacks on
    AArch64