### PR TITLE
[tests] trim trailing `\` from AndroidSdkDirectory/JavaSdkDirectory

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -154,10 +154,10 @@ namespace Xamarin.ProjectTools
 				arguments.Add ($"/t:{target}");
 			}
 			if (Directory.Exists (AndroidSdkPath)) {
-				arguments.Add ($"/p:AndroidSdkDirectory=\"{AndroidSdkPath}\"");
+				arguments.Add ($"/p:AndroidSdkDirectory=\"{AndroidSdkPath.TrimEnd('\\')}\"");
 			}
 			if (Directory.Exists (JavaSdkPath)) {
-				arguments.Add ($"/p:JavaSdkDirectory=\"{JavaSdkPath}\"");
+				arguments.Add ($"/p:JavaSdkDirectory=\"{JavaSdkPath.TrimEnd ('\\')}\"");
 			}
 			if (parameters != null) {
 				foreach (var parameter in parameters) {


### PR DESCRIPTION
When running MSBuild tests locally, both of the paths used for:

    /p:AndroidSdkDirectory="C:\Some Path\android-sdk\"
    /p:JavaSdkDirectory="C:\Some Path\jdk\"

Because the two paths have a trailing `\`, it appears that MSBuild is escaping the `\"` giving an error message that we can't build more than one project! Basically, all command-line parsing is failing!

I am unsure what changed, but making this change locally allows me to run the MSBuild tests again.