### PR TITLE
[Xamarin.Android.Build.Tasks] remove `$(AndroidSupportedAbis)` from `build.props`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -967,7 +967,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
 		<_PropertyCacheItems Include="_NuGetAssetsTimestamp=$(_NuGetAssetsTimestamp)" />
 		<_PropertyCacheItems Include="TypeMapKind=$(_TypeMapKind)" />
-		<_PropertyCacheItems Include="AndroidSupportedAbis=$(AndroidSupportedAbis)" />
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
 		<_PropertyCacheItems Include="AndroidUseDesignerAssembly=$(AndroidUseDesignerAssembly)" />


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/Visual-Studio-2022-Community-1785-ver/10577484
Related: https://github.com/xamarin/xamarin-android/issues/8662

I found the following build performance issue using a .NET Android project template inside VS Windows:

1. Create a new .NET Android project

2. Open some `AndroidResource` `.xml` file in the Android designer

3. *Every* incremental build appears to rebuild everything!

`obj\Debug\net8.0-android\build.props` appears to be changing between builds with the change:

```diff
--androidsupportedabis=armeabi-v7a;arm64-v8a;x86;x86_64
++androidsupportedabis=arm64-v8a
```

I narrowed this down to the designer running two targets, `PrepareResources;_GenerateCompileInputs`:

https://github.com/xamarin/UITools/blob/7b167eae94ae018ab19344d6bfb45a925415e2a7/src/Xamarin.Designer.Android/Xamarin.AndroidDesigner/MSBuildConstants.cs#L32

In this example:

* The designer does *not* mark the build as a "design-time build" with `-p:DesignTimeBuild=true`. This would have used a design-time `build.props`.

* The designer does *not* pass in the selected Android device.

This code is *ancient*, so I suspect this has just always been an issue? Perhaps, it only occurs in .NET 6+ projects and not Xamarin.Android?

Because `$(AndroidSupportedAbis)` is not a "supported" thing in .NET 6+, let's just remove it?

Removing `$(AndroidSupportedAbis)` from this file manually does fix the problem for me locally:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.0.52\tools\Xamarin.Android.Common.targets

There is also a *second* `adb.props` file that triggers a subset of things to rebuild if the selected Android device changes:

	<WriteLinesToFile
			File="$(_AdbPropertiesCache)"
			Lines="AdbTarget=$(AdbTarget);AdbOptions=$(AdbOptions)"

Usage of the new property, `$(RuntimeIdentifier)`, also changes `$(IntermediateOutputPath)`, so I feel like we shouldn't need this value in `build.props` in a .NET 6+ world.