### PR TITLE
Bump NDK to r26c

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "26b";
-		public const string AndroidNdkPkgRevision = "26.1.10909125";
+		public const string AndroidNdkVersion = "26c";
+		public const string AndroidNdkPkgRevision = "26.2.11394342";
 		public const int NdkMinimumAPI = 21;
 		public const int NdkMinimumAPILegacy32 = 21;
 


### PR DESCRIPTION
Changes: https://github.com/android/ndk/wiki/Changelog-r26#r26c

  * Updated LLVM to clang-r487747e. See AndroidVersion.txt and clang_source_info.md 
    in the toolchain directory for version information.
    * [Issue 1928](https://github.com/android/ndk/issues/1928): Fixed Clang crash in 
      instruction selection for 32-bit armv8 floating point.
    * [Issue 1953](https://github.com/android/ndk/issues/1953): armeabi-v7a libc++ 
      libraries are once again built as thumb.

`AndroidVersion.txt` contains:

```
17.0.2
based on r487747e
```
