### PR TITLE
[ci] Use python 3.11 for signing tasks

### DIFF
--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -9,6 +9,10 @@ steps:
     forceReinstallCredentialProvider: true
   condition: ${{ parameters.condition }}
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: 3.x
+
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates
   parameters:

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -11,7 +11,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.x
+    versionSpec: 3.11.x
 
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -11,7 +11,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.11.x
+    versionSpec: 3.11
 
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Build.Tests
 				var proj = new XamarinAndroidApplicationProject {
 					TargetSdkVersion = apiLevel.ToString (),
 				};
-				const string ExpectedPlatformToolsVersion = "34.0.4";
+				const string ExpectedPlatformToolsVersion = "34.0.5";
 				using (var b = CreateApkBuilder ()) {
 					b.CleanupAfterSuccessfulBuild = false;
 					string defaultTarget = b.Target;


### PR DESCRIPTION
Authenticode signing attempts started failing recently with:

    ERROR: 'xsign' is misspelled or not recognized by the system.

Updating to Python 3.11 is the suggested fix for this issue.