### PR TITLE
[ci] Don't emit warnings for normal `CheckAdbTarget` operations.

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			public Func<string> ArgumentsGenerator   { get; set; }
 			public bool         MergeStdoutAndStderr { get; set; } = true;
 			public bool         IgnoreExitCode       { get; set; }
+			public bool         LogIgnoredExitCodeAsWarning { get; set; } = true;
 			public string       StdoutFilePath       { get; set; }
 			public bool         StdoutAppend         { get; set; }
 			public string       StderrFilePath       { get; set; }
@@ -88,7 +89,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 						Log.LogError (message);
 						break;
 					}
-					Log.LogWarning (message);
+
+					if (info.LogIgnoredExitCodeAsWarning)
+						Log.LogWarning (message);
+					else
+						Log.LogMessage (MessageImportance.Normal, message);
 				} catch {
 					throw;
 				} finally {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
@@ -31,6 +31,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public override bool Execute ()
 		{
+			// Log messages as output rather than warnings
+			WriteOutputAsMessage = true;
+
 			base.Execute ();
 
 			// We always succeed
@@ -43,12 +46,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				new CommandInfo {
 					ArgumentsString = $"{AdbTarget} shell getprop ro.build.version.sdk",
 					IgnoreExitCode = true,
+					LogIgnoredExitCodeAsWarning = false,
 					MergeStdoutAndStderr = false,
 				},
 
 				new CommandInfo {
 					ArgumentsString = $"{AdbTarget} shell pm path com.android.shell",
 					IgnoreExitCode = true,
+					LogIgnoredExitCodeAsWarning = false,
 					MergeStdoutAndStderr = false,
 					ShouldRun = () => IsValidTarget
 				},


### PR DESCRIPTION
Currently the `start-emulator` tasks emit 4 warnings for each invocation, related to the initial probing it does to see if an emulator is already running.

```
/Users/runner/work/1/s/build-tools/scripts/TestApks.targets(50,5): warning : * daemon not running; starting now at tcp:5037 [/Users/runner/work/1/s/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj]
/Users/runner/work/1/s/build-tools/scripts/TestApks.targets(50,5): warning : * daemon started successfully [/Users/runner/work/1/s/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj]
/Users/runner/work/1/s/build-tools/scripts/TestApks.targets(50,5): warning : adb: no devices/emulators found [/Users/runner/work/1/s/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj]
/Users/runner/work/1/s/build-tools/scripts/TestApks.targets(50,5): warning :   Command /Users/runner/Library/Android/sdk/platform-tools/adb  shell getprop ro.build.version.sdk failed with exit code 1 [/Users/runner/work/1/s/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Emulator.csproj]
```

Write these messages as normal output instead of a warning.

Reduces CI reported warnings from 56 to 15.