### PR TITLE
Bump LibZipSharp to 3.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
 
   <!-- Common <PackageReference/> versions -->
   <PropertyGroup>
-    <LibZipSharpVersion>3.0.0</LibZipSharpVersion>
+    <LibZipSharpVersion>3.1.1</LibZipSharpVersion>
     <MicroBuildCoreVersion>1.0.0</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>


### PR DESCRIPTION
Update LibZipSharp to version 3.1.1.

Changes https://github.com/xamarin/LibZipSharp/compare/3.0.0...3.1.1