### PR TITLE
[ci] Always run the MAUI test job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -317,7 +317,7 @@ stages:
 - stage: maui_tests
   displayName: MAUI Tests
   dependsOn: mac_build
-  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['System.PullRequest.TargetBranch'], 'main'))
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['RunMAUITestJob'], 'true'))
   jobs:
   # Check - "Xamarin.Android (MAUI Tests MAUI Integration)"
   - job: maui_tests_integration

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -52,3 +52,5 @@ variables:
   value: 34
 - name: ExcludedNightlyNUnitCategories
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'
+- name: RunMAUITestJob
+  value: true


### PR DESCRIPTION
A new $(RunMAUITestJob) variable has been added to control execution of
the MAUI integration test job.  The value of this variable defaults to
true and it provides an easy way to disable the job on servicing/older
branches if needed.