### PR TITLE
[xaprepare] Add support for newer SparkyLinux

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.Debian.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Prepare
 			if (DebianRelease.Major >= 10 || (IsTesting && String.Compare ("buster", CodeName, StringComparison.OrdinalIgnoreCase) == 0)) {
 				if (Context.IsRunningOnHostedAzureAgent)
 					Dependencies.AddRange (packages10AndNewerBuildBots);
-				if (DebianRelease.Major >= 13) {
+				if (DebianRelease.Major >= 13 || (String.Compare ("SparkyLinux", Name, StringComparison.OrdinalIgnoreCase) == 0 && DebianRelease.Major >= 7)) {
 					Dependencies.AddRange (packagesTrixieAndLater);
 				} else {
 					Dependencies.AddRange (packagesPreTrixie);


### PR DESCRIPTION
SparkyLinux is a Debian-based distribution that's 100% compatible with its upstream, 
but it is rebranded and follows its own versioning scheme.  Add support for SparkyLinux 
detection so that `xaprepare` can properly detect the required packages.

TODO: the whole Debian detection code has to be refreshed at some point.