### PR TITLE
Add test for Binding Projects Incremental Build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -44,23 +44,31 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     />
   </Target>
 
+  <Target Name="_CollectLibrariesToBind" DependsOnTargets="_CategorizeAndroidLibraries">
+    <ItemGroup>
+      <_LibrariesToBind  Include="@(EmbeddedJar)" />
+      <_LibrariesToBind  Include="@(InputJar)" />
+      <_LibrariesToBind  Include="@(LibraryProjectZip)" />
+      <_LibrariesToBind  Include="@(_JavaBindingSource)" Condition=" '%(_JavaBindingSource.Bind)' == 'true' "/>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_SetAndroidGenerateManagedBindings"
-      Condition=" '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' Or '@(_JavaBindingSource->Count())' != '0' ">
+      Condition=" '@(_LibrariesToBind->Count())' != '0' ">
     <PropertyGroup>
       <!-- Used throughout to determine if C# binding-related targets should skip -->
       <_AndroidGenerateManagedBindings>true</_AndroidGenerateManagedBindings>
     </PropertyGroup>
   </Target>
 
-  <Target Name="_CollectGeneratedManagedBindingFiles">
+  <Target Name="_CollectGeneratedManagedBindingFiles" AfterTargets="GenerateBindings">
     <ItemGroup>
       <_GeneratedManagedBindingFiles Include="$(GeneratedOutputPath)**\*.cs" />
     </ItemGroup>
   </Target>
 
   <Target Name="_ClearGeneratedManagedBindings"
-      Condition=" '@(InputJar->Count())' == '0' And '@(EmbeddedJar->Count())' == '0' And '@(LibraryProjectZip->Count())' == '0' And '@(_JavaBindingSource->Count())' == '0' "
-      DependsOnTargets="_CollectGeneratedManagedBindingFiles"
+      Condition=" '@(_LibrariesToBind->Count())' == '0' And '$(DesignTimeBuild)' != 'True' "
   >
     <Delete Files="@(_GeneratedManagedBindingFiles)" />
   </Target>
@@ -75,7 +83,6 @@ It is shared between "legacy" binding projects and .NET 5 projects.
 
   <Target Name="GenerateBindings"
       Condition=" '$(_AndroidGenerateManagedBindings)' == 'true' "
-      DependsOnTargets="ExportJarToXml;_ResolveMonoAndroidSdks"
       Inputs="$(ApiOutputFile);@(TransformFile);@(ReferencePath);@(ReferenceDependencyPaths);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_GeneratorStampFile)">
 
@@ -128,21 +135,35 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
         NamespaceTransforms="@(AndroidNamespaceReplacement)"
-    />
+        GeneratedFileListFile="$(GeneratedOutputPath)src\$(AssemblyName).projitems"
+    >
+      <Output TaskParameter="GeneratedFiles" ItemName="_GeneratedBindingFiles" />
+    </BindingsGenerator>
 
     <!-- Write a flag so we won't redo this target if nothing changed -->
     <Touch Files="$(_GeneratorStampFile)" AlwaysCreate="true" />
 
+    <ItemGroup Condition=" '@(_GeneratedBindingFiles->Count())' != '0' ">
+      <_ExistingGeneratedFiles Include="$(GeneratedOutputPath)**\*.cs" />
+      <_ExistingGeneratedFiles Remove="@(_GeneratedBindingFiles)" />
+    </ItemGroup>
+
+    <!-- Delete any files which should not be there. -->
+    <Delete Files="@(_ExistingGeneratedFiles)" Condition=" '@(_ExistingGeneratedFiles->Count())' != '0' "/>
+
     <ItemGroup>
       <FileWrites Include="$(GeneratedOutputPath)**\*.cs" />
+      <FileWrites Include="$(GeneratedOutputPath)src\$(AssemblyName).projitems" />
       <FileWrites Include="$(_GeneratorStampFile)" />
     </ItemGroup>
+
+    <!-- Read the file list. -->
 
   </Target>
 
   <Target Name="AddBindingsToCompile"
       Condition=" '$(_AndroidGenerateManagedBindings)' == 'true' Or '@(_GeneratedManagedBindingFiles->Count())' != '0' "
-      DependsOnTargets="GenerateBindings;_CollectGeneratedManagedBindingFiles">
+    >
     <!-- bindings need AllowUnsafeBlocks -->
     <PropertyGroup>
       <AllowUnsafeBlocks Condition=" '$(AllowUnsafeBlocks)' != 'true' ">true</AllowUnsafeBlocks>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -135,21 +135,10 @@ It is shared between "legacy" binding projects and .NET 5 projects.
         Nullable="$(Nullable)"
         UseJavaLegacyResolver="$(_AndroidUseJavaLegacyResolver)"
         NamespaceTransforms="@(AndroidNamespaceReplacement)"
-        GeneratedFileListFile="$(GeneratedOutputPath)src\$(AssemblyName).projitems"
-    >
-      <Output TaskParameter="GeneratedFiles" ItemName="_GeneratedBindingFiles" />
-    </BindingsGenerator>
+    />
 
     <!-- Write a flag so we won't redo this target if nothing changed -->
     <Touch Files="$(_GeneratorStampFile)" AlwaysCreate="true" />
-
-    <ItemGroup Condition=" '@(_GeneratedBindingFiles->Count())' != '0' ">
-      <_ExistingGeneratedFiles Include="$(GeneratedOutputPath)**\*.cs" />
-      <_ExistingGeneratedFiles Remove="@(_GeneratedBindingFiles)" />
-    </ItemGroup>
-
-    <!-- Delete any files which should not be there. -->
-    <Delete Files="@(_ExistingGeneratedFiles)" Condition=" '@(_ExistingGeneratedFiles->Count())' != '0' "/>
 
     <ItemGroup>
       <FileWrites Include="$(GeneratedOutputPath)**\*.cs" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -21,7 +21,9 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <_AndroidIntermediateBindingClassesZip>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName).jar</_AndroidIntermediateBindingClassesZip>
     <_AndroidIntermediateBindingClassesDocs>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName)-docs.xml</_AndroidIntermediateBindingClassesDocs>
     <_AndroidCompileJavaStampFile>$(_AndroidStampDirectory)_CompileJava.stamp</_AndroidCompileJavaStampFile>
+    <_AndroidCompileJavaFileList>$(IntermediateOutputPath)_CompileJava.FileList.txt</_AndroidCompileJavaFileList>
     <_AndroidCompileBindingJavaStampFile>$(_AndroidStampDirectory)_CompileBindingJava.stamp</_AndroidCompileBindingJavaStampFile>
+    <_AndroidCompileBindingJavaFileList>$(IntermediateOutputPath)_CompileBindingJava.FileList.txt</_AndroidCompileBindingJavaFileList>
   </PropertyGroup>
 
   <Target Name="_AdjustJavacVersionArguments">
@@ -74,18 +76,36 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <ItemGroup>
       <_JavaBindingSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' == 'True' " />
     </ItemGroup>
+    <WriteLinesToFile
+        File="$(_AndroidCompileBindingJavaFileList)"
+        Lines="@(_JavaBindingSource->ToLowerInvariant())"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidCompileBindingJavaFileList)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CollectJavaSource">
     <ItemGroup>
       <_JavaSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' != 'True' " />
     </ItemGroup>
+   <WriteLinesToFile
+        File="$(_AndroidCompileJavaFileList)"
+        Lines="@(_JavaSource->ToLowerInvariant())"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidCompileJavaFileList)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CompileBindingJava"
       Condition=" '@(_JavaBindingSource->Count())' != '0' "
       DependsOnTargets="$(_CompileBindingJavaDependsOnTargets)"
-      Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaBindingSource)"
+      Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidCompileBindingJavaFileList);$(MonoPlatformJarPath);@(_JavaBindingSource)"
       Outputs="$(_AndroidCompileBindingJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
@@ -132,7 +152,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
 
   <Target Name="_CompileJava"
     DependsOnTargets="$(_CompileJavaDependsOnTargets);_CollectJavaSource"
-    Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(_JavaSource)"
+    Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidCompileJavaFileList);$(MonoPlatformJarPath);@(_JavaStubFiles);@(_JavaSource)"
     Outputs="$(_AndroidCompileJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -120,9 +120,6 @@ properties that determine build ordering.
       UpdateAndroidResources;
       _BuildResourceDesigner;
       UpdateAndroidInterfaceProxies;
-      _SetAndroidGenerateManagedBindings;
-      _ClearGeneratedManagedBindings;
-      AddBindingsToCompile;
       _CheckForInvalidDesignerConfig;
     </ResolveReferencesDependsOn>
     <DesignTimeResolveAssemblyReferencesDependsOn>
@@ -144,6 +141,13 @@ properties that determine build ordering.
       _AddAndroidDefines;
       _IncludeLayoutBindingSources;
       AddLibraryJarsToBind;
+      _CollectLibrariesToBind;
+      _SetAndroidGenerateManagedBindings;
+      ExportJarToXml;
+      GenerateBindings;
+      _CollectGeneratedManagedBindingFiles;
+      _ClearGeneratedManagedBindings;
+      AddBindingsToCompile;
       _BuildResourceDesigner;
       _AddResourceDesignerFiles;
       $(CompileDependsOn);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -69,10 +69,6 @@ namespace Xamarin.Android.Tasks
 
 		public bool UseJavaLegacyResolver { get; set; }
 
-		public string GeneratedFileListFile { get; set; }
-		[Output]
-		public ITaskItem [] GeneratedFiles { get; set; } = Array.Empty<ITaskItem> ();
-
 		private List<Tuple<string, string>> transform_files = new List<Tuple<string,string>> ();
 
 		public override bool RunTask ()
@@ -139,20 +135,7 @@ namespace Xamarin.Android.Tasks
 			if (Log.HasLoggedErrors)
 				return false;
 
-			var result = base.RunTask ();
-			List<ITaskItem> files = new List<ITaskItem> ();
-			if (result && GeneratedFileListFile != null && File.Exists (GeneratedFileListFile)) {
-				var doc = XDocument.Load (GeneratedFileListFile);
-				var compileItems = doc.XPathSelectElements ("//Project/ItemGroup/Compile");
-				foreach (var item in compileItems) {
-					var file = item.Attribute ("Include");
-					if (file != null && File.Exists (file.Value)) {
-						files.Add (new TaskItem (file.Value));
-					}
-				}
-			}
-			GeneratedFiles = files.ToArray ();
-			return result;
+			return base.RunTask ();
 		}
 
 		void WriteLine (StreamWriter sw, string line)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.OtherBuildItems.Add (new BuildItem ("JavaSourceJar", "javaclasses-sources.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestSourcesJar,
 			});
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
+			proj.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
 				Encoding = Encoding.ASCII,
 				TextContent = () => ResourceData.JavaSourceTestExtension,
 				Metadata = { { "Bind", "True"} },
@@ -1511,7 +1511,7 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
-				OtherBuildItems = {
+				AndroidJavaSources = {
 					new BuildItem (AndroidBuildActions.AndroidJavaSource, "ToolbarEx.java") {
 						TextContent = () => @"package com.unnamedproject.unnamedproject;
 import android.content.Context;
@@ -1556,11 +1556,11 @@ public class ToolbarEx {
 		public void CheckJavaError ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
 				TextContent = () => "public classo TestMe { }",
 				Encoding = Encoding.ASCII
 			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe2.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe2.java") {
 				TextContent = () => "public class TestMe2 {" +
 					"public vod Test ()" +
 					"}",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1000,14 +1000,14 @@ namespace UnamedProject
 		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 		{
 			var proj = new XamarinAndroidApplicationProject (debugConfigurationName, releaseConfigurationName);
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
 				TextContent = () => "public class ManyMethods { \n"
 					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
 					+ "}",
 				Encoding = Encoding.ASCII,
 				Metadata = { { "Bind", "False "}},
 			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
 				TextContent = () => "public class ManyMethods2 { \n"
 					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
 					+ "}",
@@ -1064,8 +1064,8 @@ namespace UnamedProject
 				}
 
 				//Now build project again after it no longer requires multidex, remove the *HUGE* AndroidJavaSource build items
-				while (proj.OtherBuildItems.Count > 1)
-					proj.OtherBuildItems.RemoveAt (proj.OtherBuildItems.Count - 1);
+				while (proj.AndroidJavaSources.Count > 1)
+					proj.AndroidJavaSources.RemoveAt (proj.AndroidJavaSources.Count - 1);
 				proj.SetProperty ("AndroidEnableMultiDex", "False");
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -52,9 +52,9 @@ namespace Xamarin.ProjectTools
 			return File.ReadLines (path).ToList ();
 		}
 
-		public bool IsTargetSkipped (string target) => IsTargetSkipped (Builder.LastBuildOutput, target);
+		public bool IsTargetSkipped (string target, bool defaultIfNotUsed = false) => IsTargetSkipped (Builder.LastBuildOutput, target, defaultIfNotUsed);
 
-		public static bool IsTargetSkipped (IEnumerable<string> output, string target)
+		public static bool IsTargetSkipped (IEnumerable<string> output, string target, bool defaultIfNotUsed = false)
 		{
 			bool found = false;
 			foreach (var line in output) {
@@ -69,7 +69,7 @@ namespace Xamarin.ProjectTools
 					if (found)
 						return true;
 			}
-			return false;
+			return defaultIfNotUsed;
 		}
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -17,10 +17,12 @@ namespace Xamarin.ProjectTools
 
 			Sources = new List<BuildItem> ();
 			OtherBuildItems = new List<BuildItem> ();
+			AndroidJavaSources = new List<BuildItem> ();
 
 			ItemGroupList.Add (References);
 			ItemGroupList.Add (OtherBuildItems);
 			ItemGroupList.Add (Sources);
+			ItemGroupList.Add (AndroidJavaSources);
 
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
@@ -40,6 +42,7 @@ namespace Xamarin.ProjectTools
 
 		public IList<BuildItem> OtherBuildItems { get; private set; }
 		public IList<BuildItem> Sources { get; private set; }
+		public IList<BuildItem> AndroidJavaSources { get; private set; }
 
 		public IList<Property> ActiveConfigurationProperties {
 			get { return IsRelease ? ReleaseProperties : DebugProperties; }

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -611,5 +611,73 @@ namespace Xamarin.Android.Build.Tests
 			var after = File.GetLastWriteTimeUtc (apkset);
 			Assert.AreNotEqual (before, after, $"{apkset} should change!");
 		}
+
+		[Test]
+		public void AppWithAndroidJavaSource ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var itemToDelete = new AndroidItem.AndroidJavaSource ("TestJavaClass2.java") {
+						Encoding = Encoding.ASCII,
+						TextContent = () => @"package com.test.java;
+
+public class TestJavaClass2 {
+
+	public String test(){
+		
+		return ""Java is called"";
+	}
+}",
+						Metadata = {
+							{ "Bind", "True" },
+						},
+					};
+			var proj = new XamarinAndroidApplicationProject {
+				EnableDefaultItems = true,
+				AndroidJavaSources = {
+					new AndroidItem.AndroidJavaSource ("TestJavaClass.java") {
+						Encoding = Encoding.ASCII,
+						TextContent = () => @"package com.test.java;
+
+public class TestJavaClass {
+
+	public String test(){
+		
+		return ""Java is called"";
+	}
+}",
+						Metadata = {
+							{ "Bind", "True" },
+						},
+					},
+					itemToDelete,
+				}
+			};
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.AssertHasNoWarnings ();
+				var generatedCode = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"generated", "src", "Com.Test.Java.TestJavaClass.cs");
+				var generatedCode2 = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"generated", "src", "Com.Test.Java.TestJavaClass2.cs");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have been generated.");
+				FileAssert.Exists (generatedCode2, $"'{generatedCode2}' should have been generated.");
+				Assert.IsTrue (b.DesignTimeBuild (proj, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on DTB build!");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on DTB build.");
+				FileAssert.Exists (generatedCode2, $"'{generatedCode2}' should have not be deleted on DTB build.");
+				proj.AndroidJavaSources.Remove (itemToDelete);
+				File.Delete (Path.Combine (Root, b.ProjectDirectory, itemToDelete.Include ()));
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on second build.");
+				FileAssert.DoesNotExist (generatedCode2, $"'{generatedCode2}' should have be deleted on second build.");
+				Assert.IsFalse (b.Output.IsTargetSkipped ("_CompileBindingJava"), $"`_CompileBindingJava` should run on second build!");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings"), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
+				// Call Install directly so Build does not get called automatically
+				Assert.IsTrue (b.RunTarget (proj, "Install", doNotCleanupOnUpdate: true, saveProject: false), "Install build should have succeeded.");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on Install build.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on Install build!");
+			}
+		}
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -617,8 +617,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var path = Path.Combine ("temp", TestName);
 			var itemToDelete = new AndroidItem.AndroidJavaSource ("TestJavaClass2.java") {
-						Encoding = Encoding.ASCII,
-						TextContent = () => @"package com.test.java;
+				Encoding = Encoding.ASCII,
+				TextContent = () => @"package com.test.java;
 
 public class TestJavaClass2 {
 
@@ -627,10 +627,10 @@ public class TestJavaClass2 {
 		return ""Java is called"";
 	}
 }",
-						Metadata = {
-							{ "Bind", "True" },
-						},
-					};
+				Metadata = {
+					{ "Bind", "True" },
+				},
+			};
 			var proj = new XamarinAndroidApplicationProject {
 				EnableDefaultItems = true,
 				AndroidJavaSources = {
@@ -650,7 +650,7 @@ public class TestJavaClass {
 						},
 					},
 					itemToDelete,
-				}
+				},
 			};
 			using (var b = CreateApkBuilder ()) {
 				b.ThrowOnBuildFailure = false;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/8658
Fixes https://github.com/xamarin/xamarin-android/issues/8698

The PR fixes an issue where the bindings files in intermediate `generated` folder get deleted on subsequent builds. This causes the entire binding process to run again, slowing down builds. 
The root fo the problem is the `_ClearGeneratedManagedBindings` target. It was designed to clean out the `generated` folder in the case where no binding libraries were present. However it turns out if was running during a design time build! During design time builds the binding library item groups are not evaludated, so the `_ClearGeneratedManagedBindings` would run.. deleting everything. 

To fix this issue we only run the `_ClearGeneratedManagedBindings` in a standard build. The good thing is this allowed us time to take a look at our incremental build process for bindings. The binding generator does produce a `projitems` file which lists all the files it generated. We can use that data to incrementally clean up the `generated` folder of old files. This way code that is no longer needed can be removed. While we know the linker will eventually remove unused classes and types, it is better to not have to compile this stuff in the first place. 