### PR TITLE
Build classic tests with build-tools 30.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ endif
 
 all-tests::
 	$(call MSBUILD_BINLOG,build-xabuild) /restore tools/xabuild/xabuild.csproj /p:Configuration=$(CONFIGURATION) $(_MSBUILD_ARGS)
-	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
+	MSBUILD="$(MSBUILD)" $(call MSBUILD_BINLOG,all-tests,tools/scripts/xabuild) /restore $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln /p:AndroidSdkBuildToolsVersion=30.0.3
 
 pack-dotnet::
 	$(call DOTNET_BINLOG,pack-dotnet) $(MSBUILD_FLAGS) -m:1 $(SOLUTION) -t:PackDotNet


### PR DESCRIPTION
Commit 60fd55e2 likely should have broken the release/7.0.4xx
build in the same way that it is currently failing:

    "/Users/builder/azdo/_work/4/s/xamarin-android/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj" (default target) (32:6) ->
    (_CompileToDalvik target) ->
      MSBUILD : java error JAVA0000: Error in /Users/builder/android-toolchain/sdk/build-tools/34.0.0/mainDexClasses.rules [/Users/builder/azdo/_work/4/s/xamarin-android/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj]
      MSBUILD : java error JAVA0000: Failed to read file: /Users/builder/android-toolchain/sdk/build-tools/34.0.0/mainDexClasses.rules [/Users/builder/azdo/_work/4/s/xamarin-android/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj]
      MSBUILD : java error JAVA0000: Compilation failed [/Users/builder/azdo/_work/4/s/xamarin-android/tests/Mono.Android-Tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj]

However, I believe builds including 60fd55e2 succeeded because the build
machines likely still had build-tools 32.0.0 packages installed.  Our
build pools are re-imaged and refreshed somewhat regularly, and they
seemingly no longer have build-tools 32.0.0 as we do not provision it.

The release/7.0.4xx branch does however still provision build-tools
30.0.3 for certain tests, and we can hopefully build our test projects
with this version to avoid the error highlighted above.