### PR TITLE
[Microsoft.Android.Templates] New files should open editor

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
@@ -21,5 +21,18 @@
       "replaces": "AndroidApp1",
       "type": "parameter"
     }
-  }
+  },
+  "postActions": [
+    {
+      "id": "openInEditor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Activity1.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
@@ -30,7 +30,7 @@
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
-        "files": "1"
+        "files": "0"
       },
       "continueOnError": true
     }

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
@@ -23,7 +23,7 @@
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
-        "files": "1"
+        "files": "0"
       },
       "continueOnError": true
     }

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
@@ -14,5 +14,18 @@
   "primaryOutputs": [
     { "path": "Layout1.xml" }
   ],
-  "defaultName": "Layout1"
+  "defaultName": "Layout1",
+  "postActions": [
+    {
+      "id": "openInEditor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Layout1.xml in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
 }


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1918037

Context: https://github.com/dotnet/templating/wiki/Reference-for-template.json
Context: https://github.com/dotnet/templating/wiki/Post-Action-Registry#open-a-file-in-the-editor

Within Visual Studio, if you:

 1. Create a new .NET MAUI or .NET Android app, then
 2. Go to the Solution Explorer, then
 3. Right-click a folder, then click Add > New Item > Android, then
 4. Double-click the **Android Activity** template.

The expected result is that a new Android Activity based on the Android Activity template will be added to your solution *and opened in the editor*.

Instead, a new Android Activity is added, but it is *not* opened.

Update the `.template.config/template.json` files to contain a `postActions` section with a `openInEditor` id.  This *should* cause Visual Studio to open the new files within the editor.