### PR TITLE
[ci] Fix SDL Sources Analysis for PRs from forks

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -87,12 +87,15 @@ extends:
         os: windows
       sourceRepositoriesToScan:
         include:
-        - repository: monodroid
+        - ${{ if ne(variables['System.PullRequest.IsFork'], 'True') }}:
+          - repository: monodroid
         exclude:
         - repository: yaml-templates
         - repository: maui
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     stages:
     - template: /build-tools/automation/yaml-templates/build-macos.yaml@self
 


### PR DESCRIPTION
The recent 1ES pipeline template migration added a new source code
analysis stage that is failing on PR builds from forks.  We should be
able to fix this by skipping AzDO build tagging and monodroid scanning
for such builds.