### PR TITLE
[Xamarin.Android.Build.Tasks] don't set $(PublishSelfContained) for .NET 9

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -75,7 +75,7 @@
       This prevents an early error message during 'dotnet publish'.
       We handle $(SelfContained) in a custom way where it is forced to be true.
     -->
-    <PublishSelfContained Condition=" '$(PublishSelfContained)' == '' ">false</PublishSelfContained>
+    <PublishSelfContained Condition=" '$(PublishSelfContained)' == '' and $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '9.0')) ">false</PublishSelfContained>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- For compat with user code not marked trimmable, only trim opt-in by default. -->


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/commit/d21e6bf5c5a239892d771f409841ce856bddcd89
Context: https://github.com/xamarin/xamarin-android/commit/8fa5d99341b868795b54bfa9d087bda38151a4d2
Context: https://github.com/xamarin/xamarin-android/commit/0cd963ac03fbd3d7370221adbc65b099e18f6565

Building a `net8.0-android` project with a .NET 9 SDK will fail when using specific arguments:

    > dotnet publish -r android-arm64
    MSBuild version 17.9.0-preview-23577-01+31108edc1 for .NET
    ...
    bin\Debug\dotnet\sdk\9.0.100-alpha.1.23603.1\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(494,5): error NETSDK1112: The runtime pack for Microsoft.Android.Runtime.34.android-arm64 was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'android-arm64'.

Our repo also sets `$(DisableTransitiveFrameworkReferenceDownloads)`, which causes a slightly different error message:

    error NETSDK1185: The Runtime Pack for FrameworkReference 'Microsoft.Android.Runtime.34.android-arm' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.

In .NET 8, 0cd963ac0 began setting `$(PublishSelfContained)` to `false` as a way to avoid the error:

    Microsoft.NET.RuntimeIdentifierInference.targets(212,5): error NETSDK1191: A runtime identifier for the property 'SelfContained' couldn't be inferred. Specify a rid explicitly.

Because Android is always self-contained, we set `$(SelfContained)` through other means, and everything worked.

In .NET 9, other changes were made to where this "workaround" no longer works. To fix this, Rolf introduced dotnet/sdk#d21e6bf5 and `$(AllowSelfContainedWithoutRuntimeIdentifier)` as a way to fix the issue going forward in .NET 9. We are using the new property in .NET 9 since 8fa5d993.

Unfortunately, this leaves one case that is still broken:

* Building with .NET 9 SDK

* Building a `net8.0-android` project

* `dotnet publish -r android-arm64`

Which seems like for now, we could just condition our workaround for .NET 8 and below:

    <PublishSelfContained Condition=" '$(PublishSelfContained)' == '' and $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '9.0')) ">false</PublishSelfContained>

Making this change locally, both cases work for me:

* .NET 8 project, .NET 8 SDK, `dotnet publish -r android-arm64`

* .NET 8 project, .NET 9 SDK, `dotnet publish -r android-arm64`

The only other solution would be to create our own empty `_CheckForUnsupportedAppHostUsage` target to avoid errors, but that seems explicitly worse. We should also backport dotnet/sdk#d21e6bf5 to .NET 8 SDKs, but it will probably take a month for that to ship.

After this is merged and we have a new, nightly .NET 8 build, we can restore the following unit test in main:

https://github.com/xamarin/xamarin-android/blob/40cc8eaf78eb9f95abcc0e966ab274cef1692acc/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs#L202-L205