### PR TITLE
[Mono.Android] is now "trimming safe"

### DIFF
--- a/build-tools/trim-analyzers/trim-analyzers.props
+++ b/build-tools/trim-analyzers/trim-analyzers.props
@@ -1,0 +1,53 @@
+<!-- Import this to enable trim warnings of all kinds -->
+<Project>
+  <PropertyGroup>
+    <!-- Sets assembly metadata, enable analyzers -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <!-- In app projects, tells ILLink to emit warnings as errors -->
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+    <!--
+      Trim warnings, codes listed here:
+      * https://github.com/dotnet/runtime/blob/7403a062960d092c73ce3f07d3ff323ffdf7de43/src/tools/illink/src/linker/Resources/Strings.resx
+      * https://github.com/dotnet/docs/tree/9cb45cf9cd34f3b7259a023c3d92a124a87090d5/docs/core/deploying/trimming/trim-warnings
+    -->
+    <WarningsAsErrors>
+      $(WarningsAsErrors);
+      IL2000;IL2001;IL2002;IL2003;IL2004;
+      IL2005;IL2006;IL2007;IL2008;IL2009;
+      IL2010;IL2011;IL2012;IL2013;IL2014;
+      IL2015;IL2016;IL2017;IL2018;IL2019;
+      IL2020;IL2021;IL2022;IL2023;IL2024;
+      IL2025;IL2026;IL2027;IL2028;IL2029;
+      IL2030;IL2031;IL2032;IL2033;IL2034;
+      IL2035;IL2036;IL2037;IL2038;IL2039;
+      IL2040;IL2041;IL2042;IL2043;IL2044;
+      IL2045;IL2046;IL2047;IL2048;IL2049;
+      IL2050;IL2051;IL2052;IL2053;IL2054;
+      IL2055;IL2056;IL2057;IL2058;IL2059;
+      IL2060;IL2061;IL2062;IL2063;IL2064;
+      IL2065;IL2066;IL2067;IL2068;IL2069;
+      IL2070;IL2071;IL2072;IL2073;IL2074;
+      IL2075;IL2076;IL2077;IL2078;IL2079;
+      IL2080;IL2081;IL2082;IL2083;IL2084;
+      IL2085;IL2086;IL2087;IL2088;IL2089;
+      IL2090;IL2091;IL2092;IL2093;IL2094;
+      IL2095;IL2096;IL2097;IL2098;IL2099;
+      IL2100;IL2101;IL2102;IL2103;IL2104;
+      IL2105;IL2106;IL2107;IL2108;IL2109;
+      IL2110;IL2111;IL2112;IL2113;IL2114;
+      IL2115;IL2116;IL2117;IL2118;IL2119;
+      IL2120;IL2121;IL2122;IL2123;IL2124;
+      IL2125;IL2126;IL2127;IL2128;IL2129;
+    </WarningsAsErrors>
+    <!--
+      NativeAOT warnings, codes listed here:
+      * https://github.com/dotnet/docs/tree/9cb45cf9cd34f3b7259a023c3d92a124a87090d5/docs/core/deploying/native-aot/warnings
+    -->
+    <WarningsAsErrors>
+      $(WarningsAsErrors);
+      IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056;
+    </WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/build-tools/trim-analyzers/trim-analyzers.props
+++ b/build-tools/trim-analyzers/trim-analyzers.props
@@ -41,6 +41,8 @@
       IL2120;IL2121;IL2122;IL2123;IL2124;
       IL2125;IL2126;IL2127;IL2128;IL2129;
     </WarningsAsErrors>
+    <!-- In NativeAOT app projects, tells Ilc to emit warnings as errors -->
+    <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
     <!--
       NativeAOT warnings, codes listed here:
       * https://github.com/dotnet/docs/tree/9cb45cf9cd34f3b7259a023c3d92a124a87090d5/docs/core/deploying/native-aot/warnings

--- a/src/Mono.Android/Android.OS/AsyncTask.cs
+++ b/src/Mono.Android/Android.OS/AsyncTask.cs
@@ -9,7 +9,16 @@ namespace Android.OS {
 
 	[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android30.0")]
 	[Register ("android/os/AsyncTask", DoNotGenerateAcw=true)]
-	public abstract class AsyncTask<TParams, TProgress, TResult> : AsyncTask {
+	public abstract class AsyncTask<
+			[DynamicallyAccessedMembers (Constructors)]
+			TParams,
+			[DynamicallyAccessedMembers (Constructors)]
+			TProgress,
+			[DynamicallyAccessedMembers (Constructors)]
+			TResult
+	> : AsyncTask {
+
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 		static IntPtr java_class_handle;
 		internal static IntPtr class_ref {

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -363,21 +363,27 @@ namespace Android.Runtime {
 
 		static bool IsAcceptableHttpMessageHandlerType (Type handlerType)
 		{
-			if (Type.GetType ("System.Net.Http.HttpClientHandler, System.Net.Http", throwOnError: false) is Type httpClientHandlerType &&
-				httpClientHandlerType.IsAssignableFrom (handlerType)) {
+			if (Extends (handlerType, "System.Net.Http.HttpClientHandler, System.Net.Http")) {
 				// It's not possible to construct HttpClientHandler in this method because it would cause infinite recursion
 				// as HttpClientHandler's constructor calls the GetHttpMessageHandler function
 				Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} cannot be used as the native HTTP handler because it is derived from System.Net.Htt.HttpClientHandler. Use a type that extends System.Net.Http.HttpMessageHandler instead.");
 				return false;
 			}
-			if (Type.GetType ("System.Net.Http.HttpMessageHandler, System.Net.Http", throwOnError: false) is Type httpMessageHandlerType &&
-				httpMessageHandlerType.IsAssignableFrom (handlerType)) {
-				return true;
+			if (!Extends (handlerType, "System.Net.Http.HttpMessageHandler, System.Net.Http")) {
+				Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} set as the default HTTP handler is invalid. Use a type that extends System.Net.Http.HttpMessageHandler.");
+				return false;
 			}
 
-			// Was not an acceptable type
-			Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} set as the default HTTP handler is invalid. Use a type that extends System.Net.Http.HttpMessageHandler.");
-			return false;
+			return true;
+		}
+
+		static bool Extends (
+				Type handlerType,
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+				string baseTypeName)
+		{
+			var baseType = Type.GetType (baseTypeName, throwOnError: false);
+			return baseType?.IsAssignableFrom (handlerType) ?? false;
 		}
 
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -24,6 +24,7 @@ namespace Android.Runtime {
 		static IX509TrustManager? sslTrustManager;
 		static KeyStore? certStore;
 		static object lock_ = new object ();
+		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		static Type? httpMessageHandlerType;
 
 		static void SetupTrustManager ()
@@ -335,11 +336,18 @@ namespace Android.Runtime {
 		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof (Xamarin.Android.Net.AndroidMessageHandler))]
 		static object GetHttpMessageHandler ()
 		{
+			// FIXME: https://github.com/xamarin/xamarin-android/issues/8797
+			// Note that this is a problem for custom $(AndroidHttpClientHandlerType) or $XA_HTTP_CLIENT_HANDLER_TYPE
+			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "DynamicDependency should preserve AndroidMessageHandler.")]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			static Type TypeGetType (string typeName) =>
+				Type.GetType (typeName, throwOnError: false);
+
 			if (httpMessageHandlerType is null) {
 				var handlerTypeName = Environment.GetEnvironmentVariable ("XA_HTTP_CLIENT_HANDLER_TYPE")?.Trim ();
 				Type? handlerType = null;
 				if (!String.IsNullOrEmpty (handlerTypeName))
-					handlerType = Type.GetType (handlerTypeName, throwOnError: false);
+					handlerType = TypeGetType (handlerTypeName);
 
 				// We don't do any type checking or casting here to avoid dependency on System.Net.Http in Mono.Android.dll
 				if (handlerType is null || !IsAcceptableHttpMessageHandlerType (handlerType)) {
@@ -355,27 +363,27 @@ namespace Android.Runtime {
 
 		static bool IsAcceptableHttpMessageHandlerType (Type handlerType)
 		{
-			if (Extends (handlerType, "System.Net.Http.HttpClientHandler, System.Net.Http")) {
+			if (Type.GetType ("System.Net.Http.HttpClientHandler, System.Net.Http", throwOnError: false) is Type httpClientHandlerType &&
+				httpClientHandlerType.IsAssignableFrom (handlerType)) {
 				// It's not possible to construct HttpClientHandler in this method because it would cause infinite recursion
 				// as HttpClientHandler's constructor calls the GetHttpMessageHandler function
 				Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} cannot be used as the native HTTP handler because it is derived from System.Net.Htt.HttpClientHandler. Use a type that extends System.Net.Http.HttpMessageHandler instead.");
 				return false;
 			}
-			if (!Extends (handlerType, "System.Net.Http.HttpMessageHandler, System.Net.Http")) {
-				Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} set as the default HTTP handler is invalid. Use a type that extends System.Net.Http.HttpMessageHandler.");
-				return false;
+			if (Type.GetType ("System.Net.Http.HttpMessageHandler, System.Net.Http", throwOnError: false) is Type httpMessageHandlerType &&
+				httpMessageHandlerType.IsAssignableFrom (handlerType)) {
+				return true;
 			}
 
-			return true;
+			// Was not an acceptable type
+			Logger.Log (LogLevel.Warn, "MonoAndroid", $"The type {handlerType.AssemblyQualifiedName} set as the default HTTP handler is invalid. Use a type that extends System.Net.Http.HttpMessageHandler.");
+			return false;
 		}
 
-		static bool Extends (Type handlerType, string baseTypeName) {
-			var baseType = Type.GetType (baseTypeName, throwOnError: false);
-			return baseType?.IsAssignableFrom (handlerType) ?? false;
-		}
-
-		static Type GetFallbackHttpMessageHandlerType (string typeName = "Xamarin.Android.Net.AndroidMessageHandler, Mono.Android")
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		static Type GetFallbackHttpMessageHandlerType ()
 		{
+			const string typeName = "Xamarin.Android.Net.AndroidMessageHandler, Mono.Android";
 			var handlerType = Type.GetType (typeName, throwOnError: false)
 				?? throw new InvalidOperationException ($"The {typeName} was not found. The type was probably linked away.");
 

--- a/src/Mono.Android/Android.Runtime/JavaCollection.cs
+++ b/src/Mono.Android/Android.Runtime/JavaCollection.cs
@@ -209,8 +209,6 @@ namespace Android.Runtime {
 		}
 	}
 
-	// Preserve FromJniHandle
-	[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 	[Register ("java/util/Collection", DoNotGenerateAcw=true)]
 	public sealed class JavaCollection<
 			[DynamicallyAccessedMembers (Constructors)]

--- a/src/Mono.Android/Android.Runtime/JavaDictionary.cs
+++ b/src/Mono.Android/Android.Runtime/JavaDictionary.cs
@@ -12,6 +12,8 @@ namespace Android.Runtime {
 	// java.util.HashMap allows null keys and values
 	public class JavaDictionary : Java.Lang.Object, System.Collections.IDictionary {
 
+		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
 		class DictionaryEnumerator : IDictionaryEnumerator {
 
 			IEnumerator simple_enumerator;
@@ -395,8 +397,15 @@ namespace Android.Runtime {
 	//    instantiates a type we don't know at this time, so we have no information about the exceptions
 	//    it may throw.
 	//
+	// Preserve FromJniHandle
+	[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 	[Register ("java/util/HashMap", DoNotGenerateAcw=true)]
-	public class JavaDictionary<K, V> : JavaDictionary, IDictionary<K, V> {
+	public class JavaDictionary<
+			[DynamicallyAccessedMembers (Constructors)]
+			K,
+			[DynamicallyAccessedMembers (Constructors)]
+			V
+	> : JavaDictionary, IDictionary<K, V> {
 
 		[Register (".ctor", "()V", "")]
 		public JavaDictionary ()

--- a/src/Mono.Android/Android.Runtime/JavaDictionary.cs
+++ b/src/Mono.Android/Android.Runtime/JavaDictionary.cs
@@ -397,8 +397,6 @@ namespace Android.Runtime {
 	//    instantiates a type we don't know at this time, so we have no information about the exceptions
 	//    it may throw.
 	//
-	// Preserve FromJniHandle
-	[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 	[Register ("java/util/HashMap", DoNotGenerateAcw=true)]
 	public class JavaDictionary<
 			[DynamicallyAccessedMembers (Constructors)]

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -681,8 +681,6 @@ namespace Android.Runtime {
 		#endregion
 	}
 
-	// Preserve FromJniHandle
-	[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 	[Register ("java/util/ArrayList", DoNotGenerateAcw=true)]
 	public class JavaList<
 			[DynamicallyAccessedMembers (Constructors)]

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -10,6 +10,7 @@ namespace Android.Runtime {
 	// java.util.ArrayList allows null values
 	public partial class JavaList : Java.Lang.Object, System.Collections.IList {
 
+		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		internal static readonly JniPeerMembers list_members = new XAPeerMembers ("java/util/List", typeof (JavaList), isInterface: true);
 
 		//
@@ -23,7 +24,10 @@ namespace Android.Runtime {
 		//
 		//     https://developer.android.com/reference/java/util/List.html?hl=en#get(int)
 		//
-		internal unsafe object? InternalGet (int location, Type? targetType = null)
+		internal unsafe object? InternalGet (
+				int location,
+				[DynamicallyAccessedMembers (Constructors)]
+				Type? targetType = null)
 		{
 			const string id = "get.(I)Ljava/lang/Object;";
 			JniObjectReference obj;
@@ -266,6 +270,11 @@ namespace Android.Runtime {
 
 		public void CopyTo (Array array, int array_index)
 		{
+			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "JavaList<T> constructors are preserved by the MarkJavaObjects trimmer step.")]
+			[return: DynamicallyAccessedMembers (Constructors)]
+			static Type GetElementType (Array array) =>
+				array.GetType ().GetElementType ();
+
 			if (array == null)
 				throw new ArgumentNullException ("array");
 			if (array_index < 0)
@@ -273,7 +282,7 @@ namespace Android.Runtime {
 			if (array.Length < array_index + Count)
 				throw new ArgumentException ("array");
 
-			var targetType = array.GetType ().GetElementType ();
+			var targetType = GetElementType (array);
 			int c = Count;
 			for (int i = 0; i < c; i++)
 				array.SetValue (InternalGet (i, targetType), array_index + i);
@@ -672,8 +681,13 @@ namespace Android.Runtime {
 		#endregion
 	}
 
+	// Preserve FromJniHandle
+	[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 	[Register ("java/util/ArrayList", DoNotGenerateAcw=true)]
-	public class JavaList<T> : JavaList, IList<T> {
+	public class JavaList<
+			[DynamicallyAccessedMembers (Constructors)]
+			T
+	> : JavaList, IList<T> {
 
 		//
 		// Exception audit:

--- a/src/Mono.Android/Android.Runtime/JavaSet.cs
+++ b/src/Mono.Android/Android.Runtime/JavaSet.cs
@@ -268,7 +268,10 @@ namespace Android.Runtime {
 
 	[Register ("java/util/HashSet", DoNotGenerateAcw=true)]
 	// java.util.HashSet allows null
-	public class JavaSet<T> : JavaSet, ICollection<T> {
+	public class JavaSet<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			T
+	> : JavaSet, ICollection<T> {
 
 		//
 		// Exception audit:

--- a/src/Mono.Android/Android.Util/SparseArray.cs
+++ b/src/Mono.Android/Android.Util/SparseArray.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 using Android.Runtime;
 
@@ -7,7 +8,10 @@ using Java.Interop;
 namespace Android.Util
 {
 	[Register ("android/util/SparseArray", DoNotGenerateAcw=true)]
-	public partial class SparseArray<E> : SparseArray
+	public partial class SparseArray<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			E
+	> : SparseArray
 	{
 		public SparseArray ()
 		{

--- a/src/Mono.Android/Android.Widget/AdapterView.cs
+++ b/src/Mono.Android/Android.Widget/AdapterView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Android.Views;
 using JLO = Java.Lang.Object;
 
@@ -49,7 +50,10 @@ namespace Android.Widget {
 	}
 
 	[Register ("android/widget/AdapterView", DoNotGenerateAcw=true)]
-	public abstract class AdapterView<T> : AdapterView  where T : IAdapter {
+	public abstract class AdapterView<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			T
+	> : AdapterView  where T : IAdapter {
 
 		public AdapterView (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)

--- a/src/Mono.Android/Android.Widget/ArrayAdapter.cs
+++ b/src/Mono.Android/Android.Widget/ArrayAdapter.cs
@@ -8,7 +8,10 @@ using Java.Interop;
 namespace Android.Widget {
 
 	[Register ("android/widget/ArrayAdapter", DoNotGenerateAcw=true)]
-	public partial class ArrayAdapter<T> : ArrayAdapter {
+	public partial class ArrayAdapter<
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			T
+	> : ArrayAdapter {
 
 		public ArrayAdapter (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -57,11 +57,13 @@ namespace Java.Interop {
 
 		static Func<IntPtr, JniHandleOwnership, object?>? GetJniHandleConverter (Type? target)
 		{
-			const string justification = "JavaDictionary<,>, JavaList<>, and JavaCollection<> use DynamicallyAccessedMembers for PublicMethods to preserve FromJniHandle().";
-			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = justification)]
-			[UnconditionalSuppressMessage ("Trimming", "IL2068", Justification = justification)]
+			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "JavaDictionary<,>, JavaList<>, and JavaCollection<> are preserved by the MarkJavaObjects linker step.")]
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-			static Type MakeGenericType (Type type, params Type [] typeArguments) =>
+			static Type MakeGenericType (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+					Type type,
+					params Type [] typeArguments
+			) =>
 				// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
 				// IL3050 disabled in source: if someone uses NativeAOT, they will get the warning.
 				#pragma warning disable IL3050

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -57,7 +57,9 @@ namespace Java.Interop {
 
 		static Func<IntPtr, JniHandleOwnership, object?>? GetJniHandleConverter (Type? target)
 		{
-			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "JavaDictionary<,>, JavaList<>, and JavaCollection<> are preserved by the MarkJavaObjects linker step.")]
+			// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
+			// Might cause an issue in the future for NativeAOT
+			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "We don't think the IDictionary, IList, or ICollection code paths occur if JavaDictionary<,>, JavaList<>, and JavaCollection<> do not exist.")]
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 			static Type MakeGenericType (
 					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]

--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -17,7 +17,10 @@ namespace Java.Interop {
 		}
 
 		[Obsolete ("Use Android.Runtime.JavaCollection<T>.ToLocalJniHandle()")]
-		public static JavaCollection<T> ToInteroperableCollection<T> (this ICollection<T> instance)
+		public static JavaCollection<T> ToInteroperableCollection<
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (this ICollection<T> instance)
 		{
 			return instance is JavaCollection<T> ? (JavaCollection<T>) instance : new JavaCollection<T> (instance);
 		}
@@ -29,7 +32,10 @@ namespace Java.Interop {
 		}
 
 		[Obsolete ("Use Android.Runtime.JavaList<T>.ToLocalJniHandle()")]
-		public static JavaList<T> ToInteroperableCollection<T> (this IList<T> instance)
+		public static JavaList<T> ToInteroperableCollection<
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (this IList<T> instance)
 		{
 			return instance is JavaList<T> ? (JavaList<T>) instance : new JavaList<T> (instance);
 		}
@@ -41,7 +47,12 @@ namespace Java.Interop {
 		}
 
 		[Obsolete ("Use Android.Runtime.JavaDictionary<K, V>.ToLocalJniHandle()")]
-		public static JavaDictionary<K,V> ToInteroperableCollection<K,V> (this IDictionary<K,V> instance)
+		public static JavaDictionary<K,V> ToInteroperableCollection<
+				[DynamicallyAccessedMembers (Constructors)]
+				K,
+				[DynamicallyAccessedMembers (Constructors)]
+				V
+		> (this IDictionary<K,V> instance)
 		{
 			return instance is JavaDictionary<K,V> ? (JavaDictionary<K,V>) instance : new JavaDictionary<K,V> (instance);
 		}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -3,6 +3,7 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\Configuration.props" />
+  <Import Project="$(XamarinAndroidSourcePath)\build-tools\trim-analyzers\trim-analyzers.props" />
 
   <PropertyGroup>
     <TargetFrameworks>$(DotNetTargetFramework)</TargetFrameworks>

--- a/src/Mono.Android/System.Linq/Extensions.cs
+++ b/src/Mono.Android/System.Linq/Extensions.cs
@@ -9,6 +9,8 @@ namespace System.Linq {
 
 	public static class Extensions {
 
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
 		static IntPtr id_next;
 
 		static Extensions ()
@@ -40,7 +42,10 @@ namespace System.Linq {
 				}
 		}
 
-		public static IEnumerable<T?> ToEnumerable<T> (this Java.Lang.IIterable source)
+		public static IEnumerable<T?> ToEnumerable<
+				[DynamicallyAccessedMembers (Constructors)] 
+				T
+		> (this Java.Lang.IIterable source)
 		{
 			if (source == null)
 				throw new ArgumentNullException ("source");
@@ -52,7 +57,10 @@ namespace System.Linq {
 				}
 		}
 
-		internal static IEnumerator<T> ToEnumerator_Dispose<T> (this Java.Util.IIterator source)
+		internal static IEnumerator<T> ToEnumerator_Dispose<
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (this Java.Util.IIterator source)
 		{
 			using (source)
 				while (source.HasNext) {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5652

Each trimming problem listed below.

## AndroidEnvironment ##

    src\Mono.Android\Android.Runtime\AndroidEnvironment.cs(373,19): error IL2057: Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidEnvironment.cs(379,22): error IL2057: Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidEnvironment.cs(342,20): error IL2057: Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String, Boolean)'. It's not possible to guarantee the availability of the target type.
    src\Mono.Android\Android.Runtime\AndroidEnvironment.cs(352,11): error IL2077: 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The field 'Android.Runtime.AndroidEnvironment.httpMessageHandlerType' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

To fix these:

* Use constant strings for calls like:

```csharp
Type.GetType ("System.Net.Http.HttpMessageHandler, System.Net.Http", throwOnError: false)
```

Use `Type.IsAssignableFrom()` inline, and the trimmer now understands
the code paths.

There is a problem here if either of these are used with a custom type:

* `$(AndroidHttpClientHandlerType)`
* `$XA_HTTP_CLIENT_HANDLER_TYPE`

This is a rarely used feature, I found one usage in GitHub:

https://github.com/search?q=%3CAndroidHttpClientHandlerType%3E+NOT+Xamarin.Android.Net+NOT+System.Net.Http+NOT+Default&type=code

Filed an issue to fix this in the future:

* https://github.com/xamarin/xamarin-android/issues/8797

## JavaConvert ##

    src\Mono.Android\Java.Interop\JavaConvert.cs(223,12): error IL2091: 'TResult' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Java.Interop.JavaObjectExtensions._JavaCast<TResult>(IJavaObject)'. The generic parameter 'T' of 'Java.Interop.JavaConvert.FromJavaObject<T>(IJavaObject, out Boolean)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\JavaConvert.cs(254,12): error IL2067: 'resultType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'Java.Interop.JavaObjectExtensions.JavaCast(IJavaObject, Type)'. The parameter 'targetType' of method 'Java.Interop.JavaConvert.FromJavaObject(IJavaObject, Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Java.Interop\JavaConvert.cs(67,14): error IL3050: Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
    src\Mono.Android\Java.Interop\JavaConvert.cs(73,14): error IL3050: Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
    src\Mono.Android\Java.Interop\JavaConvert.cs(79,14): error IL3050: Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.

Adding attributes fixed some of these.

I suppressed warnings for:

* `Type.MakeGenericType()`: `JavaDictionary<,>`, `JavaList<>`, and
  `JavaCollection<>` use DynamicDependency to preserve `FromJniHandle`
  method.

* `Type.GetElementType()`: for calling `MyJavaObject[]` constructors,
  the `MarkJavaObjects` trimmer step should preserve these
  constructors.

This trickled over to require more attributes for:

* `AdapterView`
* `ArrayAdapter`
* `AsyncTask`
* `JavaCollection`
* `JavaDictionary`
* `JavaList`
* `JavaList`
* `JavaObjectExtensions`
* `JavaSet`
* `SparseArray`
* `System.Linq\Extensions`

## JNIEnv ##

    src\Mono.Android\Android.Runtime\JNIEnv.cs(810,38): error IL3050: Using member 'System.Type.MakeArrayType()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(953,33): error IL3050: Using member 'System.Type.MakeArrayType()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(1078,44): error IL3050: Using member 'System.Type.MakeArrayType()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(1139,15): error IL2091: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Java.Interop.JavaConvert.FromJavaObject<T>(IJavaObject)'. The generic parameter 'T' of 'Android.Runtime.JNIEnv.GetArray<T>(Object[])' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(1060,14): error IL3050: Using member 'System.Array.CreateInstance(Type, Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(1065,14): error IL3050: Using member 'System.Array.CreateInstance(Type, Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available.
    src\Mono.Android\Android.Runtime\JNIEnv.cs(1257,23): error IL2091: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Java.Interop.JavaConvert.FromJniHandle<T>(nint, JniHandleOwnership)'. The generic parameter 'T' of 'Android.Runtime.JNIEnv.CopyObjectArray<T>(nint, T[])' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Adding some attributes fixed two of these.

Suppress NativeAOT warnings, in source, for:

* `Array.CreateInstance()`

* `Type.MakeArrayType()`

Link to an issue to fix in the future.