### PR TITLE
[Mono.Android] Commit `api-34.xml` instead of generating it on every build.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -22,7 +22,7 @@
     <_StandardLibraryPath Condition=" '$(TargetFrameworkVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' ">v4.7.1</TargetFrameworkVersion>
-    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">26</AndroidJavaRuntimeApiLevel>
+    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">34</AndroidJavaRuntimeApiLevel>
     <!-- The min API level supported by Microsoft.Android.Sdk -->
     <AndroidMinimumDotNetApiLevel Condition="'$(AndroidMinimumDotNetApiLevel)' == ''">21</AndroidMinimumDotNetApiLevel>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->

--- a/Configuration.props
+++ b/Configuration.props
@@ -22,7 +22,6 @@
     <_StandardLibraryPath Condition=" '$(TargetFrameworkVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(UsingMicrosoftNETSdk)' != 'true' ">v4.7.1</TargetFrameworkVersion>
-    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">34</AndroidJavaRuntimeApiLevel>
     <!-- The min API level supported by Microsoft.Android.Sdk -->
     <AndroidMinimumDotNetApiLevel Condition="'$(AndroidMinimumDotNetApiLevel)' == ''">21</AndroidMinimumDotNetApiLevel>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
@@ -40,6 +39,7 @@
     <AndroidPlatformId Condition=" '$(AndroidPlatformId)' == '' ">$(AndroidLatestStablePlatformId)</AndroidPlatformId>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidUseLatestPlatformSdk Condition=" '$(AndroidFrameworkVersion)' == '' ">True</AndroidUseLatestPlatformSdk>
+    <AndroidJavaRuntimeApiLevel Condition="'$(AndroidJavaRuntimeApiLevel)' == ''">$(AndroidLatestStableApiLevel)</AndroidJavaRuntimeApiLevel>
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>

--- a/Documentation/workflow/HowToAddNewApiLevel.md
+++ b/Documentation/workflow/HowToAddNewApiLevel.md
@@ -23,9 +23,16 @@ the new platform will be downloaded to your local Android SDK.
   - *or* run manually: `param-name-importer.exe -source-stub-zip C:/Users/USERNAME/android-toolchain/sdk/platforms/android-S/android-stubs-src.jar -output-text api-S.params.txt -output-xml api-S.params.xml -verbose -framework-only`
 - Copy the produced `api-X.params.txt` file to `/src/Mono.Android/Profiles/`
 
+### Generate `api.xml` File
+
+- Run `xaprepare android-sdk-platforms=all` to download all Android SDK platforms
+- Add level to `/build-tools/api-merge/merge-configuration.xml` to create `api-S.xml.class-parse`
+- Run the following command to create a merged `api.xml`:
+  - `dotnet-local.cmd build build-tools\create-android-api -t:_GenerateApiDescription`
+- Copy the `bin\BuildDebug\api\api-xx.xml` file to `src\Mono.Android\Profiles`
+
 ### Other Infrastructure Changes
 
-- Add level to `/build-tools/api-merge/merge-configuration.xml` to create `api-S.xml.class-parse`
 - Add level to `/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs`
   to enable running ApiCompat against the new level. (ex: `{ "v11.0.99", "v11.0" }`)
 - Add level to `/build-tools/api-xml-adjuster/Makefile`

--- a/Documentation/workflow/HowToAddNewApiLevel.md
+++ b/Documentation/workflow/HowToAddNewApiLevel.md
@@ -28,7 +28,7 @@ the new platform will be downloaded to your local Android SDK.
 - Run `xaprepare android-sdk-platforms=all` to download all Android SDK platforms
 - Add level to `/build-tools/api-merge/merge-configuration.xml` to create `api-S.xml.class-parse`
 - Run the following command to create a merged `api.xml`:
-  - `dotnet-local.cmd build build-tools\create-android-api -t:_GenerateApiDescription`
+  - `dotnet-local.cmd build build-tools\create-android-api -t:GenerateApiDescription`
 - Copy the `bin\BuildDebug\api\api-xx.xml` file to `src\Mono.Android\Profiles`
 
 ### Other Infrastructure Changes

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -342,7 +342,7 @@ stages:
         installLegacyDotNet: false
         restoreNUnitConsole: false
         updateMono: false
-        androidSdkPlatforms: 23,24,25,26,27,28,29,30,31,32,33,$(DefaultTestSdkPlatforms)
+        androidSdkPlatforms: $(DefaultTestSdkPlatforms)
 
     - task: NuGetAuthenticate@1
       displayName: authenticate with azure artifacts

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -98,7 +98,6 @@
   
   <!-- Merges various 'api-X.xml.in' files into single 'api.xml' file -->
   <Target Name="_GenerateApiDescription"
-      BeforeTargets="Build"
       DependsOnTargets="_AdjustApiXml"
       Inputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')"
       Outputs="@(_MergedXmlFiles->'%(MergedXml)')">

--- a/build-tools/create-android-api/create-android-api.csproj
+++ b/build-tools/create-android-api/create-android-api.csproj
@@ -97,7 +97,7 @@
   </Target>
   
   <!-- Merges various 'api-X.xml.in' files into single 'api.xml' file -->
-  <Target Name="_GenerateApiDescription"
+  <Target Name="GenerateApiDescription"
       DependsOnTargets="_AdjustApiXml"
       Inputs="@(ApiFileDefinition->'%(ApiAdjustedXml)')"
       Outputs="@(_MergedXmlFiles->'%(MergedXml)')">

--- a/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
+++ b/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
@@ -45,11 +45,15 @@ namespace Xamarin.Android.Prepare
 	class AndroidPlatformComponent : AndroidToolchainComponent
 	{
 		public string ApiLevel { get; }
+		public bool IsLatestStable { get; }
+		public bool IsPreview { get; }
 
-		public AndroidPlatformComponent (string name, string apiLevel, string pkgRevision)
-			: base (name, Path.Combine ("platforms", $"android-{apiLevel}"), pkgRevision: pkgRevision, buildToolName: $"android-sdk-{name}", buildToolVersion:$"{apiLevel}.{pkgRevision}")
+		public AndroidPlatformComponent (string name, string apiLevel, string pkgRevision, bool isLatestStable = false, bool isPreview = false)
+			: base (name, Path.Combine ("platforms", $"android-{apiLevel}"), pkgRevision: pkgRevision, buildToolName: $"android-sdk-{name}", buildToolVersion: $"{apiLevel}.{pkgRevision}")
 		{
 			ApiLevel = apiLevel;
+			IsLatestStable = isLatestStable;
+			IsPreview = isPreview;
 		}
 	}
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidPlatformComponent ("platform-31_r01",   apiLevel: "31", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-32_r01",   apiLevel: "32", pkgRevision: "1"),
 				new AndroidPlatformComponent ("platform-33-ext3_r03",   apiLevel: "33", pkgRevision: "3"),
-				new AndroidPlatformComponent ("platform-34-ext7_r02",   apiLevel: "34", pkgRevision: "2"),
+				new AndroidPlatformComponent ("platform-34-ext7_r02",   apiLevel: "34", pkgRevision: "2", isLatestStable: true),
 
 				new AndroidToolchainComponent ("sources-34_r01",
 					destDir: Path.Combine ("sources", "android-34"),

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Prepare
 			public bool IgnoreMaxMonoVersion   { get; set; }
 			public bool IgnoreMinMonoVersion   { get; set; }
 			public RefreshableComponent RefreshList { get; set; }
-			public IEnumerable<string> AndroidSdkPlatforms { get; set; } = Enumerable.Empty<string> ();
+			public IEnumerable<string> AndroidSdkPlatforms { get; set; } = new [] { "latest" };
 		}
 
 		public static int Main (string[] args)
@@ -105,7 +105,7 @@ namespace Xamarin.Android.Prepare
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
 				{"ignore-max-mono-version=", $"Ignore the maximum supported Mono version restriction", v => parsedOptions.IgnoreMaxMonoVersion = ParseBoolean (v)},
 				{"ignore-min-mono-version=", $"Ignore the minimum supported Mono version restriction", v => parsedOptions.IgnoreMinMonoVersion = ParseBoolean (v)},
-				{"android-sdk-platforms=", "Comma separated list of Android SDK platform levels to be installed. Defaults to all if no value is provided.", v => parsedOptions.AndroidSdkPlatforms = ParseAndroidSdkPlatformLevels (v?.Trim () ?? String.Empty) },
+				{"android-sdk-platforms=", "Comma separated list of Android SDK platform levels to be installed or 'latest' or 'all'. Defaults to 'latest' if no value is provided.", v => parsedOptions.AndroidSdkPlatforms = ParseAndroidSdkPlatformLevels (v?.Trim () ?? String.Empty) },
 				"",
 				{"h|help", "Show this help message", v => parsedOptions.ShowHelp = true },
 			};
@@ -333,6 +333,15 @@ namespace Xamarin.Android.Prepare
 
 		static IEnumerable<string> ParseAndroidSdkPlatformLevels (string list)
 		{
+			// If the user specified "all" we return 'all' to indicate that all platforms should be installed.
+			if (string.Compare ("all", list, StringComparison.OrdinalIgnoreCase) == 0)
+				return new string [] { "all" };
+
+			// If the user did not specify anything, we return "latest" to indicate that only the latest platform should be installed.
+			if (string.IsNullOrEmpty (list) || string.Compare ("latest", list, StringComparison.OrdinalIgnoreCase) == 0)
+				return new string [] { "latest" };
+
+			// The user specified a list of platform levels to install, so we should respect that.
 			return list.Split (',').Select (item => item.Trim ());
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -254,11 +254,9 @@ namespace Xamarin.Android.Prepare
 			}
 
 			// If only specific Android SDK platforms were requested, ignore ones that were not requested
-			if (component is AndroidPlatformComponent apc && context.AndroidSdkPlatforms.Any ()) {
-				if (!context.AndroidSdkPlatforms.Contains (apc.ApiLevel)) {
-					LogStatus ($"skipping, not requested", padLeft, Log.InfoColor);
-					return;
-				}
+			if (component is AndroidPlatformComponent apc && !ShouldInstall (apc, context)) {
+				LogStatus ($"skipping, not requested", padLeft, Log.InfoColor);
+				return;
 			}
 
 			if (missing)
@@ -276,6 +274,22 @@ namespace Xamarin.Android.Prepare
 			};
 
 			toInstall.Add (pkg);
+		}
+
+		bool ShouldInstall (AndroidPlatformComponent component, Context context)
+		{
+			var platforms = context.AndroidSdkPlatforms;
+
+			// If no specific platforms were requested, install everything
+			if (!platforms.Any () || platforms.Contains ("all"))
+				return true;
+
+			// If "latest" was requested, install the highest available stable version and any preview versions
+			if (platforms.Contains ("latest") && (component.IsLatestStable || component.IsPreview))
+				return true;
+
+			// Check if this is a user-requested platform
+			return context.AndroidSdkPlatforms.Contains (component.ApiLevel);
 		}
 
 		bool IsInstalled (AndroidToolchainComponent component, string path, out bool missing)

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -18,7 +18,7 @@
   </ItemGroup>
   
   <PropertyGroup>
-    <_ApiXmlLocation>..\..\bin\Build$(Configuration)\api\</_ApiXmlLocation>
+    <_ApiXmlLocation>Profiles\</_ApiXmlLocation>
   </PropertyGroup>
   
   <!-- Creates 'AssemblyInfo.cs' with appropriate version information -->


### PR DESCRIPTION
Today, we recalculate the `api.xml` for `Mono.Android` API-34 on every build.

This involves:
- Installing Android SDK platforms 23 - 34 (2.2 GB)
- Running `class-parse` on every API level
- Running `api-xml-adjuster` on every API level
- Running `api-merge` to merge every level into a single `api.xml`

However, the output ~never changes, as the Android API should not change once it has shipped.  Thus, we can save disk space and build time by committing a completed `api.xml` instead of rebuilding it.

Additionally, `xaprepare` no longer installs all Android SDK Platforms by default.  Instead it defaults to only installing the latest stable version and any unstable preview version(s).  New value `all` has been added to the supported `-android-sdk-platforms=` command line argument to request all platforms be installed instead.

Updated the `HowTo: Add a new Android API Level` document to instruct how to generate a new `api.xml`.

This saves:
- ~1 minute on the Mac Build (where all platform SDKs are already installed because we reuse CI agents)
- ~16 minutes on Windows Builds with fresh CI agents (where we previously had to download all the platform SDKs)