### PR TITLE
$(AndroidPackVersionSuffix)=preview.2; net9 is 34.99.0.preview.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/9.0.1xx-preview1

We branched for .NET 9 Preview 1 from cf1418d0 into 9.0.1xx-preview1; the main branch is now .NET 9 Preview 2.

Update xamarin-android/main's version number to 34.99.0-preview.2.