### PR TITLE
Bump to xamarin/monodroid@e13723e701

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@cb01503327f7723ec138ec4cc051610fecee1bf7
+xamarin/monodroid:main@e13723e701307f9f6966d4b309c3eba10a741694


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/cb01503327f7723ec138ec4cc051610fecee1bf7...e13723e701307f9f6966d4b309c3eba10a741694

  * xamarin/monodroid@e13723e70: Bump external/xamarin-android from `87d8914` to `8c7cf91`
  * xamarin/monodroid@905441a99: Pass the required parameters to BuildApk
  * xamarin/monodroid@59a052933: [ci] Add guardian supression file