### PR TITLE
Bump to xamarin/Java.Interop/main@dfcbd670

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -145,6 +145,7 @@
     <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
     <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>
     <OpenTKSourceFullPath>$([System.IO.Path]::GetFullPath ('$(OpenTKSourceDirectory)'))</OpenTKSourceFullPath>
+    <JavaInteropTargetFrameworkVersion>net8.0</JavaInteropTargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AdbToolPath Condition=" '$(AdbToolPath)' == '' ">$(AndroidSdkFullPath)\platform-tools\</AdbToolPath>

--- a/build-tools/create-packs/Microsoft.Android.Ref.proj
+++ b/build-tools/create-packs/Microsoft.Android.Ref.proj
@@ -31,7 +31,7 @@ by projects that use the Microsoft.Android framework in .NET 6+.
     </PropertyGroup>
 
     <ItemGroup>
-      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-net7.0\ref\Java.Interop.dll" />
+      <_AndroidRefPackAssemblies Include="$(JavaInteropSourceDirectory)\bin\$(Configuration)-$(JavaInteropTargetFrameworkVersion)\ref\Java.Interop.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETDefaultOutDir)ref\Mono.Android.dll" />
       <_AndroidRefPackAssemblies Include="$(_MonoAndroidNETDefaultOutDir)ref\Mono.Android.Runtime.dll" />
       <!-- Always include stable Mono.Android.Export.dll -->

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -400,7 +400,7 @@
         SkipUnchangedFiles="true"
     />
     <Copy
-        SourceFiles="$(OutputPath)ref\Mono.Android.dll;$(JavaInteropSourceDirectory)\bin\$(Configuration)-net7.0\ref\Java.Interop.dll"
+        SourceFiles="$(OutputPath)ref\Mono.Android.dll;$(JavaInteropSourceDirectory)\bin\$(Configuration)-$(JavaInteropTargetFrameworkVersion)\ref\Java.Interop.dll"
         DestinationFolder="$(MicrosoftAndroidRefPackDir)"
         SkipUnchangedFiles="true"
     />


### PR DESCRIPTION
Changes: https://github.com/xamarin/Java.Interop/compare/7f08b77f3464f2b276ec5edd2e4836b1915f86dd...dfcbd670304bb3d4becc6c76a3c16f10a158efae

  * xamarin/Java.Interop@dfcbd670: Bump to xamarin/xamarin-android-tools/main@a698a33 (xamarin/Java.Interop#1189)
  * xamarin/Java.Interop@6182baff: [build] Target `net8.0` (xamarin/Java.Interop#1186)

xamarin/java.interop@6182baff updated Java.Interop to target .NET 8 instead of .NET 7.  This introduced a build break:

	…/xamarin-android/src/Mono.Android/Mono.Android.csproj(402,5):
	  error MSB3030: Could not copy the file
	  "…/xamarin-android/external/Java.Interop/bin/Debug-net7.0/ref/Java.Interop.dll"
	  because it was not found.

Introduce a new `$(JavaInteropTargetFrameworkVersion)` MSBuild property within `Configuration.props` which contains the .NET version that Java.Interop is targeting.

Update `Mono.Android.csproj` and `Microsoft.Android.Ref.proj` so that they use `$(JavaInteropTargetFrameworkVersion)` to locate the reference `Java.Interop.dll` assembly.