### PR TITLE
[Xamarin.Android.Build.Tasks] `FixAbstractMethodsStep` performance

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -141,7 +141,7 @@ namespace MonoDroid.Tuner
 			return !type.IsAbstract && type.IsSubclassOf ("Java.Lang.Object", cache);
 		}
 
-		static bool CompareTypes (TypeReference iType, TypeReference tType)
+		bool CompareTypes (TypeReference iType, TypeReference tType)
 		{
 			if (iType.IsGenericParameter)
 				return true;
@@ -164,11 +164,11 @@ namespace MonoDroid.Tuner
 			if (iType.Namespace != tType.Namespace)
 				return false;
 
-			TypeDefinition iTypeDef = iType.Resolve ();
+			TypeDefinition iTypeDef = cache.Resolve (iType);
 			if (iTypeDef == null)
 				return false;
 
-			TypeDefinition tTypeDef = tType.Resolve ();
+			TypeDefinition tTypeDef = cache.Resolve (tType);
 			if (tTypeDef == null)
 				return false;
 
@@ -198,7 +198,7 @@ namespace MonoDroid.Tuner
 				return false;
 
 			foreach (var o in tMethod.Overrides)
-				if (o != null && iMethod == o.Resolve ())
+				if (o != null && iMethod.Name == o.Name && iMethod == cache.Resolve (o))
 					return true;
 
 			return false;
@@ -252,7 +252,7 @@ namespace MonoDroid.Tuner
 
 			foreach (var ifaceInfo in type.Interfaces) {
 				var iface    = ifaceInfo.InterfaceType;
-				var ifaceDef = iface.Resolve ();
+				var ifaceDef = cache.Resolve (iface);
 				if (ifaceDef == null) {
 					LogMessage ($"Unable to unresolve interface: {iface.FullName}");
 					continue;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8421

Working a bit on build performance, I tested:

* `dotnet new maui`

* `dotnet build -bl`

The `.binlog` shows:

    LinkAssembliesNoShrink 3.797s

Attaching `dotnet-trace` as mentioned on:

https://github.com/xamarin/xamarin-android/blob/2f192386e8072f8e0ecaf0de2fe48654f3ade423/Documentation/guides/tracing.md#how-to-dotnet-trace-our-build

I see time broken down such as:

    FixAbstractMethods: 37%
    AssemblyDefinition.Write: 27%
    ProcessAssemblyDesigner: 20%
    CopyIfChanged: 13%
    DirectoryAssemblyResolver.GetAssembly: 4.4%

This made me focus in on `FixAbstractMethodsStep` and make the following changes:

* All calls for `TypeReference.Resolve()` and `MethodReference.Resolve()` should go through the `TypeDefinitionCache` to avoid repeated lookups.

* `IsInOverrides()` can compare the `MethodReference.Name` before calling `Resolve()`. It could resolve many unnecessary methods otherwise.

After these changes, I instead see from `dotnet-trace`:

```diff
--1.45s (3.7%)    xamarin.android.build.tasks!MonoDroid.Tuner.FixAbstractMethodsStep.FixAbstractMethods()
++949.70ms (2.5%) xamarin.android.build.tasks!MonoDroid.Tuner.FixAbstractMethodsStep.FixAbstractMethods()
```

Time is now broken down differently, such as:

    AssemblyDefinition.Write: 31%
    FixAbstractMethods: 28%
    ProcessAssemblyDesigner: 23%
    CopyIfChanged: 12%
    DirectoryAssemblyResolver.GetAssembly: 4.8%

In an overall `.binlog` (without `dotnet-trace` attached):

```diff
--LinkAssembliesNoShrink 3.797s
++LinkAssembliesNoShrink 3.105s
```

This saved ~700ms on initial build of a new MAUI project.