### PR TITLE
[templates] Remove redundant "template" from display name.

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Android", "Mobile" ],
-  "name": "Android Activity template",
+  "name": "Android Activity",
   "description": "An Android Activity class",
   "tags": {
     "language": "C#",

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Android", "Mobile" ],
-  "name": "Android Layout template",
+  "name": "Android Layout",
   "description": "An Android layout (XML) file",
   "tags": {
     "language": "C#",


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8626

Removes the word "template" that shows up in the New Item dialog box, as it is unnecessary.

The original issue also mentions not having a custom icon, but as we don't have any of those available, the default icon seems good enough.