### PR TITLE
Bump to xamarin/monodroid@cb01503327

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@848d1277b76a599d8a280d58ec06e95477b4a7e5
+xamarin/monodroid:main@cb01503327f7723ec138ec4cc051610fecee1bf7


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/848d1277b76a599d8a280d58ec06e95477b4a7e5...cb01503327f7723ec138ec4cc051610fecee1bf7

  * xamarin/monodroid@cb0150332: Bump external/xamarin-android from `0c0f1fe` to `7368487`
  * xamarin/monodroid@52e7c4c09: Bump external/android-sdk-installer from `4127490` to `13b2fb3`
  * xamarin/monodroid@5003ccb4d: Bump external/android-sdk-installer from `9e143d7` to `4127490`
  * xamarin/monodroid@d7ff10afb: Bump tools/msbuild/external/androidtools from `15350e7` to `8aeb717`
  * xamarin/monodroid@ae8c39d59: Bump external/xamarin-android from `80ee320` to `0c0f1fe`
  * xamarin/monodroid@d76e18694: [tools/msbuild] introduce $(_AndroidAllowJavaDebugging) feature switch