### PR TITLE
[Xamarin.Android.Build.Tasks] remove `%(TrimMode)=link` metadata

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -29,11 +29,6 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition="'$(VSAndroidDesigner)' != ''"
           Value="$(VSAndroidDesigner)"
           Trim="true" />
-      <!-- TODO: remove setting the trim mode here, once the support packages are updated to NET6 and compatability packages not needed -->
-      <ResolvedFileToPublish
-          Condition=" '$(AndroidLinkMode)' == 'SdkOnly' and ( $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.AndroidX.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.Google.')) or $([System.String]::Copy(%(Filename)).StartsWith ('Xamarin.GooglePlayServices.')) ) ">
-        <TrimMode>link</TrimMode>
-      </ResolvedFileToPublish>
 
       <!--
         Used for the <ILLink CustomData="@(_TrimmerCustomData)" /> value:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Build.Tests
 
 			if (forms) {
 				proj.PackageReferences.Clear ();
-				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_7_0_1142);
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_5_0_0_2515);
 			}
 
 			byte [] apkDescData;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.apkdesc
@@ -2,37 +2,37 @@
   "Comment": null,
   "Entries": {
     "AndroidManifest.xml": {
-      "Size": 3572
+      "Size": 3904
     },
     "assemblies/_Microsoft.Android.Resource.Designer.dll": {
-      "Size": 2104
+      "Size": 2281
     },
     "assemblies/FormsViewGroup.dll": {
-      "Size": 7113
+      "Size": 8099
     },
     "assemblies/Java.Interop.dll": {
       "Size": 69705
     },
     "assemblies/Mono.Android.dll": {
-      "Size": 447230
+      "Size": 456294
     },
     "assemblies/Mono.Android.Runtime.dll": {
-      "Size": 5147
+      "Size": 5148
     },
     "assemblies/mscorlib.dll": {
-      "Size": 3862
+      "Size": 4052
     },
     "assemblies/netstandard.dll": {
-      "Size": 5578
+      "Size": 5643
     },
     "assemblies/rc.bin": {
       "Size": 1512
     },
     "assemblies/System.Collections.Concurrent.dll": {
-      "Size": 11514
+      "Size": 11530
     },
     "assemblies/System.Collections.dll": {
-      "Size": 15408
+      "Size": 15430
     },
     "assemblies/System.Collections.NonGeneric.dll": {
       "Size": 7452
@@ -50,7 +50,7 @@
       "Size": 6578
     },
     "assemblies/System.Core.dll": {
-      "Size": 1991
+      "Size": 1974
     },
     "assemblies/System.Diagnostics.DiagnosticSource.dll": {
       "Size": 9068
@@ -59,7 +59,7 @@
       "Size": 6552
     },
     "assemblies/System.dll": {
-      "Size": 2345
+      "Size": 2328
     },
     "assemblies/System.Drawing.dll": {
       "Size": 1939
@@ -83,7 +83,7 @@
       "Size": 165117
     },
     "assemblies/System.Net.Http.dll": {
-      "Size": 67631
+      "Size": 67653
     },
     "assemblies/System.Net.Primitives.dll": {
       "Size": 22432
@@ -92,10 +92,10 @@
       "Size": 3602
     },
     "assemblies/System.ObjectModel.dll": {
-      "Size": 8116
+      "Size": 8699
     },
     "assemblies/System.Private.CoreLib.dll": {
-      "Size": 849646
+      "Size": 850036
     },
     "assemblies/System.Private.DataContractSerialization.dll": {
       "Size": 193991
@@ -137,76 +137,85 @@
       "Size": 1774
     },
     "assemblies/UnnamedProject.dll": {
-      "Size": 4990
+      "Size": 5015
     },
     "assemblies/Xamarin.AndroidX.Activity.dll": {
-      "Size": 5944
+      "Size": 13842
     },
     "assemblies/Xamarin.AndroidX.AppCompat.AppCompatResources.dll": {
-      "Size": 6036
+      "Size": 6227
     },
     "assemblies/Xamarin.AndroidX.AppCompat.dll": {
-      "Size": 119847
+      "Size": 134494
     },
     "assemblies/Xamarin.AndroidX.CardView.dll": {
-      "Size": 6802
+      "Size": 6977
     },
     "assemblies/Xamarin.AndroidX.CoordinatorLayout.dll": {
-      "Size": 17260
+      "Size": 17886
     },
     "assemblies/Xamarin.AndroidX.Core.dll": {
-      "Size": 100665
+      "Size": 120018
+    },
+    "assemblies/Xamarin.AndroidX.CursorAdapter.dll": {
+      "Size": 9002
     },
     "assemblies/Xamarin.AndroidX.DrawerLayout.dll": {
-      "Size": 14631
+      "Size": 15330
     },
     "assemblies/Xamarin.AndroidX.Fragment.dll": {
-      "Size": 41736
+      "Size": 45683
     },
     "assemblies/Xamarin.AndroidX.Legacy.Support.Core.UI.dll": {
-      "Size": 6083
+      "Size": 6242
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.Common.dll": {
-      "Size": 6471
+      "Size": 6574
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.LiveData.Core.dll": {
-      "Size": 6618
+      "Size": 6749
     },
     "assemblies/Xamarin.AndroidX.Lifecycle.ViewModel.dll": {
-      "Size": 3071
+      "Size": 6289
     },
     "assemblies/Xamarin.AndroidX.Loader.dll": {
-      "Size": 12926
+      "Size": 13087
+    },
+    "assemblies/Xamarin.AndroidX.MultiDex.dll": {
+      "Size": 8354
     },
     "assemblies/Xamarin.AndroidX.RecyclerView.dll": {
-      "Size": 89997
+      "Size": 93990
     },
     "assemblies/Xamarin.AndroidX.SavedState.dll": {
-      "Size": 4909
+      "Size": 4969
     },
     "assemblies/Xamarin.AndroidX.SwipeRefreshLayout.dll": {
-      "Size": 10575
+      "Size": 13974
     },
     "assemblies/Xamarin.AndroidX.ViewPager.dll": {
-      "Size": 18594
+      "Size": 19073
     },
     "assemblies/Xamarin.Forms.Core.dll": {
-      "Size": 528450
+      "Size": 561410
     },
     "assemblies/Xamarin.Forms.Platform.Android.dll": {
-      "Size": 337925
+      "Size": 372848
     },
     "assemblies/Xamarin.Forms.Platform.dll": {
-      "Size": 11083
+      "Size": 17182
     },
     "assemblies/Xamarin.Forms.Xaml.dll": {
-      "Size": 60774
+      "Size": 63517
     },
     "assemblies/Xamarin.Google.Android.Material.dll": {
-      "Size": 42285
+      "Size": 66417
+    },
+    "assemblies/Xamarin.Google.Guava.ListenableFuture.dll": {
+      "Size": 10640
     },
     "classes.dex": {
-      "Size": 3502580
+      "Size": 5908848
     },
     "lib/arm64-v8a/libmono-component-marshal-ilgen.so": {
       "Size": 87080
@@ -227,12 +236,12 @@
       "Size": 155568
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 102888
-    },
-    "META-INF/android.support.design_material.version": {
-      "Size": 12
+      "Size": 113968
     },
     "META-INF/androidx.activity_activity.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.annotation_annotation-experimental.version": {
       "Size": 6
     },
     "META-INF/androidx.appcompat_appcompat-resources.version": {
@@ -271,6 +280,9 @@
     "META-INF/androidx.drawerlayout_drawerlayout.version": {
       "Size": 6
     },
+    "META-INF/androidx.dynamicanimation_dynamicanimation.version": {
+      "Size": 6
+    },
     "META-INF/androidx.fragment_fragment.version": {
       "Size": 6
     },
@@ -295,6 +307,9 @@
     "META-INF/androidx.lifecycle_lifecycle-runtime.version": {
       "Size": 6
     },
+    "META-INF/androidx.lifecycle_lifecycle-viewmodel-savedstate.version": {
+      "Size": 6
+    },
     "META-INF/androidx.lifecycle_lifecycle-viewmodel.version": {
       "Size": 6
     },
@@ -305,6 +320,18 @@
       "Size": 6
     },
     "META-INF/androidx.media_media.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.navigation_navigation-common.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.navigation_navigation-runtime.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.navigation_navigation-ui.version": {
+      "Size": 6
+    },
+    "META-INF/androidx.preference_preference.version": {
       "Size": 6
     },
     "META-INF/androidx.print_print.version": {
@@ -322,6 +349,9 @@
     "META-INF/androidx.swiperefreshlayout_swiperefreshlayout.version": {
       "Size": 6
     },
+    "META-INF/androidx.tracing_tracing.version": {
+      "Size": 6
+    },
     "META-INF/androidx.transition_transition.version": {
       "Size": 6
     },
@@ -337,25 +367,43 @@
     "META-INF/androidx.viewpager_viewpager.version": {
       "Size": 6
     },
+    "META-INF/androidx.viewpager2_viewpager2.version": {
+      "Size": 6
+    },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1221
+      "Size": 1223
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 77024
+      "Size": 89914
     },
     "META-INF/com.google.android.material_material.version": {
-      "Size": 10
+      "Size": 6
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 76897
+      "Size": 89787
+    },
+    "META-INF/maven/com.google.guava/listenablefuture/pom.properties": {
+      "Size": 96
+    },
+    "META-INF/maven/com.google.guava/listenablefuture/pom.xml": {
+      "Size": 2226
     },
     "META-INF/proguard/androidx-annotations.pro": {
-      "Size": 339
+      "Size": 433
     },
     "res/anim-v21/design_bottom_sheet_slide_in.xml": {
       "Size": 616
     },
     "res/anim-v21/design_bottom_sheet_slide_out.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/fragment_fast_out_extra_slow_in.xml": {
+      "Size": 364
+    },
+    "res/anim-v21/mtrl_bottom_sheet_slide_in.xml": {
+      "Size": 616
+    },
+    "res/anim-v21/mtrl_bottom_sheet_slide_out.xml": {
       "Size": 616
     },
     "res/anim/abc_fade_in.xml": {
@@ -448,6 +496,21 @@
     "res/anim/exittoright.xml": {
       "Size": 468
     },
+    "res/anim/mtrl_card_lowers_interpolator.xml": {
+      "Size": 400
+    },
+    "res/anim/nav_default_enter_anim.xml": {
+      "Size": 460
+    },
+    "res/anim/nav_default_exit_anim.xml": {
+      "Size": 460
+    },
+    "res/anim/nav_default_pop_enter_anim.xml": {
+      "Size": 460
+    },
+    "res/anim/nav_default_pop_exit_anim.xml": {
+      "Size": 460
+    },
     "res/animator-v21/design_appbar_state_list_animator.xml": {
       "Size": 1216
     },
@@ -457,14 +520,62 @@
     "res/animator/design_fab_show_motion_spec.xml": {
       "Size": 796
     },
+    "res/animator/fragment_close_enter.xml": {
+      "Size": 1128
+    },
+    "res/animator/fragment_close_exit.xml": {
+      "Size": 1128
+    },
+    "res/animator/fragment_fade_enter.xml": {
+      "Size": 452
+    },
+    "res/animator/fragment_fade_exit.xml": {
+      "Size": 452
+    },
+    "res/animator/fragment_open_enter.xml": {
+      "Size": 1128
+    },
+    "res/animator/fragment_open_exit.xml": {
+      "Size": 1128
+    },
+    "res/animator/linear_indeterminate_line1_head_interpolator.xml": {
+      "Size": 400
+    },
+    "res/animator/linear_indeterminate_line1_tail_interpolator.xml": {
+      "Size": 400
+    },
+    "res/animator/linear_indeterminate_line2_head_interpolator.xml": {
+      "Size": 400
+    },
+    "res/animator/linear_indeterminate_line2_tail_interpolator.xml": {
+      "Size": 400
+    },
     "res/animator/mtrl_btn_state_list_anim.xml": {
       "Size": 2664
     },
     "res/animator/mtrl_btn_unelevated_state_list_anim.xml": {
       "Size": 120
     },
+    "res/animator/mtrl_card_state_list_anim.xml": {
+      "Size": 1208
+    },
     "res/animator/mtrl_chip_state_list_anim.xml": {
       "Size": 1072
+    },
+    "res/animator/mtrl_extended_fab_change_size_collapse_motion_spec.xml": {
+      "Size": 1116
+    },
+    "res/animator/mtrl_extended_fab_change_size_expand_motion_spec.xml": {
+      "Size": 1116
+    },
+    "res/animator/mtrl_extended_fab_hide_motion_spec.xml": {
+      "Size": 608
+    },
+    "res/animator/mtrl_extended_fab_show_motion_spec.xml": {
+      "Size": 820
+    },
+    "res/animator/mtrl_extended_fab_state_list_animator.xml": {
+      "Size": 2724
     },
     "res/animator/mtrl_fab_hide_motion_spec.xml": {
       "Size": 796
@@ -477,6 +588,27 @@
     },
     "res/animator/mtrl_fab_transformation_sheet_expand_spec.xml": {
       "Size": 1888
+    },
+    "res/animator/nav_default_enter_anim.xml": {
+      "Size": 452
+    },
+    "res/animator/nav_default_exit_anim.xml": {
+      "Size": 452
+    },
+    "res/animator/nav_default_pop_enter_anim.xml": {
+      "Size": 452
+    },
+    "res/animator/nav_default_pop_exit_anim.xml": {
+      "Size": 452
+    },
+    "res/color-night-v8/material_timepicker_button_stroke.xml": {
+      "Size": 376
+    },
+    "res/color-night-v8/material_timepicker_clockface.xml": {
+      "Size": 376
+    },
+    "res/color-night-v8/material_timepicker_modebutton_tint.xml": {
+      "Size": 340
     },
     "res/color-v21/abc_btn_colored_borderless_text_material.xml": {
       "Size": 464
@@ -507,9 +639,6 @@
     },
     "res/color-v23/abc_tint_switch_track.xml": {
       "Size": 664
-    },
-    "res/color-v23/design_tint_password_toggle.xml": {
-      "Size": 376
     },
     "res/color/abc_background_cache_hint_selector_material_dark.xml": {
       "Size": 468
@@ -565,56 +694,203 @@
     "res/color/abc_tint_switch_track.xml": {
       "Size": 768
     },
+    "res/color/checkbox_themeable_attribute_color.xml": {
+      "Size": 464
+    },
+    "res/color/design_box_stroke_color.xml": {
+      "Size": 712
+    },
     "res/color/design_error.xml": {
       "Size": 464
     },
-    "res/color/design_tint_password_toggle.xml": {
-      "Size": 480
+    "res/color/design_icon_tint.xml": {
+      "Size": 376
     },
-    "res/color/mtrl_bottom_nav_colored_item_tint.xml": {
-      "Size": 684
+    "res/color/material_cursor_color.xml": {
+      "Size": 340
     },
-    "res/color/mtrl_bottom_nav_item_tint.xml": {
-      "Size": 684
+    "res/color/material_on_background_disabled.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_background_emphasis_high_type.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_background_emphasis_medium.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_primary_disabled.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_primary_emphasis_high_type.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_primary_emphasis_medium.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_surface_disabled.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_surface_emphasis_high_type.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_surface_emphasis_medium.xml": {
+      "Size": 376
+    },
+    "res/color/material_on_surface_stroke.xml": {
+      "Size": 376
+    },
+    "res/color/material_slider_active_tick_marks_color.xml": {
+      "Size": 520
+    },
+    "res/color/material_slider_active_track_color.xml": {
+      "Size": 500
+    },
+    "res/color/material_slider_halo_color.xml": {
+      "Size": 500
+    },
+    "res/color/material_slider_inactive_tick_marks_color.xml": {
+      "Size": 520
+    },
+    "res/color/material_slider_inactive_track_color.xml": {
+      "Size": 520
+    },
+    "res/color/material_slider_thumb_color.xml": {
+      "Size": 500
+    },
+    "res/color/material_timepicker_button_background.xml": {
+      "Size": 500
+    },
+    "res/color/material_timepicker_button_stroke.xml": {
+      "Size": 376
+    },
+    "res/color/material_timepicker_clock_text_color.xml": {
+      "Size": 464
+    },
+    "res/color/material_timepicker_clockface.xml": {
+      "Size": 376
+    },
+    "res/color/material_timepicker_modebutton_tint.xml": {
+      "Size": 376
     },
     "res/color/mtrl_btn_bg_color_selector.xml": {
-      "Size": 464
+      "Size": 500
     },
     "res/color/mtrl_btn_ripple_color.xml": {
       "Size": 948
     },
     "res/color/mtrl_btn_stroke_color_selector.xml": {
-      "Size": 376
+      "Size": 520
+    },
+    "res/color/mtrl_btn_text_btn_bg_color_selector.xml": {
+      "Size": 520
     },
     "res/color/mtrl_btn_text_btn_ripple_color.xml": {
       "Size": 948
     },
     "res/color/mtrl_btn_text_color_selector.xml": {
-      "Size": 464
+      "Size": 500
+    },
+    "res/color/mtrl_calendar_item_stroke_color.xml": {
+      "Size": 808
+    },
+    "res/color/mtrl_calendar_selected_range.xml": {
+      "Size": 376
+    },
+    "res/color/mtrl_card_view_foreground.xml": {
+      "Size": 788
+    },
+    "res/color/mtrl_card_view_ripple.xml": {
+      "Size": 768
     },
     "res/color/mtrl_chip_background_color.xml": {
-      "Size": 608
+      "Size": 848
     },
     "res/color/mtrl_chip_close_icon_tint.xml": {
       "Size": 1092
     },
-    "res/color/mtrl_chip_ripple_color.xml": {
-      "Size": 948
+    "res/color/mtrl_chip_surface_color.xml": {
+      "Size": 340
     },
     "res/color/mtrl_chip_text_color.xml": {
+      "Size": 520
+    },
+    "res/color/mtrl_choice_chip_background_color.xml": {
+      "Size": 848
+    },
+    "res/color/mtrl_choice_chip_ripple_color.xml": {
+      "Size": 948
+    },
+    "res/color/mtrl_choice_chip_text_color.xml": {
+      "Size": 808
+    },
+    "res/color/mtrl_error.xml": {
       "Size": 464
+    },
+    "res/color/mtrl_fab_bg_color_selector.xml": {
+      "Size": 500
+    },
+    "res/color/mtrl_fab_icon_text_color_selector.xml": {
+      "Size": 500
     },
     "res/color/mtrl_fab_ripple_color.xml": {
       "Size": 948
+    },
+    "res/color/mtrl_filled_background_color.xml": {
+      "Size": 808
+    },
+    "res/color/mtrl_filled_icon_tint.xml": {
+      "Size": 644
+    },
+    "res/color/mtrl_filled_stroke_color.xml": {
+      "Size": 788
+    },
+    "res/color/mtrl_indicator_text_color.xml": {
+      "Size": 520
+    },
+    "res/color/mtrl_navigation_bar_colored_item_tint.xml": {
+      "Size": 520
+    },
+    "res/color/mtrl_navigation_bar_colored_ripple_color.xml": {
+      "Size": 948
+    },
+    "res/color/mtrl_navigation_bar_item_tint.xml": {
+      "Size": 520
+    },
+    "res/color/mtrl_navigation_bar_ripple_color.xml": {
+      "Size": 1672
+    },
+    "res/color/mtrl_navigation_item_background_color.xml": {
+      "Size": 644
+    },
+    "res/color/mtrl_navigation_item_icon_tint.xml": {
+      "Size": 624
+    },
+    "res/color/mtrl_navigation_item_text_color.xml": {
+      "Size": 624
+    },
+    "res/color/mtrl_on_primary_text_btn_text_color_selector.xml": {
+      "Size": 500
+    },
+    "res/color/mtrl_on_surface_ripple_color.xml": {
+      "Size": 808
+    },
+    "res/color/mtrl_outlined_icon_tint.xml": {
+      "Size": 644
+    },
+    "res/color/mtrl_outlined_stroke_color.xml": {
+      "Size": 788
+    },
+    "res/color/mtrl_popupmenu_overlay_color.xml": {
+      "Size": 376
     },
     "res/color/mtrl_tabs_colored_ripple_color.xml": {
       "Size": 948
     },
     "res/color/mtrl_tabs_icon_color_selector_colored.xml": {
-      "Size": 464
+      "Size": 500
     },
     "res/color/mtrl_tabs_icon_color_selector.xml": {
-      "Size": 464
+      "Size": 500
     },
     "res/color/mtrl_tabs_legacy_text_color_selector.xml": {
       "Size": 464
@@ -623,6 +899,9 @@
       "Size": 1672
     },
     "res/color/mtrl_text_btn_text_color_selector.xml": {
+      "Size": 888
+    },
+    "res/color/radiobutton_themeable_attribute_color.xml": {
       "Size": 464
     },
     "res/color/switch_thumb_material_dark.xml": {
@@ -631,11 +910,11 @@
     "res/color/switch_thumb_material_light.xml": {
       "Size": 464
     },
-    "res/drawable-anydpi-v21/design_ic_visibility_off.xml": {
-      "Size": 1144
+    "res/color/test_mtrl_calendar_day_selected.xml": {
+      "Size": 340
     },
-    "res/drawable-anydpi-v21/design_ic_visibility.xml": {
-      "Size": 540
+    "res/color/test_mtrl_calendar_day.xml": {
+      "Size": 340
     },
     "res/drawable-hdpi-v4/abc_ab_share_pack_mtrl_alpha.9.png": {
       "Size": 272
@@ -663,39 +942,6 @@
     },
     "res/drawable-hdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
       "Size": 171
-    },
-    "res/drawable-hdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 202
-    },
-    "res/drawable-hdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 404
-    },
-    "res/drawable-hdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 226
-    },
-    "res/drawable-hdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 215
-    },
-    "res/drawable-hdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 389
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 263
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 522
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 668
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 197
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 328
-    },
-    "res/drawable-hdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 431
     },
     "res/drawable-hdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
       "Size": 167
@@ -748,22 +994,13 @@
     "res/drawable-hdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
       "Size": 190
     },
-    "res/drawable-hdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+    "res/drawable-hdpi-v4/abc_text_select_handle_left_mtrl.png": {
       "Size": 278
     },
-    "res/drawable-hdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 278
-    },
-    "res/drawable-hdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 398
-    },
-    "res/drawable-hdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+    "res/drawable-hdpi-v4/abc_text_select_handle_middle_mtrl.png": {
       "Size": 396
     },
-    "res/drawable-hdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 263
-    },
-    "res/drawable-hdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+    "res/drawable-hdpi-v4/abc_text_select_handle_right_mtrl.png": {
       "Size": 262
     },
     "res/drawable-hdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
@@ -777,12 +1014,6 @@
     },
     "res/drawable-hdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
-    },
-    "res/drawable-hdpi-v4/design_ic_visibility_off.png": {
-      "Size": 507
-    },
-    "res/drawable-hdpi-v4/design_ic_visibility.png": {
-      "Size": 470
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 2178
@@ -802,47 +1033,17 @@
     "res/drawable-hdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 107
     },
-    "res/drawable-ldrtl-hdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 199
-    },
-    "res/drawable-ldrtl-hdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 400
-    },
     "res/drawable-ldrtl-hdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 345
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 127
-    },
-    "res/drawable-ldrtl-mdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 253
     },
     "res/drawable-ldrtl-mdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 318
     },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-ldrtl-xhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 494
-    },
     "res/drawable-ldrtl-xhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 417
     },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 260
-    },
-    "res/drawable-ldrtl-xxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 705
-    },
     "res/drawable-ldrtl-xxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 525
-    },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 325
-    },
-    "res/drawable-ldrtl-xxxhdpi-v17/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 905
     },
     "res/drawable-ldrtl-xxxhdpi-v17/abc_spinner_mtrl_am_alpha.9.png": {
       "Size": 437
@@ -873,39 +1074,6 @@
     },
     "res/drawable-mdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
       "Size": 173
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 133
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 251
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 152
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 139
-    },
-    "res/drawable-mdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 270
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 193
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 364
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 467
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 146
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 253
-    },
-    "res/drawable-mdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 310
     },
     "res/drawable-mdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
       "Size": 167
@@ -958,22 +1126,13 @@
     "res/drawable-mdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
       "Size": 186
     },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl.png": {
       "Size": 203
     },
-    "res/drawable-mdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 203
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 311
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+    "res/drawable-mdpi-v4/abc_text_select_handle_middle_mtrl.png": {
       "Size": 310
     },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 187
-    },
-    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+    "res/drawable-mdpi-v4/abc_text_select_handle_right_mtrl.png": {
       "Size": 186
     },
     "res/drawable-mdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
@@ -987,12 +1146,6 @@
     },
     "res/drawable-mdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 178
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility_off.png": {
-      "Size": 351
-    },
-    "res/drawable-mdpi-v4/design_ic_visibility.png": {
-      "Size": 309
     },
     "res/drawable-mdpi-v4/icon.png": {
       "Size": 1490
@@ -1012,24 +1165,6 @@
     "res/drawable-mdpi-v4/notify_panel_notification_icon_bg.png": {
       "Size": 98
     },
-    "res/drawable-v21/$avd_hide_password__0.xml": {
-      "Size": 1176
-    },
-    "res/drawable-v21/$avd_hide_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_hide_password__2.xml": {
-      "Size": 556
-    },
-    "res/drawable-v21/$avd_show_password__0.xml": {
-      "Size": 1136
-    },
-    "res/drawable-v21/$avd_show_password__1.xml": {
-      "Size": 592
-    },
-    "res/drawable-v21/$avd_show_password__2.xml": {
-      "Size": 556
-    },
     "res/drawable-v21/abc_action_bar_item_background_material.xml": {
       "Size": 264
     },
@@ -1045,23 +1180,26 @@
     "res/drawable-v21/abc_list_divider_material.xml": {
       "Size": 516
     },
-    "res/drawable-v21/avd_hide_password.xml": {
-      "Size": 660
+    "res/drawable-v21/ic_arrow_down_24dp.xml": {
+      "Size": 644
     },
-    "res/drawable-v21/avd_show_password.xml": {
-      "Size": 660
+    "res/drawable-v21/material_cursor_drawable.xml": {
+      "Size": 588
     },
-    "res/drawable-v21/design_bottom_navigation_item_background.xml": {
+    "res/drawable-v21/mtrl_navigation_bar_item_background.xml": {
       "Size": 264
-    },
-    "res/drawable-v21/design_password_eye.xml": {
-      "Size": 816
     },
     "res/drawable-v21/notification_action_background.xml": {
       "Size": 1180
     },
+    "res/drawable-v21/preference_list_divider_material.xml": {
+      "Size": 516
+    },
     "res/drawable-v23/abc_control_background_material.xml": {
       "Size": 304
+    },
+    "res/drawable-v23/mtrl_popupmenu_background_dark.xml": {
+      "Size": 1228
     },
     "res/drawable-watch-v20/abc_dialog_material_background.xml": {
       "Size": 372
@@ -1092,39 +1230,6 @@
     },
     "res/drawable-xhdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
       "Size": 228
-    },
-    "res/drawable-xhdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 178
-    },
-    "res/drawable-xhdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 492
-    },
-    "res/drawable-xhdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 243
-    },
-    "res/drawable-xhdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 183
-    },
-    "res/drawable-xhdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 480
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 333
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 652
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 887
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 235
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 421
-    },
-    "res/drawable-xhdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 548
     },
     "res/drawable-xhdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
       "Size": 167
@@ -1177,22 +1282,13 @@
     "res/drawable-xhdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
       "Size": 194
     },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
-      "Size": 336
-    },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+    "res/drawable-xhdpi-v4/abc_text_select_handle_left_mtrl.png": {
       "Size": 335
     },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 583
-    },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+    "res/drawable-xhdpi-v4/abc_text_select_handle_middle_mtrl.png": {
       "Size": 585
     },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 319
-    },
-    "res/drawable-xhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+    "res/drawable-xhdpi-v4/abc_text_select_handle_right_mtrl.png": {
       "Size": 318
     },
     "res/drawable-xhdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
@@ -1206,12 +1302,6 @@
     },
     "res/drawable-xhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 182
-    },
-    "res/drawable-xhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 629
-    },
-    "res/drawable-xhdpi-v4/design_ic_visibility.png": {
-      "Size": 593
     },
     "res/drawable-xhdpi-v4/icon.png": {
       "Size": 3098
@@ -1257,39 +1347,6 @@
     },
     "res/drawable-xxhdpi-v4/abc_ic_commit_search_api_mtrl_alpha.png": {
       "Size": 224
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 263
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 710
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 348
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 262
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 700
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 459
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 983
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 1291
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 309
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 577
-    },
-    "res/drawable-xxhdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 789
     },
     "res/drawable-xxhdpi-v4/abc_list_divider_mtrl_alpha.9.png": {
       "Size": 171
@@ -1342,22 +1399,13 @@
     "res/drawable-xxhdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
       "Size": 204
     },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+    "res/drawable-xxhdpi-v4/abc_text_select_handle_left_mtrl.png": {
       "Size": 420
     },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
-      "Size": 420
-    },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_middle_mtrl_dark.png": {
-      "Size": 752
-    },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_middle_mtrl_light.png": {
+    "res/drawable-xxhdpi-v4/abc_text_select_handle_middle_mtrl.png": {
       "Size": 753
     },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 422
-    },
-    "res/drawable-xxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
+    "res/drawable-xxhdpi-v4/abc_text_select_handle_right_mtrl.png": {
       "Size": 422
     },
     "res/drawable-xxhdpi-v4/abc_textfield_activated_mtrl_alpha.9.png": {
@@ -1371,12 +1419,6 @@
     },
     "res/drawable-xxhdpi-v4/abc_textfield_search_default_mtrl_alpha.9.png": {
       "Size": 186
-    },
-    "res/drawable-xxhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 884
-    },
-    "res/drawable-xxhdpi-v4/design_ic_visibility.png": {
-      "Size": 868
     },
     "res/drawable-xxhdpi-v4/icon.png": {
       "Size": 4674
@@ -1399,39 +1441,6 @@
     "res/drawable-xxxhdpi-v4/abc_btn_switch_to_on_mtrl_00012.9.png": {
       "Size": 2816
     },
-    "res/drawable-xxxhdpi-v4/abc_ic_menu_copy_mtrl_am_alpha.png": {
-      "Size": 327
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_menu_cut_mtrl_alpha.png": {
-      "Size": 910
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_menu_paste_mtrl_am_alpha.png": {
-      "Size": 461
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_menu_selectall_mtrl_alpha.png": {
-      "Size": 305
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_menu_share_mtrl_alpha.png": {
-      "Size": 899
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_black_16dp.png": {
-      "Size": 599
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_black_36dp.png": {
-      "Size": 1269
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_black_48dp.png": {
-      "Size": 1680
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_half_black_16dp.png": {
-      "Size": 376
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_half_black_36dp.png": {
-      "Size": 760
-    },
-    "res/drawable-xxxhdpi-v4/abc_ic_star_half_black_48dp.png": {
-      "Size": 991
-    },
     "res/drawable-xxxhdpi-v4/abc_scrubber_control_to_pressed_mtrl_000.png": {
       "Size": 415
     },
@@ -1447,26 +1456,32 @@
     "res/drawable-xxxhdpi-v4/abc_tab_indicator_mtrl_alpha.9.png": {
       "Size": 202
     },
-    "res/drawable-xxxhdpi-v4/abc_text_select_handle_left_mtrl_dark.png": {
+    "res/drawable-xxxhdpi-v4/abc_text_select_handle_left_mtrl.png": {
       "Size": 513
     },
-    "res/drawable-xxxhdpi-v4/abc_text_select_handle_left_mtrl_light.png": {
+    "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl.png": {
       "Size": 513
-    },
-    "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_dark.png": {
-      "Size": 513
-    },
-    "res/drawable-xxxhdpi-v4/abc_text_select_handle_right_mtrl_light.png": {
-      "Size": 513
-    },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility_off.png": {
-      "Size": 1201
-    },
-    "res/drawable-xxxhdpi-v4/design_ic_visibility.png": {
-      "Size": 1155
     },
     "res/drawable-xxxhdpi-v4/icon.png": {
       "Size": 6832
+    },
+    "res/drawable/$avd_hide_password__0.xml": {
+      "Size": 1176
+    },
+    "res/drawable/$avd_hide_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable/$avd_hide_password__2.xml": {
+      "Size": 556
+    },
+    "res/drawable/$avd_show_password__0.xml": {
+      "Size": 1136
+    },
+    "res/drawable/$avd_show_password__1.xml": {
+      "Size": 592
+    },
+    "res/drawable/$avd_show_password__2.xml": {
+      "Size": 556
     },
     "res/drawable/abc_btn_borderless_material.xml": {
       "Size": 588
@@ -1504,8 +1519,23 @@
     "res/drawable/abc_ic_go_search_api_material.xml": {
       "Size": 640
     },
+    "res/drawable/abc_ic_menu_copy_mtrl_am_alpha.xml": {
+      "Size": 756
+    },
+    "res/drawable/abc_ic_menu_cut_mtrl_alpha.xml": {
+      "Size": 1096
+    },
     "res/drawable/abc_ic_menu_overflow_material.xml": {
       "Size": 792
+    },
+    "res/drawable/abc_ic_menu_paste_mtrl_am_alpha.xml": {
+      "Size": 796
+    },
+    "res/drawable/abc_ic_menu_selectall_mtrl_alpha.xml": {
+      "Size": 920
+    },
+    "res/drawable/abc_ic_menu_share_mtrl_alpha.xml": {
+      "Size": 980
     },
     "res/drawable/abc_ic_search_api_material.xml": {
       "Size": 812
@@ -1532,13 +1562,13 @@
       "Size": 1064
     },
     "res/drawable/abc_ratingbar_indicator_material.xml": {
-      "Size": 704
+      "Size": 124
     },
     "res/drawable/abc_ratingbar_material.xml": {
-      "Size": 704
+      "Size": 124
     },
     "res/drawable/abc_ratingbar_small_material.xml": {
-      "Size": 704
+      "Size": 124
     },
     "res/drawable/abc_seekbar_thumb_material.xml": {
       "Size": 1100
@@ -1551,6 +1581,12 @@
     },
     "res/drawable/abc_spinner_textfield_background_material.xml": {
       "Size": 1160
+    },
+    "res/drawable/abc_star_black_48dp.xml": {
+      "Size": 640
+    },
+    "res/drawable/abc_star_half_black_48dp.xml": {
+      "Size": 600
     },
     "res/drawable/abc_switch_thumb_material.xml": {
       "Size": 464
@@ -1566,6 +1602,12 @@
     },
     "res/drawable/abc_vector_test.xml": {
       "Size": 612
+    },
+    "res/drawable/avd_hide_password.xml": {
+      "Size": 660
+    },
+    "res/drawable/avd_show_password.xml": {
+      "Size": 660
     },
     "res/drawable/btn_checkbox_checked_mtrl.xml": {
       "Size": 2688
@@ -1594,8 +1636,26 @@
     "res/drawable/design_fab_background.xml": {
       "Size": 372
     },
+    "res/drawable/design_ic_visibility_off.xml": {
+      "Size": 1144
+    },
+    "res/drawable/design_ic_visibility.xml": {
+      "Size": 540
+    },
+    "res/drawable/design_password_eye.xml": {
+      "Size": 816
+    },
     "res/drawable/design_snackbar_background.xml": {
       "Size": 484
+    },
+    "res/drawable/ic_clock_black_24dp.xml": {
+      "Size": 752
+    },
+    "res/drawable/ic_keyboard_black_24dp.xml": {
+      "Size": 852
+    },
+    "res/drawable/ic_mtrl_checked_circle.xml": {
+      "Size": 672
     },
     "res/drawable/ic_mtrl_chip_checked_black.xml": {
       "Size": 600
@@ -1606,8 +1666,50 @@
     "res/drawable/ic_mtrl_chip_close_circle.xml": {
       "Size": 808
     },
-    "res/drawable/mtrl_snackbar_background.xml": {
-      "Size": 484
+    "res/drawable/material_ic_calendar_black_24dp.xml": {
+      "Size": 696
+    },
+    "res/drawable/material_ic_clear_black_24dp.xml": {
+      "Size": 752
+    },
+    "res/drawable/material_ic_edit_black_24dp.xml": {
+      "Size": 716
+    },
+    "res/drawable/material_ic_keyboard_arrow_left_black_24dp.xml": {
+      "Size": 712
+    },
+    "res/drawable/material_ic_keyboard_arrow_right_black_24dp.xml": {
+      "Size": 700
+    },
+    "res/drawable/material_ic_menu_arrow_down_black_24dp.xml": {
+      "Size": 648
+    },
+    "res/drawable/material_ic_menu_arrow_up_black_24dp.xml": {
+      "Size": 648
+    },
+    "res/drawable/mtrl_dialog_background.xml": {
+      "Size": 716
+    },
+    "res/drawable/mtrl_dropdown_arrow.xml": {
+      "Size": 464
+    },
+    "res/drawable/mtrl_ic_arrow_drop_down.xml": {
+      "Size": 564
+    },
+    "res/drawable/mtrl_ic_arrow_drop_up.xml": {
+      "Size": 564
+    },
+    "res/drawable/mtrl_ic_cancel.xml": {
+      "Size": 724
+    },
+    "res/drawable/mtrl_ic_error.xml": {
+      "Size": 644
+    },
+    "res/drawable/mtrl_popupmenu_background_dark.xml": {
+      "Size": 740
+    },
+    "res/drawable/mtrl_popupmenu_background.xml": {
+      "Size": 740
     },
     "res/drawable/mtrl_tabs_default_indicator.xml": {
       "Size": 628
@@ -1626,6 +1728,9 @@
     },
     "res/drawable/notification_tile_bg.xml": {
       "Size": 304
+    },
+    "res/drawable/test_custom_background.xml": {
+      "Size": 336
     },
     "res/drawable/tooltip_frame_dark.xml": {
       "Size": 484
@@ -1666,11 +1771,23 @@
     "res/interpolator/mtrl_linear.xml": {
       "Size": 132
     },
+    "res/layout-land/material_clock_period_toggle_land.xml": {
+      "Size": 1276
+    },
+    "res/layout-land/material_timepicker.xml": {
+      "Size": 1884
+    },
+    "res/layout-land/mtrl_picker_header_dialog.xml": {
+      "Size": 1440
+    },
+    "res/layout-ldrtl-v17/material_textinput_timepicker.xml": {
+      "Size": 1140
+    },
     "res/layout-sw600dp-v13/design_layout_snackbar.xml": {
       "Size": 528
     },
     "res/layout-sw600dp-v13/mtrl_layout_snackbar.xml": {
-      "Size": 528
+      "Size": 492
     },
     "res/layout-v21/notification_action_tombstone.xml": {
       "Size": 1228
@@ -1687,8 +1804,17 @@
     "res/layout-v22/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1584
     },
+    "res/layout-v22/material_timepicker_dialog.xml": {
+      "Size": 3184
+    },
+    "res/layout-v22/mtrl_alert_dialog_actions.xml": {
+      "Size": 1764
+    },
     "res/layout-v26/abc_screen_toolbar.xml": {
       "Size": 1560
+    },
+    "res/layout-v26/mtrl_calendar_month.xml": {
+      "Size": 744
     },
     "res/layout-watch-v20/abc_alert_dialog_button_bar_material.xml": {
       "Size": 1208
@@ -1742,7 +1868,7 @@
       "Size": 528
     },
     "res/layout/abc_list_menu_item_icon.xml": {
-      "Size": 684
+      "Size": 780
     },
     "res/layout/abc_list_menu_item_layout.xml": {
       "Size": 1396
@@ -1787,16 +1913,16 @@
       "Size": 1660
     },
     "res/layout/browser_actions_context_menu_row.xml": {
-      "Size": 1164
+      "Size": 1212
     },
     "res/layout/custom_dialog.xml": {
       "Size": 612
     },
     "res/layout/design_bottom_navigation_item.xml": {
-      "Size": 1492
+      "Size": 1528
     },
     "res/layout/design_bottom_sheet_dialog.xml": {
-      "Size": 1184
+      "Size": 1224
     },
     "res/layout/design_layout_snackbar_include.xml": {
       "Size": 1444
@@ -1823,7 +1949,7 @@
       "Size": 564
     },
     "res/layout/design_navigation_item.xml": {
-      "Size": 536
+      "Size": 576
     },
     "res/layout/design_navigation_menu_item.xml": {
       "Size": 856
@@ -1831,8 +1957,14 @@
     "res/layout/design_navigation_menu.xml": {
       "Size": 528
     },
-    "res/layout/design_text_input_password_icon.xml": {
-      "Size": 564
+    "res/layout/design_text_input_end_icon.xml": {
+      "Size": 616
+    },
+    "res/layout/design_text_input_start_icon.xml": {
+      "Size": 612
+    },
+    "res/layout/expand_button.xml": {
+      "Size": 1720
     },
     "res/layout/fallbacktabbardonotuse.xml": {
       "Size": 692
@@ -1841,16 +1973,139 @@
       "Size": 496
     },
     "res/layout/flyoutcontent.xml": {
-      "Size": 944
+      "Size": 776
+    },
+    "res/layout/image_frame.xml": {
+      "Size": 1088
     },
     "res/layout/main.xml": {
       "Size": 544
     },
+    "res/layout/material_chip_input_combo.xml": {
+      "Size": 372
+    },
+    "res/layout/material_clock_display_divider.xml": {
+      "Size": 752
+    },
+    "res/layout/material_clock_display.xml": {
+      "Size": 1172
+    },
+    "res/layout/material_clock_period_toggle.xml": {
+      "Size": 1504
+    },
+    "res/layout/material_clockface_textview.xml": {
+      "Size": 476
+    },
+    "res/layout/material_clockface_view.xml": {
+      "Size": 1012
+    },
+    "res/layout/material_radial_view_group.xml": {
+      "Size": 768
+    },
+    "res/layout/material_textinput_timepicker.xml": {
+      "Size": 1092
+    },
+    "res/layout/material_time_chip.xml": {
+      "Size": 380
+    },
+    "res/layout/material_time_input.xml": {
+      "Size": 1208
+    },
+    "res/layout/material_timepicker_dialog.xml": {
+      "Size": 3132
+    },
+    "res/layout/material_timepicker_textinput_display.xml": {
+      "Size": 684
+    },
+    "res/layout/material_timepicker.xml": {
+      "Size": 1136
+    },
+    "res/layout/mtrl_alert_dialog_actions.xml": {
+      "Size": 1620
+    },
+    "res/layout/mtrl_alert_dialog_title.xml": {
+      "Size": 956
+    },
+    "res/layout/mtrl_alert_dialog.xml": {
+      "Size": 2476
+    },
+    "res/layout/mtrl_alert_select_dialog_item.xml": {
+      "Size": 588
+    },
+    "res/layout/mtrl_alert_select_dialog_multichoice.xml": {
+      "Size": 940
+    },
+    "res/layout/mtrl_alert_select_dialog_singlechoice.xml": {
+      "Size": 940
+    },
+    "res/layout/mtrl_calendar_day_of_week.xml": {
+      "Size": 400
+    },
+    "res/layout/mtrl_calendar_day.xml": {
+      "Size": 352
+    },
+    "res/layout/mtrl_calendar_days_of_week.xml": {
+      "Size": 436
+    },
+    "res/layout/mtrl_calendar_horizontal.xml": {
+      "Size": 1176
+    },
+    "res/layout/mtrl_calendar_month_labeled.xml": {
+      "Size": 728
+    },
+    "res/layout/mtrl_calendar_month_navigation.xml": {
+      "Size": 1748
+    },
+    "res/layout/mtrl_calendar_month.xml": {
+      "Size": 688
+    },
+    "res/layout/mtrl_calendar_months.xml": {
+      "Size": 428
+    },
+    "res/layout/mtrl_calendar_vertical.xml": {
+      "Size": 740
+    },
+    "res/layout/mtrl_calendar_year.xml": {
+      "Size": 352
+    },
     "res/layout/mtrl_layout_snackbar_include.xml": {
-      "Size": 1404
+      "Size": 952
     },
     "res/layout/mtrl_layout_snackbar.xml": {
-      "Size": 528
+      "Size": 492
+    },
+    "res/layout/mtrl_navigation_rail_item.xml": {
+      "Size": 1464
+    },
+    "res/layout/mtrl_picker_actions.xml": {
+      "Size": 984
+    },
+    "res/layout/mtrl_picker_dialog.xml": {
+      "Size": 1140
+    },
+    "res/layout/mtrl_picker_fullscreen.xml": {
+      "Size": 848
+    },
+    "res/layout/mtrl_picker_header_dialog.xml": {
+      "Size": 1440
+    },
+    "res/layout/mtrl_picker_header_fullscreen.xml": {
+      "Size": 2728
+    },
+    "res/layout/mtrl_picker_header_selection_text.xml": {
+      "Size": 712
+    },
+    "res/layout/mtrl_picker_header_title_text.xml": {
+      "Size": 624
+    },
+    "res/layout/mtrl_picker_header_toggle.xml": {
+      "Size": 576
+    },
+    "res/layout/mtrl_picker_text_input_date_range.xml": {
+      "Size": 1460
+    },
+    "res/layout/mtrl_picker_text_input_date.xml": {
+      "Size": 984
     },
     "res/layout/notification_media_action.xml": {
       "Size": 564
@@ -1885,6 +2140,54 @@
     "res/layout/notification_template_part_time.xml": {
       "Size": 440
     },
+    "res/layout/preference_category_material.xml": {
+      "Size": 1768
+    },
+    "res/layout/preference_category.xml": {
+      "Size": 384
+    },
+    "res/layout/preference_dialog_edittext.xml": {
+      "Size": 1272
+    },
+    "res/layout/preference_dropdown_material.xml": {
+      "Size": 712
+    },
+    "res/layout/preference_dropdown.xml": {
+      "Size": 2544
+    },
+    "res/layout/preference_information_material.xml": {
+      "Size": 2056
+    },
+    "res/layout/preference_information.xml": {
+      "Size": 1732
+    },
+    "res/layout/preference_list_fragment.xml": {
+      "Size": 812
+    },
+    "res/layout/preference_material.xml": {
+      "Size": 2052
+    },
+    "res/layout/preference_recyclerview.xml": {
+      "Size": 544
+    },
+    "res/layout/preference_widget_checkbox.xml": {
+      "Size": 472
+    },
+    "res/layout/preference_widget_seekbar_material.xml": {
+      "Size": 3056
+    },
+    "res/layout/preference_widget_seekbar.xml": {
+      "Size": 2896
+    },
+    "res/layout/preference_widget_switch_compat.xml": {
+      "Size": 504
+    },
+    "res/layout/preference_widget_switch.xml": {
+      "Size": 472
+    },
+    "res/layout/preference.xml": {
+      "Size": 2352
+    },
     "res/layout/rootlayout.xml": {
       "Size": 1352
     },
@@ -1906,15 +2209,78 @@
     "res/layout/tabbar.xml": {
       "Size": 692
     },
+    "res/layout/test_action_chip.xml": {
+      "Size": 488
+    },
+    "res/layout/test_chip_zero_corner_radius.xml": {
+      "Size": 640
+    },
+    "res/layout/test_design_checkbox.xml": {
+      "Size": 836
+    },
+    "res/layout/test_design_radiobutton.xml": {
+      "Size": 840
+    },
+    "res/layout/test_navigation_bar_item_layout.xml": {
+      "Size": 1528
+    },
+    "res/layout/test_reflow_chipgroup.xml": {
+      "Size": 1060
+    },
+    "res/layout/test_toolbar_custom_background.xml": {
+      "Size": 400
+    },
+    "res/layout/test_toolbar_elevation.xml": {
+      "Size": 400
+    },
+    "res/layout/test_toolbar_surface.xml": {
+      "Size": 392
+    },
+    "res/layout/test_toolbar.xml": {
+      "Size": 360
+    },
+    "res/layout/text_view_with_line_height_from_appearance.xml": {
+      "Size": 408
+    },
+    "res/layout/text_view_with_line_height_from_layout.xml": {
+      "Size": 552
+    },
+    "res/layout/text_view_with_line_height_from_style.xml": {
+      "Size": 396
+    },
+    "res/layout/text_view_with_theme_line_height.xml": {
+      "Size": 408
+    },
+    "res/layout/text_view_without_line_height.xml": {
+      "Size": 364
+    },
     "res/layout/toolbar.xml": {
       "Size": 496
+    },
+    "res/xml/image_share_filepaths.xml": {
+      "Size": 308
     },
     "res/xml/splits0.xml": {
       "Size": 8404
     },
+    "res/xml/standalone_badge_gravity_bottom_end.xml": {
+      "Size": 312
+    },
+    "res/xml/standalone_badge_gravity_bottom_start.xml": {
+      "Size": 312
+    },
+    "res/xml/standalone_badge_gravity_top_start.xml": {
+      "Size": 312
+    },
+    "res/xml/standalone_badge_offset.xml": {
+      "Size": 360
+    },
+    "res/xml/standalone_badge.xml": {
+      "Size": 268
+    },
     "resources.arsc": {
-      "Size": 325240
+      "Size": 777972
     }
   },
-  "PackageSize": 7941134
+  "PackageSize": 9593384
 }


### PR DESCRIPTION
To keep app sizes down in the .NET 6 timeframe, we special-cased existing AndroidX and GPS packages so they were always trimmed.

Modern packages mark themselves trimmable with `$(IsTrimmable)` or the assembly-level attribute.

For nearly 2 years, we've applied the appropriate trimming setting in these packages:

* https://github.com/xamarin/AndroidX/pull/520
* https://github.com/xamarin/GooglePlayServicesComponents/pull/597

We should be able to remove this now in .NET 9.