### PR TITLE
[xaprepare] use $(XAPackagesDir) for NuGet folder

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Android.Prepare
 		public const string XABuildToolsPackagePrefix           = "XABuildToolsPackagePrefix";
 		public const string XABinRelativeInstallPrefix          = "XABinRelativeInstallPrefix";
 		public const string XAInstallPrefix                     = "XAInstallPrefix";
+		public const string XAPackagesDir                       = "XAPackagesDir";
 		public const string XAPlatformToolsVersion              = "XAPlatformToolsVersion";
 		public const string XAPlatformToolsPackagePrefix        = "XAPlatformToolsPackagePrefix";
 	}

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -62,6 +62,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.XABuildToolsPackagePrefix,           StripQuotes ("@XABuildToolsPackagePrefix@"));
 			properties.Add (KnownProperties.XABinRelativeInstallPrefix,          StripQuotes (@"@XABinRelativeInstallPrefix@"));
 			properties.Add (KnownProperties.XAInstallPrefix,                     StripQuotes (@"@XAInstallPrefix@"));
+			properties.Add (KnownProperties.XAPackagesDir,                       StripQuotes (@"@XAPackagesDir@"));
 			properties.Add (KnownProperties.XAPlatformToolsVersion,              StripQuotes ("@XAPlatformToolsVersion@"));
 			properties.Add (KnownProperties.XAPlatformToolsPackagePrefix,        StripQuotes ("@XAPlatformToolsPackagePrefix@"));
 		}

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -263,7 +263,7 @@ namespace Xamarin.Android.Prepare
 
 			// not really configurables, merely convenience aliases for more frequently used paths that come from properties
 			public static string XAInstallPrefix                => ctx.Properties.GetRequiredValue (KnownProperties.XAInstallPrefix);
-			public static string XAPackagesDir                  = DetermineNugetPackagesDir (ctx);
+			public static string XAPackagesDir                  => ctx.Properties.GetRequiredValue (KnownProperties.XAPackagesDir);
 
 			static string GetNetcoreAppRuntimePath (Context ctx, string androidTarget)
 			{
@@ -273,17 +273,6 @@ namespace Xamarin.Android.Prepare
 					ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftNETCoreAppRefPackageVersion),
 					"runtimes",
 					$"android-{androidTarget}"
-				);
-			}
-
-			static string DetermineNugetPackagesDir (Context ctx)
-			{
-				return Path.GetFullPath (
-					Path.Combine (
-						ctx.Properties.GetRequiredValue (KnownProperties.PkgXamarin_LibZipSharp),
-						"..",
-						".."
-					)
 				);
 			}
 

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -96,6 +96,7 @@
       <Replacement Include="@XAPlatformToolsVersion@=$(XAPlatformToolsVersion)" />
       <Replacement Include="@XAInstallPrefix@=$(XAInstallPrefix)" />
       <Replacement Include="@XABinRelativeInstallPrefix@=$(_XABinRelativeInstallPrefix)" />
+      <Replacement Include="@XAPackagesDir@=$(XAPackagesDir)" />
       <Replacement Include="@XAPlatformToolsPackagePrefix@=$(XAPlatformToolsPackagePrefix)" />
     </ItemGroup>
 


### PR DESCRIPTION
After returning from the holidays, xamarin-android failed to build (`-t:Prepare`) with:

    Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed: 7zip executable 'D:\7-zip.commandline\18.1.0\tools\x64\7za.exe' not found
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed: 7zip executable 'D:\7-zip.commandline\18.1.0\tools\x64\7za.exe' not found
    ---> System.InvalidOperationException: 7zip executable 'D:\7-zip.commandline\18.1.0\tools\x64\7za.exe' not found
        at Xamarin.Android.Prepare.ToolRunner..ctor(Context context, Log log, String toolPath) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\ToolRunners\ToolRunner.cs:line 57
        at Xamarin.Android.Prepare.SevenZipRunner..ctor(Context context, Log log, String toolPath) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\ToolRunners\SevenZipRunner.cs:line 19
        at Xamarin.Android.Prepare.Utilities.Unpack(String fullArchivePath, String destinationDirectory, Boolean cleanDestinatioBeforeUnpacking) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Application\Utilities.cs:line 142
        at Xamarin.Android.Prepare.Step_InstallDotNetPreview.InstallDotNetAsync(Context context, String dotnetPath, String version, Boolean runtimeOnly) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Steps\Step_InstallDotNetPreview.cs:line 250
        at Xamarin.Android.Prepare.Step_InstallDotNetPreview.Execute(Context context) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Steps\Step_InstallDotNetPreview.cs:line 24
        at Xamarin.Android.Prepare.Step.Run(Context context) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Application\Step.cs:line 42
        at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Application\Scenario.cs:line 37
        --- End of inner exception stack trace ---
        at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Application\Scenario.cs:line 48
        at Xamarin.Android.Prepare.Context.Execute() in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Application\Context.cs:line 511
        at Xamarin.Android.Prepare.App.Run(String[] args) in D:\src\xamarin-android\build-tools\xaprepare\xaprepare\Main.cs:line 162

I am using `%NUGET_PACKAGES%` on my local machine to point to a DevDrive at `D:\.nuget\packages\`, for some reason this is breaking the build?

Previously we were using logic such as:

    return Path.GetFullPath (
        Path.Combine (
            ctx.Properties.GetRequiredValue (KnownProperties.PkgXamarin_LibZipSharp),
            "..",
            ".."
        )
    );

Instead of using `$(PkgXamarin_LibZipSharp)`, let's use `$(XAPackagesDir)` as logic in `Configuration.props` was added in 66a0389e to consider `%NUGET_PACKAGES%`.