### PR TITLE
Add a property required by #8478

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -34,6 +34,9 @@ namespace Xamarin.Android.Tasks
 		public string ApkOutputPath { get; set; }
 
 		[Required]
+		public string AppSharedLibrariesDir { get; set; }
+
+		[Required]
 		public ITaskItem[] ResolvedUserAssemblies { get; set; }
 
 		[Required]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -33,7 +33,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ApkOutputPath { get; set; }
 
-		[Required]
 		public string AppSharedLibrariesDir { get; set; }
 
 		[Required]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ApkOutputPath { get; set; }
 
-		public string AppSharedLibrariesDir { get; set; } 
+		public string AppSharedLibrariesDir { get; set; }
 
 		[Required]
 		public ITaskItem[] ResolvedUserAssemblies { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ApkOutputPath { get; set; }
 
-		public string AppSharedLibrariesDir { get; set; }
+		public string AppSharedLibrariesDir { get; set; } 
 
 		[Required]
 		public ITaskItem[] ResolvedUserAssemblies { get; set; }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8478
Context: https://github.com/xamarin/monodroid/pull/1393

Merging this no-op change will make it easier to orchestrate 
merging of the two PRs above.  

It allows us to merge the `monodroid` one before merging #8478 
and prevents breaking of any other builds or PRs in between 
merging of the two PRs.