### PR TITLE
Bump to xamarin/java.interop/release/8.0.1xx@3c5cf34b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "external/Java.Interop"]
     path = external/Java.Interop
     url = https://github.com/xamarin/java.interop.git
-    branch = main
+    branch = release/8.0.1xx
 [submodule "external/lz4"]
     path = external/lz4
     url = https://github.com/lz4/lz4.git


### PR DESCRIPTION
Changes: https://github.com/xamarin/java.interop/compare/bec0326a925ff888d96cb433f5049000a6d32a33...3c5cf34b0e3cc9427521530db9aa4b4abe39d20d

  * xamarin/java.interop@3c5cf34b: [generator] Extend `skipInvokerMethods` support to interfaces. (xamarin/java.interop#1203)
