### PR TITLE
Track `Java.Interop.Tools.JavaCallableWrappers` changes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -464,6 +464,16 @@ namespace Xamarin.Android.Tasks
 			bool hasExportReference = ResolvedAssemblies.Any (assembly => Path.GetFileName (assembly.ItemSpec) == "Mono.Android.Export.dll");
 			bool generateOnCreateOverrides = int.Parse (AndroidSdkPlatform) <= 10;
 
+			var reader_options = new CallableWrapperReaderOptions {
+				DefaultApplicationJavaClass         = ApplicationJavaClass,
+				DefaultGenerateOnCreateOverrides    = generateOnCreateOverrides,
+				DefaultMonoRuntimeInitialization    = monoInit,
+				MethodClassifier                    = classifier,
+			};
+			var writer_options = new CallableWrapperWriterOptions {
+				CodeGenerationTarget    = JavaPeerStyle.XAJavaInterop1
+			};
+
 			bool ok = true;
 			foreach (JavaType jt in newJavaTypes) {
 				TypeDefinition t = jt.Type; // JCW generator doesn't care about ABI-specific types or token ids
@@ -474,19 +484,8 @@ namespace Xamarin.Android.Tasks
 
 				using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 					try {
-						var reader_options = new CallableWrapperReaderOptions {
-							DefaultApplicationJavaClass = ApplicationJavaClass,
-							DefaultGenerateOnCreateOverrides = generateOnCreateOverrides,
-							DefaultMonoRuntimeInitialization = monoInit,
-							MethodClassifier = classifier,
-						};
-
 						var jcw_type = CecilImporter.CreateType (t, cache, reader_options);
 						
-						var writer_options = new CallableWrapperWriterOptions {
-							CodeGenerationTarget = JavaPeerStyle.XAJavaInterop1
-						};
-
 						jcw_type.Generate (writer, writer_options);
 
 						if (useMarshalMethods) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1174

In https://github.com/xamarin/java.interop/pull/1174, we refactored `Java.Interop.Tools.JavaCallableWrappers` to be more maintainable.  This resulted in a changed public API for consuming the library.

Update `Xamarin.Android.Build.Tasks.GenerateJavaStubs` to consume the updated API.