### PR TITLE
[Xamarin.Android.Build.Tasks] <LinkAssembliesNoShrink/> skips symbols

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -42,19 +42,24 @@ namespace Xamarin.Android.Tasks
 
 		public bool Deterministic { get; set; }
 
+		/// <summary>
+		/// Defaults to false, enables Mono.Cecil to load symbols
+		/// </summary>
+		public bool ReadSymbols { get; set; }
+
 		public override bool RunTask ()
 		{
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");
 
 			var readerParameters = new ReaderParameters {
-				ReadSymbols = true,
+				ReadSymbols = ReadSymbols,
 			};
 			var writerParameters = new WriterParameters {
 				DeterministicMvid = Deterministic,
 			};
 
-			using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: true, loadReaderParameters: readerParameters)) {
+			using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: ReadSymbols, loadReaderParameters: readerParameters)) {
 				// Add SearchDirectories with ResolvedAssemblies
 				foreach (var assembly in ResolvedAssemblies) {
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1452,6 +1452,7 @@ because xbuild doesn't support framework reference assemblies.
       AddKeepAlives="$(AndroidAddKeepAlives)"
       UseDesignerAssembly="$(AndroidUseDesignerAssembly)"
       Deterministic="$(Deterministic)"
+      ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
       UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
   />
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8421

Reviewing the build log from:

    dotnet new maui
    dotnet build -f net8.0-android -bl

I noticed:

    LinkAssembliesNoShrink 3.410s
    ...
    Failed to read 'C:\Program Files\dotnet\packs\Microsoft.Android.Runtime.34.android-arm64\34.0.52\runtimes\android-arm64\lib\net8.0\Mono.Android.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'C:\Program Files\dotnet\packs\Microsoft.Android.Runtime.34.android-arm64\34.0.52\runtimes\android-arm64\lib\net8.0\Java.Interop.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\microsoft.maui.controls.compatibility\8.0.3\lib\net8.0-android34.0\Microsoft.Maui.Controls.Compatibility.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\microsoft.maui.controls.core\8.0.3\lib\net8.0-android34.0\Microsoft.Maui.Controls.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\microsoft.maui.core\8.0.3\lib\net8.0-android34.0\Microsoft.Maui.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.appcompat\1.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.AppCompat.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.fragment\1.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Fragment.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.drawerlayout\1.2.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.DrawerLayout.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.activity\1.7.2.1\lib\net6.0-android31.0\Xamarin.AndroidX.Activity.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.core\1.10.1.2\lib\net6.0-android31.0\Xamarin.AndroidX.Core.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.recyclerview\1.3.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.RecyclerView.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.viewpager\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.ViewPager.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.swiperefreshlayout\1.1.0.14\lib\net6.0-android31.0\Xamarin.AndroidX.SwipeRefreshLayout.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.cardview\1.0.0.21\lib\net6.0-android31.0\Xamarin.AndroidX.CardView.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.google.android.material\1.9.0.2\lib\net6.0-android31.0\Xamarin.Google.Android.Material.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.viewpager2\1.0.0.21\lib\net6.0-android31.0\Xamarin.AndroidX.ViewPager2.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.coordinatorlayout\1.2.0.7\lib\net6.0-android31.0\Xamarin.AndroidX.CoordinatorLayout.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\microsoft.maui.graphics\8.0.3\lib\net8.0-android34.0\Microsoft.Maui.Graphics.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.navigation.fragment\2.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Navigation.Fragment.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\microsoft.maui.essentials\8.0.3\lib\net8.0-android34.0\Microsoft.Maui.Essentials.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.collection\1.2.0.9\lib\net6.0-android31.0\Xamarin.AndroidX.Collection.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.vectordrawable.animated\1.1.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.VectorDrawable.Animated.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.common\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.Common.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.viewmodel\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.ViewModel.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.savedstate\1.2.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.SavedState.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.activity.ktx\1.7.2.1\lib\net6.0-android31.0\Xamarin.AndroidX.Activity.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.annotation.experimental\1.3.1.1\lib\net6.0-android31.0\Xamarin.AndroidX.Annotation.Experimental.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.annotation.jvm\1.6.0.2\lib\net6.0-android31.0\Xamarin.AndroidX.Annotation.Jvm.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.appcompat.appcompatresources\1.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.AppCompat.AppCompatResources.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.arch.core.common\2.2.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.Arch.Core.Common.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.arch.core.runtime\2.2.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.Arch.Core.Runtime.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.browser\1.5.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.Browser.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.collection.ktx\1.2.0.9\lib\net6.0-android31.0\Xamarin.AndroidX.Collection.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.concurrent.futures\1.1.0.14\lib\net6.0-android31.0\Xamarin.AndroidX.Concurrent.Futures.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.constraintlayout\2.1.4.6\lib\net6.0-android31.0\Xamarin.AndroidX.ConstraintLayout.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.constraintlayout.core\1.0.4.6\lib\net6.0-android31.0\Xamarin.AndroidX.ConstraintLayout.Core.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.versionedparcelable\1.1.1.19\lib\net6.0-android31.0\Xamarin.AndroidX.VersionedParcelable.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.core.core.ktx\1.10.1.2\lib\net6.0-android31.0\Xamarin.AndroidX.Core.Core.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.cursoradapter\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.CursorAdapter.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.customview\1.1.0.18\lib\net6.0-android31.0\Xamarin.AndroidX.CustomView.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.customview.poolingcontainer\1.0.0.5\lib\net6.0-android31.0\Xamarin.AndroidX.CustomView.PoolingContainer.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.documentfile\1.0.1.19\lib\net6.0-android31.0\Xamarin.AndroidX.DocumentFile.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.dynamicanimation\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.DynamicAnimation.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.emoji2\1.3.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.Emoji2.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.startup.startupruntime\1.1.1.7\lib\net6.0-android31.0\Xamarin.AndroidX.Startup.StartupRuntime.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.emoji2.viewshelper\1.3.0.3\lib\net6.0-android31.0\Xamarin.AndroidX.Emoji2.ViewsHelper.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.exifinterface\1.3.6.2\lib\net6.0-android31.0\Xamarin.AndroidX.ExifInterface.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.fragment.ktx\1.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Fragment.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.interpolator\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.Interpolator.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.legacy.support.core.utils\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.Legacy.Support.Core.Utils.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.livedata\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.LiveData.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.livedata.core\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.LiveData.Core.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.livedata.core.ktx\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.process\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.Process.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.runtime\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.Runtime.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.runtime.ktx\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.Runtime.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.viewmodel.ktx\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.ViewModel.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.lifecycle.viewmodelsavedstate\2.6.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.Lifecycle.ViewModelSavedState.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.loader\1.1.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.Loader.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.localbroadcastmanager\1.1.0.7\lib\net6.0-android31.0\Xamarin.AndroidX.LocalBroadcastManager.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.navigation.common\2.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Navigation.Common.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.navigation.runtime\2.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Navigation.Runtime.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.navigation.ui\2.6.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Navigation.UI.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.print\1.0.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.Print.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.profileinstaller.profileinstaller\1.3.1.2\lib\net6.0-android31.0\Xamarin.AndroidX.ProfileInstaller.ProfileInstaller.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.resourceinspection.annotation\1.0.1.7\lib\net6.0-android31.0\Xamarin.AndroidX.ResourceInspection.Annotation.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.savedstate.savedstate.ktx\1.2.1.3\lib\net6.0-android31.0\Xamarin.AndroidX.SavedState.SavedState.Ktx.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.security.securitycrypto\1.1.0.1-alpha06\lib\net6.0-android31.0\Xamarin.AndroidX.Security.SecurityCrypto.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.slidingpanelayout\1.2.0.7\lib\net6.0-android31.0\Xamarin.AndroidX.SlidingPaneLayout.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.tracing.tracing\1.1.0.6\lib\net6.0-android31.0\Xamarin.AndroidX.Tracing.Tracing.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.transition\1.4.1.12\lib\net6.0-android31.0\Xamarin.AndroidX.Transition.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.vectordrawable\1.1.0.19\lib\net6.0-android31.0\Xamarin.AndroidX.VectorDrawable.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.window\1.1.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Window.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
    Failed to read 'D:\.nuget\packages\xamarin.androidx.window.extensions.core.core\1.0.0.1\lib\net6.0-android31.0\Xamarin.AndroidX.Window.Extensions.Core.Core.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.

In general, it doesn't feel like we need `Mono.Cecil` to load symbols at all for this task. That feels like it would be useful for `Release` mode that is doing *real* trimming, but not in debug mode.

I disabled symbol loading in this task, but left a private `$(_AndroidLinkAssembliesReadSymbols)` as an escape hatch if this is ever needed.

This should avoid 74 exceptions that were try-catch'd in the build log.