### PR TITLE
[xamarin-android-tools] import $(LibZipSharpVersion) value

### DIFF
--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Import $(LibZipSharpVersion) -->
+  <Import Project="..\Directory.Build.props" />
+</Project>


### PR DESCRIPTION
Somewhere in the dotnet/maui repo, it encountered the error:

    XARLP7028
    System.IO.FileNotFoundException: Could not load file or assembly 'libZipSharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=276db85bc4e20efc' or one of its dependencies. The system cannot find the file specified.File name: 'libZipSharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=276db85bc4e20efc'   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments, ICollection`1 proguardConfigFiles)   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask()   at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25WRN: Assembly binding logging is turned OFF.To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.Note: There is some performance penalty associated with assembly bind failure logging.To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].
    Graphics (Graphics\src\Graphics)
    C:\repos\dotnet\maui\bin\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.2.171\tools\Xamarin.Android.EmbeddedResource.targets

(don't have a link)

If I download our build from main, I see that
`Microsoft.Android.Build.BaseTasks.dll` references the 3.0.0.0 version of libZipSharp, while the other MSBuild task assemblies reference the newer one.

We override `$(LibZipSharpVersion)` in `Directory.Build.props`, but this value doesn't make it inside the `external/xamarin-android-tools` submodule. Import `Directory.Build.props` from the submodule's `*.override.props` file.