### PR TITLE
[NET8] Fix assembly count when satellite assemblies are present

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -262,9 +262,16 @@ namespace Xamarin.Android.Tasks
 			HashSet<string> archAssemblyNames = null;
 			HashSet<string> uniqueAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 			Action<ITaskItem> updateAssemblyCount = (ITaskItem assembly) => {
-				// We need to use the 'RelativePath' metadata, if found, because it will give us the correct path for satellite assemblies - with the culture in the path.
-				string? relativePath = assembly.GetMetadata ("RelativePath");
-				string assemblyName = String.IsNullOrEmpty (relativePath) ? Path.GetFileName (assembly.ItemSpec) : relativePath;
+				string? culture = MonoAndroidHelper.GetAssemblyCulture (assembly);
+				string fileName = Path.GetFileName (assembly.ItemSpec);
+				tring assemblyName;
+
+				if (String.IsNullOrEmpty (culture)) {
+					assemblyName = fileName;
+				} else {
+					assemblyName = $"{culture}/{fileName}";
+				}
+
 				if (!uniqueAssemblyNames.Contains (assemblyName)) {
 					uniqueAssemblyNames.Add (assemblyName);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -264,7 +264,7 @@ namespace Xamarin.Android.Tasks
 			Action<ITaskItem> updateAssemblyCount = (ITaskItem assembly) => {
 				string? culture = MonoAndroidHelper.GetAssemblyCulture (assembly);
 				string fileName = Path.GetFileName (assembly.ItemSpec);
-				tring assemblyName;
+				string assemblyName;
 
 				if (String.IsNullOrEmpty (culture)) {
 					assemblyName = fileName;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -643,5 +643,37 @@ namespace Xamarin.Android.Tasks
 			string relPath = GetToolsRootDirectoryRelativePath (androidBinUtilsDirectory);
 			return Path.GetFullPath (Path.Combine (androidBinUtilsDirectory, relPath, "lib"));
 		}
+
+		public static string? GetAssemblyCulture (ITaskItem assembly)
+		{
+			// The best option
+			string? culture = assembly.GetMetadata ("Culture");
+			if (!String.IsNullOrEmpty (culture)) {
+				return TrimSlashes (culture);
+			}
+
+			// ...slightly worse
+			culture = assembly.GetMetadata ("RelativePath");
+			if (!String.IsNullOrEmpty (culture)) {
+				return TrimSlashes (Path.GetDirectoryName (culture));
+			}
+
+			// ...not ideal
+			culture = assembly.GetMetadata ("DestinationSubDirectory");
+			if (!String.IsNullOrEmpty (culture)) {
+				return TrimSlashes (culture);
+			}
+
+			return null;
+
+			string? TrimSlashes (string? s)
+			{
+				if (String.IsNullOrEmpty (s)) {
+					return null;
+				}
+
+				return s.TrimEnd ('/').TrimEnd ('\\');
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8790

The old method of satellite assembly counting relied on the 
`RelativePath` MSBuild item metadata, which appears to have gone
missing somewhere in .NET8+.  Update the code to check for presence
of the following metadata, in order given, to determine assembly's
culture, if any:

  * `Culture`
  * `RelativePath`
  * `DestinationSubDirectory`

Failure to count satellite assemblies can, and sometimes will,
result in a segfault since we generate a number of native code
arrays based on the assembly count and the runtime assumes that
what the build told it is true.