### PR TITLE
[build] Simplify Visual Studio detection

### DIFF
--- a/tools/vswhere/MSBuildLocator.cs
+++ b/tools/vswhere/MSBuildLocator.cs
@@ -25,10 +25,9 @@ namespace Xamarin.Android.Tools.VSWhere
 				var vswhere = Path.Combine (programFiles, "Microsoft Visual Studio", "Installer", "vswhere.exe");
 				if (!File.Exists (vswhere))
 					throw new FileNotFoundException ("Cannot find vswhere.exe!", vswhere);
-				instance.VisualStudioRootPath = Exec (vswhere, "-latest -products * -requires Microsoft.Component.MSBuild -property installationPath");
-				if (!Directory.Exists (instance.VisualStudioRootPath)) {
-					// try -prerelease
-					instance.VisualStudioRootPath = Exec (vswhere, "-prerelease -latest -products * -requires Microsoft.Component.MSBuild -property installationPath");
+				instance.VisualStudioRootPath = Exec (vswhere, "-prerelease -latest -property installationPath");
+				if (string.IsNullOrEmpty (instance.VisualStudioRootPath)) {
+					throw new DirectoryNotFoundException ($"vswhere.exe was unable to locate any Visual Studio instances!");
 				}
 				if (!Directory.Exists (instance.VisualStudioRootPath)) {
 					throw new DirectoryNotFoundException ($"vswhere.exe result returned a directory that did not exist: {instance.VisualStudioRootPath}");


### PR DESCRIPTION
CI recently started failing with:

    vswhere.exe result returned a directory that did not exist:
    System.IO.DirectoryNotFoundException: vswhere.exe result returned a directory that did not exist:
       at Xamarin.Android.Tools.VSWhere.MSBuildLocator.QueryLatest() in C:\a\_work\1\s\tools\vswhere\MSBuildLocator.cs:line 34

It is probably safe to assume that if vswhere can locate a Visual Studio installation it will contain the core components that we depend on.  We can simplify our vswhere invocation by always looking for and returning the latest release or pre-release version of Visual Studio.