### PR TITLE
[ci] Do not use self annotation for yaml-templates

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -13,7 +13,7 @@ parameters:
   retryCountOnTaskFailure: 1
 
 steps:
-- template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+- template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
   parameters:
     configuration: ${{ parameters.buildConfiguration }}
     xaSourcePath: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -97,11 +97,11 @@ stages:
           artifactName: ${{ parameters.nugetArtifactName }}
           targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/nuget-linux
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         xaSourcePath: $(System.DefaultWorkingDirectory)/xamarin-android
         artifactName: ${{ parameters.buildResultArtifactName }}
         includeBuildResults: true
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -69,7 +69,7 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - template: /build-tools/automation/yaml-templates/commercial-build.yaml@self
+    - template: /build-tools/automation/yaml-templates/commercial-build.yaml
       parameters:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         installerArtifactName: ${{ parameters.installerArtifactName }}
@@ -78,7 +78,7 @@ stages:
         windowsToolchainPdbArtifactName: ${{ parameters.windowsToolchainPdbArtifactName }}
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         artifactName: ${{ parameters.buildResultArtifactName }}

--- a/build-tools/automation/yaml-templates/build-windows.yaml
+++ b/build-tools/automation/yaml-templates/build-windows.yaml
@@ -35,15 +35,15 @@ stages:
         path: ${{ parameters.checkoutPath }}
         persistCredentials: ${{ parameters.checkoutPersistCredentials }}
 
-    - template: /build-tools/automation/yaml-templates/kill-processes.yaml@self
+    - template: /build-tools/automation/yaml-templates/kill-processes.yaml
 
-    - template: /build-tools/automation/yaml-templates/clean.yaml@self
+    - template: /build-tools/automation/yaml-templates/clean.yaml
 
     - script: |
         echo ##vso[task.setvariable variable=JI_JAVA_HOME]%JAVA_HOME_17_X64%
       displayName: set JI_JAVA_HOME to $(JAVA_HOME_17_X64)
 
-    - template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
+    - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
       parameters:
         remove_dotnet: true
 
@@ -54,7 +54,7 @@ stages:
         arguments: '-c $(XA.Build.Configuration) -t:Prepare --no-restore -p:AutoProvision=true -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\dotnet-build-prepare.binlog'
 
     # Build, pack .nupkgs, and extract workload packs to dotnet preview test directory
-    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
       parameters:
         project: Xamarin.Android.sln
         arguments: >-
@@ -63,12 +63,12 @@ stages:
         displayName: Build Solution
         continueOnError: false
 
-    - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml@self
+    - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml
       parameters:
         toolName: apkdiff
         version: $(ApkDiffToolVersion)
 
-    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
       parameters:
         testRunTitle: Smoke MSBuild Tests - Windows Dotnet Build
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\$(DotNetStableTargetFramework)\Xamarin.Android.Build.Tests.dll
@@ -80,9 +80,9 @@ stages:
         filename: dotnet-local.cmd
         arguments: build samples\HelloWorld\HelloWorld\HelloWorld.DotNet.csproj
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: ${{ parameters.buildResultArtifactName }}
         includeBuildResults: true
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -11,7 +11,7 @@ steps:
 - script: echo "##vso[task.setvariable variable=JI_JAVA_HOME]$HOME/android-toolchain/jdk-17"
   displayName: set JI_JAVA_HOME
 
-- template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
+- template: /build-tools/automation/yaml-templates/use-dot-net.yaml
   parameters:
     remove_dotnet: true
 
@@ -66,7 +66,7 @@ steps:
   displayName: CodeQL 3000 Finalize
   condition: and(succeededOrFailed(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-- template: /build-tools/automation/yaml-templates/install-microbuild-tooling.yaml@self
+- template: /build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
   parameters:
     condition: and(succeeded(), eq(variables['MicroBuildSignType'], 'Real'))
 
@@ -115,7 +115,7 @@ steps:
       /p:MicroBuildOverridePluginDirectory=$(Build.StagingDirectory)/MicroBuild/Plugins
       /bl:${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/sign-bu-ex.binlog
 
-- template: /build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml@self
+- template: /build-tools/automation/yaml-templates/remove-microbuild-tooling.yaml
   parameters:
     condition: and(succeededOrFailed(), eq(variables['MicroBuildSignType'], 'Real'))
 

--- a/build-tools/automation/yaml-templates/run-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-emulator-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         echo "##vso[task.setvariable variable=JAVA_HOME]${{ parameters.jdkTestFolder }}"
       displayName: set JAVA_HOME to ${{ parameters.jdkTestFolder }}
 
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
         jdkTestFolder: ${{ parameters.jdkTestFolder }}
@@ -36,15 +36,15 @@ jobs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
       parameters:
         emulatorMSBuildArgs: ${{ parameters.emulatorMSBuildArgs }}
 
     - ${{ parameters.testSteps }}
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - ${{ parameters.jobName }} With Emulator - macOS
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -30,11 +30,11 @@ jobs:
   - ${{ if eq(parameters.testOS, 'Windows') }}:
     - script: netsh int ipv4 set global sourceroutingbehavior=drop
 
-    - template: /build-tools/automation/yaml-templates/kill-processes.yaml@self
+    - template: /build-tools/automation/yaml-templates/kill-processes.yaml
 
-    - template: /build-tools/automation/yaml-templates/clean.yaml@self
+    - template: /build-tools/automation/yaml-templates/clean.yaml
 
-  - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+  - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
     parameters:
       installTestSlicer: true
       installLegacyXamarinAndroid: true
@@ -47,7 +47,7 @@ jobs:
       artifactName: $(TestAssembliesArtifactName)
       downloadPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
 
-  - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
     parameters:
       testAssembly: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)/$(DotNetStableTargetFramework)/Xamarin.Android.Build.Tests.dll
       testFilter: ${{ parameters.testFilter }}
@@ -55,11 +55,11 @@ jobs:
       retryFailedTests: false
       xaSourcePath: ${{ parameters.xaSourcePath }}
 
-  - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+  - template: /build-tools/automation/yaml-templates/upload-results.yaml
     parameters:
       artifactName: Test Results - MSBuild - ${{ parameters.testOS }}-$(System.JobPositionInPhase)
       xaSourcePath: ${{ parameters.xaSourcePath }}
 
-  - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+  - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
     parameters:
       condition: ${{ parameters.shouldFailOnIssue }}

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -22,4 +22,4 @@ steps:
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
-- template: /build-tools/automation/yaml-templates/kill-processes.yaml@self
+- template: /build-tools/automation/yaml-templates/kill-processes.yaml

--- a/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
@@ -28,7 +28,7 @@ steps:
 
 - ${{ if eq(parameters.retryFailedTests, 'false') }}:
   # If we aren't using auto-retry logic, then this is just a simple template call
-  - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
     parameters:
       testRunTitle: ${{ parameters.testRunTitle }}-$(System.JobPositionInPhase)
       testAssembly: ${{ parameters.testAssembly }}
@@ -70,7 +70,7 @@ steps:
       custom: build-server
       arguments: shutdown
 
-  - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml
     parameters:
       testRunTitle: ${{ parameters.testRunTitle }}-$(System.JobPositionInPhase) (Auto-Retry)
       testAssembly: ${{ parameters.testAssembly }}

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -35,14 +35,14 @@ steps:
 
 # Install .NET 6 for legacy tests
 - ${{ if eq(parameters.installLegacyDotNet, true) }}:
-  - template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
+  - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
     parameters:
       version: 6.0
       quality: GA
       remove_dotnet: ${{ parameters.remove_dotnet }}
 
 # Install latest .NET
-- template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
+- template: /build-tools/automation/yaml-templates/use-dot-net.yaml
 
 - task: DotNetCoreCLI@2
   displayName: shut down existing build daemons
@@ -52,7 +52,7 @@ steps:
     arguments: shutdown
 
 - ${{ if eq(parameters.updateMono, true) }}:
-  - template: /build-tools/automation/yaml-templates/run-xaprepare.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-xaprepare.yaml
     parameters:
       displayName: run xaprepare-UpdateMono
       arguments: --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes
@@ -60,7 +60,7 @@ steps:
       xaSourcePath: ${{ parameters.xaSourcePath }}
 
 - ${{ if eq(parameters.installLegacyXamarinAndroid, true) }}:
-  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml@self
+  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml
     parameters:
       toolName: boots
       version: $(BootsToolVersion)
@@ -68,7 +68,7 @@ steps:
   - pwsh: $(Agent.ToolsDirectory)/boots --stable Xamarin.Android
     displayName: install Xamarin.Android stable
 
-- template: /build-tools/automation/yaml-templates/run-xaprepare.yaml@self
+- template: /build-tools/automation/yaml-templates/run-xaprepare.yaml
   parameters:
     arguments: --s=${{ parameters.xaprepareScenario }}  --android-sdk-platforms="${{ parameters.androidSdkPlatforms }}"
     xaSourcePath: ${{ parameters.xaSourcePath }}
@@ -98,13 +98,13 @@ steps:
     arguments: -t:ExtractWorkloadPacks -c ${{ parameters.configuration }} -v:n -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/extract-workloads.binlog
 
 - ${{ if eq(parameters.installApkDiff, true) }}:
-  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml@self
+  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml
     parameters:
       toolName: apkdiff
       version: $(ApkDiffToolVersion)
 
 - ${{ if eq(parameters.installTestSlicer, true) }}:
-  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml@self
+  - template: /build-tools/automation/yaml-templates/install-dotnet-tool.yaml
     parameters:
       toolName: dotnet-test-slicer
       version: $(TestSlicerToolVersion)

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -33,7 +33,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         installTestSlicer: true
         installApkDiff: false
@@ -49,29 +49,29 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
       parameters:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         startContinueOnError: ${{ parameters.emulatorStartContinueOnError }}
 
-    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
       parameters:
         testAssembly: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
         testFilter: $(ExcludedNightlyNUnitCategories)
         testRunTitle: MSBuildDeviceIntegration On Device - macOS
 
     - ${{ if ne(parameters.usesCleanImages, true) }}:
-      - template: start-stop-emulator.yaml@self
+      - template: start-stop-emulator.yaml
         parameters:
           command: stop
           xaSourcePath: ${{ parameters.xaSourcePath }}
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild With Emulator - macOS-$(System.JobPositionInPhase)
         xaSourcePath: ${{ parameters.xaSourcePath }}
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
       parameters:
         condition: ${{ parameters.shouldFailOnIssue }}
 
@@ -94,7 +94,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml@self
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         installTestSlicer: true
         installApkDiff: false
@@ -108,7 +108,7 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)
 
-    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+    - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
       parameters:
         specificImage: true
         deviceName: $(deviceName)
@@ -118,7 +118,7 @@ stages:
         xaSourcePath: ${{ parameters.xaSourcePath }}
         startContinueOnError: ${{ parameters.emulatorStartContinueOnError }}
 
-    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml@self
+    - template: /build-tools/automation/yaml-templates/run-sliced-nunit-tests.yaml
       parameters:
         testRunTitle: WearOS On Device - macOS
         testAssembly: ${{ parameters.xaSourcePath }}/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/$(DotNetStableTargetFramework)/MSBuildDeviceIntegration.dll
@@ -126,7 +126,7 @@ stages:
         xaSourcePath: ${{ parameters.xaSourcePath }}
 
     - ${{ if ne(parameters.usesCleanImages, true) }}:
-      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml@self
+      - template: /build-tools/automation/yaml-templates/start-stop-emulator.yaml
         parameters:
           command: stop
           specificImage: true
@@ -136,12 +136,12 @@ stages:
           avdType: $(avdType)
           xaSourcePath: ${{ parameters.xaSourcePath }}
 
-    - template: /build-tools/automation/yaml-templates/upload-results.yaml@self
+    - template: /build-tools/automation/yaml-templates/upload-results.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
         artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi)-$(avdType) - macOS
         xaSourcePath: ${{ parameters.xaSourcePath }}
 
-    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
+    - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
       parameters:
         condition: ${{ parameters.shouldFailOnIssue }}

--- a/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
@@ -16,7 +16,7 @@ stages:
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.stageCondition }}
   jobs:
-  - template: /build-tools/automation/yaml-templates/run-msbuild-tests.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-msbuild-tests.yaml
     parameters:
       testOS: macOS
       jobName: mac_msbuild_tests
@@ -27,7 +27,7 @@ stages:
       commit: ${{ parameters.commit }}
       shouldFailOnIssue: ${{ parameters.shouldFailOnIssue }}
 
-  - template: /build-tools/automation/yaml-templates/run-msbuild-tests.yaml@self
+  - template: /build-tools/automation/yaml-templates/run-msbuild-tests.yaml
     parameters:
       testOS: Windows
       jobName: win_msbuild_tests

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -7,7 +7,7 @@ parameters:
   use1ESTemplate: true
 
 steps:
-- template: /build-tools/automation/yaml-templates/run-xaprepare.yaml@self
+- template: /build-tools/automation/yaml-templates/run-xaprepare.yaml
   parameters:
     configuration: ${{ parameters.configuration }}
     arguments: --s=CopyExtraResultFilesForCI --verbosity v
@@ -16,7 +16,7 @@ steps:
     condition: ${{ parameters.condition }}
 
 - ${{ if eq(parameters.includeBuildResults, false) }}:
-  - template: /build-tools/automation/yaml-templates/publish-artifact.yaml@self
+  - template: /build-tools/automation/yaml-templates/publish-artifact.yaml
     parameters:
       displayName: upload test results
       artifactName: ${{ parameters.artifactName }}
@@ -32,7 +32,7 @@ steps:
       targetFolder: $(Build.StagingDirectory)/Test${{ parameters.configuration }}/Build${{ parameters.configuration }}
     condition: ${{ parameters.condition }}
 
-  - template: /build-tools/automation/yaml-templates/publish-artifact.yaml@self
+  - template: /build-tools/automation/yaml-templates/publish-artifact.yaml
     parameters:
       displayName: upload build and test results
       artifactName: ${{ parameters.artifactName }}


### PR DESCRIPTION
The `@self` yaml template annotation only appears to be needed in the
pipeline file, and not in nested templates.  This should fix potential
issues with other repos that use these templates.