### PR TITLE
[ci] Don't auto-retry APK test suites.

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -10,7 +10,6 @@ parameters:
   artifactSource: ""
   artifactFolder: ""
   condition: succeeded()
-  retryCountOnTaskFailure: 1
 
 steps:
 - template: /build-tools/automation/yaml-templates/run-dotnet-preview.yaml
@@ -25,7 +24,6 @@ steps:
       -v:n -c ${{ parameters.configuration }} ${{ parameters.extraBuildArgs }}
     condition: ${{ parameters.condition }}
     continueOnError: true
-    retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}
 
 - script: >
     DEST="$(Build.StagingDirectory)/Test${{ parameters.configuration }}/${{ parameters.artifactFolder }}/" &&


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8687

In https://github.com/xamarin/xamarin-android/pull/7963, we added an automatic retry mechanism to the APK test suites.  However this mechanism does not give us a chance to run any tasks between the retry.  

This means that when the tests are run a second time the output directories have not been cleaned and thus we are running incremental builds instead of full builds.  We could unknowingly have tests that always fail on a clean build and succeed on an incremental build.

Thus we are going to remove the automatic retries.  The good news is these test suites seem to be much more stable now than when we implemented the retries, so hopefully this will not result in too many flaky CI builds.