### PR TITLE
[ci] Add 1ESPT override to MSBuild test stages

### DIFF
--- a/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-msbuild-tests.yaml
@@ -8,6 +8,7 @@ parameters:
   repositoryAlias: 'self'
   commit: ''
   shouldFailOnIssue: true
+  use1ESTemplate: true
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -59,6 +60,7 @@ jobs:
     parameters:
       artifactName: Test Results - MSBuild - ${{ parameters.testOS }}-$(System.JobPositionInPhase)
       xaSourcePath: ${{ parameters.xaSourcePath }}
+      use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
   - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
     parameters:

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -13,6 +13,7 @@ parameters:
   usesCleanImages: true
   shouldFailOnIssue: true
   emulatorStartContinueOnError: false
+  use1ESTemplate: true
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -70,6 +71,7 @@ stages:
       parameters:
         artifactName: Test Results - MSBuild With Emulator - macOS-$(System.JobPositionInPhase)
         xaSourcePath: ${{ parameters.xaSourcePath }}
+        use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
       parameters:
@@ -141,6 +143,7 @@ stages:
         configuration: $(XA.Build.Configuration)
         artifactName: Test Results - Emulator $(avdApiLevel)-$(avdAbi)-$(avdType) - macOS
         xaSourcePath: ${{ parameters.xaSourcePath }}
+        use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml@self
       parameters:

--- a/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
@@ -9,6 +9,7 @@ parameters:
   repositoryAlias: 'self'
   commit: ''
   shouldFailOnIssue: true
+  use1ESTemplate: true
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -26,6 +27,7 @@ stages:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       shouldFailOnIssue: ${{ parameters.shouldFailOnIssue }}
+      use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
   - template: /build-tools/automation/yaml-templates/run-msbuild-tests.yaml@self
     parameters:
@@ -37,3 +39,4 @@ stages:
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}
       shouldFailOnIssue: ${{ parameters.shouldFailOnIssue }}
+      use1ESTemplate: ${{ parameters.use1ESTemplate }}


### PR DESCRIPTION
The mega pipeline extends our msbuild stages and does not yet support
using the 1ES pipeline template.