### PR TITLE
Fix Proguard warning when missing Android Sdk proguard-android.txt

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1919,7 +1919,7 @@ because xbuild doesn't support framework reference assemblies.
     <_ProguardConfiguration Include="$(ProguardConfigFiles)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(ProguardConfigFiles)' == '' ">
-    <_ProguardConfiguration Include="$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt" />
+    <_ProguardConfiguration Include="$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt"     Condition=" Exists ('$(_AndroidSdkDirectory)tools\proguard\proguard-android.txt') " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"         Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(_ProguardProjectConfiguration)"                               Condition=" '$(AndroidLinkTool)' != '' " />
     <_ProguardConfiguration Include="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg" Condition=" '$(AndroidLinkTool)' != '' " />


### PR DESCRIPTION
We are seeing numerous test failures because of this warning.

```
C:\Android\android-sdk\tools\proguard\proguard-android.txt : warning XA4304: ProGuard configuration file 'C:\Android\android-sdk\tools\proguard\proguard-android.txt' was not found.
```

This is because the proguard-android.txt file no longer ships with the android sdk. We should check this file exists before adding it to the list of `_ProguardConfiguration` files. This way if a user still does have it, it will be included.