### PR TITLE
[ci] Add exe files to API Scan

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -317,11 +317,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -333,7 +333,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -343,7 +343,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -353,11 +353,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -317,6 +317,7 @@ stages:
 
     - powershell: |
         Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(Build.StagingDirectory)\binutils-pdb"
+        Get-ChildItem -Path "$(Build.StagingDirectory)\binutils-pdb" -Recurse
       displayName: Extract binutils pdbs
 
     ### Copy .dll, .exe, .pdb files for APIScan
@@ -325,7 +326,7 @@ stages:
       inputs:
         Contents: |
           $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
-          $(Build.StagingDirectory)\binutils-pdb\**\*.pdb
+          $(Build.StagingDirectory)\binutils-pdb\*.pdb
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -297,6 +297,8 @@ stages:
     variables:
     - name: ApiScan.Enabled
       value: true
+    - name: APiScan.SourceBranch
+      value: refs/heads/dev/pjc/apiscanmit
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -305,19 +307,19 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
 
-    ### Copy .dll and .pdb files for APIScan
+    ### Copy .dll, .exe, .pdb files for APIScan
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:
-        Contents: $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.pdb)
+        Contents: $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -329,7 +331,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -339,7 +341,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -349,11 +351,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -25,6 +25,10 @@ resources:
     name: dotnet/maui
     endpoint: xamarin
 
+parameters:
+- name: ApiScanSourceBranch
+  default: 'refs/heads/main'
+
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
@@ -297,8 +301,6 @@ stages:
     variables:
     - name: ApiScan.Enabled
       value: true
-    - name: APiScan.SourceBranch
-      value: refs/heads/dev/pjc/apiscanmit
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -315,11 +317,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -331,7 +333,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -341,7 +343,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -351,11 +353,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '$(APiScan.SourceBranch)'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -326,7 +326,7 @@ stages:
       inputs:
         Contents: |
           $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
-          $(Build.StagingDirectory)\binutils-pdb\*.pdb
+          $(Build.StagingDirectory)\**\*.pdb
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -289,6 +289,7 @@ stages:
 - stage: compliance_scan
   displayName: Compliance
   dependsOn: mac_build
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   jobs:
   - job: api_scan
     displayName: API Scan
@@ -298,9 +299,6 @@ stages:
     timeoutInMinutes: 480
     workspace:
       clean: all
-    variables:
-    - name: ApiScan.Enabled
-      value: true
     steps:
     - template: yaml-templates/setup-test-environment.yaml
       parameters:
@@ -316,8 +314,8 @@ stages:
         downloadPath: $(Build.StagingDirectory)\binutils-pdb
 
     - powershell: |
-        Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(Build.StagingDirectory)\binutils-pdb"
-        Get-ChildItem -Path "$(Build.StagingDirectory)\binutils-pdb" -Recurse
+        Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(System.DefaultWorkingDirectory)\binutils-pdb"
+        Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
       displayName: Extract binutils pdbs
 
     ### Copy .dll, .exe, .pdb files for APIScan
@@ -326,15 +324,13 @@ stages:
       inputs:
         Contents: |
           $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
-          $(Build.StagingDirectory)\**\*.pdb
+          $(System.DefaultWorkingDirectory)\binutils-pdb\*.pdb
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -343,10 +339,9 @@ stages:
         softwareFolder: $(Build.StagingDirectory)\apiscan
         symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
         softwareName: $(ApiScanName)
-        softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+        softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -356,7 +351,6 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -366,11 +360,9 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -309,11 +309,23 @@ stages:
         restoreNUnitConsole: false
         updateMono: false
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download binutils pdbs
+      inputs:
+        artifactName: $(WindowsToolchainPdbArtifactName)
+        downloadPath: $(Build.StagingDirectory)\binutils-pdb
+
+    - powershell: |
+        Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(Build.StagingDirectory)\binutils-pdb"
+      displayName: Extract binutils pdbs
+
     ### Copy .dll, .exe, .pdb files for APIScan
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:
-        Contents: $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
+        Contents: |
+          $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
+          $(Build.StagingDirectory)\binutils-pdb\**\*.pdb
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -49,6 +49,7 @@ stages:
         installerArtifactName: ${{ parameters.installerArtifactName }}
         nugetArtifactName: ${{ parameters.nugetArtifactName }}
         testAssembliesArtifactName: ${{ parameters.testAssembliesArtifactName }}
+        windowsToolchainPdbArtifactName: ${{ parameters.windowsToolchainPdbArtifactName }}
 
     - powershell: |
         [IO.Directory]::CreateDirectory("$(Build.StagingDirectory)/empty")
@@ -72,19 +73,6 @@ stages:
       inputs:
         artifactName: sbom-components-macos
         pathToPublish: $(Build.StagingDirectory)/sbom-components
-
-    - script: >
-        mkdir -p $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&
-        cd $(System.DefaultWorkingDirectory)/xamarin-android/bin/$(XA.Build.Configuration)/lib/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/windows-toolchain-pdb &&
-        zip -r $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb/windows-toolchain-pdb.zip .
-      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
-      displayName: zip Windows toolchain pdb files
-
-    - task: PublishPipelineArtifact@1
-      displayName: upload Windows toolchain pdb files
-      inputs:
-        artifactName: ${{ parameters.windowsToolchainPdbArtifactName }}
-        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb
 
     - template: upload-results.yaml
       parameters:

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -4,6 +4,7 @@ parameters:
   makeMSBuildArgs: ''
   nugetArtifactName: $(NuGetArtifactName)
   testAssembliesArtifactName: $(TestAssembliesArtifactName)
+  windowsToolchainPdbArtifactName: $(WindowsToolchainPdbArtifactName)
 
 steps:
 - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
@@ -139,6 +140,19 @@ steps:
   inputs:
     artifactName: ${{ parameters.testAssembliesArtifactName }}
     targetPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
+
+- script: >
+    mkdir -p ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb &&
+    cd ${{ parameters.xaSourcePath }}/bin/$(XA.Build.Configuration)/lib/packs/Microsoft.Android.Sdk.Darwin/*/tools/binutils/windows-toolchain-pdb &&
+    zip -r ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb/windows-toolchain-pdb.zip .
+  workingDirectory: ${{ parameters.xaSourcePath }}
+  displayName: zip Windows toolchain pdb files
+
+- task: PublishPipelineArtifact@1
+  displayName: upload Windows toolchain pdb files
+  inputs:
+    artifactName: ${{ parameters.windowsToolchainPdbArtifactName }}
+    targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/windows-toolchain-pdb
 
 - task: PublishPipelineArtifact@1
   displayName: upload build tools inventory


### PR DESCRIPTION
The API Scan job added in commit a10aa383cb accidentally excluded some
of our xamarin-android-binutils artifacts.  The job has been fixed to
scan the EXE files (and corresponding symbols) that were previously
skipped.  The latest scan results appear to be consistent with what was
being reported through VS scans, and we can continue working through
these issues: 

    1. ApiScan Error missingsymbols - File: aapt2.exe.
    Tool: ApiScan: Rule: missingsymbols (Missing Symbols)

    2. ApiScan Error documentationnotfound - File: aapt2.exe.
    Tool: ApiScan: Rule: documentationnotfound (Documentation Not Found).

    3. ApiScan Error improperfileformat - File: as.exe.
    Tool: ApiScan: Rule: improperfileformat (Improper File Format).

    4. ApiScan Error missingsymbols - File: ld.exe.
    Tool: ApiScan: Rule: missingsymbols (Missing Symbols).

    5. ApiScan Error improperfileformat - File: libzipsharpnative-3-0.dll.
    Tool: ApiScan: Rule: improperfileformat (Improper File Format).

    6. ApiScan Error improperfileformat - File: llc.exe.
    Tool: ApiScan: Rule: improperfileformat (Improper File Format).

    7. ApiScan Error improperfileformat - File: llvm-mc.exe.
    Tool: ApiScan: Rule: improperfileformat (Improper File Format).

    8. ApiScan Error missingsymbols - File: llvm-strip.exe.
    Tool: ApiScan: Rule: missingsymbols (Missing Symbols).