### PR TITLE
Bump to xamarin/java.interop/main@07c73009

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = main
+    branch = dev/jonp/ji-typemap-support
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/xamarin/lz4

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = dev/jonp/ji-typemap-support
+    branch = main
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/xamarin/lz4

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -11,7 +11,7 @@ parameters:
   artifactFolder: ""
   useDotNet: true
   condition: succeeded()
-  retryCountOnTaskFailure: 0
+  retryCountOnTaskFailure: 1
 
 steps:
 - ${{ if eq(parameters.useDotNet, false) }}:

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -11,7 +11,7 @@ parameters:
   artifactFolder: ""
   useDotNet: true
   condition: succeeded()
-  retryCountOnTaskFailure: 1
+  retryCountOnTaskFailure: 0
 
 steps:
 - ${{ if eq(parameters.useDotNet, false) }}:

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -286,15 +286,19 @@ namespace Java.Interop {
 
 			JNIEnv.DeleteLocalRef (class_ptr);
 
-			if (type == null) {
-				JNIEnv.DeleteRef (handle, transfer);
-				throw new NotSupportedException (
-						FormattableString.Invariant ($"Internal error finding wrapper class for '{JNIEnv.GetClassNameFromInstance (handle)}'. (Where is the Java.Lang.Object wrapper?!)"),
-						CreateJavaLocationException ());
+			if (targetType != null &&
+					(type == null ||
+					 !targetType.IsAssignableFrom (type))) {
+				type = targetType;
 			}
 
-			if (targetType != null && !targetType.IsAssignableFrom (type))
-				type = targetType;
+			if (type == null) {
+				class_name = JNIEnv.GetClassNameFromInstance (handle);
+				JNIEnv.DeleteRef (handle, transfer);
+				throw new NotSupportedException (
+						FormattableString.Invariant ($"Internal error finding wrapper class for '{class_name}'. (Where is the Java.Lang.Object wrapper?!)"),
+						CreateJavaLocationException ());
+			}
 
 			if (type.IsInterface || type.IsAbstract) {
 				var invokerType = JavaObjectExtensions.GetInvokerType (type);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 
 			void Generate (IDictionary<string, CompressedAssemblyInfo> dict)
 			{
-				var composer = new CompressedAssembliesNativeAssemblyGenerator (dict);
+				var composer = new CompressedAssembliesNativeAssemblyGenerator (dict, s => Log.LogDebugMessage (s));
 				LLVMIR.LlvmIrModule compressedAssemblies = composer.Construct ();
 
 				foreach (string abi in SupportedAbis) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 
 			void Generate (IDictionary<string, CompressedAssemblyInfo> dict)
 			{
-				var composer = new CompressedAssembliesNativeAssemblyGenerator (dict, s => Log.LogDebugMessage (s));
+				var composer = new CompressedAssembliesNativeAssemblyGenerator (Log, dict);
 				LLVMIR.LlvmIrModule compressedAssemblies = composer.Construct ();
 
 				foreach (string abi in SupportedAbis) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -213,7 +213,7 @@ namespace Xamarin.Android.Tasks
 			var scanner = new XAJavaTypeScanner (Log, cache) {
 				ErrorOnCustomJavaObject     = ErrorOnCustomJavaObject,
 			};
-			List<JavaType> allJavaTypes = scanner.GetJavaTypes (GetAllTypemapAssemblies (allTypemapAssemblies.Values), res);
+			List<JavaType> allJavaTypes = scanner.GetJavaTypes (allTypemapAssemblies.Values, res);
 			var javaTypes = new List<JavaType> ();
 
 			foreach (JavaType jt in allJavaTypes) {
@@ -420,19 +420,6 @@ namespace Xamarin.Android.Tasks
 					items.Add (assembly);
 				}
 			}
-		}
-
-		static ICollection<ITaskItem> GetAllTypemapAssemblies (ICollection<ITaskItem> assemblies)
-		{
-			// We need `Mono.Android.dll` to be *first*, so that in `acw-map.txt` the
-			// entry for `java/lang/Object` always resolves to `Java.Lang.Object, Mono.Android`.
-			var c = new List<ITaskItem>(assemblies);
-			var e = c.Find (item => string.Compare ("Mono.Android.dll", Path.GetFileName (item.ItemSpec), StringComparison.OrdinalIgnoreCase) == 0);
-			if (e != null) {
-				c.Remove (e);
-				c.Insert (0, e);
-			}
-			return c;
 		}
 
 		AssemblyDefinition LoadAssembly (string path, XAAssemblyResolver? resolver = null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -213,7 +213,7 @@ namespace Xamarin.Android.Tasks
 			var scanner = new XAJavaTypeScanner (Log, cache) {
 				ErrorOnCustomJavaObject     = ErrorOnCustomJavaObject,
 			};
-			List<JavaType> allJavaTypes = scanner.GetJavaTypes (allTypemapAssemblies.Values, res);
+			List<JavaType> allJavaTypes = scanner.GetJavaTypes (GetAllTypemapAssemblies (allTypemapAssemblies.Values), res);
 			var javaTypes = new List<JavaType> ();
 
 			foreach (JavaType jt in allJavaTypes) {
@@ -420,6 +420,19 @@ namespace Xamarin.Android.Tasks
 					items.Add (assembly);
 				}
 			}
+		}
+
+		static ICollection<ITaskItem> GetAllTypemapAssemblies (ICollection<ITaskItem> assemblies)
+		{
+			// We need `Mono.Android.dll` to be *first*, so that in `acw-map.txt` the
+			// entry for `java/lang/Object` always resolves to `Java.Lang.Object, Mono.Android`.
+			var c = new List<ITaskItem>(assemblies);
+			var e = c.Find (item => string.Compare ("Mono.Android.dll", Path.GetFileName (item.ItemSpec), StringComparison.OrdinalIgnoreCase) == 0);
+			if (e != null) {
+				c.Remove (e);
+				c.Insert (0, e);
+			}
+			return c;
 		}
 
 		AssemblyDefinition LoadAssembly (string path, XAAssemblyResolver? resolver = null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -570,7 +570,7 @@ namespace Xamarin.Android.Tasks
 
 		void WriteTypeMappings (List<JavaType> types, TypeDefinitionCache cache)
 		{
-			var tmg = new TypeMapGenerator ((string message) => Log.LogDebugMessage (message), SupportedAbis);
+			var tmg = new TypeMapGenerator (Log, SupportedAbis);
 			if (!tmg.Generate (Debug, SkipJniAddNativeMethodRegistrationAttributeScan, types, cache, TypemapOutputDirectory, GenerateNativeAssembly, out ApplicationConfigTaskState appConfState)) {
 				throw new XamarinAndroidException (4308, Properties.Resources.XA4308);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJniRemappingNativeCode.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJniRemappingNativeCode.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateEmpty ()
 		{
-			Generate (new JniRemappingAssemblyGenerator (), typeReplacementsCount: 0);
+			Generate (new JniRemappingAssemblyGenerator (s => Log.LogDebugMessage (s)), typeReplacementsCount: 0);
 		}
 
 		void Generate ()
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			Generate (new JniRemappingAssemblyGenerator (typeReplacements, methodReplacements), typeReplacements.Count);
+			Generate (new JniRemappingAssemblyGenerator (typeReplacements, methodReplacements, s => Log.LogDebugMessage (s)), typeReplacements.Count);
 		}
 
 		void Generate (JniRemappingAssemblyGenerator jniRemappingComposer, int typeReplacementsCount)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJniRemappingNativeCode.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJniRemappingNativeCode.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateEmpty ()
 		{
-			Generate (new JniRemappingAssemblyGenerator (s => Log.LogDebugMessage (s)), typeReplacementsCount: 0);
+			Generate (new JniRemappingAssemblyGenerator (Log), typeReplacementsCount: 0);
 		}
 
 		void Generate ()
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			Generate (new JniRemappingAssemblyGenerator (typeReplacements, methodReplacements, s => Log.LogDebugMessage (s)), typeReplacements.Count);
+			Generate (new JniRemappingAssemblyGenerator (Log, typeReplacements, methodReplacements), typeReplacements.Count);
 		}
 
 		void Generate (JniRemappingAssemblyGenerator jniRemappingComposer, int typeReplacementsCount)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -392,7 +392,7 @@ namespace Xamarin.Android.Tasks
 					Log
 				);
 			} else {
-				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (assemblyCount, uniqueAssemblyNames);
+				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (assemblyCount, uniqueAssemblyNames, s => Log.LogDebugMessage (s));
 			}
 			LLVMIR.LlvmIrModule marshalMethodsModule = marshalMethodsAsmGen.Construct ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -386,13 +386,13 @@ namespace Xamarin.Android.Tasks
 
 			if (enableMarshalMethods) {
 				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (
+					Log,
 					assemblyCount,
 					uniqueAssemblyNames,
-					marshalMethodsState?.MarshalMethods,
-					Log
+					marshalMethodsState?.MarshalMethods
 				);
 			} else {
-				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (assemblyCount, uniqueAssemblyNames, s => Log.LogDebugMessage (s));
+				marshalMethodsAsmGen = new MarshalMethodsNativeAssemblyGenerator (Log, assemblyCount, uniqueAssemblyNames);
 			}
 			LLVMIR.LlvmIrModule marshalMethodsModule = marshalMethodsAsmGen.Construct ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -63,10 +63,8 @@ namespace Xamarin.Android.Tasks
 				WriteOptionsToResponseFile (sw);
 				// Include any user .java files
 				if (JavaSourceFiles != null)
-					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java")) {
-						var path    = file.ItemSpec.Replace (@"\", @"\\");
-						sw.WriteLine (string.Format ("\"{0}\"", path));
-					}
+					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java"))
+						sw.WriteLine (string.Format ("\"{0}\"", file.ItemSpec.Replace (@"\", @"\\")));
 
 				if (string.IsNullOrEmpty (StubSourceDirectory))
 					return;
@@ -88,9 +86,8 @@ namespace Xamarin.Android.Tasks
 					// Solution:
 					//    Since '\' is an escape character, we need to escape it.
 					// [0] http://download.oracle.com/javase/1.4.2/docs/api/java/io/StreamTokenizer.html#quoteChar(int)
-					var path    = file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC);
 					sw.WriteLine (string.Format ("\"{0}\"",
-								path));
+								file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC)));
 				}
 			}
 			Log.LogDebugMessage ($"javac response file contents: {TemporarySourceListFile}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -63,8 +63,11 @@ namespace Xamarin.Android.Tasks
 				WriteOptionsToResponseFile (sw);
 				// Include any user .java files
 				if (JavaSourceFiles != null)
-					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java"))
-						sw.WriteLine (string.Format ("\"{0}\"", file.ItemSpec.Replace (@"\", @"\\")));
+					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java")) {
+						var path    = file.ItemSpec.Replace (@"\", @"\\");
+						sw.WriteLine (string.Format ("\"{0}\"", path));
+						Log.LogDebugMessage ($"javac source: {path}");
+					}
 
 				if (string.IsNullOrEmpty (StubSourceDirectory))
 					return;
@@ -86,8 +89,10 @@ namespace Xamarin.Android.Tasks
 					// Solution:
 					//    Since '\' is an escape character, we need to escape it.
 					// [0] http://download.oracle.com/javase/1.4.2/docs/api/java/io/StreamTokenizer.html#quoteChar(int)
+					var path    = file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC);
 					sw.WriteLine (string.Format ("\"{0}\"",
-								file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC)));
+								path));
+					Log.LogDebugMessage ($"javac source: {path}");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -66,7 +66,6 @@ namespace Xamarin.Android.Tasks
 					foreach (var file in JavaSourceFiles.Where (p => Path.GetExtension (p.ItemSpec) == ".java")) {
 						var path    = file.ItemSpec.Replace (@"\", @"\\");
 						sw.WriteLine (string.Format ("\"{0}\"", path));
-						Log.LogDebugMessage ($"javac source: {path}");
 					}
 
 				if (string.IsNullOrEmpty (StubSourceDirectory))
@@ -92,8 +91,11 @@ namespace Xamarin.Android.Tasks
 					var path    = file.Replace (@"\", @"\\").Normalize (NormalizationForm.FormC);
 					sw.WriteLine (string.Format ("\"{0}\"",
 								path));
-					Log.LogDebugMessage ($"javac source: {path}");
 				}
+			}
+			Log.LogDebugMessage ($"javac response file contents: {TemporarySourceListFile}");
+			foreach (var line in File.ReadLines (TemporarySourceListFile)) {
+				Log.LogDebugMessage ($"  {line}");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -136,7 +136,6 @@ namespace Xamarin.Android.Tasks
 
 		SortedDictionary <string, string>? environmentVariables;
 		SortedDictionary <string, string>? systemProperties;
-		TaskLoggingHelper log;
 		StructureInstance? application_config;
 		List<StructureInstance<DSOCacheEntry>>? dsoCache;
 		List<StructureInstance<XamarinAndroidBundledAssembly>>? xamarinAndroidBundledAssemblies;
@@ -173,7 +172,7 @@ namespace Xamarin.Android.Tasks
 		public bool MarshalMethodsEnabled { get; set; }
 
 		public ApplicationConfigNativeAssemblyGenerator (IDictionary<string, string> environmentVariables, IDictionary<string, string> systemProperties, TaskLoggingHelper log)
-			: base (s => log.LogDebugMessage (s))
+			: base (log)
 		{
 			if (environmentVariables != null) {
 				this.environmentVariables = new SortedDictionary<string, string> (environmentVariables, StringComparer.Ordinal);
@@ -182,8 +181,6 @@ namespace Xamarin.Android.Tasks
 			if (systemProperties != null) {
 				this.systemProperties = new SortedDictionary<string, string> (systemProperties, StringComparer.Ordinal);
 			}
-
-			this.log = log;
 		}
 
 		protected override void Construct (LlvmIrModule module)
@@ -324,7 +321,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 
-				dsos.Add ((name, $"dsoName{dsos.Count.ToString (CultureInfo.InvariantCulture)}", ELFHelper.IsEmptyAOTLibrary (log, item.ItemSpec)));
+				dsos.Add ((name, $"dsoName{dsos.Count.ToString (CultureInfo.InvariantCulture)}", ELFHelper.IsEmptyAOTLibrary (Log, item.ItemSpec)));
 			}
 
 			var dsoCache = new List<StructureInstance<DSOCacheEntry>> ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
@@ -172,6 +173,7 @@ namespace Xamarin.Android.Tasks
 		public bool MarshalMethodsEnabled { get; set; }
 
 		public ApplicationConfigNativeAssemblyGenerator (IDictionary<string, string> environmentVariables, IDictionary<string, string> systemProperties, TaskLoggingHelper log)
+			: base (s => log.LogDebugMessage (s))
 		{
 			if (environmentVariables != null) {
 				this.environmentVariables = new SortedDictionary<string, string> (environmentVariables, StringComparer.Ordinal);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
@@ -66,8 +68,8 @@ namespace Xamarin.Android.Tasks
 		StructureInfo compressedAssemblyDescriptorStructureInfo;
 		StructureInfo compressedAssembliesStructureInfo;
 
-		public CompressedAssembliesNativeAssemblyGenerator (IDictionary<string, CompressedAssemblyInfo> assemblies, Action<string> logger)
-			: base (logger)
+		public CompressedAssembliesNativeAssemblyGenerator (TaskLoggingHelper log, IDictionary<string, CompressedAssemblyInfo> assemblies)
+			: base (log)
 		{
 			this.assemblies = assemblies;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
@@ -66,7 +66,8 @@ namespace Xamarin.Android.Tasks
 		StructureInfo compressedAssemblyDescriptorStructureInfo;
 		StructureInfo compressedAssembliesStructureInfo;
 
-		public CompressedAssembliesNativeAssemblyGenerator (IDictionary<string, CompressedAssemblyInfo> assemblies)
+		public CompressedAssembliesNativeAssemblyGenerator (IDictionary<string, CompressedAssemblyInfo> assemblies, Action<string> logger)
+			: base (logger)
 		{
 			this.assemblies = assemblies;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
@@ -190,10 +190,12 @@ namespace Xamarin.Android.Tasks
 
 		public int ReplacementMethodIndexEntryCount { get; private set; } = 0;
 
-		public JniRemappingAssemblyGenerator ()
+		public JniRemappingAssemblyGenerator (Action<string> logger)
+			: base (logger)
 		{}
 
-		public JniRemappingAssemblyGenerator (List<JniRemappingTypeReplacement> typeReplacements, List<JniRemappingMethodReplacement> methodReplacements)
+		public JniRemappingAssemblyGenerator (List<JniRemappingTypeReplacement> typeReplacements, List<JniRemappingMethodReplacement> methodReplacements, Action<string> logger)
+			: base (logger)
 		{
 			this.typeReplacementsInput = typeReplacements ?? throw new ArgumentNullException (nameof (typeReplacements));
 			this.methodReplacementsInput = methodReplacements ?? throw new ArgumentNullException (nameof (methodReplacements));

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JniRemappingAssemblyGenerator.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
@@ -190,12 +192,12 @@ namespace Xamarin.Android.Tasks
 
 		public int ReplacementMethodIndexEntryCount { get; private set; } = 0;
 
-		public JniRemappingAssemblyGenerator (Action<string> logger)
-			: base (logger)
+		public JniRemappingAssemblyGenerator (TaskLoggingHelper log)
+			: base (log)
 		{}
 
-		public JniRemappingAssemblyGenerator (List<JniRemappingTypeReplacement> typeReplacements, List<JniRemappingMethodReplacement> methodReplacements, Action<string> logger)
-			: base (logger)
+		public JniRemappingAssemblyGenerator (TaskLoggingHelper log, List<JniRemappingTypeReplacement> typeReplacements, List<JniRemappingMethodReplacement> methodReplacements)
+			: base (log)
 		{
 			this.typeReplacementsInput = typeReplacements ?? throw new ArgumentNullException (nameof (typeReplacements));
 			this.methodReplacementsInput = methodReplacements ?? throw new ArgumentNullException (nameof (methodReplacements));

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -11,6 +11,13 @@ namespace Xamarin.Android.Tasks.LLVMIR
 	{
 		bool constructed;
 
+		protected readonly Action<string> logger;
+
+		protected LlvmIrComposer (Action<string> logger)
+		{
+			this.logger = logger;
+		}
+
 		protected abstract void Construct (LlvmIrModule module);
 
 		public LlvmIrModule Construct ()

--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrComposer.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.IO.Hashing;
 using System.Text;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks.LLVMIR
@@ -11,11 +13,11 @@ namespace Xamarin.Android.Tasks.LLVMIR
 	{
 		bool constructed;
 
-		protected readonly Action<string> logger;
+		protected readonly TaskLoggingHelper Log;
 
-		protected LlvmIrComposer (Action<string> logger)
+		protected LlvmIrComposer (TaskLoggingHelper log)
 		{
-			this.logger = logger;
+			this.Log = log ?? throw new ArgumentNullException (nameof (log));
 		}
 
 		protected abstract void Construct (LlvmIrModule module);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -243,7 +243,8 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are DISABLED
 		/// </summary>
-		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames)
+		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, Action<string> logger)
+			: base (logger)
 		{
 			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 			this.uniqueAssemblyNames = uniqueAssemblyNames ?? throw new ArgumentNullException (nameof (uniqueAssemblyNames));
@@ -255,6 +256,7 @@ namespace Xamarin.Android.Tasks
 		/// Constructor to be used ONLY when marshal methods are ENABLED
 		/// </summary>
 		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, IDictionary<string, IList<MarshalMethodEntry>> marshalMethods, TaskLoggingHelper logger)
+			: base (s => logger.LogDebugMessage (s))
 		{
 			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 			this.uniqueAssemblyNames = uniqueAssemblyNames ?? throw new ArgumentNullException (nameof (uniqueAssemblyNames));

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MarshalMethodsNativeAssemblyGenerator.cs
@@ -228,7 +228,6 @@ namespace Xamarin.Android.Tasks
 		ICollection<string> uniqueAssemblyNames;
 		int numberOfAssembliesInApk;
 		IDictionary<string, IList<MarshalMethodEntry>> marshalMethods;
-		TaskLoggingHelper logger;
 
 		StructureInfo marshalMethodsManagedClassStructureInfo;
 		StructureInfo marshalMethodNameStructureInfo;
@@ -243,8 +242,8 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are DISABLED
 		/// </summary>
-		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, Action<string> logger)
-			: base (logger)
+		public MarshalMethodsNativeAssemblyGenerator (TaskLoggingHelper log, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames)
+			: base (log)
 		{
 			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 			this.uniqueAssemblyNames = uniqueAssemblyNames ?? throw new ArgumentNullException (nameof (uniqueAssemblyNames));
@@ -255,13 +254,12 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Constructor to be used ONLY when marshal methods are ENABLED
 		/// </summary>
-		public MarshalMethodsNativeAssemblyGenerator (int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, IDictionary<string, IList<MarshalMethodEntry>> marshalMethods, TaskLoggingHelper logger)
-			: base (s => logger.LogDebugMessage (s))
+		public MarshalMethodsNativeAssemblyGenerator (TaskLoggingHelper log, int numberOfAssembliesInApk, ICollection<string> uniqueAssemblyNames, IDictionary<string, IList<MarshalMethodEntry>> marshalMethods)
+			: base (log)
 		{
 			this.numberOfAssembliesInApk = numberOfAssembliesInApk;
 			this.uniqueAssemblyNames = uniqueAssemblyNames ?? throw new ArgumentNullException (nameof (uniqueAssemblyNames));
 			this.marshalMethods = marshalMethods;
-			this.logger = logger ?? throw new ArgumentNullException (nameof (logger));
 
 			generateEmptyCode = false;
 			defaultCallMarker = LlvmIrCallMarker.Tail;
@@ -336,7 +334,7 @@ namespace Xamarin.Android.Tasks
 
 			foreach (MarshalMethodInfo method in allMethods) {
 				if (seenNativeSymbols.Contains (method.NativeSymbolName)) {
-					logger.LogDebugMessage ($"Removed MM duplicate '{method.NativeSymbolName}' (implemented: {method.Method.ImplementedMethod.FullName}; registered: {method.Method.RegisteredMethod.FullName}");
+					Log.LogDebugMessage ($"Removed MM duplicate '{method.NativeSymbolName}' (implemented: {method.Method.ImplementedMethod.FullName}; registered: {method.Method.RegisteredMethod.FullName}");
 					continue;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tasks
 		public uint MapModuleCount { get; }
 		public uint JavaTypeCount  { get; }
 
-		public NativeTypeMappingData (TypeMapGenerator.ModuleReleaseData[] modules)
+		public NativeTypeMappingData (TypeMapGenerator.ModuleReleaseData[] modules, Action<string> logger)
 		{
 			Modules = modules ?? throw new ArgumentNullException (nameof (modules));
 
@@ -21,15 +21,37 @@ namespace Xamarin.Android.Tasks
 			var tempJavaTypes = new Dictionary<string, TypeMapGenerator.TypeMapReleaseEntry> (StringComparer.Ordinal);
 			var moduleComparer = new TypeMapGenerator.ModuleUUIDArrayComparer ();
 
+			TypeMapGenerator.ModuleReleaseData? monoAndroid = null;
 			foreach (TypeMapGenerator.ModuleReleaseData data in modules) {
+				if (data.AssemblyName == "Mono.Android") {
+					monoAndroid = data;
+					break;
+				}
+			}
+
+			if (monoAndroid != null) {
+				ProcessModule (monoAndroid);
+			}
+
+			foreach (TypeMapGenerator.ModuleReleaseData data in modules) {
+				if (data.AssemblyName == "Mono.Android") {
+					continue;
+				}
+				ProcessModule (data);
+			};
+
+			void ProcessModule (TypeMapGenerator.ModuleReleaseData data)
+			{
 				int moduleIndex = Array.BinarySearch (modules, data, moduleComparer);
 				if (moduleIndex < 0)
 					throw new InvalidOperationException ($"Unable to map module with MVID {data.Mvid} to array index");
 
 				foreach (TypeMapGenerator.TypeMapReleaseEntry entry in data.Types) {
 					entry.ModuleIndex = moduleIndex;
-					if (tempJavaTypes.ContainsKey (entry.JavaName))
+					if (tempJavaTypes.ContainsKey (entry.JavaName)) {
+						logger ($"Skipping typemap entry for `{entry.ManagedTypeName}, {data.AssemblyName}`; `{entry.JavaName}` is already mapped.");
 						continue;
+					}
 					tempJavaTypes.Add (entry.JavaName, entry);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeTypeMappingData.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Microsoft.Build.Utilities;
+using Microsoft.Android.Build.Tasks;
+
 namespace Xamarin.Android.Tasks
 {
 	class NativeTypeMappingData
@@ -12,7 +15,7 @@ namespace Xamarin.Android.Tasks
 		public uint MapModuleCount { get; }
 		public uint JavaTypeCount  { get; }
 
-		public NativeTypeMappingData (TypeMapGenerator.ModuleReleaseData[] modules, Action<string> logger)
+		public NativeTypeMappingData (TaskLoggingHelper log, TypeMapGenerator.ModuleReleaseData[] modules)
 		{
 			Modules = modules ?? throw new ArgumentNullException (nameof (modules));
 
@@ -49,7 +52,7 @@ namespace Xamarin.Android.Tasks
 				foreach (TypeMapGenerator.TypeMapReleaseEntry entry in data.Types) {
 					entry.ModuleIndex = moduleIndex;
 					if (tempJavaTypes.ContainsKey (entry.JavaName)) {
-						logger ($"Skipping typemap entry for `{entry.ManagedTypeName}, {data.AssemblyName}`; `{entry.JavaName}` is already mapped.");
+						log.LogDebugMessage ($"Skipping typemap entry for `{entry.ManagedTypeName}, {data.AssemblyName}`; `{entry.JavaName}` is already mapped.");
 						continue;
 					}
 					tempJavaTypes.Add (entry.JavaName, entry);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -257,7 +257,7 @@ namespace Xamarin.Android.Tasks
 			}
 			GeneratedBinaryTypeMaps.Add (typeMapIndexPath);
 
-			var composer = new TypeMappingDebugNativeAssemblyGenerator (new ModuleDebugData ());
+			var composer = new TypeMappingDebugNativeAssemblyGenerator (new ModuleDebugData (), logger);
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
 
 			return true;
@@ -289,7 +289,7 @@ namespace Xamarin.Android.Tasks
 
 			PrepareDebugMaps (data);
 
-			var composer = new TypeMappingDebugNativeAssemblyGenerator (data);
+			var composer = new TypeMappingDebugNativeAssemblyGenerator (data, logger);
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
 
 			return true;
@@ -482,7 +482,7 @@ namespace Xamarin.Android.Tasks
 					module.Types = module.TypesScratch.Values.ToArray ();
 				}
 
-				var composer = new TypeMappingReleaseNativeAssemblyGenerator (new NativeTypeMappingData (modules));
+				var composer = new TypeMappingReleaseNativeAssemblyGenerator (new NativeTypeMappingData (modules, logger), logger);
 				GenerateNativeAssembly (arch, composer, composer.Construct (), outputDirectory);
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -5,6 +5,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
+using Microsoft.Build.Utilities;
+
 using Java.Interop.Tools.Cecil;
 using Mono.Cecil;
 using Microsoft.Android.Build.Tasks;
@@ -133,7 +135,7 @@ namespace Xamarin.Android.Tasks
 			public string GetAssemblyName (TypeDefinition td) => td.Module.Assembly.FullName;
 		}
 
-		Action<string> logger;
+		TaskLoggingHelper log;
 		Encoding outputEncoding;
 		byte[] moduleMagicString;
 		byte[] typemapIndexMagicString;
@@ -141,9 +143,9 @@ namespace Xamarin.Android.Tasks
 
 		public IList<string> GeneratedBinaryTypeMaps { get; } = new List<string> ();
 
-		public TypeMapGenerator (Action<string> logger, string[] supportedAbis)
+		public TypeMapGenerator (TaskLoggingHelper log, string[] supportedAbis)
 		{
-			this.logger = logger ?? throw new ArgumentNullException (nameof (logger));
+			this.log = log ?? throw new ArgumentNullException (nameof (log));
 			if (supportedAbis == null)
 				throw new ArgumentNullException (nameof (supportedAbis));
 			this.supportedAbis = supportedAbis;
@@ -257,7 +259,7 @@ namespace Xamarin.Android.Tasks
 			}
 			GeneratedBinaryTypeMaps.Add (typeMapIndexPath);
 
-			var composer = new TypeMappingDebugNativeAssemblyGenerator (new ModuleDebugData (), logger);
+			var composer = new TypeMappingDebugNativeAssemblyGenerator (log, new ModuleDebugData ());
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
 
 			return true;
@@ -289,7 +291,7 @@ namespace Xamarin.Android.Tasks
 
 			PrepareDebugMaps (data);
 
-			var composer = new TypeMappingDebugNativeAssemblyGenerator (data, logger);
+			var composer = new TypeMappingDebugNativeAssemblyGenerator (log, data);
 			GenerateNativeAssembly (composer, composer.Construct (), outputDirectory);
 
 			return true;
@@ -443,7 +445,7 @@ namespace Xamarin.Android.Tasks
 				// This is disabled because it costs a lot of time (around 150ms per standard XF Integration app
 				// build) and has no value for the end user. The message is left here because it may be useful to us
 				// in our devloop at some point.
-				//logger ($"Warning: duplicate Java type name '{entry.JavaName}' in assembly '{moduleData.AssemblyName}' (new token: {entry.Token}).");
+				//log.LogDebugMessage ($"Warning: duplicate Java type name '{entry.JavaName}' in assembly '{moduleData.AssemblyName}' (new token: {entry.Token}).");
 				moduleData.DuplicateTypes.Add (entry);
 			} else {
 				moduleData.TypesScratch.Add (entry.JavaName, entry);
@@ -482,7 +484,7 @@ namespace Xamarin.Android.Tasks
 					module.Types = module.TypesScratch.Values.ToArray ();
 				}
 
-				var composer = new TypeMappingReleaseNativeAssemblyGenerator (new NativeTypeMappingData (modules, logger), logger);
+				var composer = new TypeMappingReleaseNativeAssemblyGenerator (log, new NativeTypeMappingData (log, modules));
 				GenerateNativeAssembly (arch, composer, composer.Construct (), outputDirectory);
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingAssemblyGenerator.cs
@@ -1,7 +1,13 @@
+using System;
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
 {
 	abstract class TypeMappingAssemblyGenerator : LlvmIrComposer
-	{}
+	{
+		protected TypeMappingAssemblyGenerator (Action<string> logger)
+			: base (logger)
+		{
+		}
+	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingAssemblyGenerator.cs
@@ -1,12 +1,14 @@
 using System;
 using Xamarin.Android.Tasks.LLVMIR;
 
+using Microsoft.Build.Utilities;
+
 namespace Xamarin.Android.Tasks
 {
 	abstract class TypeMappingAssemblyGenerator : LlvmIrComposer
 	{
-		protected TypeMappingAssemblyGenerator (Action<string> logger)
-			: base (logger)
+		protected TypeMappingAssemblyGenerator (TaskLoggingHelper log)
+			: base (log)
 		{
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
@@ -116,8 +118,8 @@ namespace Xamarin.Android.Tasks
 		List<StructureInstance<TypeMapEntry>> managedToJavaMap;
 		StructureInstance<TypeMap> type_map;
 
-		public TypeMappingDebugNativeAssemblyGenerator (TypeMapGenerator.ModuleDebugData data, Action<string> logger)
-			: base (logger)
+		public TypeMappingDebugNativeAssemblyGenerator (TaskLoggingHelper log, TypeMapGenerator.ModuleDebugData data)
+			: base (log)
 		{
 			this.data = data;
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingDebugNativeAssemblyGenerator.cs
@@ -116,7 +116,8 @@ namespace Xamarin.Android.Tasks
 		List<StructureInstance<TypeMapEntry>> managedToJavaMap;
 		StructureInstance<TypeMap> type_map;
 
-		public TypeMappingDebugNativeAssemblyGenerator (TypeMapGenerator.ModuleDebugData data)
+		public TypeMappingDebugNativeAssemblyGenerator (TypeMapGenerator.ModuleDebugData data, Action<string> logger)
+			: base (logger)
 		{
 			this.data = data;
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO.Hashing;
 using System.Text;
 
+using Microsoft.Build.Utilities;
+
 using Xamarin.Android.Tasks.LLVMIR;
 
 namespace Xamarin.Android.Tasks
@@ -176,8 +178,8 @@ namespace Xamarin.Android.Tasks
 
 		ulong moduleCounter = 0;
 
-		public TypeMappingReleaseNativeAssemblyGenerator (NativeTypeMappingData mappingData, Action<string> logger)
-			: base (logger)
+		public TypeMappingReleaseNativeAssemblyGenerator (TaskLoggingHelper log, NativeTypeMappingData mappingData)
+			: base (log)
 		{
 			this.mappingData = mappingData ?? throw new ArgumentNullException (nameof (mappingData));
 			javaNameHash32Comparer = new JavaNameHash32Comparer ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingReleaseNativeAssemblyGenerator.cs
@@ -176,7 +176,8 @@ namespace Xamarin.Android.Tasks
 
 		ulong moduleCounter = 0;
 
-		public TypeMappingReleaseNativeAssemblyGenerator (NativeTypeMappingData mappingData)
+		public TypeMappingReleaseNativeAssemblyGenerator (NativeTypeMappingData mappingData, Action<string> logger)
+			: base (logger)
 		{
 			this.mappingData = mappingData ?? throw new ArgumentNullException (nameof (mappingData));
 			javaNameHash32Comparer = new JavaNameHash32Comparer ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XAJavaTypeScanner.cs
@@ -77,7 +77,7 @@ class XAJavaTypeScanner
 
 	void AddJavaType (TypeDefinition type, Dictionary<string, TypeData> types, AndroidTargetArch arch)
 	{
-		if (type.IsSubclassOf ("Java.Lang.Object", cache) || type.IsSubclassOf ("Java.Lang.Throwable", cache) || (type.IsInterface && type.ImplementsInterface ("Java.Interop.IJavaPeerable", cache))) {
+		if (type.HasJavaPeer (cache)) {
 			// For subclasses of e.g. Android.App.Activity.
 			string typeName = type.GetPartialAssemblyQualifiedName (cache);
 			if (!types.TryGetValue (typeName, out TypeData typeData)) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1181
Context: https://github.com/xamarin/xamarin-android/pull/8625
Context: https://github.com/xamarin/java.interop/commit/005c914170a0af9069ff18fd4dd9d45463dd5dc6

Does It Build™?

PR #8625 has turned into a cluster, *probably* because of xamarin/java.interop@005c9141, which implicitly requires typemap support for *non*-`Java.Lang.Object` subclasses such as the `CallVirtualFromConstructorDerived` test type.

Java.Interop#1181 updates typemap and JCW generation to support `Java.Interop.JavaObject` and `Java.Interop.JavaException` subclasses, which will *hopefully* allow the
`CallVirtualFromConstructorDerived`-using tests to work.