### PR TITLE
Add ApiScan to nightly build

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -313,11 +313,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -329,7 +329,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -339,6 +339,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -348,9 +349,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -332,3 +332,25 @@ stages:
       condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+
+    - task: SdtReport@2
+      displayName: Guardian Export - Security Report
+      inputs:
+        GdnExportAllTools: false
+        GdnExportGdnToolApiScan: true
+        GdnExportOutputSuppressionFile: source.gdnsuppress
+
+    - task: PublishSecurityAnalysisLogs@3
+      displayName: Publish Guardian Artifacts
+      inputs:
+        ArtifactName: APIScan Logs
+        ArtifactType: Container
+        AllTools: false
+        APIScan: true
+        ToolLogsNotFoundAction: Warning
+
+    - task: PostAnalysis@2
+      displayName: Fail Build on Guardian Issues
+      inputs:
+        GdnBreakAllTools: false
+        GdnBreakGdnToolApiScan: true

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -309,7 +309,7 @@ stages:
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:
-        Contents: $(System.DefaultWorkingDirectory)\xamarin-android\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.pdb)
+        Contents: $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.pdb)
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -58,34 +58,6 @@ stages:
       parameters:
         makeMSBuildArgs: /p:EnableNativeAnalyzers=true
 
-    ### Copy .dll and .pdb files for APIScan
-    - task: CopyFiles@2
-      displayName: Collect Files for APIScan
-      inputs:
-        Contents: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Release/lib/packs/Microsoft.Android*/**/?(*.dll|*.pdb)
-        TargetFolder: $(Build.StagingDirectory)/apiscan
-        OverWrite: true
-        flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
-
-    - script: find $(Build.StagingDirectory)/apiscan
-      displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
-
-    ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
-    - task: APIScan@2
-      displayName: Run APIScan
-      inputs:
-        softwareFolder: $(Build.StagingDirectory)/apiscan
-        symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)/apiscan'
-        softwareName: $(ApiScanName)
-        softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
-        isLargeApp: true
-        toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
-      env:
-        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
-
     - template: yaml-templates/upload-results.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
@@ -310,3 +282,55 @@ stages:
         artifactName: Test Results - Localization With Emulator - macOS-$(System.JobPositionInPhase)
 
     - template: yaml-templates/fail-on-issue.yaml
+
+
+- stage: compliance_scan
+  displayName: Compliance
+  dependsOn: mac_build
+  jobs:
+  - job: api_scan
+    displayName: API Scan
+    pool:
+      name: Azure Pipelines
+      vmImage: windows-2022
+    timeoutInMinutes: 180
+    workspace:
+      clean: all
+    variables:
+    - name: ApiScan.Enabled
+      value: true
+    steps:
+    - template: yaml-templates/setup-test-environment.yaml
+      parameters:
+        installApkDiff: false
+        installLegacyDotNet: false
+        restoreNUnitConsole: false
+        updateMono: false
+
+    ### Copy .dll and .pdb files for APIScan
+    - task: CopyFiles@2
+      displayName: Collect Files for APIScan
+      inputs:
+        Contents: $(System.DefaultWorkingDirectory)\xamarin-android\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.pdb)
+        TargetFolder: $(Build.StagingDirectory)\apiscan
+        OverWrite: true
+        flattenFolders: true
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+
+    - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
+      displayName: List Files for APIScan
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+
+    ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
+    - task: APIScan@2
+      displayName: Run APIScan
+      inputs:
+        softwareFolder: $(Build.StagingDirectory)\apiscan
+        symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
+        softwareName: $(ApiScanName)
+        softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+        isLargeApp: true
+        toolVersion: Latest
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+      env:
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -67,11 +67,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)/apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
 
     - script: find $(Build.StagingDirectory)/apiscan
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -83,7 +83,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -48,6 +48,8 @@ stages:
       - group: xamops-azdev-secrets
       - name: Codeql.Enabled
         value: true
+      - name: ApiScan.Enabled
+        value: true
     steps:
     - checkout: self
       submodules: recursive
@@ -55,6 +57,35 @@ stages:
     - template: yaml-templates/commercial-build.yaml
       parameters:
         makeMSBuildArgs: /p:EnableNativeAnalyzers=true
+
+    ### Copy .dll and .pdb files for APIScan
+    - task: CopyFiles@2
+      displayName: Collect Files for APIScan
+      inputs:
+        Contents: |
+          $(System.DefaultWorkingDirectory)/xamarin-android/bin/Release/dotnet/packs/Microsoft.Android*/**/?(*.dll|*.pdb)
+        TargetFolder: $(Build.StagingDirectory)/apiscan
+        OverWrite: true
+        flattenFolders: true
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
+    - script: find $(Build.StagingDirectory)/apiscan
+      displayName: List Files for APIScan
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
+    ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
+    - task: APIScan@2
+      displayName: Run APIScan
+      inputs:
+        softwareFolder: $(Build.StagingDirectory)/apiscan
+        symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)/apiscan'
+        softwareName: $(ApiScanName)
+        softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+        isLargeApp: true
+        toolVersion: Latest
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      env:
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
     - template: yaml-templates/upload-results.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -54,16 +54,11 @@ stages:
     - checkout: self
       submodules: recursive
 
-    - template: yaml-templates/commercial-build.yaml
-      parameters:
-        makeMSBuildArgs: /p:EnableNativeAnalyzers=true
-
     ### Copy .dll and .pdb files for APIScan
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:
-        Contents: |
-          $(System.DefaultWorkingDirectory)/xamarin-android/bin/Release/dotnet/packs/Microsoft.Android*/**/?(*.dll|*.pdb)
+        Contents: $(System.DefaultWorkingDirectory)/xamarin-android/build-*/**/?(*.props|*.targets)
         TargetFolder: $(Build.StagingDirectory)/apiscan
         OverWrite: true
         flattenFolders: true
@@ -72,6 +67,10 @@ stages:
     - script: find $(Build.StagingDirectory)/apiscan
       displayName: List Files for APIScan
       condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
+
+    - template: yaml-templates/commercial-build.yaml
+      parameters:
+        makeMSBuildArgs: /p:EnableNativeAnalyzers=true
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -37,8 +37,8 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Create Installers
     pool:
-      name: Azure Pipelines
-      vmImage: internal-macos12
+      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
+      demands: macOS.Name -equals Monterey
     timeoutInMinutes: 420
     workspace:
       clean: all
@@ -47,8 +47,6 @@ stages:
       - group: Xamarin Signing
       - group: xamops-azdev-secrets
       - name: Codeql.Enabled
-        value: true
-      - name: ApiScan.Enabled
         value: true
     steps:
     - checkout: self

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -54,11 +54,15 @@ stages:
     - checkout: self
       submodules: recursive
 
+    - template: yaml-templates/commercial-build.yaml
+      parameters:
+        makeMSBuildArgs: /p:EnableNativeAnalyzers=true
+
     ### Copy .dll and .pdb files for APIScan
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:
-        Contents: $(System.DefaultWorkingDirectory)/xamarin-android/build-*/**/?(*.props|*.targets)
+        Contents: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Release/lib/packs/Microsoft.Android*/**/?(*.dll|*.pdb)
         TargetFolder: $(Build.StagingDirectory)/apiscan
         OverWrite: true
         flattenFolders: true
@@ -67,10 +71,6 @@ stages:
     - script: find $(Build.StagingDirectory)/apiscan
       displayName: List Files for APIScan
       condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/nightly-apiscan'))
-
-    - template: yaml-templates/commercial-build.yaml
-      parameters:
-        makeMSBuildArgs: /p:EnableNativeAnalyzers=true
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -37,8 +37,8 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Create Installers
     pool:
-      name: VSEng-Xamarin-RedmondMac-Android-Untrusted
-      demands: macOS.Name -equals Monterey
+      name: Azure Pipelines
+      vmImage: internal-macos12
     timeoutInMinutes: 420
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -291,7 +291,7 @@ stages:
     pool:
       name: Azure Pipelines
       vmImage: windows-2022
-    timeoutInMinutes: 180
+    timeoutInMinutes: 480
     workspace:
       clean: all
     variables:


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline

The ApiScan task has been added to the nightly build and test run.  This
task should help us identify related issues earlier, rather than having
to wait for a full scan of VS.  The task can take a long time to execute
so it has been added to the nightly job rather than the PR or CI jobs.
