### PR TITLE
[xaprepare] Track the versions of Android SDK Levels available on CI agents.

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -69,8 +69,8 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-30_r01",   apiLevel: "30", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-31_r01",   apiLevel: "31", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-32_r01",   apiLevel: "32", pkgRevision: "1"),
-				new AndroidPlatformComponent ("platform-33_r02",   apiLevel: "33", pkgRevision: "2"),
-				new AndroidPlatformComponent ("platform-34-ext7_r01",   apiLevel: "34", pkgRevision: "1"),
+				new AndroidPlatformComponent ("platform-33-ext3_r03",   apiLevel: "33", pkgRevision: "3"),
+				new AndroidPlatformComponent ("platform-34-ext7_r02",   apiLevel: "34", pkgRevision: "2"),
 
 				new AndroidToolchainComponent ("sources-34_r01",
 					destDir: Path.Combine ("sources", "android-34"),


### PR DESCRIPTION
Context: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

By using the revisions of Android SDK Platforms already on the MS Hosted CI images we do not need to spend time downloading and installing alternate versions.

Current `main` `xaprepare`:
```
  * Checking platform-33_r02
    outdated
  * Checking platform-34-ext7_r01
    outdated
```

This PR `xaprepare`:
```
  * Checking platform-33-ext3_r03
    installed
  * Checking platform-34-ext7_r02
    installed
```

Note these "ext" versions seem to be the new "baseline" versions.  That is, there is no longer a "plain" `platform-33` or `platform-34` listed in the Google SDK manifest.

Neither `ApiCompat` nor `PublicApiAnalyzers` were triggered, so we can safely assume the public API has not changed in these new revisions.