### PR TITLE
$(AndroidPackVersionSuffix)=preview.3; net9 is 34.99.0.preview.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/9.0.1xx-preview2

We branched for .NET 9 Preview 2 from 8c7cf91f into release/9.0.1xx-preview2; the main branch is now .NET 9 Preview 3.

Update xamarin-android/main's version number to 34.99.0-preview.3.