### PR TITLE
Empty commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ endif
 
 all-tests::
 	$(call MSBUILD_BINLOG,build-xabuild) /restore tools/xabuild/xabuild.csproj /p:Configuration=$(CONFIGURATION) $(_MSBUILD_ARGS)
-	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
+	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln /p:AndroidSdkBuildToolsVersion=30.0.3
 
 pack-dotnet::
 	$(call DOTNET_BINLOG,pack-dotnet) $(MSBUILD_FLAGS) -m:1 $(SOLUTION) -t:PackDotNet


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8580

Does It Build™?

It *should* build, it *used* to build (on 2023-09-02), but #8580 *doesn't* build, as it's trying to reference
`android-toolchain/sdk/build-tools/34.0.0/mainDexClasses.rules`, which doesn't exist.

Furthermore, AFAICT `xaprepare` uses `$(XABuildToolsVersion)` to specify which build-tools package is installed, which has been `34` since 326ac889d5, so… how did it build then and why is it failing to build now?  What am I missing?