### PR TITLE
Bump 'NuGet.*' and 'Newtonsoft.Json' NuGet versions.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,7 +44,7 @@
     <LibZipSharpVersion>3.1.1</LibZipSharpVersion>
     <MicroBuildCoreVersion>1.0.0</MicroBuildCoreVersion>
     <MonoCecilVersion>0.11.4</MonoCecilVersion>
-    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+    <NewtonsoftJsonPackageVersion>13.0.3</NewtonsoftJsonPackageVersion>
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
     <LZ4PackageVersion>1.1.11</LZ4PackageVersion>
     <MonoOptionsVersion>6.12.0.148</MonoOptionsVersion>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" />
-    <PackageReference Include="NuGet.Common" Version="6.7.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
+    <PackageReference Include="NuGet.Common" Version="6.9.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -28,8 +28,6 @@
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" />
-    <PackageReference Include="NuGet.Common" Version="6.9.1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.9.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />


### PR DESCRIPTION
Update `NuGet.ProjectModel` to the latest version.  This new version requires a newer version of `Newtonsoft.Json`, so update to the latest of it as well.

Remove unneeded NuGet PackageReferences.