### PR TITLE
[tests] fix duplicate sources in `NuGet.config`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -395,7 +395,6 @@ $@"<Project>
 
 		/// <summary>
 		/// Updates a NuGet.config based on sources in ExtraNuGetConfigSources
-		/// If target framework is not the latest or default, sources are added for previous releases
 		/// </summary>
 		protected void AddNuGetConfigSources (string nugetConfigPath)
 		{
@@ -413,12 +412,6 @@ $@"<Project>
 
 			if (ExtraNuGetConfigSources == null) {
 				ExtraNuGetConfigSources = new List<string> ();
-			}
-
-			if (TargetFramework?.IndexOf ("net8.0", StringComparison.OrdinalIgnoreCase) != -1
-				|| TargetFrameworks?.IndexOf ("net8.0", StringComparison.OrdinalIgnoreCase) != -1) {
-				ExtraNuGetConfigSources.Add ("https://api.nuget.org/v3/index.json");
-				ExtraNuGetConfigSources.Add ("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json");
 			}
 
 			int sourceIndex = 0;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -415,7 +415,7 @@ $@"<Project>
 			}
 
 			int sourceIndex = 0;
-			foreach (var source in ExtraNuGetConfigSources) {
+			foreach (var source in ExtraNuGetConfigSources.Distinct ()) {
 				var sourceElement = new XElement ("add");
 				sourceElement.SetAttributeValue ("key", $"testsource{++sourceIndex}");
 				sourceElement.SetAttributeValue ("value", source);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -495,7 +495,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void IncrementalFastDeployment ()
 		{
-			Assert.Ignore ("https://github.com/NuGet/Home/issues/13269");
 			AssertCommercialBuild ();
 
 			var class1src = new BuildItem.Source ("Class1.cs") {


### PR DESCRIPTION
Context: https://github.com/NuGet/Home/issues/13269#issuecomment-1969883700

In 2f4e01ec, we saw a problem with no-op NuGet restore, no longer being a no-op. So we temporarily disabled the failing `IncrementalFastDeployment` test.

It turns out, it might be related to a duplicate source listed in our `NuGet.config` during MSBuild tests:

    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
    <add key="testsource2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />

This might have surfaced a bug in NuGet, but for now let's stop emitting duplicate sources?