### PR TITLE
[Xamarin.Android.Build.Tasks] remove checks for `$(UsingAndroidNETSdk)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets
@@ -29,31 +29,14 @@ This item group populates the Build Action drop-down in IDEs.
     <AvailableItemName Include="ProjectReference" />
     <AvailableItemName Include="AndroidManifestOverlay" />
   </ItemGroup>
-  <!-- Legacy, non-binding projects -->
-  <ItemGroup Condition=" '$(_AndroidIsBindingProject)' != 'true' and '$(UsingAndroidNETSdk)' != 'true' ">
-    <AvailableItemName Include="AndroidAarLibrary" />
-    <AvailableItemName Include="AndroidJavaLibrary" />
-  </ItemGroup>
-  <!-- Legacy, non-application projects -->
-  <ItemGroup Condition=" '$(AndroidApplication)' != 'true' and '$(UsingAndroidNETSdk)' != 'true' ">
-    <AvailableItemName Include="EmbeddedNativeLibrary" />
-  </ItemGroup>
-  <!-- Legacy binding projects or .NET 6 -->
-  <ItemGroup Condition=" '$(_AndroidIsBindingProject)' == 'true' or '$(UsingAndroidNETSdk)' == 'true' ">
+
+  <!-- All project types -->
+  <ItemGroup>
     <AvailableItemName Include="TransformFile" />
     <AvailableItemName Include="LibraryProjectProperties" />
     <AvailableItemName Include="JavaDocIndex" />
     <AvailableItemName Include="JavaDocJar" />
     <AvailableItemName Include="JavaSourceJar" />
-  </ItemGroup>
-  <!-- Legacy binding projects -->
-  <ItemGroup Condition=" '$(_AndroidIsBindingProject)' == 'true' and '$(UsingAndroidNETSdk)' != 'true' ">
-    <AvailableItemName Include="EmbeddedJar" />
-    <AvailableItemName Include="EmbeddedNativeLibrary" />
-    <AvailableItemName Include="EmbeddedReferenceJar" />
-    <AvailableItemName Include="InputJar" />
-    <AvailableItemName Include="ReferenceJar" />
-    <AvailableItemName Include="LibraryProjectZip" />
   </ItemGroup>
 
   <!-- Default item metadata -->
@@ -64,13 +47,13 @@ This item group populates the Build Action drop-down in IDEs.
     </AndroidResource>
     <AndroidLibrary>
       <Bind>true</Bind>
-      <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
+      <Pack>true</Pack>
     </AndroidLibrary>
     <LibraryProjectZip>
-      <Pack Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Pack>
+      <Pack>true</Pack>
     </LibraryProjectZip>
     <AndroidJavaSource>
-      <Bind Condition=" '$(UsingAndroidNETSdk)' == 'true' ">true</Bind>
+      <Bind>true</Bind>
     </AndroidJavaSource>
     <AndroidAarLibrary>
       <!-- NOTE: .aar items should skip %(AndroidSkipResourceProcessing) by default -->
@@ -80,38 +63,26 @@ This item group populates the Build Action drop-down in IDEs.
 
   <!-- Convert @(AndroidLibrary) to the legacy item group names -->
   <Target Name="_CategorizeAndroidLibraries">
-    <!-- Applications, or legacy class libraries -->
-    <ItemGroup Condition=" '$(AndroidApplication)' == 'true' or ('$(_AndroidIsBindingProject)' != 'true' and '$(UsingAndroidNETSdk)' != 'true') ">
+    <!-- Applications -->
+    <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
       <AndroidAarLibrary  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' " />
       <AndroidJavaLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' " />
-    </ItemGroup>
-    <!-- Any library that is not an app -->
-    <ItemGroup Condition=" '$(AndroidApplication)' != 'true' ">
-      <EmbeddedNativeLibrary Include="@(AndroidNativeLibrary)" />
-    </ItemGroup>
-    <!-- Any .NET 6 project -->
-    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
-      <LibraryProjectZip  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
-    </ItemGroup>
-    <!-- .NET 6 application projects -->
-    <ItemGroup Condition=" '$(AndroidApplication)' == 'true' and '$(UsingAndroidNETSdk)' == 'true' ">
       <InputJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
     </ItemGroup>
-    <!-- .NET 6 class libraries-->
-    <ItemGroup Condition=" '$(AndroidApplication)' != 'true' and '$(UsingAndroidNETSdk)' == 'true' ">
+    <!-- Class libraries, not an application -->
+    <ItemGroup Condition=" '$(AndroidApplication)' != 'true' ">
+      <EmbeddedNativeLibrary Include="@(AndroidNativeLibrary)" />
       <AndroidAarLibrary  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' != 'true' " />
       <AndroidJavaLibrary Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
       <EmbeddedJar        Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
-      <!-- .aar files should be copied to $(OutputPath) in .NET 6-->
+      <!-- .aar files should be copied to $(OutputPath) in .NET 6+ -->
       <None Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' " TfmSpecificPackageFile="%(AndroidLibrary.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
       <!-- @(LibraryProjectZip) items that are not in @(AndroidLibrary) -->
       <None Include="@(LibraryProjectZip)" Exclude="@(AndroidLibrary)" TfmSpecificPackageFile="%(LibraryProjectZip.Pack)" Pack="false" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" />
     </ItemGroup>
-    <!-- Legacy binding projects -->
-    <ItemGroup Condition=" '$(_AndroidIsBindingProject)' == 'true' and '$(UsingAndroidNETSdk)' != 'true' ">
-      <LibraryProjectZip    Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
-      <EmbeddedJar          Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' == 'true' " />
-      <EmbeddedReferenceJar Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.jar' and '%(AndroidLibrary.Bind)' != 'true' " />
+    <!-- All projects -->
+    <ItemGroup>
+      <LibraryProjectZip  Include="@(AndroidLibrary)" Condition=" '%(AndroidLibrary.Extension)' == '.aar' and '%(AndroidLibrary.Bind)' == 'true' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -20,10 +20,8 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     <GeneratedOutputPath        Condition=" '$(GeneratedOutputPath)' == '' ">$(IntermediateOutputPath)generated\</GeneratedOutputPath>
     <AndroidJavadocVerbosity    Condition=" '$(AndroidJavadocVerbosity)' == '' ">intellisense</AndroidJavadocVerbosity>
     <ApiOutputFile              Condition=" '$(ApiOutputFile)' == '' ">$(IntermediateOutputPath)api.xml</ApiOutputFile>
-    <ClassParseToolExe          Condition=" '$(UsingAndroidNETSdk)' == 'true' ">class-parse.dll</ClassParseToolExe>
-    <ClassParseToolExe          Condition=" '$(ClassParseToolExe)' == '' ">class-parse.exe</ClassParseToolExe>
-    <BindingsGeneratorToolExe   Condition=" '$(UsingAndroidNETSdk)' == 'true' ">generator.dll</BindingsGeneratorToolExe>
-    <BindingsGeneratorToolExe   Condition=" '$(BindingsGeneratorToolExe)' == '' ">generator.exe</BindingsGeneratorToolExe>
+    <ClassParseToolExe          Condition=" '$(ClassParseToolExe)' == '' ">class-parse.dll</ClassParseToolExe>
+    <BindingsGeneratorToolExe   Condition=" '$(BindingsGeneratorToolExe)' == '' ">generator.dll</BindingsGeneratorToolExe>
     <JavadocToMdocToolExe       Condition=" '$(JavadocToMdocToolExe)' == '' ">javadoc-to-mdoc.exe</JavadocToMdocToolExe>
     <_GeneratorStampFile>$(_AndroidStampDirectory)generator.stamp</_GeneratorStampFile>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -8,8 +8,7 @@
     <MonoAndroidAssetsPrefix Condition=" '$(MonoAndroidAssetsPrefix)' == '' ">Assets</MonoAndroidAssetsPrefix>
     <AndroidResgenClass Condition=" '$(AndroidResgenClass)' == '' ">Resource</AndroidResgenClass>
     <AndroidEnableSGenConcurrent Condition=" '$(AndroidEnableSGenConcurrent)' == '' ">true</AndroidEnableSGenConcurrent>
-    <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' == 'true' ">Xamarin.Android.Net.AndroidMessageHandler</AndroidHttpClientHandlerType>
-    <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' and '$(UsingAndroidNETSdk)' != 'true' ">Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidHttpClientHandlerType Condition=" '$(AndroidHttpClientHandlerType)' == '' ">Xamarin.Android.Net.AndroidMessageHandler</AndroidHttpClientHandlerType>
     <AndroidGenerateResourceDesigner Condition=" '$(AndroidGenerateResourceDesigner)' == '' ">true</AndroidGenerateResourceDesigner>
     <AndroidUseDesignerAssembly Condition=" '$(AndroidUseDesignerAssembly)' == '' ">true</AndroidUseDesignerAssembly>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidUseIntermediateDesignerFile>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -79,7 +79,6 @@ namespace Xamarin.Android.Tasks
 		public string TlsProvider { get; set; }
 		public string AndroidSequencePointsMode { get; set; }
 		public bool EnableSGenConcurrent { get; set; }
-		public bool UsingAndroidNETSdk { get; set; }
 
 		[Output]
 		public string BuildId { get; set; }
@@ -195,7 +194,7 @@ namespace Xamarin.Android.Tasks
 				BrokenExceptionTransitions = false,
 				UsesAssemblyPreload = EnablePreloadAssembliesDefault,
 			};
-			environmentParser.Parse (Environments, sequencePointsMode, UsingAndroidNETSdk, Log);
+			environmentParser.Parse (Environments, sequencePointsMode, Log);
 
 			foreach (string line in environmentParser.EnvironmentVariableLines) {
 				AddEnvironmentVariableLine (line);
@@ -217,13 +216,6 @@ namespace Xamarin.Android.Tasks
 					AddEnvironmentVariable (defaultHttpMessageHandler[0], defaultHttpMessageHandler[1]);
 				else
 					AddEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE", HttpClientHandlerType.Trim ());
-			}
-
-			if (!UsingAndroidNETSdk && !environmentParser.HaveTlsProvider) {
-				if (TlsProvider == null)
-					AddEnvironmentVariable (defaultTlsProvider[0], defaultTlsProvider[1]);
-				else
-					AddEnvironmentVariable ("XA_TLS_PROVIDER", TlsProvider.Trim ());
 			}
 
 			if (!environmentParser.HaveMonoGCParams) {
@@ -352,19 +344,6 @@ namespace Xamarin.Android.Tasks
 
 					seenNativeLibraryNames.Add (name);
 					uniqueNativeLibraries.Add (item);
-				}
-			}
-
-			// In "classic" Xamarin.Android, we need to add libaot-*.dll.so files
-			if (!UsingAndroidNETSdk && usesMonoAOT) {
-				foreach (var assembly in ResolvedAssemblies) {
-					string name = $"libaot-{Path.GetFileNameWithoutExtension (assembly.ItemSpec)}.dll.so";
-					if (seenNativeLibraryNames.Contains (name)) {
-						continue;
-					}
-
-					seenNativeLibraryNames.Add (name);
-					uniqueNativeLibraries.Add (new TaskItem (name));
 				}
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/EnvironmentFilesParser.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-		public void Parse (ITaskItem[] environments, SequencePointsMode sequencePointsMode, bool usingAndroidNETSdk, TaskLoggingHelper log)
+		public void Parse (ITaskItem[] environments, SequencePointsMode sequencePointsMode, TaskLoggingHelper log)
 		{
 			foreach (ITaskItem env in environments ?? Array.Empty<ITaskItem> ()) {
 				foreach (string line in File.ReadLines (env.ItemSpec)) {
@@ -55,9 +55,6 @@ namespace Xamarin.Android.Tasks
 					}
 					if (lineToWrite.StartsWith ("XA_HTTP_CLIENT_HANDLER_TYPE=", StringComparison.Ordinal))
 						HaveHttpMessageHandler = true;
-
-					if (!usingAndroidNETSdk && lineToWrite.StartsWith ("XA_TLS_PROVIDER=", StringComparison.Ordinal))
-						HaveTlsProvider = true;
 
 					if (lineToWrite.StartsWith ("mono.enable_assembly_preload=", StringComparison.Ordinal)) {
 						int idx = lineToWrite.IndexOf ('=');

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -2,7 +2,6 @@
 	<!-- Android Sdk Tool versions are sourced from this file. This is maintained in the xamarin-android-tools repo. -->
 	<Import Project="$(MSBuildThisFileDirectory)\Xamarin.Android.Tools.Versions.props" />
 	<PropertyGroup>
-		<XamarinAndroidVersion Condition=" '$(UsingAndroidNETSdk)' != 'true' ">@PACKAGE_VERSION@-@PACKAGE_VERSION_BUILD@</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<Debugger Condition=" '$(Debugger)' == '' ">Xamarin</Debugger>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -134,9 +134,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 *******************************************
 -->
 
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.props"
-	Condition=" '$(UsingAndroidNETSdk)' != 'True' And Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.props')" />
-
 <Import Project="Xamarin.Android.AvailableItems.targets" />
 
 <!--
@@ -208,8 +205,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 	<!-- Obsolete build property: should be removed in the future releases -->
 	<AndroidMultiDexSupportJar></AndroidMultiDexSupportJar>
-
-	<AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' And '$(UsingAndroidNETSdk)' != 'True' ">armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
 
 	<!--- Default Lint Enabled and Disabled Checks -->
 	<AndroidLintEnabledIssues Condition=" '$(AndroidLintEnabledIssues)' == '' "></AndroidLintEnabledIssues>
@@ -299,8 +294,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
 
 	<!-- If true it will cause all the assemblies in the apk to be preloaded on startup time -->
-	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' == 'true' ">False</_AndroidEnablePreloadAssembliesDefault>
-	<_AndroidEnablePreloadAssembliesDefault Condition=" '$(UsingAndroidNETSdk)' != 'true' ">True</_AndroidEnablePreloadAssembliesDefault>
+	<_AndroidEnablePreloadAssembliesDefault>False</_AndroidEnablePreloadAssembliesDefault>
 	<AndroidEnablePreloadAssemblies Condition=" '$(AndroidEnablePreloadAssemblies)' == '' ">$(_AndroidEnablePreloadAssembliesDefault)</AndroidEnablePreloadAssemblies>
 	<_NativeAssemblySourceDir>$(IntermediateOutputPath)android\</_NativeAssemblySourceDir>
 	<_AndroidUseNewTypemaps>True</_AndroidUseNewTypemaps>
@@ -335,8 +329,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' and ('$(EmbedAssembliesIntoApk)' != 'true' or '$(AndroidIncludeDebugSymbols)' == 'true') ">false</AndroidUseAssemblyStore>
   <AndroidUseAssemblyStore Condition=" '$(AndroidUseAssemblyStore)' == '' ">true</AndroidUseAssemblyStore>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
-  <AndroidEnableMarshalMethods Condition=" '$(UsingAndroidNETSdk)' == 'True' And '$(AndroidEnableMarshalMethods)' == '' ">False</AndroidEnableMarshalMethods>
-  <AndroidEnableMarshalMethods Condition=" '$(UsingAndroidNETSdk)' != 'True' ">False</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' ">False</AndroidEnableMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' ">False</_AndroidUseMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">$(AndroidEnableMarshalMethods)</_AndroidUseMarshalMethods>
 </PropertyGroup>
@@ -387,15 +380,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AppExtensionReference Condition=" '%(ProjectReference.IsAppExtension)' == 'True' " Include="@(ProjectReference)" />
     <ProjectReference Remove="@(_AppExtensionReference)" />
   </ItemGroup>
-  <PropertyGroup>
-    <_AppExtensionContinueOnError Condition=" '$(UsingAndroidNETSdk)' == 'true' ">ErrorAndStop</_AppExtensionContinueOnError>
-    <_AppExtensionContinueOnError Condition=" '$(UsingAndroidNETSdk)' != 'true' ">WarnAndContinue</_AppExtensionContinueOnError>
-  </PropertyGroup>
   <AndroidError
       Code="XA4312"
       ResourceName="XA4312"
       FormatArguments="%(_AppExtensionReference.FullPath)"
-      ContinueOnError="$(_AppExtensionContinueOnError)"
       Condition=" '%(FullPath)' != '' "
   />
 </Target>
@@ -543,17 +531,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA1023"
       Condition="  '$(AndroidDexTool)' == 'dx' "
   />
-  <AndroidWarning Code="XA1026"
-      ResourceName="XA1026"
-      Condition=" '$(AndroidUseAapt2)' != 'true' and '$(UsingAndroidNETSdk)' != 'true' "
-  />
   <AndroidError Code="XA1026"
       ResourceName="XA1026_dotnet"
-      Condition=" '$(AndroidUseAapt2)' != 'true' and '$(UsingAndroidNETSdk)' == 'true' "
+      Condition=" '$(AndroidUseAapt2)' != 'true' "
   />
   <AndroidWarning Code="XA1035"
       ResourceName="XA1035"
-      Condition=" '$(BundleAssemblies)' == 'true' and '$(UsingAndroidNETSdk)' == 'true' "
+      Condition=" '$(BundleAssemblies)' == 'true' "
   />
 </Target>
 
@@ -843,23 +827,17 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CheckForObsoleteFrameworkAssemblies">
-  <PropertyGroup>
-    <_TreatErrorAsWarning Condition="'$(UsingAndroidNETSdk)' != 'true' " >True</_TreatErrorAsWarning>
-    <_TreatErrorAsWarning Condition=" '$(_TreatErrorAsWarning)' == ''">False</_TreatErrorAsWarning>
-  </PropertyGroup>
   <AndroidError
     Condition=" '%(Reference.Identity)' == 'OpenTK-1.0' "
     Code="XA4313"
     ResourceName="XA4313"
     FormatArguments="OpenTK-1.0;Xamarin.Legacy.OpenTK"
-    ContinueOnError="$(_TreatErrorAsWarning)"
   />
   <AndroidError
     Condition=" '%(Reference.Identity)' == 'Xamarin.Android.NUnitLite' "
     Code="XA4313"
     ResourceName="XA4313"
     FormatArguments="Xamarin.Android.NUnitLite;Xamarin.Legacy.NUnitLite"
-    ContinueOnError="$(_TreatErrorAsWarning)"
   />
 </Target>
 
@@ -971,8 +949,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidNdkPath=$(_AndroidNdkDirectory)" />
 		<_PropertyCacheItems Include="JavaSdkPath=$(_JavaSdkDirectory)" />
 		<_PropertyCacheItems Include="AndroidSequencePointsMode=$(_AndroidSequencePointsMode)" />
-		<_PropertyCacheItems Include="XamarinAndroidVersion=$(XamarinAndroidVersion)" Condition=" '$(UsingAndroidNETSdk)' != 'true' " />
-		<_PropertyCacheItems Include="AndroidNETSdkVersion=$(AndroidNETSdkVersion)"   Condition=" '$(UsingAndroidNETSdk)' == 'true' " />
+		<_PropertyCacheItems Include="AndroidNETSdkVersion=$(AndroidNETSdkVersion)" />
 		<_PropertyCacheItems Include="MonoSymbolArchive=$(MonoSymbolArchive)" />
 		<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
 		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
@@ -1374,18 +1351,14 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CollectRuntimeJarFilenames">
   <PropertyGroup>
-    <_RuntimeJar Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(MSBuildThisFileDirectory)\java_runtime.jar</_RuntimeJar>
-    <_RuntimeDex Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(MSBuildThisFileDirectory)\java_runtime.dex</_RuntimeDex>
-
-    <_RuntimeJar Condition=" '$(UsingAndroidNETSdk)' == 'True' ">$(MSBuildThisFileDirectory)\java_runtime_net6.jar</_RuntimeJar>
-    <_RuntimeDex Condition=" '$(UsingAndroidNETSdk)' == 'True' ">$(MSBuildThisFileDirectory)\java_runtime_net6.dex</_RuntimeDex>
+    <_RuntimeJar>$(MSBuildThisFileDirectory)\java_runtime_net6.jar</_RuntimeJar>
+    <_RuntimeDex>$(MSBuildThisFileDirectory)\java_runtime_net6.dex</_RuntimeDex>
   </PropertyGroup>
 </Target>
 
 <Target Name="_GetMonoPlatformJarPath">
   <PropertyGroup>
-    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' != 'True' ">$(TargetFrameworkDirectory)</_AndroidJarAndDexDirectory>
-    <_AndroidJarAndDexDirectory Condition=" '$(UsingAndroidNETSdk)' == 'True' ">$(_XATargetFrameworkDirectories)</_AndroidJarAndDexDirectory>
+    <_AndroidJarAndDexDirectory>$(_XATargetFrameworkDirectories)</_AndroidJarAndDexDirectory>
   </PropertyGroup>
   <GetMonoPlatformJar Condition=" '$(_AndroidUseMarshalMethods)' != 'True' " TargetFrameworkDirectory="$(_AndroidJarAndDexDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
@@ -1457,7 +1430,6 @@ because xbuild doesn't support framework reference assemblies.
       UseDesignerAssembly="$(AndroidUseDesignerAssembly)"
       Deterministic="$(Deterministic)"
       ReadSymbols="$(_AndroidLinkAssembliesReadSymbols)"
-      UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
   />
   <ItemGroup>
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)**" />
@@ -1648,7 +1620,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <_GeneratedAndroidEnvironment Include="__XA_PACKAGE_NAMING_POLICY__=$(AndroidPackageNamingPolicy)" />
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
-    <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(UsingAndroidNETSdk)' == 'true' and '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
+    <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />
   </ItemGroup>
   <WriteLinesToFile
       File="$(IntermediateOutputPath)__environment__.txt"
@@ -1766,7 +1738,6 @@ because xbuild doesn't support framework reference assemblies.
     BoundExceptionType="$(AndroidBoundExceptionType)"
     InstantRunEnabled="$(_InstantRunEnabled)"
     RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
-    UsingAndroidNETSdk="$(UsingAndroidNETSdk)"
     UseAssemblyStore="$(AndroidUseAssemblyStore)"
     EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
   >
@@ -2763,8 +2734,6 @@ because xbuild doesn't support framework reference assemblies.
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Application.targets"
         Condition=" '$(AndroidApplication)' == 'True' "/>
-<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets"
-        Condition=" '$(UsingAndroidNETSdk)' != 'true' " />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Designer.targets" />
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Tooling.targets
@@ -37,16 +37,11 @@ projects.
     </PropertyGroup>
     <ItemGroup>
       <FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
-      <!-- These references are implicitly defined in .NET 5 -->
-      <Reference Include="$(_JavaInteropReferences)" Condition=" '$(UsingAndroidNETSdk)' != 'True' " />
     </ItemGroup>
   </Target>
 
-  <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' == 'True' ">
+  <PropertyGroup>
     <_ResolveSdksDependsOnTargets>ResolveTargetingPackAssets</_ResolveSdksDependsOnTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(UsingAndroidNETSdk)' != 'True' ">
-    <_ResolveSdksDependsOnTargets>_GetReferenceAssemblyPaths</_ResolveSdksDependsOnTargets>
   </PropertyGroup>
 
   <Target Name="_ResolveSdks" DependsOnTargets="$(_ResolveSdksDependsOnTargets)">
@@ -55,17 +50,14 @@ projects.
           `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0-preview.6.20264.1\ref\net5.0\`
          See https://github.com/dotnet/sdk/blob/9eeb58e24af894597a534326156d09173d9f0f91/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs#L56
     -->
-    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' == 'true' ">
+    <ItemGroup>
       <_AndroidApiInfo Include="$(MSBuildThisFileDirectory)..\data\*\AndroidApiInfo.xml" />
       <_AndroidApiInfoDirectories Include="@(_AndroidApiInfo->'%(RootDir)%(Directory)')" />
       <_ResolveSdksFrameworkRefAssemblyPaths Include="@(Reference->'$([System.String]::Copy('%(RootDir)%(Directory)').TrimEnd('\'))')" Condition=" '%(Reference.FrameworkReferenceName)' != '' " />
     </ItemGroup>
-    <ItemGroup Condition=" '$(UsingAndroidNETSdk)' != 'true' ">
-      <_AndroidApiInfoDirectories Include="$(_XATargetFrameworkDirectories)" />
-    </ItemGroup>
     <PropertyGroup>
       <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-      <_XATargetFrameworkDirectories Condition=" '$(UsingAndroidNETSdk)' == 'True' ">@(_ResolveSdksFrameworkRefAssemblyPaths->Distinct())</_XATargetFrameworkDirectories>
+      <_XATargetFrameworkDirectories>@(_ResolveSdksFrameworkRefAssemblyPaths->Distinct())</_XATargetFrameworkDirectories>
     </PropertyGroup>
     <ResolveSdks
         ContinueOnError="$(_AndroidAllowMissingSdkTooling)"


### PR DESCRIPTION
In .NET 6+, `$(UsingAndroidNETSdk)` is always `true` as the general identifier that this project is .NET and not Xamarin.Android. We used this flag as a way to share code between .NET Android and Xamarin.Android.

* Remove checks for `$(UsingAndroidNETSdk)`

* No longer need to pass in this value to MSBuilds tasks or other C# classes

* Checks if `true` leave in place, and remove the condition

* Checks if `false` can just be completely removed now

In a future PR, we may also be able to remove `$(_AndroidIsBindingProject)`, which is slightly related. We removed the "binding project" as a concept in .NET 6+.

I left the `$(UsingAndroidNETSdk)` property in place, even though it is not used in these targets. Other general MSBuild targets may continue to use it in perpetuity.