### PR TITLE
[Xamarin.Android.Build.Tasks] Add check for aapt2 invalid data path error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -542,7 +542,7 @@ namespace Xamarin.Android.Tasks {
 			Tuple.Create ("APT2263", "found in <manifest>"),  // unexpected element <xxxxx> found in <manifest>
 			Tuple.Create ("APT2264", "The system cannot find the file specified. (2)"), // Windows Long Path error from aapt2
 			Tuple.Create ("APT2265", "The system cannot find the file specified. (2)"), // Windows non-ASCII characters error from aapt2
-			Tuple.Create ("APT2266", "in <data> tag has value of")
+			Tuple.Create ("APT2266", "in <data> tag has value of") //  error: attribute ‘android:path’ in <data> tag has value of ‘code/fooauth://com.foo.foo, it must start with a leading slash ‘/’.
 		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -541,7 +541,8 @@ namespace Xamarin.Android.Tasks {
 			Tuple.Create ("APT2262", "unexpected element <activity> found in <manifest>"),
 			Tuple.Create ("APT2263", "found in <manifest>"),  // unexpected element <xxxxx> found in <manifest>
 			Tuple.Create ("APT2264", "The system cannot find the file specified. (2)"), // Windows Long Path error from aapt2
-			Tuple.Create ("APT2265", "The system cannot find the file specified. (2)") // Windows non-ASCII characters error from aapt2
+			Tuple.Create ("APT2265", "The system cannot find the file specified. (2)"), // Windows non-ASCII characters error from aapt2
+			Tuple.Create ("APT2266", "in <data> tag has value of")
 		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -560,6 +560,32 @@ namespace Bug12935
 		}
 
 		[Test]
+		public void ManifestDataPathError ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			var s = proj.AndroidManifest.Replace ("</application>", @"<activity android:name=""net.openid.appauth.RedirectUriReceiverActivity"" android:exported=""true"">
+			<intent-filter>
+				<action android:name=""android.intent.action.VIEW""/>
+				<category android:name=""android.intent.category.DEFAULT""/>
+				<category android:name=""android.intent.category.BROWSABLE""/>
+				<data android:path=""code/buildproauth://com.hyphensolutions.buildpro"" android:scheme=""msauth""/>
+				<data android:path=""callback"" android:scheme=""buildproauth""/>
+			</intent-filter>
+	</activity>
+</application>");
+			proj.AndroidManifest = s;
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				var messages = builder.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build FAILED.", StringComparison.Ordinal));
+				string error = messages.FirstOrDefault (x => x.Contains ("error APT2266:"));
+				Assert.IsNotNull (error, "Warning should be APT2266");
+			}
+		}
+
+		[Test]
 		public void ManifestPlaceholders ([Values ("legacy", "manifestmerger.jar")] string manifestMerger)
 		{
 			var proj = new XamarinAndroidApplicationProject () {


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1922983

Our error matching in Aapt2.cs did not include a new error message which has been introduced. As a result we got a APT2000 error instead of an actual error message which we get for other errors.
The error message in question is 
```
 error: attribute ‘android:path’ in <data> tag has value of ‘code/fooauth://com.foo.foo, it must start with a leading slash ‘/’.
```