### PR TITLE
[ci] Only install Android SDK API-34 on test agents.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -342,7 +342,7 @@ stages:
         installLegacyDotNet: false
         restoreNUnitConsole: false
         updateMono: false
-        androidSdkPlatforms: 23,24,25,26,27,28,29,30,31,32,$(DefaultTestSdkPlatforms)
+        androidSdkPlatforms: 23,24,25,26,27,28,29,30,31,32,33,$(DefaultTestSdkPlatforms)
 
     - task: NuGetAuthenticate@0
       displayName: authenticate with azure artifacts

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -86,7 +86,7 @@ stages:
       avdAbi: x86
       avdType: android-wear
       deviceName: wear_square
-      androidSdkPlatforms: 33
+      androidSdkPlatforms: 34
     pool:
       vmImage: $(HostedMacImage)
     workspace:

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -49,6 +49,6 @@ variables:
 - name: IsRelOrTargetingRel
   value: $[or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'))]
 - name: DefaultTestSdkPlatforms  # Comma-separated SDK Platform(s) to install on test agents (no spaces)
-  value: 33,34
+  value: 34
 - name: ExcludedNightlyNUnitCategories
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'


### PR DESCRIPTION
Now that API-34 is our baseline, we no longer need to install the API-33 Android SDK on our test agents, saving a little bit of space and time.