### PR TITLE
[tests] introduce test that builds with `MSBuild.exe`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -97,6 +97,21 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildWithMSBuildExe ([Values (true, false)] bool isRelease)
+		{
+			if (!IsWindows)
+				Assert.Ignore ("Test is only valid on Windows");
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+
+			using var b = CreateApkBuilder ();
+			b.UseMSBuildExe = true;
+			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+		}
+
+		[Test]
 		public void BuildBasicApplicationThenMoveIt ([Values (true, false)] bool isRelease)
 		{
 			string path = Path.Combine (Root, "temp", TestName, "App1");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml.XPath;
 using System.Xml.Linq;
+using Xamarin.Android.Tools.VSWhere;
 
 namespace Xamarin.ProjectTools
 {
@@ -142,6 +143,8 @@ namespace Xamarin.ProjectTools
 			BuildLogFile = "build.log";
 		}
 
+		public bool UseMSBuildExe { get; set; }
+
 		public void Dispose ()
 		{
 			Dispose (true);
@@ -173,9 +176,16 @@ namespace Xamarin.ProjectTools
 
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
-			var psi   = new ProcessStartInfo (Path.Combine (TestEnvironment.DotNetPreviewDirectory, "dotnet"));
+			var psi   = new ProcessStartInfo ();
 			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "project.rsp");
-			args.Append ("build ");
+			if (UseMSBuildExe) {
+				psi.FileName = MSBuildLocator.QueryLatest ().MSBuildPath;
+				args.Append ("/restore ");
+				psi.SetEnvironmentVariable ("PATH", TestEnvironment.DotNetPreviewDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable ("PATH"));
+			} else {
+				psi.FileName = Path.Combine (TestEnvironment.DotNetPreviewDirectory, "dotnet");
+				args.Append ("build ");
+			}
 
 			if (TestEnvironment.UseLocalBuildOutput) {
 				psi.SetEnvironmentVariable ("DOTNETSDK_WORKLOAD_MANIFEST_ROOTS", TestEnvironment.WorkloadManifestOverridePath);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/20752

We think this might catch problems specific to .NET framework going forward.