### PR TITLE
[Mono.Android] Remove `AdditionalProperties` from Java.Interop tools project references.

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -360,10 +360,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\build-tools\create-android-api\create-android-api.csproj" ReferenceOutputAssembly="false" />
-    <!-- Explicitly pass the target framework of the project so we don't have conflicts with the multiple targets in this file. -->
-    <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net7.0" />
-    <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net7.0" />
-    <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" AdditionalProperties="TargetFramework=net7.0" />
+    <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\external\Java.Interop\tools\java-source-utils\java-source-utils.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\java-runtime\java-runtime.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\r8\r8.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/e2854ee71961d4a9910944e5b2aa7107cdf2349c

Often when compiling XA locally on Windows I get this error:
```
CSC : error CS2012: Cannot open 'c:\code\xamarin-android\external\Java.Interop\tools\generator\obj\Debug-net7.0\generat
or.dll' for writing -- 'The process cannot access the file 'c:\code\xamarin-android\external\Java.Interop\tools\generat
or\obj\Debug-net7.0\generator.dll' because it is being used by another process.' [c:\code\xamarin-android\external\Java
.Interop\tools\generator\generator.csproj]
```

This is caused by our usage of `AdditionalProperties` in our `<ProjectReference>`.  This was needed as a result of trying to reference a `net472;net7.0` `generator` project in a `MonoAndroid1.0;net7.0` `Mono.Android` project.  `AdditionalProperties` cause an additional build of the referenced project, setting global properties.  Both this additional build and the original build are now `net7.0` causing them to clobber each other.

Since we're now in a fully .NET world, we are no longer multi-targeting `generator` or `Mono.Android` so we can remove this hack and avoid the extra builds and potential sharing violation errors.