### PR TITLE
[ci] Use Python 3.11 for signing tasks

### DIFF
--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -11,7 +11,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.x
+    versionSpec: 3.11
 
 # ESRP signing requires minimum azure client version 2.8.0
 - template: azure-tools/az-client-update.yml@yaml-templates


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/fff1f4c724d90d3b29d401b8751514f2a074f73c

Authenticode signing attempts recently started failing again due to
issues installing the `xsignextension`.  We believe python 3.12 may have
caused this breakage, so we're pinning to 3.11.x for now.