### PR TITLE
[tests] use `dotnet/maui/net9.0` branch

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -406,6 +406,13 @@ stages:
         displayName: Create MAUI template
         continueOnError: false
 
+    - powershell: >-
+        [xml] $xml = Get-Content $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
+        $node = $xml.SelectSingleNode("/Project/PropertyGroup/TargetFrameworks")
+        $node.Value = $(DotNetTargetFramework)-android
+        $xml.Save($(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj)
+      displayName: set TargetFrameworks to Android-only
+
     - template: yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -410,7 +410,7 @@ stages:
         $project = '$(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj'
         [xml] $xml = Get-Content $project
         $node = $xml.SelectSingleNode('/Project/PropertyGroup/TargetFrameworks')
-        $node.Value = '$(DotNetTargetFramework)-android'
+        $node.InnerText = '$(DotNetTargetFramework)-android'
         $xml.Save($project)
       displayName: set TargetFrameworks to Android-only
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -33,7 +33,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/net8.0
+    ref: refs/heads/net9.0
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -407,10 +407,11 @@ stages:
         continueOnError: false
 
     - powershell: >-
-        [xml] $xml = Get-Content $(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj
-        $node = $xml.SelectSingleNode("/Project/PropertyGroup/TargetFrameworks")
-        $node.Value = $(DotNetTargetFramework)-android
-        $xml.Save($(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj)
+        $project = '$(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj'
+        [xml] $xml = Get-Content $project
+        $node = $xml.SelectSingleNode('/Project/PropertyGroup/TargetFrameworks')
+        $node.Value = '$(DotNetTargetFramework)-android'
+        $xml.Save($project)
       displayName: set TargetFrameworks to Android-only
 
     - template: yaml-templates/run-dotnet-preview.yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -406,7 +406,7 @@ stages:
         displayName: Create MAUI template
         continueOnError: false
 
-    - powershell: >-
+    - powershell: |
         $project = '$(Build.StagingDirectory)/MauiTestProj/MauiTestProj.csproj'
         [xml] $xml = Get-Content $project
         $node = $xml.SelectSingleNode('/Project/PropertyGroup/TargetFrameworks')


### PR DESCRIPTION
The `MAUI Integration` test lane is currently failing with:

    Unhandled exception: Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadManifestCompositionException: Could not find workload 'microsoft-net-runtime-android-net8' extended by workload 'android' in manifest 'microsoft.net.sdk.android' [C:\a\_work\1\s\maui\bin\dotnet\sdk-manifests\8.0.100\microsoft.net.sdk.android\WorkloadManifest.json]
        at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.<>c__DisplayClass26_0.<<EnumerateWorkloadWithExtends>g__EnumerateWorkloadWithExtendsRec|0>d.MoveNext()
        at System.Linq.Enumerable.AppendPrependIterator`1.LoadFromEnumerator()
        at System.Linq.Enumerable.AppendPrepend1Iterator`1.MoveNext()
        at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
        at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.GetAvailableWorkloadDefinitions()+MoveNext()
        at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
        at System.Linq.Enumerable.Contains[TSource](IEnumerable`1 source, TSource value, IEqualityComparer`1 comparer)
        at Microsoft.DotNet.Workloads.Workload.Install.WorkloadInstallCommand.ValidateWorkloadIdsInput()
        at Microsoft.DotNet.Workloads.Workload.Install.WorkloadInstallCommand..ctor(ParseResult parseResult, IReporter reporter, IWorkloadResolverFactory workloadResolverFactory, IInstaller workloadInstaller, INuGetPackageDownloader nugetPackageDownloader, IWorkloadManifestUpdater workloadManifestUpdater, String tempDirPath, IReadOnlyCollection`1 workloadIds)
        at Microsoft.DotNet.Cli.WorkloadInstallCommandParser.<>c.<ConstructCommand>b__6_0(ParseResult parseResult)
        at System.CommandLine.Invocation.InvocationPipeline.Invoke(ParseResult parseResult)
        at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, TimeSpan startupTime, ITelemetry telemetryClient)
    C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj(198,5): error MSB3073: The command ""C:\a\_work\1\s\maui\bin/dotnet/dotnet" workload install android --skip-sign-check --skip-manifest-update --verbosity diag --temp-dir "C:\a\_work\1\s\maui\bin/temp/" --configfile "C:\a\_work\1\s\maui\NuGet.config"" exited with code 1.

This is likely just due to the fact that it's using the `dotnet/maui/net8.0` branch. Hopefully, switching to the proper branch fixes things.