### PR TITLE
AssetPack Support

### DIFF
--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -5,30 +5,30 @@ packs with the introduction of the `aab` package format. This format allows
 the developer to split the app up into multiple `packs`. Each `pack` can be
 downloaded to the device either at install time or on demand. This allows
 application developers to save space and install time by only installing
-the required parts of the app initially. Then installing other `packs`
+the required parts of the app initially, then installing other `packs`
 as required.
 
-There are two types of `pack`. The first is a `Feature` pack, this type
-of pack contains code and other resources. Code in these types of `pack`
-can be launched via the `StartActivity` API call. At this time due to
-various constraints .NET Android cannot support `Feature` packs.
+There are two types of `pack`: Feature packs and Asset packs.
+*Feature* pack contains *non-native* Java code and other resources.
+Code in these types of `pack` can be launched via the `Context.StartActivity()`
+API call. At this time due to various constraints .NET Android cannot support
+Feature packs.
 
-The second type of `pack` is the `Asset` pack. This type of pack ONLY
-contains `AndroidAsset` items. It CANNOT contain any code or other
-resources. This type of `pack` can be installed at install-time,
-fast-follow or ondemand. It is most useful for apps which contain a lot
-of `Assets`, such as Games or Multi Media applications.
-See the [documentation](https://developer.android.com/guide/playcore/asset-delivery) for details on how this all works.
+*Asset* packs contain *only*
+[`@(AndroidAsset)`](~/android/deploy-test/building-apps/build-items.md#androidasset) items.
+It *cannot* contain any code or other resources. This type of `pack` can be
+installed at install-time, fast-follow or ondemand. It is most useful for apps
+which contain a lot of Assets, such as Games or Multi Media applications.
+See the [Android Asset Delivery documentation](https://developer.android.com/guide/playcore/asset-delivery)
+for details on how this all works.
 
 ## Asset Pack Specification
 
-We want to provide our users the ability to use `Asset` packs without
-having rely on hacks provided by the community.
+We want to provide our users the ability to use `Asset` packs without relying
+on [Alternative Methods](#alternativemethods)
 
-The new idea is to make use of additional metadata on `AndroidAsset`
-Items to allow the build system to split up the assets into packs
-automatically. So it is proposed that we implement support for something
-like this
+Add support for new `%(AndroidAsset.AssetPack)` item metadata, which
+allows the build system to split up the assets into packs automatically:
 
 ```xml
 <ItemGroup>
@@ -38,44 +38,53 @@ like this
 </ItemGroup>
 ```
 
-In this case the additional `AssetPack` attribute is used to tell the
-build system which pack to place this asset in. If the `AssetPack` attribute is not present, the default behavior will be to include the asset in the main application package.
-Since auto import of items is common now we need a way for a user to add this additional attribute to auto included items. Fortunately we are able to use the following.
+The default value for `%(AndroidAsset.AssetPack)` is `base`, which will
+cause the asset to be included in the main application package.
+
+As auto import of items is now common, we need a way for a user to add
+this additional attribute to auto included items.  This can be done by
+using `Update`:
 
 ```xml
 <ItemGroup>
-   <AndroidAsset Update="Asset/movie1.mp4" />
-   <AndroidAsset Update="Asset/movie.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie.mp4"  AssetPack="assets1" />
    <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
    <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
 </ItemGroup>
 ```
 
-This code uses the `Update` attribute to tell MSBuild that we are going
-to update a specific item. Note in the sample we do NOT need to include
-an `Update` for the `data.xml`, since this is auto imported it will still
-end up in the main feature in the aab.
+`%(AndroidAsset.DeliveryType)` item metadata can be specified to control what
+*type* of asset pack is produced.  Valid values are:
 
-Additional attributes can be used to control what type of asset pack is
-produced. The only extra one supported at this time is `DeliveryType`,
-this can have a value of `InstallTime`, `FastFollow` or `OnDemand`.
-The `DeliveryType` attribute will be picked up from the first item which has it
-for a specified `AssetPack`. For example the `DeliveryType` attribute in the
-code below will be applied to the items for `AssetPack` `assets1`, it will not be applied
-to the other `packs` or the `base` pack.
+  * `InstallTime`: Asset pack will be delivered when the app is installed.
+    This is the default value for assets not in the base package.
+  * `FastFollow`: Asset pack will be downloaded automatically as soon as the app is installed.
+  * `OnDemand`: Asset pack will be downloaded while the app is running.
+
+The `DeliveryType` for a given asset pack is based on the *first*
+`@(AndroidAsset.DeliveryType)` value encountered for a `%(AssetPack)` name.
+
+Consider the following example, in which `Asset/movie2.mp4` and `Asset/movie3.mp4`
+are both in the `assets1` pack, which will have a `%(DeliveryType)` of `InstallTime`
+(the first encountered value "wins").  `Asset/movie1.mp4` will be in the base package,
+while `Asset/movie4.mp4` will be in the "asset2" asset pack.
 
 ```xml
 <ItemGroup>
    <AndroidAsset Update="Asset/movie1.mp4" />
    <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" DeliveryType="InstallTime" />
-   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets1" DeliveryType="FastFollow" />
    <AndroidAsset Update="Asset/movie4.mp4" AssetPack="assets2" />
 </ItemGroup>
 ```
 
 See Google's [documentation](https://developer.android.com/guide/playcore/asset-delivery#asset-updates) for details on what each of the `DeliveryType` values do.
 
-If however you have a large number of assets it might be cleaner in the csproj to make use of the `base` value for the `AssetPack` attribute. In this scenario you update ALL assets to be in a single asset pack then use the `AssetPack="base"` metadata to declare which specific assets end up in the base aab file. With this you can use wildcards to move most assets into the asset pack.
+If however you have a large number of assets it might be cleaner in the
+`.csproj` to make use of the `base` value for the `%(AssetPack)` attribute.
+In this scenario you update *all* assets to be in a single asset pack then use
+`AssetPack="base"` metadata to declare which specific assets end up in the base
+aab file. With this you can use wildcards to move most assets into the asset pack:
 
 ```xml
 <ItemGroup>
@@ -85,38 +94,53 @@ If however you have a large number of assets it might be cleaner in the csproj t
 </ItemGroup>
 ```
 
-In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, but ALL the other assets will end up in the `assets1` asset pack.
+In this example, `movie.mp4` and `some.png` will end up in the `base` aab file,
+but *all the other assets* will end up in the `assets1` asset pack.
 
-At this time @(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.
+At this time the `@(AndroidAsset)` build action does not support `%(AssetPack)`
+or `%(DeliveryType)` Metadata in Library Projects.
 
-NOTE: `AssetPacks` are only used when the `AndroidPackageFormat` is set to `aab` (the default for Release). When using the `apk` setting the assets will be placed inside the `apk`.
+NOTE: `AssetPacks` are only used when the
+[`$(AndroidPackageFormat)`](~/android/deploy-test/building-apps/build-properties.md#debugsymbols)
+property is set to `aab` (the default for Release).
+When using the `apk` setting the assets will be placed inside the `apk`.
 
 ## Release Configuration
 
-In order for the application to function correctly we need to inform the `R8` linker which java classes we need to keep. To do this we need to add the following lines to a `ProGuard.cfg` file which is in the root of our project folder.
+In order for the application to function correctly we need to inform the `R8`
+linker which Java classes we need to keep. To do this we need to add the
+following lines to a `ProGuard.cfg` file which is in the root of our project folder:
 
 ```
 -keep com.google.android.play.*
 ```
 
-Alternatively you can create a file called `ProGuard.cfg` and use the [@(ProguardConfiguration)](~/android/deploy-test/building-apps/build-items.md#proguardconfiguration) built action.
-Adding these lines will ensure that all the required java components are not linked away during the Release build.
+Alternatively you can create a file called `ProGuard.cfg` and use the
+[@(ProguardConfiguration)](~/android/deploy-test/building-apps/build-items.md#proguardconfiguration)
+build action.  Adding these lines will ensure that all the required Java components are not linked
+away during the Release build.
 
 ## Testing and Debugging
 
-In order to test your asset packs in the `Debug` configuration, you will need to make some changes to your `.csproj`. Firstly we need to change the `AndroidPackageFormat` to `aab`. It will be `aab` by default for `Release` builds, but will default to `apk` for `Debug` builds. Setting the `AndroidPackageFormat` to `aab` will disable
-fast deployment, so it is advised that you only do this when you need to test your `AssetPacks`.
+In order to test your asset packs in the `Debug` configuration, you will need to
+make some changes to your `.csproj`. Firstly we need to change the
+`$(AndroidPackageFormat)` to `aab`. It will be `aab` by default for `Release` builds,
+but will default to `apk` for `Debug` builds. Setting the `AndroidPackageFormat` to `aab`
+will disable fast deployment, so it is advised that you only do this when you need to test
+your `AssetPacks`.
 
-To test your asset packs add the following to the first `PropertyGroup` in your `.csproj`. 
+To test your asset packs add the following to the first `<PropertyGroup/>` in your `.csproj`. 
 
 ```xml
 <AndroidPackageFormat>aab</AndroidPackageFormat>
 <AndroidBundleToolExtraArgs Condition=" '$(Configuration)' == 'Debug' ">--local-testing $(AndroidBundleToolExtraArgs)</AndroidBundleToolExtraArgs>
 ```
 
-The `--local-testing` argument tells the `bundletool` application to install ALL the asset packs in a local cache on the device. `InstallTime` packs will be installed during the app installation process.
+The `--local-testing` argument tells the `bundletool` application to install all the asset packs
+in a local cache on the device. `InstallTime` packs will be installed during the app installation process.
 
-`FastFollow` packs behave like `OnDemand` packs. They will not automatically installed when the game is sideloaded. You will need to request them manually when the game starts.
+`FastFollow` packs behave like `OnDemand` packs. They will not automatically installed when the app
+is sideloaded. You will need to request them manually when the game starts.
 
 For more details see [https://developer.android.com/guide/playcore/asset-delivery/test](https://developer.android.com/guide/playcore/asset-delivery/test).
 
@@ -124,7 +148,7 @@ For more details see [https://developer.android.com/guide/playcore/asset-deliver
 
 There are a few changes we need to make in order to support this feature.
 One of the issues we will hit is the build times when dealing with large assets.
-Current the assets which are to be included in the `aab` are COPIED
+Current the assets which are to be included in the `aab` are ***copied***
 into the `$(IntermediateOutputPath)assets` directory. This folder is
 then passed to `aapt2` for the build process.
 
@@ -146,19 +170,19 @@ All the building of the `pack` zip file would take place in these subfolders.
 The name of the pack will be based on the main "packagename" with the asset pack
 name appended to the end. e.g `com.microsoft.assetpacksample.assets1`.
 
-During the build process we identify ALL the `AndroidAsset` items which
-define an `AssetPack` attribute. These files are then copied to the
+During the build process we identify all the `AndroidAsset` items which
+have an `AssetPack` attribute. These files are then copied to the
 new `$(IntermediateOutputPath)assetpacks` directory rather than the
 existing `$(IntermediateOutputPath)assets` directory. This allows us to
 continue to support the normal `AndroidAsset` behavior while adding the
 new system.
 
 Once we have collected and copied all the assets we then use the new
-`GetAssetPacks` Task to figure out which asset packs we need to create.
-We then call the `CreateDynamicFeatureManifest` to create a required
+`<GetAssetPacks/>` Task to figure out which asset packs we need to create.
+We then call the `<CreateDynamicFeatureManifest/>` task to create a required
 `AndroidManifest.xml` file for the asset pack. This file will end
 up in the same `$(IntermediateOutputPath)assetpacks` directory.
-We call this Task `CreateDynamicFeatureManifest` because it can be used
+We call this Task `<CreateDynamicFeatureManifest/>` because it can be used
 to create any feature pack if and when we get to implement full feature
 packs.
 
@@ -175,36 +199,37 @@ assetpacks/
 ```
 
 We can then call `aapt2` to build these packs into `.zip` files. A new
-task `Aapt2LinkAssetPack` takes care of this. This is a special version
+task `<Aapt2LinkAssetPack/>` task takes care of this. This is a special version
 of `Aapt2Link` which implements linking for asset packs only.
 It also takes care of a few problems which `aapt2` introduces. For some
 reason the zip file that is created has the `AndroidManifest.xml` file
 in the wrong place. It creates it in the root of the zip file, but the
 `bundletool` expects it to be in a `manifest` directory.
 `bundletool` will error out if its not in the right place.
-So `Aapt2LinkAssetPack` takes care of this for us. It also removes a
+So `<Aapt2LinkAssetPack/>` takes care of this for us. It also removes a
 `resources.pb` which gets added. Again, `bundletool` will error if this
 file is in the zip file.
 
 Once the zip files have been created they are then added to the
-`AndroidAppBundleModules` ItemGroup. This will ensure that when the
+`@(AndroidAppBundleModules)` ItemGroup. This will ensure that when the
 final `.aab` file is generated they are included as asset packs.
 
 ## Alternative Methods
 
 An alternative method is available on [github](https://github.com/infinitespace-studios/MauiAndroidAssetPackExample).
 This method allows developers to place additional assets in a special
-[NoTargets](https://github.com/microsoft/MSBuildSdks/blob/main/src/NoTargets/README.md) project. This project is built just after the final `aab` is
-produced. It builds a zip file which is then added to the `@(Modules)`
-ItemGroup in the main application. This zip is then included into the
+[NoTargets](https://github.com/microsoft/MSBuildSdks/blob/main/src/NoTargets/README.md) project.
+This project is built just after the final `aab` is produced. It builds a zip
+file which is then added to the `@(Modules)` ItemGroup in the main application.
+This zip is then included into the
 final app as an additional feature.
 
 Using a separate project like in the hack is one way to go. It does have some
 issues though.
 
-1. It is a `special` type of project. It requires a `global.json` which imports the
-   `NoTargets` sdk.
-2. There is no IDE support for building this type of project.
+ 1. It is a `special` type of project. It requires a `global.json` which imports
+    the `NoTargets` sdk.
+ 2. There is no IDE support for building this type of project.
 
 Having the user go through a number of hoops to implement this for
-.NET Android or .net Maui is not ideal.
+.NET Android or .NET MAUI is not ideal.

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -91,6 +91,17 @@ At this time @(AndroidAsset) build action does not support 'AssetPack' or 'Deliv
 
 NOTE: `AssetPacks` are only used when the `AndroidPackageFormat` is set to `aab` (the default for Release). When using the `apk` setting the assets will be placed inside the `apk`.
 
+## Release Configuration
+
+In order for the application to function correctly we need to inform the `R8` linker which java classes we need to keep. To do this we need to add the following lines to a `Proguard.cfg` file which is in the root of our project folder.
+
+```
+-keep com.google.android.play.*
+```
+
+Alternatively you can create a file called `Proguard.cfg` and use the `ProguardConfiguration` built action.
+Adding these lines will ensure that all the required java components are not linked away during the Release build.
+
 ## Testing and Debugging
 
 In order to test your asset packs in the `Debug` configuration, you will need to make some changes to your `.csproj`. Firstly we need to change the `AndroidPackageFormat` to `aab`. It will be `aab` by default for `Release` builds, but will default to `apk` for `Debug` builds. Setting the `AndroidPackageFormat` to `aab` will disable

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -93,13 +93,13 @@ NOTE: `AssetPacks` are only used when the `AndroidPackageFormat` is set to `aab`
 
 ## Release Configuration
 
-In order for the application to function correctly we need to inform the `R8` linker which java classes we need to keep. To do this we need to add the following lines to a `Proguard.cfg` file which is in the root of our project folder.
+In order for the application to function correctly we need to inform the `R8` linker which java classes we need to keep. To do this we need to add the following lines to a `ProGuard.cfg` file which is in the root of our project folder.
 
 ```
 -keep com.google.android.play.*
 ```
 
-Alternatively you can create a file called `Proguard.cfg` and use the `ProguardConfiguration` built action.
+Alternatively you can create a file called `ProGuard.cfg` and use the [@(ProguardConfiguration)](~/android/deploy-test/building-apps/build-items.md#proguardconfiguration) built action.
 Adding these lines will ensure that all the required java components are not linked away during the Release build.
 
 ## Testing and Debugging

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -1,0 +1,176 @@
+# Android Asset Packs
+
+Google Android began supporting splitting up the app package into multiple
+packs with the introduction of the `aab` package format. This format allows
+the developer to split the app up into multiple `packs`. Each `pack` can be
+downloaded to the device either at install time or on demand. This allows
+application developers to save space and install time by only installing
+the required parts of the app initially. Then installing other `packs`
+as required.
+
+There are two types of `pack`. The first is a `Feature` pack, this type
+of pack contains code and other resources. Code in these types of `pack`
+can be launched via the `StartActivity` API call. At this time due to
+various constraints .NET Android cannot support `Feature` packs.
+
+The second type of `pack` is the `Asset` pack. This type of pack ONLY
+contains `AndroidAsset` items. It CANNOT contain any code or other
+resources. This type of `feature` pack can be installed at install-time,
+fast-follow or ondemand. It is most useful for apps which contain allot
+of `Assets`, such as Games or Multi Media applications.
+See the [documentation](https://developer.android.com/guide/playcore/asset-delivery) for details on how this all works.
+.NET Android does not have any official support for this type of pack.
+However a hack is available via the excellent @infinitespace-studios on
+[github](https://github.com/infinitespace-studios/MauiAndroidAssetPackExample).
+This hack allows developers to place additional assets in a special
+`NoTargets` project. This project is built just after the final `aab` is
+produced. It builds a zip file which is then added to the `@(Modules)`
+ItemGroup in the main application. This zip is then included into the
+final app as an additional feature.
+
+## Asset Pack Specification
+
+We want to provide our users the ability to use `Asset` packs without
+having to implement the hack provided by @infinitespace-studios. Using
+a separate project like in the hack is one way to go. It does have some
+issues though.
+
+1. It is a `special` type of project. It requires a `global.json` which imports the
+   `NoTargets` sdk.
+2. There is no IDE support for building this type of project.
+
+Having the user go through a number of hoops to implement this for
+.NET Android or .net Maui is not ideal. We need a simpler method.
+
+The new idea is to make use of additional metadata on `AndroidAsset`
+Items to allow the build system to split up the assets into packs
+automatically. So it is proposed that we implement support for something
+like this
+
+```xml
+<ItemGroup>
+   <AndroidAsset Include="Asset/data.xml" />
+   <AndroidAsset Include="Asset/movie.mp4" AssetPack="assets1" />
+   <AndroidAsset Include="Asset/movie2.mp4" AssetPack="assets1" />
+</ItemGroup>
+```
+
+In this case the additional `AssetPack` attribute is used to tell the
+build system which pack to place this asset in. Since auto import of items
+is common now we need a way for a user to add this additional attribute
+to auto included items. Fortunately we are able to use the following.
+
+```xml
+<ItemGroup>
+   <AndroidAsset Update="Asset/movie.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
+</ItemGroup>
+```
+
+This code uses the `Update` attribute to tell MSBuild that we are going
+to update a specific item. Note in the sample we do NOT need to include
+an `Update` for the `data.xml`, since this is auto imported it will still
+end up in the main feature in the aab.
+
+Additional attributes can be used to control what type of asset pack is
+produced. The only extra one supported at this time is `DeliveryType`,
+this can have a value of `InstallTime`, `FastFollow` or `OnDemand`.
+Additional attributes do not need to be included on ALL items. Any one
+will do, only the `AssetPack` attribute will be needed.
+See Google's [documentation](https://developer.android.com/guide/playcore/asset-delivery#asset-updates) for details on what each item does.
+
+```xml
+<ItemGroup>
+   <AndroidAsset Update="Asset/movie.mp4" AssetPack="assets1" DeliveryType="InstallTime" />
+   <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
+</ItemGroup>
+```
+
+If the `AssetPack` attribute is not present, the default behavior will
+be to include the asset in the main application package.
+
+If however you have a large number of assets it might be more efficient to make use of the `base` asset pack setting. In this scenario you update ALL assets to be in a single asset pack then use the `AssetPack="base"` metadata to declare which specific assets end up in the base aab file. With this you can use wildcards to move most assets into the asset pack.
+
+```xml
+<ItemGroup>
+   <AndroidAsset Update="Assets/*" AssetPack="assets1" />
+   <AndroidAsset Update="Assets/movie.mp4" AssetPack="base" />
+   <AndroidAsset Update="Assets/some.png" AssetPack="base" />
+</ItemGroup>
+```
+
+In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, but ALL the other assets
+will end up in the `assets1` asset pack.
+
+## Implementation Details
+
+There are a few changes we need to make in order to support this feature.
+One of the issues we will hit is the build times when dealing with large assets.
+Current the assets which are to be included in the `aab` are COPIED
+into the `$(IntermediateOutputPath)assets` directory. This folder is
+then passed to `aapt2` for the build process.
+
+The new system adds a new directory `$(IntermediateOutputPath)assetpacks`.
+This directory would contain a subdirectory for each `pack` that the
+user wants to include.
+
+```dotnetcli
+assetpacks/
+    assets1/
+        assets/
+            movie1.mp4
+    feature2/
+        assets/
+             movie2.mp4
+```
+
+All the building of the `pack` zip file would take place in these subfolders.
+The name of the pack will be based on the main "packagename" with the asset pack
+name appended to the end. e.g `com.microsoft.assetpacksample.assets1`.
+
+During the build process we identify ALL the `AndroidAsset` items which
+define an `AssetPack` attribute. These files are then copied to the
+new `$(IntermediateOutputPath)assetpacks` directory rather than the
+existing `$(IntermediateOutputPath)assets` directory. This allows us to
+continue to support the normal `AndroidAsset` behavior while adding the
+new system.
+
+Once we have collected and copied all the assets we then use the new
+`GetAssetPacks` Task to figure out which asset packs we need to create.
+We then call the `CreateDynamicFeatureManifest` to create a required
+`AndroidManifest.xml` file for the asset pack. This file will end
+up in the same `$(IntermediateOutputPath)assetpacks` directory.
+We call this Task `CreateDynamicFeatureManifest` because it can be used
+to create any feature pack if and when we get to implement full feature
+packs.
+
+```dotnetcli
+assetpacks/
+    assets1/
+        AndroidManifest.xml
+        assets/
+            movie1.mp4
+    feature2/
+        AndroidManifest.xml
+        assets/
+             movie2.mp4
+```
+
+We can then call `aapt2` to build these packs into `.zip` files. A new
+task `Aapt2LinkAssetPack` takes care of this. This is a special version
+of `Aapt2Link` which implements linking for asset packs only.
+It also takes care of a few problems which `aapt2` introduces. For some
+reason the zip file that is created has the `AndroidManifest.xml` file
+in the wrong place. It creates it in the root of the zip file, but the
+`bundletool` expects it to be in a `manifest` directory.
+`bundletool` will error out if its not in the right place.
+So `Aapt2LinkAssetPack` takes care of this for us. It also removes a
+`resources.pb` which gets added. Again, `bundletool` will error if this
+file is in the zip file.
+
+Once the zip files have been created they are then added to the
+`AndroidAppBundleModules` ItemGroup. This will ensure that when the
+final `.aab` file is generated they are included as asset packs.
+

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -1,4 +1,4 @@
-g# Android Asset Packs
+# Android Asset Packs
 
 Google Android began supporting splitting up the app package into multiple
 packs with the introduction of the `aab` package format. This format allows

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -1,4 +1,4 @@
-# Android Asset Packs
+g# Android Asset Packs
 
 Google Android began supporting splitting up the app package into multiple
 packs with the introduction of the `aab` package format. This format allows
@@ -19,14 +19,6 @@ resources. This type of `pack` can be installed at install-time,
 fast-follow or ondemand. It is most useful for apps which contain a lot
 of `Assets`, such as Games or Multi Media applications.
 See the [documentation](https://developer.android.com/guide/playcore/asset-delivery) for details on how this all works.
-.NET Android does not have any official support for this type of pack.
-However a hack is available via the excellent @infinitespace-studios on
-[github](https://github.com/infinitespace-studios/MauiAndroidAssetPackExample).
-This hack allows developers to place additional assets in a special
-`NoTargets` project. This project is built just after the final `aab` is
-produced. It builds a zip file which is then added to the `@(Modules)`
-ItemGroup in the main application. This zip is then included into the
-final app as an additional feature.
 
 ## Asset Pack Specification
 
@@ -169,8 +161,14 @@ final `.aab` file is generated they are included as asset packs.
 
 ## Alternative Methods
 
-to implement the hack provided by @infinitespace-studios. Using
-a separate project like in the hack is one way to go. It does have some
+An alternative method is available on [github](https://github.com/infinitespace-studios/MauiAndroidAssetPackExample).
+This method allows developers to place additional assets in a special
+[NoTargets](https://github.com/microsoft/MSBuildSdks/blob/main/src/NoTargets/README.md) project. This project is built just after the final `aab` is
+produced. It builds a zip file which is then added to the `@(Modules)`
+ItemGroup in the main application. This zip is then included into the
+final app as an additional feature.
+
+Using a separate project like in the hack is one way to go. It does have some
 issues though.
 
 1. It is a `special` type of project. It requires a `global.json` which imports the
@@ -178,4 +176,4 @@ issues though.
 2. There is no IDE support for building this type of project.
 
 Having the user go through a number of hoops to implement this for
-.NET Android or .net Maui is not ideal. We need a simpler method.
+.NET Android or .net Maui is not ideal.

--- a/Documentation/guides/AndroidAssetPacks.md
+++ b/Documentation/guides/AndroidAssetPacks.md
@@ -89,6 +89,26 @@ In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, 
 
 At this time @(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.
 
+NOTE: `AssetPacks` are only used when the `AndroidPackageFormat` is set to `aab` (the default for Release). When using the `apk` setting the assets will be placed inside the `apk`.
+
+## Testing and Debugging
+
+In order to test your asset packs in the `Debug` configuration, you will need to make some changes to your `.csproj`. Firstly we need to change the `AndroidPackageFormat` to `aab`. It will be `aab` by default for `Release` builds, but will default to `apk` for `Debug` builds. Setting the `AndroidPackageFormat` to `aab` will disable
+fast deployment, so it is advised that you only do this when you need to test your `AssetPacks`.
+
+To test your asset packs add the following to the first `PropertyGroup` in your `.csproj`. 
+
+```xml
+<AndroidPackageFormat>aab</AndroidPackageFormat>
+<AndroidBundleToolExtraArgs Condition=" '$(Configuration)' == 'Debug' ">--local-testing $(AndroidBundleToolExtraArgs)</AndroidBundleToolExtraArgs>
+```
+
+The `--local-testing` argument tells the `bundletool` application to install ALL the asset packs in a local cache on the device. `InstallTime` packs will be installed during the app installation process.
+
+`FastFollow` packs behave like `OnDemand` packs. They will not automatically installed when the game is sideloaded. You will need to request them manually when the game starts.
+
+For more details see [https://developer.android.com/guide/playcore/asset-delivery/test](https://developer.android.com/guide/playcore/asset-delivery/test).
+
 ## Implementation Details
 
 There are a few changes we need to make in order to support this feature.

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -19,6 +19,38 @@ or library project is built.
 Supports [Android Assets](https://developer.android.com/guide/topics/resources/providing-resources#OriginalFiles),
 files that would be included in the `assets` folder in a Java Android project.
 
+The `AndroidAsset` ItemGroup also supports additional metadata for generating [Asset Packs](https://developer.android.com/guide/playcore/asset-delivery). Adding the `AssetPack` attribute to and `AndroidAsset` will automatically generate an asset pack of that name. This feature is only supported when using the `.aab`
+`AndroidPackageFormat`. The following example will place `movie2.mp4` and `movie3.mp4` in separate asset packs.
+
+```xml
+<ItemGroup>
+   <AndroidAsset Update="Asset/movie.mp4" />
+   <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
+   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
+</ItemGroup>
+```
+
+This feature can be used to include large files in your application which would normally exceed the max
+package size limits of Google Play.
+
+If you have a large number of assets it might be more efficient to make use of the `base` asset pack.
+In this scenario you update ALL assets to be in a single asset pack then use the `AssetPack="base"` metadata
+to declare which specific assets end up in the base aab file. With this you can use wildcards to move most
+assets into the asset pack.
+
+```xml
+<ItemGroup>
+   <AndroidAsset Update="Assets/*" AssetPack="assets1" />
+   <AndroidAsset Update="Assets/movie.mp4" AssetPack="base" />
+   <AndroidAsset Update="Assets/some.png" AssetPack="base" />
+</ItemGroup>
+```
+
+In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, but ALL the other assets
+will end up in the `assets1` asset pack.
+
+The additional metadata is only supported on .NET Android 9 and above.
+
 ## AndroidAarLibrary
 
 The Build action of `AndroidAarLibrary` should be used to directly

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -19,8 +19,7 @@ or library project is built.
 Supports [Android Assets](https://developer.android.com/guide/topics/resources/providing-resources#OriginalFiles),
 files that would be included in the `assets` folder in a Java Android project.
 
-The `AndroidAsset` ItemGroup also supports additional metadata for generating [Asset Packs](https://developer.android.com/guide/playcore/asset-delivery). Adding the `AssetPack` attribute to and `AndroidAsset` will automatically generate an asset pack of that name. This feature is only supported when using the `.aab`
-`AndroidPackageFormat`. The following example will place `movie2.mp4` and `movie3.mp4` in separate asset packs.
+Starting with .NET 9 the `AndroidAsset` ItemGroup also supports additional metadata for generating [Asset Packs](https://developer.android.com/guide/playcore/asset-delivery). Adding the `AssetPack` attribute to and `AndroidAsset` will automatically generate an asset pack of that name. This feature is only supported when the [`$(AndroidPackageFormat)`](#androidpackageformat) is set to `.aab`. The following example will place `movie2.mp4` and `movie3.mp4` in separate asset packs.
 
 ```xml
 <ItemGroup>

--- a/Documentation/guides/building-apps/build-items.md
+++ b/Documentation/guides/building-apps/build-items.md
@@ -19,7 +19,7 @@ or library project is built.
 Supports [Android Assets](https://developer.android.com/guide/topics/resources/providing-resources#OriginalFiles),
 files that would be included in the `assets` folder in a Java Android project.
 
-Starting with .NET 9 the `AndroidAsset` ItemGroup also supports additional metadata for generating [Asset Packs](https://developer.android.com/guide/playcore/asset-delivery). Adding the `AssetPack` attribute to and `AndroidAsset` will automatically generate an asset pack of that name. This feature is only supported when the [`$(AndroidPackageFormat)`](#androidpackageformat) is set to `.aab`. The following example will place `movie2.mp4` and `movie3.mp4` in separate asset packs.
+Starting with .NET 9 the `@(AndroidAsset)` build action also supports additional metadata for generating [Asset Packs](https://developer.android.com/guide/playcore/asset-delivery). The `%(AndroidAsset.AssetPack)` metadata can be used to automatically generate an asset pack of that name. This feature is only supported when the [`$(AndroidPackageFormat)`](#androidpackageformat) is set to `.aab`. The following example will place `movie2.mp4` and `movie3.mp4` in separate asset packs.
 
 ```xml
 <ItemGroup>
@@ -45,7 +45,7 @@ assets into the asset pack.
 </ItemGroup>
 ```
 
-In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, but ALL the other assets
+In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, while all the other assets
 will end up in the `assets1` asset pack.
 
 The additional metadata is only supported on .NET Android 9 and above.

--- a/Documentation/guides/building-apps/build-process.md
+++ b/Documentation/guides/building-apps/build-process.md
@@ -195,6 +195,7 @@ Extension points include:
 
 - [`$(AfterGenerateAndroidManifest)](~/android/deploy-test/building-apps/build-properties.md#aftergenerateandroidmanifest)
 - [`$(BeforeGenerateAndroidManifest)](~/android/deploy-test/building-apps/build-properties.md#beforegenerateandroidmanifest)
+- [`$(BeforeBuildAndroidAssetPacks)`](~/android/deploy-test/building-apps/build-properties.md#beforebuildandroidassetpacks)
 
 A word of caution about extending the build process: If not
 written correctly, build extensions can affect your build

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -1689,7 +1689,7 @@ Extra options to pass to `aprofutil`.
 ## BeforeBuildAndroidAssetPacks
 
 MSBuild Targets listed in this
-property will run directly before `_BuildAssetPacks`.
+property will run directly before the `AssetPack` items are built.
 
 Added in .NET 9
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -838,7 +838,7 @@ This property controls if an Asset Packs build automatically are auto
 included in the final `.aab` file. It will default to `true`.
 
 In certain cases the user might want to release an interim release. In
-these cases the user does not NEED to update the asset pack. Especially
+these cases the user does not need to update the asset pack. Especially
 if the contents of the asset pack have not changed. This property allows
 the user to skip the asset packs if they are not required.
 

--- a/Documentation/guides/building-apps/build-properties.md
+++ b/Documentation/guides/building-apps/build-properties.md
@@ -832,6 +832,18 @@ APK root directory. The format of the path is `lib\ARCH\wrap.sh` where
 + `x86_64`
 + `x86`
 
+## AndroidIncludeAssetPacksInPackage
+
+This property controls if an Asset Packs build automatically are auto
+included in the final `.aab` file. It will default to `true`.
+
+In certain cases the user might want to release an interim release. In
+these cases the user does not NEED to update the asset pack. Especially
+if the contents of the asset pack have not changed. This property allows
+the user to skip the asset packs if they are not required.
+
+Added in .NET 9
+
 ## AndroidInstallJavaDependencies
 
 The default value is `true` for command line builds. When set to `true`, enables
@@ -1673,6 +1685,13 @@ as support for `$(AotAssemblies)` will be removed in a future release.
 ## AProfUtilExtraOptions
 
 Extra options to pass to `aprofutil`.
+
+## BeforeBuildAndroidAssetPacks
+
+MSBuild Targets listed in this
+property will run directly before `_BuildAssetPacks`.
+
+Added in .NET 9
 
 ## BeforeGenerateAndroidManifest
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -100,7 +100,8 @@ package from all the users on device and try again. If that does not work you ca
 Fast Deployment is not currently supported on this device.
 Please file an issue with the exact error message using the 'Help->Send Feedback->Report a Problem' menu item in Visual Studio
 or 'Help->Report a Problem' in Visual Studio for Mac.
-+ [XA0138](xa0138.md): @(AndroidAsset) build action does not support 'AssetPack' Metadata in Library Projects.
++ [XA0138](xa0138.md): %(AndroidAsset.AssetPack) and %(AndroidAsset.AssetPack) item metadata are only supported when `$(AndroidApplication)` is `true`.
++ [XA0139](xa0139.md): `@(AndroidAsset)` `{0}` has invalid `DeliveryType` metadata of `{1}`. Supported values are `installtime`, `ondemand` or `fastfollow`
 
 ## XA1xxx: Project related
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -100,6 +100,7 @@ package from all the users on device and try again. If that does not work you ca
 Fast Deployment is not currently supported on this device.
 Please file an issue with the exact error message using the 'Help->Send Feedback->Report a Problem' menu item in Visual Studio
 or 'Help->Report a Problem' in Visual Studio for Mac.
++ [XA0138](xa0138.md): @(AndroidAsset) build action does not support 'AssetPack' Metadata in Library Projects.
 
 ## XA1xxx: Project related
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -102,6 +102,7 @@ Please file an issue with the exact error message using the 'Help->Send Feedback
 or 'Help->Report a Problem' in Visual Studio for Mac.
 + [XA0138](xa0138.md): %(AndroidAsset.AssetPack) and %(AndroidAsset.AssetPack) item metadata are only supported when `$(AndroidApplication)` is `true`.
 + [XA0139](xa0139.md): `@(AndroidAsset)` `{0}` has invalid `DeliveryType` metadata of `{1}`. Supported values are `installtime`, `ondemand` or `fastfollow`
++ [XA0140](xa0140.md): 
 
 ## XA1xxx: Project related
 

--- a/Documentation/guides/messages/xa0138.md
+++ b/Documentation/guides/messages/xa0138.md
@@ -1,0 +1,13 @@
+title: Xamarin.Android error XA0138
+description: XA0138 error code
+ms.date: 02/05/2024
+---
+# Xamarin.Android error XA0138
+
+## Issue
+
+@(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.
+
+## Solution
+
+Remove the 'AssetPack' or 'DeliveryType' Metadata from your `AndroidAsset` build Items.

--- a/Documentation/guides/messages/xa0138.md
+++ b/Documentation/guides/messages/xa0138.md
@@ -6,8 +6,8 @@ ms.date: 02/05/2024
 
 ## Issue
 
-@(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.
+%(AndroidAsset.AssetPack) and %(AndroidAsset.AssetPack) item metadata are only supported when `$(AndroidApplication)` is `true`.
 
 ## Solution
 
-Remove the 'AssetPack' or 'DeliveryType' Metadata from your `AndroidAsset` build Items.
+Remove the 'AssetPack' or 'DeliveryType' Metadata from your `AndroidAsset` build Items in the project the error was raised for.

--- a/Documentation/guides/messages/xa0139.md
+++ b/Documentation/guides/messages/xa0139.md
@@ -1,0 +1,13 @@
+title: Xamarin.Android error XA0138
+description: XA0138 error code
+ms.date: 02/05/2024
+---
+# Xamarin.Android error XA0138
+
+## Issue
+
+`@(AndroidAsset)` `{0}` has an invalid `DeliveryType` metadata of `{1}`. Supported values are `installtime`, `ondemand` or `fastfollow`.
+
+## Solution
+
+Make sure that all `DeliveryType` attributes are one of the following valid values, `installtime`, `ondemand` or `fastfollow`.

--- a/Documentation/guides/messages/xa0140.md
+++ b/Documentation/guides/messages/xa0140.md
@@ -1,0 +1,13 @@
+title: Xamarin.Android error XA0138
+description: XA0140 error code
+ms.date: 02/05/2024
+---
+# Xamarin.Android error XA0140
+
+## Issue
+
+The AssetPack value defined for `{0}` has invalid characters. `{1}` should only contain A-z, a-z, 0-9 or an underscore.
+
+## Solution
+
+Make sure that all `AssetPack` attributes only contain valid characters.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -136,6 +136,7 @@
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Aapt2.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Analysis.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Application.targets" />
+    <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Assets.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.ClassParse.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.Core.targets" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Bindings.Maven.targets" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -1,0 +1,147 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Assets.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+	created a backup copy.  Incorrect changes to this file will make it
+	impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2010-2011 Novell. All rights reserved.
+Copyright (C) 2011-2012 Xamarin. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidComputeResPaths" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.Aapt2LinkAssetPack" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.GetAssetPacks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.RemoveUnknownFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CreateDynamicFeatureManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+
+<!-- Assets build properties -->
+<PropertyGroup>
+		<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+		<MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks</MonoAndroidAssetPacksDirIntermediate>
+		<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
+		<AndroidIncludeAssetPacksInPackage Condition=" '$(AndroidIncludeAssetPacksInPackage)' == '' ">true</AndroidIncludeAssetPacksInPackage>
+</PropertyGroup>
+
+<PropertyGroup>
+	<BeforeBuildAndroidAssetPacks>
+		UpdateAndroidAssets
+		;_CalculateAssetsWithAssetPackMetaData
+		;_CalculateAssetPacks
+		;$(BeforeBuildAndroidAssetPacks)
+		;_CreateAssetPackManifests
+	</BeforeBuildAndroidAssetPacks>
+</PropertyGroup>
+
+<!-- Assets Build -->
+
+<Target Name="UpdateAndroidAssets"
+	DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_CalculateAssetPacks;_GenerateAndroidAssetsDir" />
+
+<Target Name="_ComputeAndroidAssetsPaths">
+	<AndroidComputeResPaths
+		ResourceFiles="@(AndroidAsset)"
+		IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
+		AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
+		Prefixes="$(MonoAndroidAssetsPrefix)"
+		ProjectDir="$(ProjectDir)"
+	>
+		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
+		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
+	</AndroidComputeResPaths>
+</Target>
+
+<Target Name="_GenerateAndroidAssetsDir"
+		Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
+		Outputs="@(_AndroidAssetsDest)">
+	<ItemGroup>
+		<_AssetDirectories Include="$(MonoAndroidAssetsDirIntermediate)" />
+		<_AssetDirectories Include="@(_AssetPacks->'%(AssetPackDirectory)')" />
+	</ItemGroup>
+	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate);$(MonoAndroidAssetPacksDirIntermediate)" />
+	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
+	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directories="@(_AssetDirectories)" RemoveDirectories="true" FileType="AndroidAsset" />
+	<Touch Files="@(_AndroidAssetsDest)" />
+	<ItemGroup>
+		<FileWrites Include="@(_AndroidAssetsDest)" />
+	</ItemGroup>
+</Target>
+
+<Target Name="_CalculateAssetsWithAssetPackMetaData">
+	<ItemGroup>
+		<_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
+	</ItemGroup>
+	<AndroidError 
+		Code="XA0138"
+		ResourceName="XA0138"
+		Condition=" '$(AndroidApplication)' != 'true' And '@(_AssetsWithAssetPackMetaData->Count())' != '0' "
+	/>
+</Target>
+
+<Target Name="_CalculateAssetPacks"
+		DependsOnTargets="_CalculateAssetsWithAssetPackMetaData"
+		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+	>
+	<!-- Enumerate the assetpacks directory and build a pack per top level directory -->
+	<GetAssetPacks Assets="@(_AssetsWithAssetPackMetaData)" IntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)">
+		<Output ItemName="_AndroidAsset" TaskParameter="AssetPacks" />
+	</GetAssetPacks>
+	<ItemGroup>
+		<_AssetPacks Include="@(_AndroidAsset)">
+			<AssetPackDirectory>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\assets</AssetPackDirectory>
+			<AssetPackOutput>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack).zip</AssetPackOutput>
+			<ManifestFile>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\AndroidManifest.xml</ManifestFile>
+			<DeliveryType Condition=" '%(_AndroidAsset.DeliveryType)' == '' ">InstallTime</DeliveryType>
+		</_AssetPacks>
+		<FileWrites Include="@(_AssetPacks->'%(AssetPackCacheFile)')" />
+	</ItemGroup>
+</Target>
+
+<Target Name="_CreateAssetPackManifests"
+		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+		Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
+		Outputs="@(_AssetPacks->'%(ManifestFile)')">
+
+	<CreateDynamicFeatureManifest
+		FeatureSplitName="%(_AssetPacks.AssetPack)"
+		FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
+		FeatureType="AssetPack"
+		PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+		OutputFile="%(_AssetPacks.ManifestFile)"
+	/>
+	<ItemGroup>
+		<FileWrites Include="%(_AssetPacks.ManifestFile)" />
+	</ItemGroup>
+</Target>
+
+<Target Name="_BuildAssetPacks"
+		DependsOnTargets="$(BeforeBuildAndroidAssetPacks)"
+		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+		Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
+		Outputs="@(_AssetPacks->'%(AssetPackOutput)')">
+
+	<Aapt2LinkAssetPack
+		DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+		DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+		OutputArchive="%(_AssetPacks.AssetPackOutput)"
+		AssetDirectories="%(_AssetPacks.AssetPackDirectory)"
+		Manifest="%(_AssetPacks.ManifestFile)"
+		PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+		ToolPath="$(Aapt2ToolPath)"
+		ToolExe="$(Aapt2ToolExe)"
+	/>
+	<ItemGroup>
+		<AndroidAppBundleModules Include="%(_AssetPacks.AssetPackOutput)" Condition=" '$(AndroidIncludeAssetPacksInPackage)' == 'true' "/>
+		<FileWrites Include="$%(_AssetPacks.AssetPackOutput)" />
+	</ItemGroup>
+</Target>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -3,8 +3,8 @@
 Xamarin.Android.Assets.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
-	created a backup copy.  Incorrect changes to this file will make it
-	impossible to load or build your projects from the command-line or the IDE.
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
 
 This file imports the version- and platform-specific targets for the project importing
 this file. This file also defines targets to produce an error if the specified targets
@@ -25,123 +25,125 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <!-- Assets build properties -->
 <PropertyGroup>
-		<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
-		<MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks</MonoAndroidAssetPacksDirIntermediate>
-		<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
-		<AndroidIncludeAssetPacksInPackage Condition=" '$(AndroidIncludeAssetPacksInPackage)' == '' ">true</AndroidIncludeAssetPacksInPackage>
+    <MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+    <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks</MonoAndroidAssetPacksDirIntermediate>
+    <MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
+    <AndroidIncludeAssetPacksInPackage Condition=" '$(AndroidIncludeAssetPacksInPackage)' == '' ">true</AndroidIncludeAssetPacksInPackage>
 </PropertyGroup>
 
 <PropertyGroup>
-	<BeforeBuildAndroidAssetPacks>
-		UpdateAndroidAssets
-		;_CalculateAssetsWithAssetPackMetaData
-		;_CalculateAssetPacks
-		;$(BeforeBuildAndroidAssetPacks)
-		;_CreateAssetPackManifests
-	</BeforeBuildAndroidAssetPacks>
+  <BeforeBuildAndroidAssetPacks>
+    UpdateAndroidAssets
+    ;_CalculateAssetsWithAssetPackMetaData
+    ;_CalculateAssetPacks
+    ;$(BeforeBuildAndroidAssetPacks)
+    ;_CreateAssetPackManifests
+  </BeforeBuildAndroidAssetPacks>
 </PropertyGroup>
 
 <!-- Assets Build -->
 
 <Target Name="UpdateAndroidAssets"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_CalculateAssetPacks;_GenerateAndroidAssetsDir" />
+  DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_CalculateAssetPacks;_GenerateAndroidAssetsDir" />
 
 <Target Name="_ComputeAndroidAssetsPaths">
-	<AndroidComputeResPaths
-		ResourceFiles="@(AndroidAsset)"
-		IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
-		AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
-		Prefixes="$(MonoAndroidAssetsPrefix)"
-		ProjectDir="$(ProjectDir)"
-	>
-		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
-		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
-	</AndroidComputeResPaths>
+  <AndroidComputeResPaths
+    ResourceFiles="@(AndroidAsset)"
+    IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
+    AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
+    Prefixes="$(MonoAndroidAssetsPrefix)"
+    ProjectDir="$(ProjectDir)"
+  >
+    <Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
+    <Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
+  </AndroidComputeResPaths>
 </Target>
 
 <Target Name="_GenerateAndroidAssetsDir"
-		Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
-		Outputs="@(_AndroidAssetsDest)">
-	<ItemGroup>
-		<_AssetDirectories Include="$(MonoAndroidAssetsDirIntermediate)" />
-		<_AssetDirectories Include="@(_AssetPacks->'%(AssetPackDirectory)')" />
-	</ItemGroup>
-	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate);$(MonoAndroidAssetPacksDirIntermediate)" />
-	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
-	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directories="@(_AssetDirectories)" RemoveDirectories="true" FileType="AndroidAsset" />
-	<Touch Files="@(_AndroidAssetsDest)" />
-	<ItemGroup>
-		<FileWrites Include="@(_AndroidAssetsDest)" />
-	</ItemGroup>
+    Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
+    Outputs="@(_AndroidAssetsDest)">
+  <ItemGroup>
+    <_AssetDirectories Include="$(MonoAndroidAssetsDirIntermediate)" />
+    <_AssetDirectories Include="@(_AssetPacks->'%(AssetPackDirectory)')" />
+  </ItemGroup>
+  <MakeDir Directories="$(MonoAndroidAssetsDirIntermediate);$(MonoAndroidAssetPacksDirIntermediate)" />
+  <Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
+  <RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directories="@(_AssetDirectories)" RemoveDirectories="true" FileType="AndroidAsset" />
+  <Touch Files="@(_AndroidAssetsDest)" />
+  <ItemGroup>
+    <FileWrites Include="@(_AndroidAssetsDest)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_CalculateAssetsWithAssetPackMetaData">
-	<ItemGroup>
-		<_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
-	</ItemGroup>
-	<AndroidError 
-		Code="XA0138"
-		ResourceName="XA0138"
-		Condition=" '$(AndroidApplication)' != 'true' And '@(_AssetsWithAssetPackMetaData->Count())' != '0' "
-	/>
+  <ItemGroup>
+    <_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
+  </ItemGroup>
+  <AndroidError 
+    Code="XA0138"
+    ResourceName="XA0138"
+    Condition=" '$(AndroidApplication)' != 'true' And '@(_AssetsWithAssetPackMetaData->Count())' != '0' "
+  />
 </Target>
 
 <Target Name="_CalculateAssetPacks"
-		DependsOnTargets="_CalculateAssetsWithAssetPackMetaData"
-		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
-	>
-	<!-- Enumerate the assetpacks directory and build a pack per top level directory -->
-	<GetAssetPacks Assets="@(_AssetsWithAssetPackMetaData)" IntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)">
-		<Output ItemName="_AndroidAsset" TaskParameter="AssetPacks" />
-	</GetAssetPacks>
-	<ItemGroup>
-		<_AssetPacks Include="@(_AndroidAsset)">
-			<AssetPackDirectory>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\assets</AssetPackDirectory>
-			<AssetPackOutput>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack).zip</AssetPackOutput>
-			<ManifestFile>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\AndroidManifest.xml</ManifestFile>
-			<DeliveryType Condition=" '%(_AndroidAsset.DeliveryType)' == '' ">InstallTime</DeliveryType>
-		</_AssetPacks>
-		<FileWrites Include="@(_AssetPacks->'%(AssetPackCacheFile)')" />
-	</ItemGroup>
+    DependsOnTargets="_CalculateAssetsWithAssetPackMetaData"
+    Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+  >
+  <!-- Enumerate the assetpacks directory and build a pack per top level directory -->
+  <GetAssetPacks Assets="@(_AssetsWithAssetPackMetaData)" IntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)">
+    <Output ItemName="_AndroidAsset" TaskParameter="AssetPacks" />
+  </GetAssetPacks>
+  <ItemGroup>
+    <_AssetPacks Include="@(_AndroidAsset)">
+      <AssetPackDirectory>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\assets</AssetPackDirectory>
+      <AssetPackOutput>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack).zip</AssetPackOutput>
+      <ManifestFile>$(MonoAndroidAssetPacksDirIntermediate)\%(_AndroidAsset.AssetPack)\AndroidManifest.xml</ManifestFile>
+      <DeliveryType Condition=" '%(_AndroidAsset.DeliveryType)' == '' ">InstallTime</DeliveryType>
+    </_AssetPacks>
+    <FileWrites Include="@(_AssetPacks->'%(AssetPackCacheFile)')" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_CreateAssetPackManifests"
-		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
-		Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
-		Outputs="@(_AssetPacks->'%(ManifestFile)')">
+    Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+    Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
+    Outputs="@(_AssetPacks->'%(ManifestFile)')">
 
-	<CreateDynamicFeatureManifest
-		FeatureSplitName="%(_AssetPacks.AssetPack)"
-		FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
-		FeatureType="AssetPack"
-		PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
-		OutputFile="%(_AssetPacks.ManifestFile)"
-	/>
-	<ItemGroup>
-		<FileWrites Include="%(_AssetPacks.ManifestFile)" />
-	</ItemGroup>
+  <CreateDynamicFeatureManifest
+    FeatureSplitName="%(_AssetPacks.AssetPack)"
+    FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
+    FeatureType="AssetPack"
+    PackageName="$(_AndroidPackage)"
+    OutputFile="%(_AssetPacks.ManifestFile)"
+  />
+  <ItemGroup>
+    <FileWrites Include="%(_AssetPacks.ManifestFile)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_BuildAssetPacks"
-		DependsOnTargets="$(BeforeBuildAndroidAssetPacks)"
-		Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
-		Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
-		Outputs="@(_AssetPacks->'%(AssetPackOutput)')">
+    DependsOnTargets="$(BeforeBuildAndroidAssetPacks)"
+    Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
+    Inputs="@(_AssetPacks->'%(AssetPackCacheFile)')"
+    Outputs="@(_AssetPacks->'%(AssetPackOutput)')">
 
-	<Aapt2LinkAssetPack
-		DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
-		DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
-		OutputArchive="%(_AssetPacks.AssetPackOutput)"
-		AssetDirectories="%(_AssetPacks.AssetPackDirectory)"
-		Manifest="%(_AssetPacks.ManifestFile)"
-		PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
-		ToolPath="$(Aapt2ToolPath)"
-		ToolExe="$(Aapt2ToolExe)"
-	/>
-	<ItemGroup>
-		<AndroidAppBundleModules Include="%(_AssetPacks.AssetPackOutput)" Condition=" '$(AndroidIncludeAssetPacksInPackage)' == 'true' "/>
-		<FileWrites Include="$%(_AssetPacks.AssetPackOutput)" />
-	</ItemGroup>
+  <Aapt2LinkAssetPack
+    DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+    DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+    OutputArchive="%(_AssetPacks.AssetPackOutput)"
+    AssetDirectories="%(_AssetPacks.AssetPackDirectory)"
+    Manifest="%(_AssetPacks.ManifestFile)"
+    PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+    ToolPath="$(Aapt2ToolPath)"
+    ToolExe="$(Aapt2ToolExe)"
+  />
+  <ItemGroup>
+    <AndroidAppBundleModules Include="%(_AssetPacks.AssetPackOutput)" Condition=" '$(AndroidIncludeAssetPacksInPackage)' == 'true' "/>
+    <FileWrites Include="$%(_AssetPacks.AssetPackOutput)" />
+  </ItemGroup>
 </Target>
+
+<Target Name="BuildAndroidAssetPacks" DependsOnTargets="_BuildAssetPacks"/>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Assets.targets
@@ -25,10 +25,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <!-- Assets build properties -->
 <PropertyGroup>
-    <MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
-    <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks</MonoAndroidAssetPacksDirIntermediate>
-    <MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
-    <AndroidIncludeAssetPacksInPackage Condition=" '$(AndroidIncludeAssetPacksInPackage)' == '' ">true</AndroidIncludeAssetPacksInPackage>
+  <MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
+  <MonoAndroidAssetPacksDirIntermediate>$(IntermediateOutputPath)assetpacks</MonoAndroidAssetPacksDirIntermediate>
+  <MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
+  <AndroidIncludeAssetPacksInPackage Condition=" '$(AndroidIncludeAssetPacksInPackage)' == '' ">true</AndroidIncludeAssetPacksInPackage>
 </PropertyGroup>
 
 <PropertyGroup>
@@ -44,15 +44,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- Assets Build -->
 
 <Target Name="UpdateAndroidAssets"
-  DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_CalculateAssetPacks;_GenerateAndroidAssetsDir" />
+    DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_CalculateAssetPacks;_GenerateAndroidAssetsDir" />
 
 <Target Name="_ComputeAndroidAssetsPaths">
   <AndroidComputeResPaths
-    ResourceFiles="@(AndroidAsset)"
-    IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
-    AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
-    Prefixes="$(MonoAndroidAssetsPrefix)"
-    ProjectDir="$(ProjectDir)"
+      ResourceFiles="@(AndroidAsset)"
+      IntermediateDir="$(MonoAndroidAssetsDirIntermediate)"
+      AssetPackIntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)"
+      Prefixes="$(MonoAndroidAssetsPrefix)"
+      ProjectDir="$(ProjectDir)"
   >
     <Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
     <Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
@@ -80,9 +80,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AssetsWithAssetPackMetaData Include="@(AndroidAsset)" Condition=" '%(AndroidAsset.AssetPack)' != '' " />
   </ItemGroup>
   <AndroidError 
-    Code="XA0138"
-    ResourceName="XA0138"
-    Condition=" '$(AndroidApplication)' != 'true' And '@(_AssetsWithAssetPackMetaData->Count())' != '0' "
+      Condition=" '$(AndroidApplication)' != 'true' And '@(_AssetsWithAssetPackMetaData->Count())' != '0' "
+      Code="XA0138"
+      ResourceName="XA0138"
   />
 </Target>
 
@@ -91,7 +91,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Condition=" ('$(AndroidPackageFormat)' == 'aab' And '$(AndroidApplication)' == 'true') "
   >
   <!-- Enumerate the assetpacks directory and build a pack per top level directory -->
-  <GetAssetPacks Assets="@(_AssetsWithAssetPackMetaData)" IntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)">
+  <GetAssetPacks
+      Assets="@(_AssetsWithAssetPackMetaData)"
+      IntermediateDir="$(MonoAndroidAssetPacksDirIntermediate)">
     <Output ItemName="_AndroidAsset" TaskParameter="AssetPacks" />
   </GetAssetPacks>
   <ItemGroup>
@@ -111,11 +113,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Outputs="@(_AssetPacks->'%(ManifestFile)')">
 
   <CreateDynamicFeatureManifest
-    FeatureSplitName="%(_AssetPacks.AssetPack)"
-    FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
-    FeatureType="AssetPack"
-    PackageName="$(_AndroidPackage)"
-    OutputFile="%(_AssetPacks.ManifestFile)"
+      FeatureSplitName="%(_AssetPacks.AssetPack)"
+      FeatureDeliveryType="%(_AssetPacks.DeliveryType)"
+      FeatureType="AssetPack"
+      PackageName="$(_AndroidPackage)"
+      OutputFile="%(_AssetPacks.ManifestFile)"
   />
   <ItemGroup>
     <FileWrites Include="%(_AssetPacks.ManifestFile)" />
@@ -129,14 +131,14 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Outputs="@(_AssetPacks->'%(AssetPackOutput)')">
 
   <Aapt2LinkAssetPack
-    DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
-    DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
-    OutputArchive="%(_AssetPacks.AssetPackOutput)"
-    AssetDirectories="%(_AssetPacks.AssetPackDirectory)"
-    Manifest="%(_AssetPacks.ManifestFile)"
-    PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
-    ToolPath="$(Aapt2ToolPath)"
-    ToolExe="$(Aapt2ToolExe)"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+      OutputArchive="%(_AssetPacks.AssetPackOutput)"
+      AssetDirectories="%(_AssetPacks.AssetPackDirectory)"
+      Manifest="%(_AssetPacks.ManifestFile)"
+      PackageName="$(_AndroidPackage).%(_AssetPacks.AssetPack)"
+      ToolPath="$(Aapt2ToolPath)"
+      ToolExe="$(Aapt2ToolExe)"
   />
   <ItemGroup>
     <AndroidAppBundleModules Include="%(_AssetPacks.AssetPackOutput)" Condition=" '$(AndroidIncludeAssetPacksInPackage)' == 'true' "/>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -76,7 +76,7 @@ properties that determine build ordering.
       _LintChecks;
       _IncludeNativeSystemLibraries;
       _CheckGoogleSdkRequirements;
-      _BuildAssetPacks;
+      BuildAndroidAssetPacks;
     </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -76,6 +76,7 @@ properties that determine build ordering.
       _LintChecks;
       _IncludeNativeSystemLibraries;
       _CheckGoogleSdkRequirements;
+      _BuildAssetPacks;
     </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>
 
@@ -91,6 +92,7 @@ properties that determine build ordering.
       _AddAndroidDefines;
       _CheckForContent;
       _CheckForObsoleteFrameworkAssemblies;
+      _CalculateAssetsWithAssetPackMetaData;
       _RemoveLegacyDesigner;
       _ValidateAndroidPackageProperties;
       AddLibraryJarsToBind;

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1600,5 +1600,15 @@ namespace Xamarin.Android.Tasks.Properties {
                 return ResourceManager.GetString("XA1036", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AndroidManifest.xml //uses-sdk/@android:minSdkVersion &apos;{0}&apos; does not match the $(SupportedOSPlatformVersion) value &apos;{1}&apos; in the project file (if there is no $(SupportedOSPlatformVersion) value in the project file, then a default value has been assumed).
+        ///Either change the value in the AndroidManifest.xml to match the $(SupportedOSPlatformVersion) value, or remove the value in the AndroidManifest.xml (and add a $(SupportedOSPlatformVersion) value to the project file if it doesn&apos;t already exist)..
+        /// </summary>
+        public static string XA1039 {
+            get {
+                return ResourceManager.GetString("XA1039", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -330,8 +330,13 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
 {0} - The file name of a deprecated symbol file</comment>
   </data>
   <data name="XA0138" xml:space="preserve">
-    <value>@(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.</value>
+    <value>%(AndroidAsset.AssetPack) and %(AndroidAsset.AssetPack) item metadata are only supported when `$(AndroidApplication)` is `true`.</value>
     <comment></comment>
+  </data>
+  <data name="XA0139" xml:space="preserve">
+    <value>`@(AndroidAsset)` `{0}` has an invalid `DeliveryType` metadata of `{1}`. Supported values are `installtime`, `ondemand` or `fastfollow`.</value>
+    <comment>{0} - The file name
+{1} - The value of the attribute in the project file.</comment>
   </data>
   <data name="XA1000" xml:space="preserve">
     <value>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -338,6 +338,11 @@ The capitalized word "Portable" that appears earlier in the message is plain tex
     <comment>{0} - The file name
 {1} - The value of the attribute in the project file.</comment>
   </data>
+  <data name="XA0140" xml:space="preserve">
+    <value>The AssetPack value defined for `{0}` has invalid characters. `{1}` should only contain A-z, a-z, 0-9 or an underscore.</value>
+    <comment>{0} - The file name
+{1} - The value of the attribute in the metadata.</comment>
+  </data>
   <data name="XA1000" xml:space="preserve">
     <value>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</value>
     <comment>{0} - The file name

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -329,6 +329,10 @@ If this file comes from a NuGet package, update to a newer version of the NuGet 
 The capitalized word "Portable" that appears earlier in the message is plain text and should be translated, but the lowercase word "portable" later in the message is a literal value and should not be translated.
 {0} - The file name of a deprecated symbol file</comment>
   </data>
+  <data name="XA0138" xml:space="preserve">
+    <value>@(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.</value>
+    <comment></comment>
+  </data>
   <data name="XA1000" xml:space="preserve">
     <value>There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}</value>
     <comment>{0} - The file name

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Android.Tasks {
 					zip.FixupWindowsPathSeparators ((a, b) => Log.LogDebugMessage ($"Fixing up malformed entry `{a}` -> `{b}`"));
 				}
 			}
+			await System.Threading.Tasks.Task.CompletedTask;
 		}
 
 		protected string[] GenerateCommandLineCommands (ITaskItem manifest, ITaskItem output)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks {
+
+	public class Aapt2LinkAssetPack : Aapt2 {
+		public override string TaskPrefix => "A2LAP";
+
+		[Required]
+		public ITaskItem Manifest { get; set; }
+
+		[Required]
+		public ITaskItem[] AssetDirectories { get; set; }
+
+		[Required]
+		public string PackageName { get; set; }
+
+		[Required]
+		public ITaskItem OutputArchive { get; set; }
+
+		public string OutputFormat { get; set; } = "proto";
+
+		protected override int GetRequiredDaemonInstances ()
+		{
+			return Math.Min (1, DaemonMaxInstanceCount);
+		}
+
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
+		{
+			RunAapt (GenerateCommandLineCommands (Manifest, OutputArchive), OutputArchive.ItemSpec);
+			ProcessOutput ();
+			if (OutputFormat == "proto" && File.Exists (OutputArchive.ItemSpec)) {
+				// move the manifest to the right place.
+				using (var zip = new ZipArchiveEx (OutputArchive.ItemSpec, File.Exists (OutputArchive.ItemSpec) ? FileMode.Open : FileMode.Create)) {
+					zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml");
+					zip.Archive.DeleteEntry ("resources.pb");
+				}
+			}
+		}
+
+		protected string[] GenerateCommandLineCommands (ITaskItem manifest, ITaskItem output)
+		{
+			//link --manifest AndroidManifest.xml --proto-format --custom-package $(Package) -A $(AssetsDirectory) -o $(_TempOutputFile)
+			List<string> cmd = new List<string> ();
+			cmd.Add ("link");
+			if (MonoAndroidHelper.LogInternalExceptions)
+				cmd.Add ("-v");
+			cmd.Add ("--manifest");
+			cmd.Add (GetFullPath (manifest.ItemSpec));
+			if (OutputFormat == "proto") {
+				cmd.Add ("--proto-format");
+			}
+			cmd.Add ("--custom-package");
+			cmd.Add (PackageName);
+			foreach (var assetDirectory in AssetDirectories) {
+				cmd.Add ("-A");
+				cmd.Add (GetFullPath (assetDirectory.ItemSpec));
+			}
+			cmd.Add ($"-o");
+			cmd.Add (GetFullPath (output.ItemSpec));
+			return cmd.ToArray ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Android.Tasks {
 				using (var zip = new ZipArchiveEx (OutputArchive.ItemSpec, File.Exists (OutputArchive.ItemSpec) ? FileMode.Open : FileMode.Create)) {
 					zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml");
 					zip.Archive.DeleteEntry ("resources.pb");
+					// Fix up aapt2 not dealing with '\' in subdirectories for assets.
+					zip.FixupWindowsPathSeparators ((a, b) => Log.LogDebugMessage ($"Fixing up malformed entry `{a}` -> `{b}`"));
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2LinkAssetPack.cs
@@ -29,8 +29,6 @@ namespace Xamarin.Android.Tasks {
 		[Required]
 		public ITaskItem OutputArchive { get; set; }
 
-		public string OutputFormat { get; set; } = "proto";
-
 		protected override int GetRequiredDaemonInstances ()
 		{
 			return Math.Min (1, DaemonMaxInstanceCount);
@@ -40,7 +38,7 @@ namespace Xamarin.Android.Tasks {
 		{
 			RunAapt (GenerateCommandLineCommands (Manifest, OutputArchive), OutputArchive.ItemSpec);
 			ProcessOutput ();
-			if (OutputFormat == "proto" && File.Exists (OutputArchive.ItemSpec)) {
+			if (File.Exists (OutputArchive.ItemSpec)) {
 				// move the manifest to the right place.
 				using (var zip = new ZipArchiveEx (OutputArchive.ItemSpec, File.Exists (OutputArchive.ItemSpec) ? FileMode.Open : FileMode.Create)) {
 					zip.MoveEntry ("AndroidManifest.xml", "manifest/AndroidManifest.xml");
@@ -61,9 +59,7 @@ namespace Xamarin.Android.Tasks {
 				cmd.Add ("-v");
 			cmd.Add ("--manifest");
 			cmd.Add (GetFullPath (manifest.ItemSpec));
-			if (OutputFormat == "proto") {
-				cmd.Add ("--proto-format");
-			}
+			cmd.Add ("--proto-format");
 			cmd.Add ("--custom-package");
 			cmd.Add (PackageName);
 			foreach (var assetDirectory in AssetDirectories) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string IntermediateDir { get; set; }
 
+		public string AssetPackIntermediateDir { get; set; }
+
 		public string Prefixes { get; set; }
 
 		public bool LowercaseFilenames { get; set; }
@@ -83,6 +85,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				//compute the target path
 				string rel;
+				var assetPack = item.GetMetadata ("AssetPack");
 				var logicalName = item.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);
 				if (item.GetMetadata ("IsWearApplicationResource") == "True") {
 					rel = item.ItemSpec.Substring (IntermediateDir.Length);
@@ -126,6 +129,11 @@ namespace Xamarin.Android.Tasks
 				}
 				string dest = Path.GetFullPath (Path.Combine (IntermediateDir, baseFileName));
 				string intermediateDirFullPath = Path.GetFullPath (IntermediateDir);
+				if (!string.IsNullOrEmpty (assetPack) && (string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) != 0) && !string.IsNullOrEmpty (AssetPackIntermediateDir)) {
+					dest = Path.GetFullPath (Path.Combine (AssetPackIntermediateDir, assetPack, "assets", baseFileName));
+					intermediateDirFullPath = Path.GetFullPath (AssetPackIntermediateDir);
+				}
+				
 				// if the path ends up "outside" of our target intermediate directory, just use the filename
 				if (String.Compare (intermediateDirFullPath, 0, dest, 0, intermediateDirFullPath.Length, StringComparison.OrdinalIgnoreCase) != 0) {
 					dest = Path.GetFullPath (Path.Combine (IntermediateDir, Path.GetFileName (baseFileName)));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -129,7 +129,9 @@ namespace Xamarin.Android.Tasks
 				}
 				string dest = Path.GetFullPath (Path.Combine (IntermediateDir, baseFileName));
 				string intermediateDirFullPath = Path.GetFullPath (IntermediateDir);
-				if (!string.IsNullOrEmpty (assetPack) && (string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) != 0) && !string.IsNullOrEmpty (AssetPackIntermediateDir)) {
+				if (!string.IsNullOrEmpty (assetPack) &&
+						(string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) != 0) &&
+						!string.IsNullOrEmpty (AssetPackIntermediateDir)) {
 					dest = Path.GetFullPath (Path.Combine (AssetPackIntermediateDir, assetPack, "assets", baseFileName));
 					intermediateDirFullPath = Path.GetFullPath (AssetPackIntermediateDir);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -61,7 +61,8 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		void GenerateFeatureManifest (XDocument doc) {
+		void GenerateFeatureManifest (XDocument doc)
+		{
 			XAttribute featureTitleResource = null;
 			if (!string.IsNullOrEmpty (FeatureTitleResource))
 				featureTitleResource = new XAttribute (distNS + "title", FeatureTitleResource);
@@ -71,9 +72,9 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (MinSdkVersion))
 				usesSdk.Add (new XAttribute (androidNS + "targetSdkVersion", TargetSdkVersion));
 			doc.Add (new XElement ("manifest",
-					new XAttribute(XNamespace.Xmlns + "android", androidNS),
-					new XAttribute(XNamespace.Xmlns + "tools", toolsNS),
-					new XAttribute(XNamespace.Xmlns + "dist", distNS),
+					new XAttribute (XNamespace.Xmlns + "android", androidNS),
+					new XAttribute (XNamespace.Xmlns + "tools", toolsNS),
+					new XAttribute (XNamespace.Xmlns + "dist", distNS),
 					new XAttribute (androidNS + "versionCode", "1"),
 					new XAttribute (androidNS + "versionName", "1.0"),
 					new XAttribute ("package", PackageName),
@@ -98,7 +99,8 @@ namespace Xamarin.Android.Tasks
 			);
 		}
 
-		void GenerateAssetPackManifest (XDocument doc) {
+		void GenerateAssetPackManifest (XDocument doc)
+		{
 			doc.Add (new XElement ("manifest",
 					new XAttribute (XNamespace.Xmlns + "android", androidNS),
 					new XAttribute (XNamespace.Xmlns + "tools", toolsNS),
@@ -121,15 +123,15 @@ namespace Xamarin.Android.Tasks
 		XElement GetDistribution ()
 		{
 			XElement distribution;
-			switch (FeatureDeliveryType)
+			switch (FeatureDeliveryType.ToLowerInvariant ())
 			{
-				case "OnDemand":
+				case "ondemand":
 					distribution = new XElement (distNS + "on-demand");
 					break;
-				case "FastFollow":
+				case "fastfollow":
 					distribution = new XElement (distNS + "fast-follow");
 					break;
-				case "InstallTime":
+				case "installtime":
 				default:
 					distribution = new XElement (distNS + "install-time");
 					break;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+
+using Xamarin.Android.Tools;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CreateDynamicFeatureManifest : AndroidTask
+	{
+		readonly XNamespace androidNS = "http://schemas.android.com/apk/res/android";
+		readonly XNamespace distNS = "http://schemas.android.com/apk/distribution";
+		readonly XNamespace toolsNS = "http://schemas.android.com/tools";
+
+		public override string TaskPrefix => "CDFM";
+
+		[Required]
+		public string FeatureSplitName { get; set; }
+
+		[Required]
+		public string FeatureDeliveryType { get; set; }
+
+		[Required]
+		public string FeatureType { get; set; }
+
+		[Required]
+		public string PackageName { get; set; }
+
+		[Required]
+		public ITaskItem OutputFile { get; set; }
+
+		public string FeatureTitleResource { get; set; }
+
+		public string MinSdkVersion { get; set; }
+
+		public string TargetSdkVersion { get; set; }
+
+		public bool IsFeatureSplit { get; set; } = false;
+		public bool IsInstant { get; set; } = false;
+		public bool HasCode { get; set; } = false;
+
+		public override bool RunTask ()
+		{
+			XDocument doc = new XDocument ();
+			switch (FeatureType) {
+				case "AssetPack":
+					GenerateAssetPackManifest (doc);
+					break;
+				default:
+					GenerateFeatureManifest (doc);
+					break;
+			}
+			doc.SaveIfChanged (OutputFile.ItemSpec);
+			return !Log.HasLoggedErrors;
+		}
+
+		void GenerateFeatureManifest (XDocument doc) {
+			XAttribute featureTitleResource = null;
+			if (!string.IsNullOrEmpty (FeatureTitleResource))
+				featureTitleResource = new XAttribute (distNS + "title", FeatureTitleResource);
+			XElement usesSdk = new XElement ("uses-sdk");
+			if (!string.IsNullOrEmpty (MinSdkVersion))
+				usesSdk.Add (new XAttribute (androidNS + "minSdkVersion", MinSdkVersion));
+			if (!string.IsNullOrEmpty (MinSdkVersion))
+				usesSdk.Add (new XAttribute (androidNS + "targetSdkVersion", TargetSdkVersion));
+			doc.Add (new XElement ("manifest",
+					new XAttribute(XNamespace.Xmlns + "android", androidNS),
+					new XAttribute(XNamespace.Xmlns + "tools", toolsNS),
+					new XAttribute(XNamespace.Xmlns + "dist", distNS),
+					new XAttribute (androidNS + "versionCode", "1"),
+					new XAttribute (androidNS + "versionName", "1.0"),
+					new XAttribute ("package", PackageName),
+					new XAttribute ("featureSplit", FeatureSplitName),
+					new XAttribute (androidNS + "isFeatureSplit", IsFeatureSplit),
+					new XElement (distNS + "module",
+						featureTitleResource,
+						new XAttribute (distNS + "instant", IsInstant),
+						new XElement (distNS + "delivery",
+							GetDistribution ()
+						),
+						new XElement (distNS + "fusing",
+							new XAttribute (distNS + "include", true)
+						)
+					),
+					usesSdk,
+					new XElement ("application",
+						new XAttribute (androidNS + "hasCode", HasCode),
+						new XAttribute (toolsNS + "replace", "android:hasCode")
+					)
+				)
+			);
+		}
+
+		void GenerateAssetPackManifest (XDocument doc) {
+			doc.Add (new XElement ("manifest",
+					new XAttribute (XNamespace.Xmlns + "android", androidNS),
+					new XAttribute (XNamespace.Xmlns + "tools", toolsNS),
+					new XAttribute (XNamespace.Xmlns + "dist", distNS),
+					new XAttribute ("package", PackageName),
+					new XAttribute ("split", FeatureSplitName),
+					new XElement (distNS + "module",
+						new XAttribute (distNS + "type", "asset-pack"),
+						new XElement (distNS + "delivery",
+							GetDistribution ()
+						),
+						new XElement (distNS + "fusing",
+							new XAttribute (distNS + "include", true)
+						)
+					)
+				)
+			);
+		}
+
+		XElement GetDistribution ()
+		{
+			XElement distribution;
+			switch (FeatureDeliveryType)
+			{
+				case "OnDemand":
+					distribution = new XElement (distNS + "on-demand");
+					break;
+				case "FastFollow":
+					distribution = new XElement (distNS + "fast-follow");
+					break;
+				case "InstallTime":
+				default:
+					distribution = new XElement (distNS + "install-time");
+					break;
+			}
+			return distribution;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateDynamicFeatureManifest.cs
@@ -49,8 +49,8 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			XDocument doc = new XDocument ();
-			switch (FeatureType) {
-				case "AssetPack":
+			switch (FeatureType.ToLowerInvariant ()) {
+				case "assetpack":
 					GenerateAssetPackManifest (doc);
 					break;
 				default:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	// We have a list of files, we want to get the
+	// ones that actually exist on disk.
+	public class GetAssetPacks : AndroidTask
+	{
+		public override string TaskPrefix => "GAP";
+
+		[Required]
+		public ITaskItem[] Assets { get; set; }
+
+		[Required]
+		public ITaskItem IntermediateDir { get; set; }
+
+		public string[] MetadataToCopy { get; set; } = { "DeliveryType" };
+
+		[Output]
+		public ITaskItem[] AssetPacks { get; set; }
+
+		public override bool RunTask ()
+		{
+			Dictionary<string, ITaskItem> assetPacks = new Dictionary<string, ITaskItem> ();
+			Dictionary<string, List<string>> files = new Dictionary<string, List<string>> ();
+			foreach (var asset in Assets)
+			{
+				var assetPack = asset.GetMetadata ("AssetPack");
+				if (string.IsNullOrEmpty (assetPack) || string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) == 0)
+					continue;
+				if (!assetPacks.TryGetValue (assetPack, out ITaskItem item))
+				{
+					item = new TaskItem (assetPack);
+					item.SetMetadata ("AssetPack", assetPack);
+					item.SetMetadata ("AssetPackCacheFile", Path.Combine (IntermediateDir.ItemSpec, assetPack, "assetpack.cache"));
+					assetPacks[assetPack] = item;
+				}
+				foreach (var metadata in MetadataToCopy)
+					if (string.IsNullOrEmpty (item.GetMetadata (metadata)))
+						item.SetMetadata (metadata, asset.GetMetadata (metadata));
+				if (!files.ContainsKey (assetPack))
+					files[assetPack] = new List<string> ();
+				files[assetPack].Add (asset.ItemSpec);
+			}
+
+			foreach (var kvp in assetPacks) {
+				// write out the file cache list
+				// write out the metadata as well.
+				ITaskItem item = kvp.Value;
+				var cacheFile = kvp.Value.GetMetadata ("AssetPackCacheFile");
+				using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) { 
+					foreach (var file in files [kvp.Key])
+						sw.WriteLine ($"{file}:{File.GetLastWriteTimeUtc (file)}");
+					sw.WriteLine (item.GetMetadata ("DeliveryType") ?? "InstallTime");
+					sw.Flush (); 
+					Files.CopyIfStreamChanged (sw.BaseStream, cacheFile); 
+				}
+			}
+
+			AssetPacks = assetPacks.Values.ToArray();
+
+			return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
@@ -30,8 +30,7 @@ namespace Xamarin.Android.Tasks
 		{
 			Dictionary<string, ITaskItem> assetPacks = new Dictionary<string, ITaskItem> ();
 			Dictionary<string, List<string>> files = new Dictionary<string, List<string>> ();
-			foreach (var asset in Assets)
-			{
+			foreach (var asset in Assets) {
 				var assetPack = asset.GetMetadata ("AssetPack");
 				if (string.IsNullOrEmpty (assetPack) || string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) == 0)
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAssetPacks.cs
@@ -35,18 +35,19 @@ namespace Xamarin.Android.Tasks
 				var assetPack = asset.GetMetadata ("AssetPack");
 				if (string.IsNullOrEmpty (assetPack) || string.Compare (assetPack, "base", StringComparison.OrdinalIgnoreCase) == 0)
 					continue;
-				if (!assetPacks.TryGetValue (assetPack, out ITaskItem item))
-				{
+				if (!assetPacks.TryGetValue (assetPack, out ITaskItem item)) {
 					item = new TaskItem (assetPack);
 					item.SetMetadata ("AssetPack", assetPack);
 					item.SetMetadata ("AssetPackCacheFile", Path.Combine (IntermediateDir.ItemSpec, assetPack, "assetpack.cache"));
 					assetPacks[assetPack] = item;
 				}
-				foreach (var metadata in MetadataToCopy)
+				foreach (var metadata in MetadataToCopy) {
 					if (string.IsNullOrEmpty (item.GetMetadata (metadata)))
 						item.SetMetadata (metadata, asset.GetMetadata (metadata));
-				if (!files.ContainsKey (assetPack))
+				}
+				if (!files.ContainsKey (assetPack)) {
 					files[assetPack] = new List<string> ();
+				}
 				files[assetPack].Add (asset.ItemSpec);
 			}
 
@@ -56,8 +57,9 @@ namespace Xamarin.Android.Tasks
 				ITaskItem item = kvp.Value;
 				var cacheFile = kvp.Value.GetMetadata ("AssetPackCacheFile");
 				using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) { 
-					foreach (var file in files [kvp.Key])
+					foreach (var file in files [kvp.Key]) {
 						sw.WriteLine ($"{file}:{File.GetLastWriteTimeUtc (file)}");
+					}
 					sw.WriteLine (item.GetMetadata ("DeliveryType") ?? "InstallTime");
 					sw.Flush (); 
 					Files.CopyIfStreamChanged (sw.BaseStream, cacheFile); 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveUnknownFiles.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				var files = System.IO.Directory.GetFiles (absDir, "*", SearchOption.AllDirectories);
-				foreach (string f in files)
+				foreach (string f in files) {
 					if (!knownFiles.Contains (f)) {
 						Log.LogDebugMessage ("Deleting File {0}", f);
 						var item = new TaskItem (f.Replace (absDir, root + Path.DirectorySeparatorChar));
@@ -62,18 +62,20 @@ namespace Xamarin.Android.Tasks
 						Microsoft.Android.Build.Tasks.Files.SetWriteable (f);
 						File.Delete (f);
 					}
+				}
 				
 				if (RemoveDirectories) {
 					var knownDirs = new HashSet<string> (knownFiles.Select (d => Path.GetDirectoryName (d)));
 					var dirs = System.IO.Directory.GetDirectories (absDir, "*", SearchOption.AllDirectories);
 
-					foreach (string d in dirs.OrderByDescending (s => s.Length))
+					foreach (string d in dirs.OrderByDescending (s => s.Length)) {
 						if (!knownDirs.Contains (d) && IsDirectoryEmpty (d)) {
 							Log.LogDebugMessage ("Deleting Directory {0}", d);
 							removedDirectories.Add (new TaskItem(d));
 							Microsoft.Android.Build.Tasks.Files.SetDirectoryWriteable (d);
 							System.IO.Directory.Delete (d);
 						}
+					}
 				}
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var builder = CreateDllBuilder (Path.Combine (path, lib.ProjectName))) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (lib), $"{lib.ProjectName} should fail.");
-				StringAssertEx.Contains ("error XA0138: @(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.", builder.LastBuildOutput,
+				StringAssertEx.Contains ("error XA0138:", builder.LastBuildOutput,
 					"Build Output did not contain error XA0138'.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -1,0 +1,208 @@
+using System;
+using NUnit.Framework;
+using System.IO;
+using System.Text;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[Category ("Node-3")]
+	[Parallelizable (ParallelScope.Children)]
+	public class AssetPackTests : BaseTest
+	{
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildLibraryWithAssetPack ([Values (true, false)] bool isRelease)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidLibraryProject {
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset1.txt") {
+						TextContent = () => "Asset1",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1",
+					},
+				}
+			};
+			using (var builder = CreateDllBuilder (Path.Combine (path, lib.ProjectName))) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (lib), $"{lib.ProjectName} should fail.");
+				StringAssertEx.Contains ("error XA0138: @(AndroidAsset) build action does not support 'AssetPack' or 'DeliveryType' Metadata in Library Projects.", builder.LastBuildOutput,
+					"Build Output did not contain error XA0138'.");
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildApplicationWithAssetPackOutsideProjectDirectory ([Values (true, false)] bool isRelease)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("..\\Assets\\asset1.txt") {
+						TextContent = () => "Asset1",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1;Link=Assets\\asset1.txt",
+					},
+					new AndroidItem.AndroidAsset ("..\\Assets\\asset2.txt") {
+						TextContent = () => "Asset2",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1;Link=Assets\\asset2.txt",
+					},
+					new AndroidItem.AndroidAsset ("..\\Assets\\SubDirectory\\asset3.txt") {
+						TextContent = () => "Asset2",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1;Link=Assets\\SubDirectory\\asset3.txt",
+					},
+				}
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
+				// Check the final aab has the required feature files in it.
+				var aab = Path.Combine (Root, appBuilder.ProjectDirectory,
+					app.OutputPath, $"{app.PackageName}.aab");
+				using (var zip = ZipHelper.OpenZip (aab)) {
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset1.txt"), "aab should not contain base/assets/asset1.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset2.txt"), "aab should not contain base/assets/asset2.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/SubDirectory/asset3.txt"), "aab should not contain base/assets/SubDirectory/asset3.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset1.txt"), "aab should contain assetpack1/assets/asset1.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset2.txt"), "aab should contain assetpack1/assets/asset2.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/SubDirectory/asset3.txt"), "aab should contain assetpack1/assets/SubDirectory/asset3.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets.pb"), "aab should contain assetpack1/assets.pb");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
+				}
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildApplicationWithAssetPackOverrides ([Values (true, false)] bool isRelease)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset1.txt") {
+						TextContent = () => "Asset1",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1",
+					},
+					new AndroidItem.AndroidAsset ("Assets\\asset2.txt") {
+						TextContent = () => "Asset2",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=base",
+					},
+				}
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
+				// Check the final aab has the required feature files in it.
+				var aab = Path.Combine (Root, appBuilder.ProjectDirectory,
+					app.OutputPath, $"{app.PackageName}.aab");
+				using (var zip = ZipHelper.OpenZip (aab)) {
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset1.txt"), "aab should not contain base/assets/asset1.txt");
+					Assert.IsTrue (zip.ContainsEntry ("base/assets/asset2.txt"), "aab should contain base/assets/asset2.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset1.txt"), "aab should contain assetpack1/assets/asset1.txt");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/assets/asset2.txt"), "aab should not contain assetpack1/assets/asset2.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets.pb"), "aab should contain assetpack1/assets.pb");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
+				}
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
+		public void BuildApplicationWithAssetPack ([Values (true, false)] bool isRelease) {
+			var path = Path.Combine ("temp", TestName);
+			var asset3 = new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
+				TextContent = () => "Asset3",
+				Encoding = Encoding.ASCII,
+				MetadataValues="AssetPack=assetpack1",
+			};
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset1.txt") {
+						TextContent = () => "Asset1",
+						Encoding = Encoding.ASCII,
+					},
+					new AndroidItem.AndroidAsset ("Assets\\asset2.txt") {
+						TextContent = () => "Asset2",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack1;DeliveryType=InstallTime",
+					},
+					asset3,
+					new AndroidItem.AndroidAsset ("Assets\\asset4.txt") {
+						TextContent = () => "Asset4",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack2;DeliveryType=OnDemand",
+					},
+					new AndroidItem.AndroidAsset ("Assets\\asset5.txt") {
+						TextContent = () => "Asset5",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=assetpack3;DeliveryType=FastFollow",
+					},
+				}
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should succeed");
+				// Check the final aab has the required feature files in it.
+				var aab = Path.Combine (Root, appBuilder.ProjectDirectory,
+					app.OutputPath, $"{app.PackageName}.aab");
+				var asset3File = Path.Combine (Root, path, app.ProjectName,
+					app.IntermediateOutputPath, "assetpacks", "assetpack1", "assets", "asset3.txt");
+				using (var zip = ZipHelper.OpenZip (aab)) {
+					Assert.IsTrue (zip.ContainsEntry ("base/assets/asset1.txt"), "aab should contain base/assets/asset1.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset2.txt"), "aab should not contain base/assets/asset2.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset3.txt"), "aab should not contain base/assets/asset3.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset4.txt"), "aab should not contain base/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset2.txt"), "aab should contain assetpack1/assets/asset2.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset3.txt"), "aab should contain assetpack1/assets/asset3.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack2/assets/asset4.txt"), "aab should contain assetpack2/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack3/assets/asset5.txt"), "aab should contain assetpack3/assets/asset5.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets.pb"), "aab should contain assetpack1/assets.pb");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
+				}
+				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), $"{app.ProjectName} should succeed");
+				appBuilder.Output.AssertTargetIsSkipped ("_CreateAssetPackManifests");
+				appBuilder.Output.AssertTargetIsSkipped ("_BuildAssetPacks");
+				appBuilder.Output.AssertTargetIsSkipped ("_GenerateAndroidAssetsDir");
+				FileAssert.Exists (asset3File, $"file {asset3File} should exist.");
+				asset3.TextContent = () => "Asset3 Updated";
+				asset3.Timestamp = DateTime.UtcNow.AddSeconds(1);
+				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), $"{app.ProjectName} should succeed");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_CreateAssetPackManifests");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_BuildAssetPacks");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_GenerateAndroidAssetsDir");
+				FileAssert.Exists (asset3File, $"file {asset3File} should exist.");
+				Assert.AreEqual (asset3.TextContent (), File.ReadAllText (asset3File), $"Contents of {asset3File} should have been updated.");
+				app.OtherBuildItems.Remove (asset3);
+				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true), $"{app.ProjectName} should succeed");
+				FileAssert.DoesNotExist (asset3File, $"file {asset3File} should not exist.");
+				using (var zip = ZipHelper.OpenZip (aab)) {
+					Assert.IsTrue (zip.ContainsEntry ("base/assets/asset1.txt"), "aab should contain base/assets/asset1.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset2.txt"), "aab should not contain base/assets/asset2.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset3.txt"), "aab should not contain base/assets/asset3.txt");
+					Assert.IsFalse (zip.ContainsEntry ("base/assets/asset4.txt"), "aab should not contain base/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets/asset2.txt"), "aab should contain assetpack1/assets/asset2.txt");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/assets/asset3.txt"), "aab should not contain assetpack1/assets/asset3.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack2/assets/asset4.txt"), "aab should contain assetpack2/assets/asset4.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack3/assets/asset5.txt"), "aab should contain assetpack3/assets/asset5.txt");
+					Assert.IsTrue (zip.ContainsEntry ("assetpack1/assets.pb"), "aab should contain assetpack1/assets.pb");
+					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
+				}
+				appBuilder.Output.AssertTargetIsNotSkipped ("_CreateAssetPackManifests");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_BuildAssetPacks");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_GenerateAndroidAssetsDir");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -35,6 +35,30 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Category ("SmokeTests")]
+		public void BuildApplicationWithAssetPackThatHasInvalidName ([Values (true, false)] bool isRelease)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var app = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\asset1.txt") {
+						TextContent = () => "Asset1",
+						Encoding = Encoding.ASCII,
+						MetadataValues="AssetPack=asset-pack1",
+					},
+				}
+			};
+			app.SetProperty ("AndroidPackageFormat", "aab");
+			using (var builder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (app), $"{app.ProjectName} should fail.");
+				StringAssertEx.Contains ("error XA0140:", builder.LastBuildOutput,
+					"Build Output did not contain error XA0140'.");
+			}
+		}
+
+		[Test]
+		[Category ("SmokeTests")]
 		public void BuildApplicationWithAssetPackOutsideProjectDirectory ([Values (true, false)] bool isRelease)
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -124,6 +124,22 @@ namespace Xamarin.Android.Tasks
 				zip.DeleteEntry ((ulong)index);
 		}
 
+		public bool MoveEntry (string from, string to)
+		{
+			if (!zip.ContainsEntry (from)) {
+				return false;
+			}
+			var entry = zip.ReadEntry (from);
+			using (var stream = new MemoryStream ()) {
+				entry.Extract (stream);
+				stream.Position = 0;
+				zip.AddEntry (to, stream);
+				zip.DeleteEntry (entry);
+				Flush ();
+			}
+			return true;
+		}
+
 		public void AddDirectory (string folder, string folderInArchive, CompressionMethod method = CompressionMethod.Default)
 		{
 			if (!string.IsNullOrEmpty (folder)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -98,6 +98,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Aapt2.targets</Link>
     </None>
+    <None Include="MSBuild\Xamarin\Android\Xamarin.Android.Assets.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.Assets.targets</Link>
+    </None>
     <None Include="MSBuild\Xamarin\Android\Xamarin.Android.Javac.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Javac.targets</Link>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -351,12 +351,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</AllowedReferenceRelatedFileExtensions>
 </PropertyGroup>
 
-<!-- Assets build properties -->
-<PropertyGroup>
-	<MonoAndroidAssetsDirIntermediate>$(IntermediateOutputPath)assets\</MonoAndroidAssetsDirIntermediate>
-	<MonoAndroidAssetsPrefix Condition="'$(MonoAndroidAssetsPrefix)' == ''">Assets</MonoAndroidAssetsPrefix>
-</PropertyGroup>
-
 <!--
 *******************************************
           Imports
@@ -365,6 +359,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- As we split up/refactor this file, put new imports here -->
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" Condition=" '$(AndroidDexTool)' == 'd8' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Assets.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.DesignTime.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.EmbeddedResource.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Javac.targets" />
@@ -593,8 +588,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_ValidateAndroidPackageProperties"
     DependsOnTargets="_GetAndroidPackageName;_GetJavaPlatformJar">
 	<PropertyGroup>
-		<ApkFileIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apk</ApkFileIntermediate>
-		<_BaseZipIntermediate>$(IntermediateOutputPath)android\bin\base.zip</_BaseZipIntermediate>
+		<ApkFileIntermediate Condition=" '$(ApkFileIntermediate)' == ''">$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apk</ApkFileIntermediate>
+		<_BaseZipIntermediate Condition=" '$(_BaseZipIntermediate)' == '' ">$(IntermediateOutputPath)android\bin\base.zip</_BaseZipIntermediate>
 		<_AppBundleIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).aab</_AppBundleIntermediate>
 		<_ApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage).apks</_ApkSetIntermediate>
 		<_UniversalApkSetIntermediate>$(IntermediateOutputPath)android\bin\$(_AndroidPackage)-Universal.apks</_UniversalApkSetIntermediate>
@@ -870,27 +865,6 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 </Target>
 
-<!-- Assets Build -->
-
-<Target Name="UpdateAndroidAssets"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_ComputeAndroidAssetsPaths;_GenerateAndroidAssetsDir" />
-
-<Target Name="_ComputeAndroidAssetsPaths">
-	<AndroidComputeResPaths ResourceFiles="@(AndroidAsset)" IntermediateDir="$(MonoAndroidAssetsDirIntermediate)" Prefixes="$(MonoAndroidAssetsPrefix)" ProjectDir="$(ProjectDir)">
-		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
-		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
-	</AndroidComputeResPaths>
-</Target>
-
-<Target Name="_GenerateAndroidAssetsDir"
-	Inputs="@(_AndroidMSBuildAllProjects);@(_AndroidResolvedAssets)"
-	Outputs="@(_AndroidAssetsDest)">
-	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate)" />
-	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
-	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directory="$(MonoAndroidAssetsDirIntermediate)" RemoveDirectories="true" />
-	<Touch Files="@(_AndroidAssetsDest)" />
-</Target>
-
 <!-- Resource build properties -->
 <PropertyGroup>
 	<MonoAndroidResDirIntermediate>$(IntermediateOutputPath)res\</MonoAndroidResDirIntermediate>
@@ -1095,7 +1069,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ItemGroup>
 		<_AndroidResourceDest Include="@(_WearableApplicationDescriptionFile);@(_BundledWearApplicationApkResourceFile)" />
 	</ItemGroup>
-	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
+	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directories="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>
 	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" Condition=" !Exists ('$(_AndroidResFlagFile)') Or  '@(_ModifiedResources->Count())' != '0' Or '@(_AndroidResourceDestRemovedFiles->Count())' != '0' " />
@@ -1796,15 +1770,6 @@ because xbuild doesn't support framework reference assemblies.
       LibraryProjectImportsDirectoryName="$(_LibraryProjectImportsDirectoryName)">
     <Output TaskParameter="ExtraPackages" PropertyName="AaptExtraPackages" />
   </GetExtraPackages>
-
-  <!--
-  For aapt copy the assets into one folder.
-  For aapt2 we will consule the library assets in place.
-  -->
-  <CollectLibraryAssets
-      Condition=" '$(AndroidUseAapt2)' != 'true' "
-      AdditionalAssetDirectories="@(LibraryAssetDirectories)"
-      AssetDirectory="$(MonoAndroidAssetsDirIntermediate)" />
 </Target>
 
 <PropertyGroup>


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/4810

Google Android began supporting splitting up the app package into multiple
packs with the introduction of the `aab` package format. This format allows
the developer to split the app up into multiple `packs`. Each `pack` can be
downloaded to the device either at install time or on demand. This allows
application developers to save space and install time by only installing
the required parts of the app initially. Then installing other `packs`
as required.

There are two types of `pack`. The first is a `Feature` pack, this type
of pack contains code and other resources. Code in these types of `pack`
can be launched via the `StartActivity` API call. At this time due to
various constraints .NET Android cannot support `Feature` packs.

The second type of `pack` is the `Asset` pack. This type of pack ONLY
contains `AndroidAsset` items. It CANNOT contain any code or other
resources. This type of `feature` pack can be installed at install-time,
fast-follow or ondemand. It is most useful for apps which contain allot
of `Assets`, such as Games or Multi Media applications.
See the [documentation](https://developer.android.com/guide/playcore/asset-delivery) for details on how this all works.
.NET Android does not have any official support for this type of pack.
However a hack is available via the excellent @infinitespace-studios on
[github](https://github.com/infinitespace-studios/MauiAndroidAssetPackExample).
This hack allows developers to place additional assets in a special
`NoTargets` project. This project is built just after the final `aab` is
produced. It builds a zip file which is then added to the `@(AndroidAppBundleModules)`
ItemGroup in the main application. This zip is then included into the
final app as an additional feature.

## Asset Pack Specification

We want to provide our users the ability to use `Asset` packs without
having to implement the hack provided by @infinitespace-studios. Using
a separate project like in the hack is one way to go. It does have some
issues though.

1. It is a `special` type of project. It requires a `global.json` which imports the
   `NoTargets` sdk.
2. There is no IDE support for building this type of project.

Having the user go through a number of hoops to implement this for
.NET Android or .net Maui is not ideal. We need a simpler method.

The new idea is to make use of additional metadata on `AndroidAsset`
Items to allow the build system to split up the assets into packs
automatically. So it is proposed that we implement support for something
like this

```xml
<ItemGroup>
   <AndroidAsset Include="Asset/data.xml" />
   <AndroidAsset Include="Asset/movie.mp4" AssetPack="assets1" />
   <AndroidAsset Include="Asset/movie2.mp4" AssetPack="assets1" />
</ItemGroup>
```

In this case the additional `AssetPack` attribute is used to tell the
build system which pack to place this asset in. Since auto import of items
is common now we need a way for a user to add this additional attribute
to auto included items. Fortunately we are able to use the following.

```xml
<ItemGroup>
   <AndroidAsset Update="Asset/movie.mp4" AssetPack="assets1" />
   <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
</ItemGroup>
```

This code uses the `Update` attribute to tell MSBuild that we are going
to update a specific item. Note in the sample we do NOT need to include
an `Update` for the `data.xml`, since this is auto imported it will still
end up in the main feature in the aab.

Additional attributes can be used to control what type of asset pack is
produced. The only extra one supported at this time is `DeliveryType`,
this can have a value of `InstallTime`, `FastFollow` or `OnDemand`.
Additional attributes do not need to be included on ALL items. Any one
will do, only the `AssetPack` attribute will be needed.
See Google's [documentation](https://developer.android.com/guide/playcore/asset-delivery#asset-updates) for details on what each item does.

```xml
<ItemGroup>
   <AndroidAsset Update="Asset/movie.mp4" AssetPack="assets1" DeliveryType="InstallTime" />
   <AndroidAsset Update="Asset/movie2.mp4" AssetPack="assets1" />
   <AndroidAsset Update="Asset/movie3.mp4" AssetPack="assets2" />
</ItemGroup>
```

If the `AssetPack` attribute is not present, the default behavior will
be to include the asset in the main application package.

If however you have a large number of assets it might be more efficient to make use of the `base` asset pack setting. In this scenario you update ALL assets to be in a single asset pack then use the `AssetPack="base"` metadata to declare which specific assets end up in the base aab file. With this you can use wildcards to move most assets into the asset pack.

```xml
<ItemGroup>
   <AndroidAsset Update="Assets/*" AssetPack="assets1" />
   <AndroidAsset Update="Assets/movie.mp4" AssetPack="base" />
   <AndroidAsset Update="Assets/some.png" AssetPack="base" />
</ItemGroup>
```

In this example, `movie.mp4` and `some.png` will end up in the `base` aab file, but ALL the other assets
will end up in the `assets1` asset pack.

## Implementation Details

There are a few changes we need to make in order to support this feature.
One of the issues we will hit is the build times when dealing with large assets.
Current the assets which are to be included in the `aab` are COPIED
into the `$(IntermediateOutputPath)assets` directory. This folder is
then passed to `aapt2` for the build process.

The new system adds a new directory `$(IntermediateOutputPath)assetpacks`.
This directory would contain a subdirectory for each `pack` that the
user wants to include.

```dotnetcli
assetpacks/
    assets1/
        assets/
            movie1.mp4
    feature2/
        assets/
             movie2.mp4
```

All the building of the `pack` zip file would take place in these subfolders.
The name of the pack will be based on the main "packagename" with the asset pack
name appended to the end. e.g `com.microsoft.assetpacksample.assets1`.

During the build process we identify ALL the `AndroidAsset` items which
define an `AssetPack` attribute. These files are then copied to the
new `$(IntermediateOutputPath)assetpacks` directory rather than the
existing `$(IntermediateOutputPath)assets` directory. This allows us to
continue to support the normal `AndroidAsset` behavior while adding the
new system.

Once we have collected and copied all the assets we then use the new
`GetAssetPacks` Task to figure out which asset packs we need to create.
We then call the `CreateDynamicFeatureManifest` to create a required
`AndroidManifest.xml` file for the asset pack. This file will end
up in the same `$(IntermediateOutputPath)assetpacks` directory.
We call this Task `CreateDynamicFeatureManifest` because it can be used
to create any feature pack if and when we get to implement full feature
packs.

```dotnetcli
assetpacks/
    assets1/
        AndroidManifest.xml
        assets/
            movie1.mp4
    feature2/
        AndroidManifest.xml
        assets/
             movie2.mp4
```

We can then call `aapt2` to build these packs into `.zip` files. A new
task `Aapt2LinkAssetPack` takes care of this. This is a special version
of `Aapt2Link` which implements linking for asset packs only.
It also takes care of a few problems which `aapt2` introduces. For some
reason the zip file that is created has the `AndroidManifest.xml` file
in the wrong place. It creates it in the root of the zip file, but the
`bundletool` expects it to be in a `manifest` directory.
`bundletool` will error out if its not in the right place.
So `Aapt2LinkAssetPack` takes care of this for us. It also removes a
`resources.pb` which gets added. Again, `bundletool` will error if this
file is in the zip file.

Once the zip files have been created they are then added to the
`AndroidAppBundleModules` ItemGroup. This will ensure that when the
final `.aab` file is generated they are included as asset packs.

