### PR TITLE
[.github] Re-enable locking closed issues after 30 days of inactivity.

### DIFF
--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,0 +1,36 @@
+name: Locker - Lock stale issues and PRs
+on:
+  schedule:
+    - cron: '0 9 * * *' # Once per day, early morning PT
+
+  workflow_dispatch:
+    # Manual triggering through the GitHub UI, API, or CLI
+    inputs:
+      daysSinceClose:
+        required: true
+        default: "30"
+      daysSinceUpdate:
+        required: true
+        default: "30"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          path: ./actions
+          ref: cd16cd2aad6ba2da74bb6c6f7293adddd579a90e # locker action commit sha
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Locker
+        uses: ./actions/locker
+        with:
+          daysSinceClose:  ${{ fromJson(inputs.daysSinceClose  || 30) }}
+          daysSinceUpdate: ${{ fromJson(inputs.daysSinceUpdate || 30) }}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8173
Context: https://github.com/dotnet/maui/pull/19145

When we [accepted migration](https://github.com/xamarin/xamarin-android/pull/8173) from `FabricBot` to `GitOps.ResourceManagement` due to `FabricBot` being decommissioned, one rule we lost was `[Closed Issue Management] Lock issues closed without activity for over 30 days`.  This rule is useful because comments on old, closed issues rarely will be seen or responded to, making us seem unresponsive to users.

MAUI has [replaced this rule](https://github.com/dotnet/maui/pull/19145) with a GitHub action written by the VSCode team that runs daily and performs the locking. We should ~~steal~~ borrow this for our own.

Unfortunately I'm not aware of a way to test a GitHub Action without it already being in `main`, so this is untested.  😦 