### PR TITLE
[Microsoft.Android.Templates] Update EN localization templatestrings.

### DIFF
--- a/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-activity/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Android Activity template",
+  "name": "Android Activity",
   "description": "An Android Activity class",
   "symbols/namespace/description": "namespace for the generated code",
   "postActions/openInEditor/description": "Opens Activity1.cs in the editor"

--- a/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.en.json
+++ b/src/Microsoft.Android.Templates/android-layout/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "Android Layout template",
+  "name": "Android Layout",
   "description": "An Android layout (XML) file",
   "postActions/openInEditor/description": "Opens Layout1.xml in the editor"
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8773

In https://github.com/xamarin/xamarin-android/pull/8773 we removed some redundant verbiage from our Android item templates.  Now a complete XA build produces generated file changes, leaving us with a dirty local tree.

Commit the updated generated EN localization string files.