### PR TITLE
[Mono.Android] Remove Mono_UnhandledException lookup

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -317,11 +317,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -333,7 +333,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -343,7 +343,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -353,11 +353,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -25,10 +25,6 @@ resources:
     name: dotnet/maui
     endpoint: xamarin
 
-parameters:
-- name: ApiScanSourceBranch
-  default: 'refs/heads/main'
-
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
@@ -317,11 +313,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -333,7 +329,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -343,7 +339,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -353,11 +349,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -25,6 +25,10 @@ resources:
     name: dotnet/maui
     endpoint: xamarin
 
+parameters:
+- name: ApiScanSourceBranch
+  default: 'refs/heads/main'
+
 # Global variables
 variables:
 - template: yaml-templates/variables.yaml
@@ -313,11 +317,11 @@ stages:
         TargetFolder: $(Build.StagingDirectory)\apiscan
         OverWrite: true
         flattenFolders: true
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
     - task: APIScan@2
@@ -329,7 +333,7 @@ stages:
         softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
         isLargeApp: true
         toolVersion: Latest
-      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
       env:
         AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -339,7 +343,7 @@ stages:
         GdnExportAllTools: false
         GdnExportGdnToolApiScan: true
         GdnExportOutputSuppressionFile: source.gdnsuppress
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - task: PublishSecurityAnalysisLogs@3
       displayName: Publish Guardian Artifacts
@@ -349,11 +353,11 @@ stages:
         AllTools: false
         APIScan: true
         ToolLogsNotFoundAction: Warning
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))
 
     - task: PostAnalysis@2
       displayName: Fail Build on Guardian Issues
       inputs:
         GdnBreakAllTools: false
         GdnBreakGdnToolApiScan: true
-      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], ${{ parameters.ApiScanSourceBranch }}))

--- a/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
@@ -6,25 +6,11 @@ namespace Android.Runtime
 {
 	public static class AndroidRuntimeInternal
 	{
-		internal static MethodInfo? mono_unhandled_exception_method = null;
 		internal static Action<Exception> mono_unhandled_exception = RuntimeNativeMethods.monodroid_debugger_unhandled_exception;
 
 #pragma warning disable CS0649 // Field is never assigned to.  This field is assigned from monodroid-glue.cc.
 		internal static volatile bool BridgeProcessing; // = false
 #pragma warning restore CS0649 // Field is never assigned to.
-
-		internal static void InitializeUnhandledExceptionMethod ()
-		{
-			if (mono_unhandled_exception == null) {
-				mono_unhandled_exception_method = typeof (System.Diagnostics.Debugger)
-					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
-				if (mono_unhandled_exception_method != null)
-					mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_unhandled_exception_method);
-			}
-			if (mono_unhandled_exception_method == null && mono_unhandled_exception != null) {
-				mono_unhandled_exception_method = mono_unhandled_exception.Method;
-			}
-		}
 
 		public static void WaitForBridgeProcessing ()
 		{

--- a/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
@@ -6,7 +6,7 @@ namespace Android.Runtime
 {
 	public static class AndroidRuntimeInternal
 	{
-		internal static Action<Exception> mono_unhandled_exception = RuntimeNativeMethods.monodroid_debugger_unhandled_exception;
+		internal static readonly Action<Exception> mono_unhandled_exception = RuntimeNativeMethods.monodroid_debugger_unhandled_exception;
 
 #pragma warning disable CS0649 // Field is never assigned to.  This field is assigned from monodroid-glue.cc.
 		internal static volatile bool BridgeProcessing; // = false

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -103,21 +103,10 @@ namespace Android.Runtime {
 			GC.SuppressFinalize (obj);
 		}
 
-		static void Initialize ()
-		{
-			AndroidRuntimeInternal.InitializeUnhandledExceptionMethod ();
-		}
-
 		internal static void PropagateUncaughtException (IntPtr env, IntPtr javaThreadPtr, IntPtr javaExceptionPtr)
 		{
 			if (!JNIEnvInit.PropagateExceptions)
 				return;
-
-			try {
-				Initialize ();
-			} catch (Exception e) {
-				Android.Runtime.AndroidEnvironment.FailFast ($"Unable to initialize UncaughtExceptionHandler. Nested exception caught: {e}");
-			}
 
 			var javaException = JavaObject.GetObject<Java.Lang.Throwable> (env, javaExceptionPtr, JniHandleOwnership.DoNotTransfer)!;
 

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -73,10 +73,10 @@ namespace Android.Runtime {
 			ig.Emit (OpCodes.Leave, label);
 
 			bool  filter = Debugger.IsAttached || !JNIEnvInit.PropagateExceptions;
-			if (filter && AndroidRuntimeInternal.mono_unhandled_exception_method != null) {
+			if (filter && AndroidRuntimeInternal.mono_unhandled_exception.Method != null) {
 				ig.BeginExceptFilterBlock ();
 
-				ig.Emit (OpCodes.Call, AndroidRuntimeInternal.mono_unhandled_exception_method);
+				ig.Emit (OpCodes.Call, AndroidRuntimeInternal.mono_unhandled_exception.Method);
 				ig.Emit (OpCodes.Ldc_I4_1);
 				ig.BeginCatchBlock (null!);
 			} else {

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -73,7 +73,7 @@ namespace Android.Runtime {
 			ig.Emit (OpCodes.Leave, label);
 
 			bool  filter = Debugger.IsAttached || !JNIEnvInit.PropagateExceptions;
-			if (filter && AndroidRuntimeInternal.mono_unhandled_exception.Method != null) {
+			if (filter) {
 				ig.BeginExceptFilterBlock ();
 
 				ig.Emit (OpCodes.Call, AndroidRuntimeInternal.mono_unhandled_exception.Method);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.apkdesc
@@ -8,61 +8,61 @@
       "Size": 1028
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 61348
+      "Size": 61588
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 90896
+      "Size": 90724
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5577
+      "Size": 5147
     },
     "assemblies/rc.bin": {
       "Size": 1512
     },
     "assemblies/System.Console.dll": {
-      "Size": 6548
+      "Size": 6547
     },
     "assemblies/System.Linq.dll": {
-      "Size": 7171
+      "Size": 7163
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 553674
+      "Size": 554659
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2630
+      "Size": 2551
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 4033
+      "Size": 4028
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 2935
+      "Size": 2937
     },
     "classes.dex": {
-      "Size": 377956
+      "Size": 377856
     },
     "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 86944
+      "Size": 87080
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 334496
+      "Size": 339864
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3182072
+      "Size": 3184512
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723560
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 94208
+      "Size": 94504
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
       "Size": 155568
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 11680
+      "Size": 11648
     },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1213
+      "Size": 1223
     },
     "META-INF/BNDLTOOL.SF": {
       "Size": 3037

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -5,136 +5,136 @@
       "Size": 3572
     },
     "assemblies/_Microsoft.Android.Resource.Designer.dll": {
-      "Size": 2105
+      "Size": 2104
     },
     "assemblies/FormsViewGroup.dll": {
       "Size": 7113
     },
     "assemblies/Java.Interop.dll": {
-      "Size": 69478
+      "Size": 69705
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 447443
+      "Size": 447230
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5577
+      "Size": 5147
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3863
+      "Size": 3862
     },
     "assemblies/netstandard.dll": {
-      "Size": 5581
+      "Size": 5578
     },
     "assemblies/rc.bin": {
       "Size": 1512
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11516
+      "Size": 11514
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15409
+      "Size": 15408
     },
     "assemblies/System.Collections.NonGeneric.dll": {
-      "Size": 7454
+      "Size": 7452
     },
     "assemblies/System.ComponentModel.dll": {
       "Size": 1939
     },
     "assemblies/System.ComponentModel.Primitives.dll": {
-      "Size": 2553
+      "Size": 2549
     },
     "assemblies/System.ComponentModel.TypeConverter.dll": {
-      "Size": 6037
+      "Size": 6033
     },
     "assemblies/System.Console.dll": {
-      "Size": 6579
+      "Size": 6578
     },
     "assemblies/System.Core.dll": {
-      "Size": 1993
+      "Size": 1991
     },
     "assemblies/System.Diagnostics.DiagnosticSource.dll": {
-      "Size": 9071
+      "Size": 9068
     },
     "assemblies/System.Diagnostics.TraceSource.dll": {
-      "Size": 6555
+      "Size": 6552
     },
     "assemblies/System.dll": {
       "Size": 2345
     },
     "assemblies/System.Drawing.dll": {
-      "Size": 1940
+      "Size": 1939
     },
     "assemblies/System.Drawing.Primitives.dll": {
       "Size": 11975
     },
     "assemblies/System.IO.Compression.Brotli.dll": {
-      "Size": 11194
+      "Size": 11196
     },
     "assemblies/System.IO.Compression.dll": {
-      "Size": 15863
+      "Size": 15880
     },
     "assemblies/System.IO.IsolatedStorage.dll": {
       "Size": 9875
     },
     "assemblies/System.Linq.dll": {
-      "Size": 19604
+      "Size": 19599
     },
     "assemblies/System.Linq.Expressions.dll": {
-      "Size": 165118
+      "Size": 165117
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 67636
+      "Size": 67631
     },
     "assemblies/System.Net.Primitives.dll": {
-      "Size": 22437
+      "Size": 22432
     },
     "assemblies/System.Net.Requests.dll": {
-      "Size": 3604
+      "Size": 3602
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8119
+      "Size": 8116
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 848850
+      "Size": 849646
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
-      "Size": 193994
+      "Size": 193991
     },
     "assemblies/System.Private.Uri.dll": {
-      "Size": 42863
+      "Size": 42860
     },
     "assemblies/System.Private.Xml.dll": {
-      "Size": 216250
+      "Size": 216226
     },
     "assemblies/System.Private.Xml.Linq.dll": {
-      "Size": 16646
+      "Size": 16639
     },
     "assemblies/System.Runtime.dll": {
-      "Size": 2755
+      "Size": 2708
     },
     "assemblies/System.Runtime.InteropServices.dll": {
-      "Size": 4033
+      "Size": 4028
     },
     "assemblies/System.Runtime.Serialization.dll": {
-      "Size": 1866
+      "Size": 1865
     },
     "assemblies/System.Runtime.Serialization.Formatters.dll": {
-      "Size": 2485
+      "Size": 2484
     },
     "assemblies/System.Runtime.Serialization.Primitives.dll": {
-      "Size": 3760
+      "Size": 3758
     },
     "assemblies/System.Security.Cryptography.dll": {
-      "Size": 8109
+      "Size": 8111
     },
     "assemblies/System.Text.RegularExpressions.dll": {
-      "Size": 159114
+      "Size": 159112
     },
     "assemblies/System.Xml.dll": {
-      "Size": 1757
+      "Size": 1758
     },
     "assemblies/System.Xml.Linq.dll": {
-      "Size": 1777
+      "Size": 1774
     },
     "assemblies/UnnamedProject.dll": {
       "Size": 4990
@@ -206,28 +206,28 @@
       "Size": 42285
     },
     "classes.dex": {
-      "Size": 3514468
+      "Size": 3502580
     },
     "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
-      "Size": 86944
+      "Size": 87080
     },
     "lib/arm64-v8a/libmonodroid.so": {
-      "Size": 334496
+      "Size": 339864
     },
     "lib/arm64-v8a/libmonosgen-2.0.so": {
-      "Size": 3182072
+      "Size": 3184512
     },
     "lib/arm64-v8a/libSystem.IO.Compression.Native.so": {
       "Size": 723560
     },
     "lib/arm64-v8a/libSystem.Native.so": {
-      "Size": 94208
+      "Size": 94504
     },
     "lib/arm64-v8a/libSystem.Security.Cryptography.Native.Android.so": {
       "Size": 155568
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 102920
+      "Size": 102888
     },
     "META-INF/android.support.design_material.version": {
       "Size": 12
@@ -338,7 +338,7 @@
       "Size": 6
     },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1213
+      "Size": 1221
     },
     "META-INF/BNDLTOOL.SF": {
       "Size": 77024
@@ -1916,5 +1916,5 @@
       "Size": 325240
     }
   },
-  "PackageSize": 7949326
+  "PackageSize": 7941134
 }


### PR DESCRIPTION
We can simplify `JNIEnv.PropagateUncaughtException` by removing the
fallback case that would attempt to look for
`System.Diagnostics.Debugger.Mono_UnhandledException`.  In .NET the
`MonodroidRuntime::monodroid_debugger_unhandled_exception` function will
always be defined, and `Mono_UnhandledException` appears to no longer
exist in .NET.  This simplification should also appease our latest set
of API scan results that were complaining about missing documentation
for `Mono_UnhandledException`.