### PR TITLE
Bump to xamarin/monodroid@848d1277b7

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/sdk-install-9e143d7298@ed0c2d93a1450bbb8028939460a3b38b8403aadd
+xamarin/monodroid:main@848d1277b76a599d8a280d58ec06e95477b4a7e5

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/install-deps-linux@d3fa182f01e638d00b7dc37aff90965c71d1df50
+xamarin/monodroid:dev/pjc/sdk-install-9e143d7298@ed0c2d93a1450bbb8028939460a3b38b8403aadd

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@66a65e3b3e5fa4314d8e8d4f1b8ad578a4a56ab0
+xamarin/monodroid:dependabot/submodules/external/android-sdk-installer-7278021@bf4a9b65f33dc840b55e81a1bc31f97cb82e3691

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dependabot/submodules/external/android-sdk-installer-7278021@bf4a9b65f33dc840b55e81a1bc31f97cb82e3691
+xamarin/monodroid:dev/pjc/install-deps-linux@5e695f2b90bda9e6cefeba6696ea18d9413681fe

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:dev/pjc/install-deps-linux@5e695f2b90bda9e6cefeba6696ea18d9413681fe
+xamarin/monodroid:dev/pjc/install-deps-linux@d3fa182f01e638d00b7dc37aff90965c71d1df50


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/66a65e3b3e5fa4314d8e8d4f1b8ad578a4a56ab0...848d1277b76a599d8a280d58ec06e95477b4a7e5

The `<_InstallAndroidJdk/>` target has been removed from the
`<InstallAndroidDependencies/>` target, as Java SDK installation support
has been added to `Xamarin.Installer.Build.Tasks`.