### PR TITLE
[Xamarin.Android.build.Tasks] `<CheckDuplicateJavaLibraries/>` ignores `repackaged.jar`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -9,16 +9,12 @@ namespace Xamarin.Android.Tasks
 {
 	public class CheckDuplicateJavaLibraries : AndroidTask
 	{
-		readonly static string [] ExcludedFiles = new [] {
-			"classes.jar",
-			"r-classes.jar",
-		};
-
 		public override string TaskPrefix => "CDJ";
 
 		public ITaskItem [] JavaSourceFiles { get; set; }
 		public ITaskItem[] JavaLibraries { get; set; }
 		public ITaskItem[] LibraryProjectJars { get; set; }
+		public string [] ExcludedFiles { get; set; }
 
 		public override bool RunTask ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -722,31 +722,45 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 		}
 
 		/// <summary>
-		/// Tests two .aar files with r-classes.jar
+		/// Tests two .aar files with r-classes.jar, repackaged.jar
 		/// </summary>
 		[Test]
-		public void AarWithRClassesJar ()
+		public void CheckDuplicateJavaLibraries ()
 		{
 			var path = Path.Combine ("temp", TestName);
 			var lib1 = new XamarinAndroidBindingProject {
 				ProjectName = "Library1",
 				AndroidClassParser = "class-parse",
 				Jars = {
+					// r-classes.jar
 					new AndroidItem.LibraryProjectZip ("Library1.aar") {
 						BinaryContent = () => ResourceData.Library1Aar
-					}
+					},
+					// repackaged.jar
+					new AndroidItem.AndroidLibrary ("emoji2-1.4.0.aar") {
+						MetadataValues = "Bind=false",
+						WebContent = "https://maven.google.com/androidx/emoji2/emoji2/1.4.0/emoji2-1.4.0.aar",
+					},
 				},
 			};
 			var lib2 = new XamarinAndroidBindingProject {
 				ProjectName = "Library2",
 				AndroidClassParser = "class-parse",
 				Jars = {
+					// r-classes.jar
 					new AndroidItem.LibraryProjectZip ("Library2.aar") {
 						BinaryContent = () => ResourceData.Library2Aar
-					}
+					},
+					// repackaged.jar
+					new AndroidItem.AndroidLibrary ("connect-client-1.1.0-alpha07.aar") {
+						MetadataValues = "Bind=false",
+						WebContent = "https://maven.google.com/androidx/health/connect/connect-client/1.1.0-alpha07/connect-client-1.1.0-alpha07.aar",
+					},
 				},
 			};
-			var app = new XamarinAndroidApplicationProject ();
+			var app = new XamarinAndroidApplicationProject {
+				SupportedOSPlatformVersion = "30", // androidx.health requires minSdkVersion="30"
+			};
 			app.AddReference (lib1);
 			app.AddReference (lib2);
 			using (var lib1Builder = CreateDllBuilder (Path.Combine (path, lib1.ProjectName)))

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -842,10 +842,17 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CheckDuplicateJavaLibraries" DependsOnTargets="_GetLibraryImports">
+  <ItemGroup>
+    <_AndroidExcludedDuplicateJavaLibraries Include="classes.jar" />
+    <_AndroidExcludedDuplicateJavaLibraries Include="r-classes.jar" />
+    <_AndroidExcludedDuplicateJavaLibraries Include="repackaged.jar" />
+  </ItemGroup>
   <CheckDuplicateJavaLibraries
     JavaSourceFiles="@(AndroidJavaSource)"
     JavaLibraries="@(AndroidJavaLibrary)"
-    LibraryProjectJars="@(ExtractedJarImports)" />
+    LibraryProjectJars="@(ExtractedJarImports)"
+    ExcludedFiles="@(_AndroidExcludedDuplicateJavaLibraries)"
+  />
 </Target>
 
 <Target Name="_LintChecks" Condition=" '$(AndroidLintEnabled)' == 'True' ">


### PR DESCRIPTION
Context: https://maven.google.com/androidx/emoji2/emoji2/1.4.0/emoji2-1.4.0.aar
Context: https://maven.google.com/androidx/health/connect/connect-client/1.1.0-alpha07/connect-client-1.1.0-alpha07.aar

When using the two AARs linked above, you get the build error:

    Xamarin.Android.Common.targets(845,3): error XA1014: JAR library references with identical file names but different contents were found: repackaged.jar. Please remove any conflicting libraries from EmbeddedJar, InputJar and AndroidJavaLibrary.

They both contain `libs/repackaged.jar`, which I'm not able to find any information about. I can reproduce this problem in an MSBuild test.

Unfortunately, the only way to workaround the error message is to:

* Unzip the `.aar`

* Rename `libs/repackaged.jar` to `libs/repackaged-emoji2-1.4.0.jar`, for example

* Re-zip the `.aar`

a9ca3d46 had a similar problem with `r-classes.jar`. Let's expand upon this change by introducing a private item group:

    <ItemGroup>
      <_AndroidExcludedDuplicateJavaLibraries Include="classes.jar" />
      <_AndroidExcludedDuplicateJavaLibraries Include="r-classes.jar" />
      <_AndroidExcludedDuplicateJavaLibraries Include="repackaged.jar" />
    </ItemGroup>

So if this occurs in the future, we can add future files to this list without rebuilding the Android workload.