### PR TITLE
[Xamarin.Android.Build.Tasks] Bump to NuGet 6.7.1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" />
-    <PackageReference Include="NuGet.Common" Version="6.7.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
+    <PackageReference Include="NuGet.Common" Version="6.7.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.7.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemIOHashingPackageVersion)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/security/dependabot/1

Bumps NuGet.Packaging and related packages from version 6.7.0 to 6.7.1
to address a security issue.