### PR TITLE
[Xamarin.Android.Build.Tasks] fix net7.0 "out of support" message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/Eol.targets
@@ -28,7 +28,7 @@ Things to note:
   </PropertyGroup>
   <ItemGroup>
     <SdkSupportedTargetPlatformVersion Include="21.0" />
-    <EolWorkload Include="net6.0-android" Url="https://aka.ms/maui-support-policy" />
+    <EolWorkload Include="net$(TargetFrameworkVersion.TrimStart('vV'))-android" Url="https://aka.ms/maui-support-policy" />
   </ItemGroup>
   <Target Name="_ClearMissingWorkloads">
     <!--

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
@@ -58,16 +58,16 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void EolFrameworks()
+		public void EolFrameworks ([Values ("net6.0-android", "net7.0-android")] string targetFramework)
 		{
 			var library = new XamarinAndroidLibraryProject () {
-				TargetFramework = "net6.0-android",
+				TargetFramework = targetFramework,
 				EnableDefaultItems = true,
 			};
 			var builder = CreateApkBuilder ();
 			builder.ThrowOnBuildFailure = false;
 			Assert.IsFalse (builder.Restore (library), $"{library.ProjectName} restore should fail");
-			Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "NETSDK1202"), $"{builder.BuildLogFile} should have NETSDK1202.");
+			Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"NETSDK1202: The workload '{targetFramework}' is out of support"), $"{builder.BuildLogFile} should have NETSDK1202.");
 		}
 
 		[Test]


### PR DESCRIPTION
When .NET 9 ships, the .NET 7 Android workload will be out of support. We already have this behavior setup, but unfortunately the error message is wrong:

    Microsoft.NET.EolTargetFrameworks.targets(38,5):
    error NETSDK1202: The workload 'net6.0-android' is out of support and will not receive security updates in the future. Please refer to
    https://aka.ms/maui-support-policy for more information about the support policy.
    [MauiTest.csproj::TargetFramework=net7.0-android]

It says `net6.0-android`!

In a48a9c56, we hardcoded `net6.0` to align with the iOS team, but we can use the `$(TargetFrameworkVersion)` property (removing `v`) so we don't have to update this line every year.

I updated a test for this scenario.