### PR TITLE
[release/8.0.1xx] [Xamarin.Android.Build.Tasks] XA1039 warning for Android.Support

### DIFF
--- a/Documentation/guides/messages/xa1039.md
+++ b/Documentation/guides/messages/xa1039.md
@@ -1,0 +1,47 @@
+---
+title: Xamarin.Android warning XA1039
+description: XA1039 warning code
+ms.date: 1/10/2024
+---
+# Xamarin.Android warning XA1039
+
+## Example messages
+
+```
+warning XA1039: The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/xamarin/androidx for more details.
+```
+
+## Issue
+
+Outdated "Android Support Library" packages are no longer supported in .NET 9:
+
+* `Xamarin.Android.Arch.*`
+* `Xamarin.Android.Support.*`
+
+The underlying Java libraries are no longer supported by Google since the final
+28.0.0 release. See the [Android Support Library Documentation][support] for
+details.
+
+Some example prefixes of the newer, supported AndroidX packages are:
+
+* `Xamarin.AndroidX.*`
+* `Xamarin.AndroidX.Arch.*`
+
+For more information about the Android Support libraries or AndroidX, see:
+
+* [Android Support Library Documentation][support]
+* [AndroidX Documentation](https://developer.android.com/jetpack/androidx)
+
+[support]: https://developer.android.com/topic/libraries/support-library/packages
+
+## Solution
+
+Remove all NuGet package references to `Xamarin.Android.Support` or
+`Xamarin.Android.Arch` in favor of the new AndroidX equivalents.
+
+This also can occur if you are using a NuGet package with a transitive
+dependency on the Android support packages. In this case, you will need to
+remove the package or contact the package author.
+
+See the [AndroidX migration documentation](https://aka.ms/xamarin/androidx) for
+details.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -947,4 +947,8 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {0} - An Android Resource Identifier.
     </comment>
   </data>
+  <data name="XA1039" xml:space="preserve">
+    <value>The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/xamarin/androidx for more details.</value>
+    <comment>The following are literal names and should not be translated: Android Support, AndroidX, .NET.</comment>
+  </data>
 </root>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1464,6 +1464,19 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void XA1039 ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				PackageReferences = {
+					KnownPackages.SupportCompat_27_0_2_1
+				}
+			};
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "build should have succeeded");
+			StringAssertEx.Contains ("warning XA1039", builder.LastBuildOutput, "Should get XA1039 warning");
+		}
+
+		[Test]
 		[NonParallelizable]
 		public void CheckLintErrorsAndWarnings ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -499,6 +499,23 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
 </Target>
 
+<Target Name="_CheckUnsupportedPackages"
+    Condition=" '$(_AndroidIgnoreAndroidSupportWarning)' != 'true' "
+    AfterTargets="ResolvePackageAssets">
+  <ItemGroup>
+    <_AndroidUnsupportedPackages
+        Include="%(ResolvedCompileFileDefinitions.NuGetPackageId)"
+        Condition=" '%(ResolvedCompileFileDefinitions.NuGetPackageId)' != '' and
+            ( $([System.String]::Copy(%(ResolvedCompileFileDefinitions.NuGetPackageId)).StartsWith ('Xamarin.Android.Arch.')) or
+              $([System.String]::Copy(%(ResolvedCompileFileDefinitions.NuGetPackageId)).StartsWith ('Xamarin.Android.Support.')) )"
+    />
+  </ItemGroup>
+  <AndroidWarning Code="XA1039"
+      ResourceName="XA1039"
+      Condition=" '@(_AndroidUnsupportedPackages->Count())' != '0' "
+  />
+</Target>
+
 <Target Name="_CheckNonIdealConfigurations">
   <AndroidWarning Code="XA0119"
       ResourceName="XA0119_AOT"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8629

This partially backports 2f192386 to .NET 8, but reduces XA1039 to a warning.

Also introduce `$(_AndroidIgnoreAndroidSupportWarning)` as an escape hatch if someone needs to completely disable the warning:

    <_AndroidIgnoreAndroidSupportWarning>true</_AndroidIgnoreAndroidSupportWarning>