### PR TITLE
[One .NET] "greenfield" projects opt into trimming

### DIFF
--- a/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
+++ b/src/Microsoft.Android.Templates/android-bindinglib/AndroidBinding1.csproj
@@ -6,6 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!--
+      Enable trim analyzers for Android class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <!--
       NOTE: you can simply add .aar or .jar files in this directory to be included in the project.
       To learn more, see: https://learn.microsoft.com/dotnet/maui/migration/android-binding-projects
     -->

--- a/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android-wear/AndroidApp1.csproj
@@ -11,6 +11,13 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);XA4218</MSBuildWarningsAsMessages>
   </PropertyGroup>
+  <!--
+    Enable full trimming in Release mode.
+    To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TrimMode>full</TrimMode>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Wear" Version="1.2.0.5" />
   </ItemGroup>

--- a/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
+++ b/src/Microsoft.Android.Templates/android/AndroidApp1.csproj
@@ -10,4 +10,11 @@
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
   </PropertyGroup>
+  <!--
+    Enable full trimming in Release mode.
+    To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TrimMode>full</TrimMode>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Android.Templates/androidlib/AndroidLib1.csproj
+++ b/src/Microsoft.Android.Templates/androidlib/AndroidLib1.csproj
@@ -5,5 +5,10 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">AndroidLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      Enable trim analyzers for Android class libraries.
+      To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
+    -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -74,8 +74,9 @@
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' and '$(PublishTrimmed)' == 'true' ">SdkOnly</AndroidLinkMode>
     <AndroidLinkMode Condition=" '$(AndroidLinkMode)' == '' ">None</AndroidLinkMode>
     <!-- For compat with user code not marked trimmable, only trim opt-in by default. -->
-    <TrimMode Condition=" '$(TrimMode)' == '' and '$(AndroidLinkMode)' == 'Full' ">link</TrimMode>
+    <TrimMode Condition=" '$(TrimMode)' == '' and '$(AndroidLinkMode)' == 'Full' ">full</TrimMode>
 		<TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
+    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' and '$(TrimMode)' == 'full' ">false</SuppressTrimAnalysisWarnings>
     <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>
     <!-- Prefer $(RuntimeIdentifiers) plural -->
     <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)' == '' And '$(RuntimeIdentifiers)' == '' ">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>

--- a/src/Xamarin.Android.Build.Tasks/Resources/LayoutBinding.cs
+++ b/src/Xamarin.Android.Build.Tasks/Resources/LayoutBinding.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Diagnostics.CodeAnalysis;
 using Android.App;
 using Android.Views;
 
@@ -9,6 +9,8 @@ namespace Xamarin.Android.Design
 
 	abstract class LayoutBinding
 	{
+		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
 		Activity boundActivity;
 		View boundView;
 		OnLayoutItemNotFoundHandler onLayoutItemNotFound;
@@ -25,7 +27,13 @@ namespace Xamarin.Android.Design
 			this.onLayoutItemNotFound = onLayoutItemNotFound;
 		}
 
-		protected T FindView <T> (int resourceId, ref T cachedField) where T: View
+		protected T FindView <
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (
+				int resourceId,
+				ref T cachedField)
+			where T: View
 		{
 			if (cachedField != null)
 				return cachedField;
@@ -58,7 +66,14 @@ namespace Xamarin.Android.Design
 			throw new InvalidOperationException ("Finding fragments is supported only for Activity instances");
 		}
 
-		T __FindFragment<T> (int resourceId, Func<Activity, T> finder, ref T cachedField) where T: Java.Lang.Object
+		T __FindFragment<
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (
+				int resourceId,
+				Func<Activity, T> finder,
+				ref T cachedField)
+			where T: Java.Lang.Object
 		{
 			if (cachedField != null)
 				return cachedField;
@@ -74,7 +89,15 @@ namespace Xamarin.Android.Design
 			return ret;
 		}
 #if __ANDROID_11__
-		protected T FindFragment<T> (int resourceId, global::Android.App.Fragment __ignoreMe, ref T cachedField) where T: global::Android.App.Fragment
+		protected T FindFragment<
+				[DynamicallyAccessedMembers (Constructors)]
+				T
+		> (
+				int resourceId,
+				global::Android.App.Fragment __ignoreMe,
+				ref T cachedField
+		)
+			where T: global::Android.App.Fragment
 		{
 			return __FindFragment<T> (resourceId, (activity) => activity.FragmentManager.FindFragmentById<T> (resourceId), ref cachedField);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -232,6 +232,10 @@ namespace Xamarin.Android.Build.Tests
 				new XamarinFormsAndroidApplicationProject () :
 				new XamarinAndroidApplicationProject ();
 			proj.IsRelease = isRelease;
+			// Enable full trimming
+			if (!xamarinForms && isRelease) {
+				proj.TrimModeRelease = TrimMode.Full;
+			}
 			if (multidex) {
 				proj.SetProperty ("AndroidEnableMultiDex", "True");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidLinkMode.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidLinkMode.cs
@@ -9,4 +9,10 @@ namespace Xamarin.ProjectTools
 		SdkOnly,
 		Full,
 	}
+
+	public enum TrimMode
+	{
+		Partial,
+		Full,
+	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Xamarin.ProjectTools
 {
@@ -18,6 +18,7 @@ namespace Xamarin.ProjectTools
 		public const string RuntimeIdentifiers = "RuntimeIdentifiers";
 		public const string RunAOTCompilation = "RunAOTCompilation";
 		public const string PublishTrimmed = "PublishTrimmed";
+		public const string TrimMode = "TrimMode";
 		public const string SupportedOSPlatformVersion = "SupportedOSPlatformVersion";
 
 		public const string Deterministic = "Deterministic";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -155,6 +155,11 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (ReleaseProperties, KnownProperties.AndroidLinkMode, value.ToString ()); }
 		}
 
+		public TrimMode TrimModeRelease {
+			get => Enum.TryParse (GetProperty (ReleaseProperties, KnownProperties.TrimMode), out TrimMode trimMode) ? trimMode : TrimMode.Partial;
+			set => SetProperty (ReleaseProperties, KnownProperties.TrimMode, value.ToString ().ToLowerInvariant ());
+		}
+
 		public bool EnableMarshalMethods {
 			get { return string.Equals (GetProperty (KnownProperties.AndroidEnableMarshalMethods), "True", StringComparison.OrdinalIgnoreCase); }
 			set { SetProperty (KnownProperties.AndroidEnableMarshalMethods, value.ToString ()); }

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using NUnit.Framework;
 
@@ -180,6 +181,7 @@ namespace Xamarin.Android.JcwGenTests {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void JavaAbstractMethodTest ()
 		{
 			// Library is referencing APIv1, ICursor is from APIv2
@@ -198,7 +200,7 @@ namespace Xamarin.Android.JcwGenTests {
 					throw e;
 			}
 
-			var mi = ic.GetType ().GetMethod ("global::Test.Bindings.ICursor.MethodWithCursor", BindingFlags.Instance | BindingFlags.NonPublic);
+			var mi = typeof (Library.MyClrCursor).GetMethod ("global::Test.Bindings.ICursor.MethodWithCursor", BindingFlags.Instance | BindingFlags.NonPublic);
 			Assert.IsNotNull (mi, "ICursor.MethodWithCursor not found");
 			if (mi.GetMethodBody ()?.LocalVariables?.Count is not int x || x == 0)
 				throw new Exception ("FixAbstractMethodStep broken, MethodWithRT added, while it should not be");

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
@@ -18,6 +18,10 @@
     <OutputPath>..\..\..\bin\Test$(Configuration)</OutputPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TrimMode Condition=" '$(TrimMode)' == '' ">full</TrimMode>
+  </PropertyGroup>
+
   <ItemGroup>
     <AndroidJavaSource Include="../Xamarin.Android.McwGen-Tests/java/**/*.java" />
     <Compile Remove="TimingTests.cs" />

--- a/tests/Mono.Android-Tests/Android.Graphics/NinePatchTests.cs
+++ b/tests/Mono.Android-Tests/Android.Graphics/NinePatchTests.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Diagnostics.CodeAnalysis;
 using Android.App;
 using Android.Content.Res;
 using Android.Graphics;
@@ -25,6 +25,7 @@ namespace Android.GraphicsTests
 		};
 
 		[Test, TestCaseSource (nameof (NinePatchDrawables))]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (NinePatchDrawable))]
 		public void DrawableFromRes_ShouldBeTypeNinePatchDrawable (int resId, string name)
 		{
 			var d = Application.Context.Resources.GetDrawable (resId);
@@ -33,6 +34,7 @@ namespace Android.GraphicsTests
 		}
 
 		[Test, TestCaseSource (nameof (NinePatchDrawables))]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (NinePatchDrawable))]
 		public void DrawableFromResStream_ShouldBeTypeNinePatchDrawable (int resId, string name)
 		{
 			var value = new Android.Util.TypedValue ();

--- a/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -1,9 +1,11 @@
-﻿using Android.App;
+﻿using System.Diagnostics.CodeAnalysis;
+using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
 using NUnit.Framework;
+using Mono.Android_Test.Library;
 
 namespace Xamarin.Android.RuntimeTests
 {
@@ -12,6 +14,7 @@ namespace Xamarin.Android.RuntimeTests
 	{
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=23880
 		[Test]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -21,6 +24,7 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void LowerCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -30,6 +34,7 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperAndLowerCaseCustomWidget_FromLibrary_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {

--- a/tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
+++ b/tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -47,12 +48,19 @@ namespace Java.LangTests
 
 		static Func<IJavaObject, int> GetIJavaObjectToInt32 ()
 		{
-			var JavaConvert       = typeof (Java.Lang.Object).Assembly.GetType ("Java.Interop.JavaConvert");
+			[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = "")]
+			static MethodInfo MakeGenericMethod (MethodInfo method, Type type) =>
+				// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
+				#pragma warning disable IL3050
+				method.MakeGenericMethod (type);
+				#pragma warning restore IL3050
+
+			var JavaConvert       = Type.GetType ("Java.Interop.JavaConvert, Mono.Android");
 			var FromJavaObject_T  = JavaConvert.GetMethods (BindingFlags.Public | BindingFlags.Static)
 				.First (m => m.Name == "FromJavaObject" && m.IsGenericMethod);
 			return (Func<IJavaObject, int>) Delegate.CreateDelegate (
 					typeof(Func<IJavaObject, int>),
-					FromJavaObject_T.MakeGenericMethod (typeof (int)));
+					MakeGenericMethod (FromJavaObject_T, typeof (int)));
 		}
 
 		[Test]

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/Mono.Android.NET-Tests.csproj
@@ -36,9 +36,13 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
+    <TrimMode Condition=" '$(TrimMode)' == '' ">full</TrimMode>
+    <!-- Trimmer switches required for tests -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>
+    <TrimmerRootAssembly Include="Java.Interop-Tests" RootMode="All" />
     <_AndroidRemapMembers Include="Remaps.xml" />
   </ItemGroup>
 

--- a/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/System/AppContextTests.cs
+++ b/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk/System/AppContextTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace SystemTests
@@ -44,7 +45,11 @@ namespace SystemTests
 
 		[Test]
 		[TestCaseSource (nameof (TestPrivateSwitchesSource))]
-		public void TestPrivateSwitches (string className, string propertyName, object expected)
+		public void TestPrivateSwitches (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+				string className,
+				string propertyName,
+				object expected)
 		{
 			var type = Type.GetType (className, throwOnError: true);
 			var members = type.GetMember (propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
+++ b/tests/Mono.Android-Tests/System.Drawing/TypeConverterTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 using NUnit.Framework;
@@ -10,6 +11,7 @@ namespace System.Drawing {
 	public class TypeConverterTest {
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void ColorConverter ()
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (Color));
@@ -22,6 +24,7 @@ namespace System.Drawing {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void RectangleConverter ()
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (Rectangle));
@@ -34,6 +37,7 @@ namespace System.Drawing {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void PointConverter ()
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (Point));
@@ -44,6 +48,7 @@ namespace System.Drawing {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void SizeConverter ()
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (Size));
@@ -54,6 +59,7 @@ namespace System.Drawing {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void SizeFConverter ()
 		{
 			var typeConverter = TypeDescriptor.GetConverter (typeof (SizeF));

--- a/tests/Mono.Android-Tests/System.Text.Json/JsonSerializerTest.cs
+++ b/tests/Mono.Android-Tests/System.Text.Json/JsonSerializerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 using NUnit.Framework;
@@ -9,16 +10,24 @@ namespace System.Text.JsonTests {
 	public class JsonSerializerTest {
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void Serialize ()
 		{
+			// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
+			#pragma warning disable IL3050
 			string text = JsonSerializer.Serialize(42);
+			#pragma warning restore IL3050
 			Assert.AreEqual("42", text);
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void Deserialize ()
 		{
+			// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
+			#pragma warning disable IL3050
 			object value = JsonSerializer.Deserialize("42", typeof(int));
+			#pragma warning restore IL3050
 			Assert.AreEqual(42, value);
 		}
 	}

--- a/tests/Mono.Android-Tests/System/AppDomainTest.cs
+++ b/tests/Mono.Android-Tests/System/AppDomainTest.cs
@@ -1,10 +1,5 @@
 using System;
 using System.Globalization;
-
-using Android.App;
-using Android.Content;
-using Android.Runtime;
-
 using NUnit.Framework;
 
 namespace SystemTests {
@@ -13,34 +8,9 @@ namespace SystemTests {
 	public class AppDomainTest {
 
 		[Test]
-		[Category ("HybridAotNotWorking")] // See https://github.com/xamarin/xamarin-android/issues/1536
-		[Category ("DotNetIgnore")] // System.PlatformNotSupportedException : Secondary AppDomains are not supported on this platform.
-		public void DateTime_Now_Works ()
+		public void AppDomain_CreateDomain_Throws ()
 		{
-			new Boom().Bang();
-			
-
-			var otherDomain = AppDomain.CreateDomain ("other domain");
-
-			var otherType = typeof (Boom);
-			var obj = (Boom) otherDomain.CreateInstanceAndUnwrap (
-					otherType.Assembly.FullName,
-					otherType.FullName);
-			obj.Bang ();
-		}
-	}
-
-	class Boom : MarshalByRefObject
-	{
-		public void Bang()
-		{
-			var x = DateTime.Now;
-			Console.WriteLine ("Within AppDomain {0}, DateTime.Now={1}.", AppDomain.CurrentDomain.FriendlyName, x);
-		}
-
-		public override object InitializeLifetimeService ()
-		{
-			return null;
+			Assert.Throws<PlatformNotSupportedException> (() => AppDomain.CreateDomain ("other domain"));
 		}
 	}
 }

--- a/tests/Mono.Android-Tests/System/ExceptionTest.cs
+++ b/tests/Mono.Android-Tests/System/ExceptionTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -16,9 +17,7 @@ namespace Xamarin.Android.RuntimeTests {
 
 		static Java.Lang.Throwable CreateJavaProxyThrowable (Exception e)
 		{
-			var JavaProxyThrowable_type = typeof (Java.Lang.Object)
-				.Assembly
-				.GetType ("Android.Runtime.JavaProxyThrowable");
+			var JavaProxyThrowable_type = Type.GetType ("Android.Runtime.JavaProxyThrowable, Mono.Android");
 			MethodInfo? create = JavaProxyThrowable_type.GetMethod (
 				"Create",
 				BindingFlags.Static | BindingFlags.Public,
@@ -30,6 +29,7 @@ namespace Xamarin.Android.RuntimeTests {
 		}
 
 		[Test]
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		public void InnerExceptionIsSet ()
 		{
 			Exception ex;
@@ -48,6 +48,7 @@ namespace Xamarin.Android.RuntimeTests {
 			}
 		}
 
+		[RequiresUnreferencedCode ("Tests trimming unsafe features")]
 		void CompareStackTraces (Exception ex, Java.Lang.Throwable throwable)
 		{
 			var managedTrace = new StackTrace (ex);

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -30,6 +30,7 @@ using System;
 using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -160,6 +161,7 @@ namespace Xamarin.Android.NetTests {
 			return Exceptions (e).Any (v => (v as WebException)?.Status == WebExceptionStatus.SecureChannelFailure);
 		}
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "Tests private fields are preserved by other means")]
 		static Type GetInnerHandlerType (HttpClient httpClient)
 		{
 			BindingFlags bflasgs = BindingFlags.Instance | BindingFlags.NonPublic;


### PR DESCRIPTION
As we have solved all trimming warnings in the Android workload, we
can now go "all in" on trimming.

Early in .NET 6 (maybe even 5?) we "hid" many trimming warnings as we
did not yet plan to solve them:

    <SuppressTrimAnalysisWarnings Condition=" '$(SuppressTrimAnalysisWarnings)' == '' ">true</SuppressTrimAnalysisWarnings>

These warnings were not *actionable* at the time for customers, as
many warnings were in `Mono.Android.dll`, `Java.Interop.dll`, etc.

Going forward, let's stop suppressing these warnings if `TrimMode=full`.

We can also enable trimming for new projects:

* `dotnet new android`
* `dotnet new android-wear`

These will have the `TrimMode` property set to `Full` by default:

```xml
<!--
  Enable full trimming in Release mode.
  To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
-->
<PropertyGroup Condition="'$(Configuration)' == 'Release'">
  <TrimMode>full</TrimMode>
</PropertyGroup>
```

We wouldn't want to do this for existing projects *yet*, as they might
have existing code, NuGet packages, etc. where trimming warnings might
be present.

We can also improve the templates for Android class libraries:

* `dotnet new androidlib`
* `dotnet new android-bindinglib`

```xml
<!--
  Enable trim analyzers for Android class libraries.
  To learn more, see: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
-->
<IsTrimmable>true</IsTrimmable>
```

This way, new class libraries will be "trimmable" by default and be
able to react to trimming warnings.

We can also use `TrimMode=full` in many of our existing tests:

* MSBuild tests that assert 0 warnings can use `TrimMode=full`.

* On-device tests can use `TrimMode=full`.

## General trimming warnings ##

This was discovered through `Mono.Android-NET-Tests.csproj`, but there
were a few trimmer warnings in the "layout bindings" feature:

    dotnet\packs\Microsoft.Android.Sdk.Windows\...\tools\LayoutBinding.cs(79,56): warning IL2091: Xamarin.Android.Design.LayoutBinding.<>c__DisplayClass8_0<T>.<FindFragment>b__0(Activity): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.App.FragmentManager.FindFragmentById<T>(Int32)'. The generic parameter 'T' of 'Xamarin.Android.Design.LayoutBinding.<>c__DisplayClass8_0<T>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    dotnet\packs\Microsoft.Android.Sdk.Windows\...\tools\LayoutBinding.cs(35,5): warning IL2091: Xamarin.Android.Design.LayoutBinding.FindView<T>(Int32, T&): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.App.Activity.FindViewById<T>(Int32)'. The generic parameter 'T' of 'Xamarin.Android.Design.LayoutBinding.FindView<T>(Int32, T&)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    dotnet\packs\Microsoft.Android.Sdk.Windows\...\tools\LayoutBinding.cs(37,5): warning IL2091: Xamarin.Android.Design.LayoutBinding.FindView<T>(Int32, T&): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.Views.View.FindViewById<T>(Int32)'. The generic parameter 'T' of 'Xamarin.Android.Design.LayoutBinding.FindView<T>(Int32, T&)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

We can `[DynamicallyAccessedMembers (Constructors)]` to fix these.

## Trimming warnings in tests ##

Several tests that verify "trimming unsafe features" just specify:

    [RequiresUnreferencedCode ("Tests trimming unsafe features")]

If the test might have an issue under NativeAOT, I used:

    // FIXME: https://github.com/xamarin/xamarin-android/issues/8724
    #pragma warning disable IL3050

Places that use `Assembly.GetType()` can use `Type.GetType()` instead:

    --var JavaProxyThrowable_type = typeof (Java.Lang.Object)
    --    .Assembly
    --    .GetType ("Android.Runtime.JavaProxyThrowable");
    ++var JavaProxyThrowable_type = Type.GetType ("Android.Runtime.JavaProxyThrowable, Mono.Android");

`AppDomainTest` was just ignored (and had warnings). Updated to just
verify `PlatformNotSupportedException` is thrown.

## Test failures ##

`JsonSerializerTest` requires a feature flag:

    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>

Otherwise, an exception is thrown:

    System.InvalidOperationException : JsonSerializerIsReflectionDisabled

`Java.Interop-Tests` were initially not loaded at all. With the log
message:

    03-13 16:13:59.940  5262  5344 W NUnit   : Failed to load tests from assembly 'Java.Interop-Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065

If we make `Java.Interop-Tests.dll` a `@(TrimmerRootAssembly)`:

    <TrimmerRootAssembly Include="Java.Interop-Tests" RootMode="All" />

Then all the tests cases are preserved and can be run, in the same way
the "main app assembly" is preserved.

`NinePatchTests` failed with:

    The drawable created from resource tile should be a NinePatchDrawable.
    Expected: not null
    But was:  null

The only usage of `NinePatchDrawable` was:

    Assert.IsNotNull (d as NinePatchDrawable);

`NinePatchDrawable` likely needs its interfaces and constructors
preserved for this test to pass. I added an attribute for just `All`
for the test to pass:

    [DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (NinePatchDrawable))]

`CustomWidgetTests` failed with:

    (Binary XML file line #1 in Mono.Android.NET_Tests:layout/uppercase_custom: Binary XML file line #1 in Mono.Android.NET_Tests:layout/uppercase_custom: Error inflating class Mono.Android_Test.Library.CustomTextView)
    at Java.Interop.JniEnvironment.InstanceMethods.CallObjectMethod(JniObjectReference , JniMethodInfo , JniArgumentValue* )
    at Java.Interop.JniPeerMembers.JniInstanceMethods.InvokeVirtualObjectMethod(String , IJavaPeerable , JniArgumentValue* )
    at Android.Views.LayoutInflater.Inflate(Int32 , ViewGroup )
    at Xamarin.Android.RuntimeTests.CustomWidgetTests.<>c.<UpperCaseCustomWidget_ShouldNotThrowInflateException>b__0_0()
    at NUnit.Framework.Constraints.VoidInvocationDescriptor.Invoke()
    at NUnit.Framework.Constraints.ExceptionInterceptor.Intercept(Object )
    --- End of managed Java.Lang.RuntimeException stack trace ---
    android.view.InflateException: Binary XML file line #1 in Mono.Android.NET_Tests:layout/uppercase_custom: Binary XML file line #1 in Mono.Android.NET_Tests:layout/uppercase_custom: Error inflating class Mono.Android_Test.Library.CustomTextView
    Caused by: android.view.InflateException: Binary XML file line #1 in Mono.Android.NET_Tests:layout/uppercase_custom: Error inflating class Mono.Android_Test.Library.CustomTextView
    Caused by: java.lang.ClassNotFoundException: Mono.Android_Test.Library.CustomTextView
    at java.lang.Class.classForName(Native Method)
    at java.lang.Class.forName(Class.java:454)
    at android.view.LayoutInflater.createView(LayoutInflater.java:815)
    at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:1006)
    at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961)
    at android.view.LayoutInflater.rInflate(LayoutInflater.java:1123)
    at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:682)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:534)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:481)
    at crc643df67da7b13bb6b1.TestInstrumentation_1.n_onStart(Native Method)
    at crc643df67da7b13bb6b1.TestInstrumentation_1.onStart(TestInstrumentation_1.java:32)
    at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
    Caused by: java.lang.ClassNotFoundException: Didn't find class "Mono.Android_Test.Library.CustomTextView" on path

In this case, `Mono.Android_Test.Library.CustomTextView` was used from
an Android layout, but not used anywhere in managed code.

To fix, I added:

    [DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (Mono.Android_Test.Library.CustomTextView))]

I could have also made `Mono.Android_Test.Library` a `@(TrimmerRootAssembly)`.