### PR TITLE
[ci] Fix remaining permanent CI warnings.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -17,6 +17,7 @@
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />
   <PropertyGroup>
+    <ConfigurationPropsImported>true</ConfigurationPropsImported>
     <!-- TFV for all projects, try v4.7.2 but fallback if needed -->
     <_StandardLibraryPath Condition=" '$(TargetFrameworkVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <DirectoryBuildPropsImported>true</DirectoryBuildPropsImported>
     <DotNetTargetFrameworkVersion>9.0</DotNetTargetFrameworkVersion>
     <DotNetTargetFramework>net$(DotNetTargetFrameworkVersion)</DotNetTargetFramework>
     <DotNetAndroidTargetFramework>$(DotNetTargetFramework)-android</DotNetAndroidTargetFramework>

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -11,7 +11,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.11.x
+    versionSpec: 3.11
 
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="RunAllTests" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props'))" Condition=" '$(DirectoryBuildPropsImported)' != 'true' " />
   <PropertyGroup>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
   </PropertyGroup>
-  <Import Project="$(_TopDir)\Configuration.props" />
+  <Import Project="$(_TopDir)\Configuration.props" Condition=" '$(ConfigurationPropsImported)' != 'true' " />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.RunParallelTargets" />
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -605,7 +605,8 @@ namespace Xamarin.Android.Prepare
 
 		void WriteBuildToolsInventoryCsv ()
 		{
-			var inventoryFilePath = Path.Combine (Path.GetDirectoryName (MainLogFilePath), "buildtoolsinventory.csv");
+			var mainLogFileDirectory = Path.GetDirectoryName (MainLogFilePath) ?? throw new ArgumentException ("Could not get directory for MainLogFilePath");
+			var inventoryFilePath = Path.Combine (mainLogFileDirectory, "buildtoolsinventory.csv");
 			var lines = new List<string> {
 				"BuildToolName,BuildToolVersion",
 			};

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Prepare
 			(bool success, ulong size, HttpStatusCode status) = await Utilities.GetDownloadSizeWithStatus (archiveUrl);
 			if (!success) {
 				if (status == HttpStatusCode.NotFound) {
-					Log.WarningLine ($"dotnet archive URL {archiveUrl} not found");
+					Log.InfoLine ($"dotnet archive URL {archiveUrl} not found");
 					return false;
 				} else {
 					Log.WarningLine ($"Failed to obtain dotnet archive size. HTTP status code: {status} ({(int)status})");

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
@@ -172,7 +172,7 @@ implication, estoppel or otherwise."			}
 			Log.StatusLine ($"  {Context.Instance.Characters.Bullet} Processing: ", tpn.Name, ConsoleColor.Gray, ConsoleColor.White);
 
 			if (licenses.ContainsKey (tpn.Name)) {
-				Log.WarningLine ($"Duplicate Third Party Notice '{tpn.Name}' (old class: {licenses [tpn.Name]}; new class: {tpn})");
+				Log.InfoLine ($"Duplicate Third Party Notice '{tpn.Name}' (old class: {licenses [tpn.Name]}; new class: {tpn})");
 				return;
 			}
 

--- a/tests/api-compatibility/api-compatibility.targets
+++ b/tests/api-compatibility/api-compatibility.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\Configuration.props" Condition=" '$(ConfigurationPropsImported)' != 'true' " />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.Zip" />
   <Target Name="UpdateMonoAndroidContract">
     <Error


### PR DESCRIPTION
Fixes various CI warnings.

```
Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can 
be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is 
recommended to specify only major or major and minor version (Example: `3` or `3.9`)
```

Fix: only specify `major.minor` as requested.

```
build-tools\scripts\RunTests.targets(3,3): Warning MSB4011: "C:\a\_work\1\s\Directory.Build.props" 
cannot be imported again. It was already imported at "C:\a\_work\1\s\build-tools\scripts\PrepareWindows.targets 
(3,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
build-tools\scripts\RunTests.targets(7,3): Warning MSB4011: "C:\a\_work\1\s\Configuration.props" 
cannot be imported again. It was already imported at "C:\a\_work\1\s\build-tools\scripts\PrepareWindows.targets 
(11,3)". This is most likely a build authoring error. This subsequent import will be ignored.
tests\api-compatibility\api-compatibility.targets(3,3): Warning MSB4011: "C:\a\_work\1\s\Configuration.props" 
cannot be imported again. It was already imported at "C:\a\_work\1\s\build-tools\scripts\PrepareWindows.targets 
(11,3)". This is most likely a build authoring error. This subsequent import will be ignored.
```

Fix: add a flag denoting that we have already imported a project and a `Condition` to prevent duplicate imports.

```
build-tools\xaprepare\xaprepare\Application\Context.cs(608,42): Warning CS8604: Possible null reference 
argument for parameter 'path1' in 'string Path.Combine(string path1, string path2)'.
```

Fix: add null check.

```
EXEC(0,0): Warning : dotnet archive URL https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100-
alpha.1.23610.1/dotnet-sdk-9.0.100-alpha.1.23610.1-win-x64.zip not found
```

Fix: checking multiple URLs is part of the expected flow, downgrade message to "info".

```
EXEC(0,0): Warning : Duplicate Third Party Notice 'IronyProject/Irony' 
(old class: Xamarin.Android.Prepare.XamarinAndroidBuildTasks_IronyProject_Irony_TPN; 
new class: Xamarin.Android.Prepare.XamarinAndroidToolsAidl_IronyProject_Irony_TPN)
```

Fix: multiple projects may use the same dependencies, downgrade to "info".

Remaining CI warnings are temporary because our MAUI tests are failing:

![image](https://github.com/xamarin/xamarin-android/assets/179295/1455637d-3f8d-4582-b5c8-50a23b1b8b25)


🎉 