### PR TITLE
[build] bump `$(AndroidNetPreviousVersion)` to 34.0.63

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -42,7 +42,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.56</AndroidNetPreviousVersion>
+    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.63</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -199,11 +199,6 @@ public class JavaSourceTest {
 			var platform = (string)data[1];
 			var apiLevel = (int)data[2];
 
-			//FIXME: will revisit this in a future PR
-			if (dotnetVersion == "net8.0") {
-				Assert.Ignore ("error NETSDK1185: The Runtime Pack for FrameworkReference 'Microsoft.Android.Runtime.34.android-arm' was not available. This may be because DisableTransitiveFrameworkReferenceDownloads was set to true.");
-			}
-
 			if (string.IsNullOrEmpty (platform))
 				Assert.Ignore ($"Test for API level {apiLevel} was skipped as it matched the default or latest stable API level.");
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/73efcfcad027bbab036ecc4e06293b20cee93d11

Bump to a newer .NET 8 build, so we can re-enable some tests.