### PR TITLE
[ci] Use managed identity for ApiScan

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -335,7 +335,7 @@ stages:
         isLargeApp: true
         toolVersion: Latest
       env:
-        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
 
     - task: SdtReport@2
       displayName: Guardian Export - Security Report

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -283,7 +283,7 @@ stages:
 
 - stage: compliance_scan
   displayName: Compliance
-  #dependsOn: mac_build
+  dependsOn: []
   #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   jobs:
   - job: api_scan

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -283,8 +283,8 @@ stages:
 
 - stage: compliance_scan
   displayName: Compliance
-  dependsOn: []
-  #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  dependsOn: mac_build
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   jobs:
   - job: api_scan
     displayName: API Scan
@@ -295,36 +295,31 @@ stages:
     workspace:
       clean: all
     steps:
-    #- template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
-    #  parameters:
-    #    installApkDiff: false
+    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
+      parameters:
+        installApkDiff: false
 
-    #- task: DownloadPipelineArtifact@2
-    #  displayName: Download binutils pdbs
-    #  inputs:
-    #    artifactName: $(WindowsToolchainPdbArtifactName)
-    #    downloadPath: $(Build.StagingDirectory)\binutils-pdb
+    - task: DownloadPipelineArtifact@2
+      displayName: Download binutils pdbs
+      inputs:
+        artifactName: $(WindowsToolchainPdbArtifactName)
+        downloadPath: $(Build.StagingDirectory)\binutils-pdb
 
-    #- powershell: |
-    #    Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(System.DefaultWorkingDirectory)\binutils-pdb"
-    #    Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
-    #  displayName: Extract binutils pdbs
+    - powershell: |
+        Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(System.DefaultWorkingDirectory)\binutils-pdb"
+        Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
+      displayName: Extract binutils pdbs
 
-    ### Copy .dll, .exe, .pdb files for APIScan
-    #- task: CopyFiles@2
-    #  displayName: Collect Files for APIScan
-    #  inputs:
-    #    Contents: |
-    #      $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
-    #      $(System.DefaultWorkingDirectory)\binutils-pdb\*.pdb
-    #    TargetFolder: $(Build.StagingDirectory)\apiscan
-    #    OverWrite: true
-    #    flattenFolders: true
-
-    - pwsh: |
-        mkdir $(Build.StagingDirectory)\apiscan
-        New-Item $(Build.StagingDirectory)\apiscan\dummy.dll
-      displayName: create invalid file
+    ## Copy .dll, .exe, .pdb files for APIScan
+    - task: CopyFiles@2
+      displayName: Collect Files for APIScan
+      inputs:
+        Contents: |
+          $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
+          $(System.DefaultWorkingDirectory)\binutils-pdb\*.pdb
+        TargetFolder: $(Build.StagingDirectory)\apiscan
+        OverWrite: true
+        flattenFolders: true
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -335,7 +335,7 @@ stages:
         isLargeApp: true
         toolVersion: Latest
       env:
-        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTMangedId)
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTManagedId)
 
     - task: SdtReport@2
       displayName: Guardian Export - Security Report

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -310,7 +310,7 @@ stages:
         Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
       displayName: Extract binutils pdbs
 
-    ## Copy .dll, .exe, .pdb files for APIScan
+    ### Copy .dll, .exe, .pdb files for APIScan
     - task: CopyFiles@2
       displayName: Collect Files for APIScan
       inputs:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -283,8 +283,8 @@ stages:
 
 - stage: compliance_scan
   displayName: Compliance
-  dependsOn: mac_build
-  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  #dependsOn: mac_build
+  #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   jobs:
   - job: api_scan
     displayName: API Scan
@@ -295,31 +295,36 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
-      parameters:
-        installApkDiff: false
+    #- template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
+    #  parameters:
+    #    installApkDiff: false
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download binutils pdbs
-      inputs:
-        artifactName: $(WindowsToolchainPdbArtifactName)
-        downloadPath: $(Build.StagingDirectory)\binutils-pdb
+    #- task: DownloadPipelineArtifact@2
+    #  displayName: Download binutils pdbs
+    #  inputs:
+    #    artifactName: $(WindowsToolchainPdbArtifactName)
+    #    downloadPath: $(Build.StagingDirectory)\binutils-pdb
 
-    - powershell: |
-        Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(System.DefaultWorkingDirectory)\binutils-pdb"
-        Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
-      displayName: Extract binutils pdbs
+    #- powershell: |
+    #    Expand-Archive "$(Build.StagingDirectory)\binutils-pdb\$(WindowsToolchainPdbArtifactName).zip" "$(System.DefaultWorkingDirectory)\binutils-pdb"
+    #    Get-ChildItem -Path "$(System.DefaultWorkingDirectory)\binutils-pdb" -Recurse
+    #  displayName: Extract binutils pdbs
 
     ### Copy .dll, .exe, .pdb files for APIScan
-    - task: CopyFiles@2
-      displayName: Collect Files for APIScan
-      inputs:
-        Contents: |
-          $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
-          $(System.DefaultWorkingDirectory)\binutils-pdb\*.pdb
-        TargetFolder: $(Build.StagingDirectory)\apiscan
-        OverWrite: true
-        flattenFolders: true
+    #- task: CopyFiles@2
+    #  displayName: Collect Files for APIScan
+    #  inputs:
+    #    Contents: |
+    #      $(System.DefaultWorkingDirectory)\bin\$(XA.Build.Configuration)\dotnet\packs\Microsoft.Android*\**\?(*.dll|*.exe|*.pdb)
+    #      $(System.DefaultWorkingDirectory)\binutils-pdb\*.pdb
+    #    TargetFolder: $(Build.StagingDirectory)\apiscan
+    #    OverWrite: true
+    #    flattenFolders: true
+
+    - pwsh: |
+        mkdir $(Build.StagingDirectory)\apiscan
+        New-Item $(Build.StagingDirectory)\apiscan\dummy.dll
+      displayName: create invalid file
 
     - pwsh: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
       displayName: List Files for APIScan

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -289,8 +289,8 @@ stages:
   - job: api_scan
     displayName: API Scan
     pool:
-      name: Azure Pipelines
-      vmImage: windows-2022
+      name: MAUI-1ESPT
+      demands: ImageOverride -equals $(WindowsPoolImage1ESPT)
     timeoutInMinutes: 480
     workspace:
       clean: all
@@ -340,7 +340,7 @@ stages:
         isLargeApp: true
         toolVersion: Latest
       env:
-        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+        AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTMangedId)
 
     - task: SdtReport@2
       displayName: Guardian Export - Security Report


### PR DESCRIPTION
I've configured a new [managed identity][0] (MSI) for API Scan, which
allows us to enable a more modern authentication approach when running
API Scan on the `MAUI-1ESPT` agent pool.

A new `$(ApiScanMAUI1ESPTManagedId)` variable has been configured in the
pipeline settings to pass the app ID for this MSI to the API Scan task.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourcegroups/1esobjects/providers/microsoft.managedidentity/userassignedidentities/maui1esptapiscanidentity/overview