### PR TITLE
[release/8.0.2xx] [Xamarin.Android.Build.Tasks] DTBs should not rm generator output

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.Core.targets
@@ -33,23 +33,31 @@ It is shared between "legacy" binding projects and .NET 5 projects.
     <NoWarn Condition=" '$(DocumentationFile)' != '' ">$(NoWarn);CS1573;CS1591</NoWarn>
   </PropertyGroup>
 
+  <Target Name="_CollectLibrariesToBind" DependsOnTargets="_CategorizeAndroidLibraries">
+    <ItemGroup>
+      <_LibrariesToBind  Include="@(EmbeddedJar)" />
+      <_LibrariesToBind  Include="@(InputJar)" />
+      <_LibrariesToBind  Include="@(LibraryProjectZip)" />
+      <_LibrariesToBind  Include="@(_JavaBindingSource)" Condition=" '%(_JavaBindingSource.Bind)' == 'true' "/>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_SetAndroidGenerateManagedBindings"
-      Condition=" '@(InputJar->Count())' != '0' Or '@(EmbeddedJar->Count())' != '0' Or '@(LibraryProjectZip->Count())' != '0' Or '@(_JavaBindingSource->Count())' != '0' ">
+      Condition=" '@(_LibrariesToBind->Count())' != '0' ">
     <PropertyGroup>
       <!-- Used throughout to determine if C# binding-related targets should skip -->
       <_AndroidGenerateManagedBindings>true</_AndroidGenerateManagedBindings>
     </PropertyGroup>
   </Target>
 
-  <Target Name="_CollectGeneratedManagedBindingFiles">
+  <Target Name="_CollectGeneratedManagedBindingFiles" AfterTargets="GenerateBindings">
     <ItemGroup>
       <_GeneratedManagedBindingFiles Include="$(GeneratedOutputPath)**\*.cs" />
     </ItemGroup>
   </Target>
 
   <Target Name="_ClearGeneratedManagedBindings"
-      Condition=" '@(InputJar->Count())' == '0' And '@(EmbeddedJar->Count())' == '0' And '@(LibraryProjectZip->Count())' == '0' And '@(_JavaBindingSource->Count())' == '0' "
-      DependsOnTargets="_CollectGeneratedManagedBindingFiles"
+      Condition=" '@(_LibrariesToBind->Count())' == '0' And '$(DesignTimeBuild)' != 'True' "
   >
     <Delete Files="@(_GeneratedManagedBindingFiles)" />
   </Target>
@@ -64,7 +72,6 @@ It is shared between "legacy" binding projects and .NET 5 projects.
 
   <Target Name="GenerateBindings"
       Condition=" '$(_AndroidGenerateManagedBindings)' == 'true' "
-      DependsOnTargets="ExportJarToXml;_ResolveMonoAndroidSdks"
       Inputs="$(ApiOutputFile);@(TransformFile);@(ReferencePath);@(ReferenceDependencyPaths);@(_AndroidMSBuildAllProjects)"
       Outputs="$(_GeneratorStampFile)">
 
@@ -123,14 +130,17 @@ It is shared between "legacy" binding projects and .NET 5 projects.
 
     <ItemGroup>
       <FileWrites Include="$(GeneratedOutputPath)**\*.cs" />
+      <FileWrites Include="$(GeneratedOutputPath)src\$(AssemblyName).projitems" />
       <FileWrites Include="$(_GeneratorStampFile)" />
     </ItemGroup>
+
+    <!-- Read the file list. -->
 
   </Target>
 
   <Target Name="AddBindingsToCompile"
       Condition=" '$(_AndroidGenerateManagedBindings)' == 'true' Or '@(_GeneratedManagedBindingFiles->Count())' != '0' "
-      DependsOnTargets="GenerateBindings;_CollectGeneratedManagedBindingFiles">
+    >
     <!-- bindings need AllowUnsafeBlocks -->
     <PropertyGroup>
       <AllowUnsafeBlocks Condition=" '$(AllowUnsafeBlocks)' != 'true' ">true</AllowUnsafeBlocks>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Javac.targets
@@ -21,7 +21,9 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <_AndroidIntermediateBindingClassesZip>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName).jar</_AndroidIntermediateBindingClassesZip>
     <_AndroidIntermediateBindingClassesDocs>$(IntermediateOutputPath)binding\bin\$(MSBuildProjectName)-docs.xml</_AndroidIntermediateBindingClassesDocs>
     <_AndroidCompileJavaStampFile>$(_AndroidStampDirectory)_CompileJava.stamp</_AndroidCompileJavaStampFile>
+    <_AndroidCompileJavaFileList>$(IntermediateOutputPath)_CompileJava.FileList.txt</_AndroidCompileJavaFileList>
     <_AndroidCompileBindingJavaStampFile>$(_AndroidStampDirectory)_CompileBindingJava.stamp</_AndroidCompileBindingJavaStampFile>
+    <_AndroidCompileBindingJavaFileList>$(IntermediateOutputPath)_CompileBindingJava.FileList.txt</_AndroidCompileBindingJavaFileList>
   </PropertyGroup>
 
   <Target Name="_AdjustJavacVersionArguments">
@@ -74,18 +76,36 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
     <ItemGroup>
       <_JavaBindingSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' == 'True' " />
     </ItemGroup>
+    <WriteLinesToFile
+        File="$(_AndroidCompileBindingJavaFileList)"
+        Lines="@(_JavaBindingSource->ToLowerInvariant())"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidCompileBindingJavaFileList)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CollectJavaSource">
     <ItemGroup>
       <_JavaSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' != 'True' " />
     </ItemGroup>
+   <WriteLinesToFile
+        File="$(_AndroidCompileJavaFileList)"
+        Lines="@(_JavaSource->ToLowerInvariant())"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidCompileJavaFileList)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CompileBindingJava"
       Condition=" '@(_JavaBindingSource->Count())' != '0' "
       DependsOnTargets="$(_CompileBindingJavaDependsOnTargets)"
-      Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaBindingSource)"
+      Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidCompileBindingJavaFileList);$(MonoPlatformJarPath);@(_JavaBindingSource)"
       Outputs="$(_AndroidCompileBindingJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
@@ -132,7 +152,7 @@ It is shared between "legacy" binding projects and .NET 7+ projects.
 
   <Target Name="_CompileJava"
     DependsOnTargets="$(_CompileJavaDependsOnTargets);_CollectJavaSource"
-    Inputs="@(_AndroidMSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(_JavaSource)"
+    Inputs="@(_AndroidMSBuildAllProjects);$(_AndroidCompileJavaFileList);$(MonoPlatformJarPath);@(_JavaStubFiles);@(_JavaSource)"
     Outputs="$(_AndroidCompileJavaStampFile)">
 
     <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -117,9 +117,6 @@ properties that determine build ordering.
       UpdateAndroidResources;
       _BuildResourceDesigner;
       UpdateAndroidInterfaceProxies;
-      _SetAndroidGenerateManagedBindings;
-      _ClearGeneratedManagedBindings;
-      AddBindingsToCompile;
       _CheckForInvalidDesignerConfig;
     </ResolveReferencesDependsOn>
     <DesignTimeResolveAssemblyReferencesDependsOn>
@@ -141,6 +138,13 @@ properties that determine build ordering.
       _AddAndroidDefines;
       _IncludeLayoutBindingSources;
       AddLibraryJarsToBind;
+      _CollectLibrariesToBind;
+      _SetAndroidGenerateManagedBindings;
+      ExportJarToXml;
+      GenerateBindings;
+      _CollectGeneratedManagedBindingFiles;
+      _ClearGeneratedManagedBindings;
+      AddBindingsToCompile;
       _BuildResourceDesigner;
       _AddResourceDesignerFiles;
       $(CompileDependsOn);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.XPath;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Microsoft.Android.Build.Tasks;
 
 namespace Xamarin.Android.Tasks

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.OtherBuildItems.Add (new BuildItem ("JavaSourceJar", "javaclasses-sources.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestSourcesJar,
 			});
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
+			proj.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
 				Encoding = Encoding.ASCII,
 				TextContent = () => ResourceData.JavaSourceTestExtension,
 				Metadata = { { "Bind", "True"} },
@@ -74,6 +74,7 @@ namespace Xamarin.Android.Build.Tests
 				"GenerateBindings",
 				"_ResolveLibraryProjectImports",
 				"CoreCompile",
+				"_ClearGeneratedManagedBindings",
 			};
 			if (Builder.UseDotNet) {
 				targets.Add ("_CreateAar");
@@ -119,6 +120,23 @@ namespace Xamarin.Android.Build.Tests
 				foreach (var target in targets) {
 					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped on second build!");
 				}
+
+				Assert.IsTrue (b.DesignTimeBuild (proj, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
+				var cs_file = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "generated", "src", "Com.Larvalabs.Svgandroid.SVGParser.cs");
+				FileAssert.Exists (cs_file);
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "third build should succeed");
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped on second build!");
+				}
+				// Fast Update Check Build
+				Assert.IsTrue (b.DesignTimeBuild (proj, target: "PrepareResources;_GenerateCompileInputs"), "DTB should have succeeded.");
+				cs_file = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "generated", "src", "Com.Larvalabs.Svgandroid.SVGParser.cs");
+				FileAssert.Exists (cs_file);
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "forth build should succeed");
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped on second build!");
+				}
+
 			}
 		}
 
@@ -726,6 +744,10 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 				StringAssertEx.ContainsText (File.ReadAllLines (generatedIface), "string GreetWithQuestion (string name, global::Java.Util.Date date, string question);");
 				Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
 				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava"), $"`_CompileBindingJava` should be skipped on second build!");
+				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings"), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on second build.");
+				Assert.IsTrue (libBuilder.DesignTimeBuild (lib, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on DTB build.");
 				Assert.IsTrue (appBuilder.Build (app), "App build should have succeeded.");
 				appBuilder.Target = "SignAndroidPackage";
 				Assert.IsTrue (appBuilder.Build (app), "App SignAndroidPackage should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.OtherBuildItems.Add (new BuildItem ("JavaSourceJar", "javaclasses-sources.jar") {
 				BinaryContent = () => ResourceData.JavaSourceJarTestSourcesJar,
 			});
-			proj.OtherBuildItems.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
+			proj.AndroidJavaSources.Add (new AndroidItem.AndroidJavaSource ("JavaSourceTestExtension.java") {
 				Encoding = Encoding.ASCII,
 				TextContent = () => ResourceData.JavaSourceTestExtension,
 				Metadata = { { "Bind", "True"} },
@@ -1579,7 +1579,7 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
-				OtherBuildItems = {
+				AndroidJavaSources = {
 					new BuildItem (AndroidBuildActions.AndroidJavaSource, "ToolbarEx.java") {
 						TextContent = () => @"package com.unnamedproject.unnamedproject;
 import android.content.Context;
@@ -1624,11 +1624,11 @@ public class ToolbarEx {
 		public void CheckJavaError ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
 				TextContent = () => "public classo TestMe { }",
 				Encoding = Encoding.ASCII
 			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe2.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe2.java") {
 				TextContent = () => "public class TestMe2 {" +
 					"public vod Test ()" +
 					"}",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1149,14 +1149,14 @@ namespace UnamedProject
 		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 		{
 			var proj = new XamarinAndroidApplicationProject (debugConfigurationName, releaseConfigurationName);
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
 				TextContent = () => "public class ManyMethods { \n"
 					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
 					+ "}",
 				Encoding = Encoding.ASCII,
 				Metadata = { { "Bind", "False "}},
 			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
+			proj.AndroidJavaSources.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
 				TextContent = () => "public class ManyMethods2 { \n"
 					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
 					+ "}",
@@ -1229,8 +1229,8 @@ namespace UnamedProject
 				}
 
 				//Now build project again after it no longer requires multidex, remove the *HUGE* AndroidJavaSource build items
-				while (proj.OtherBuildItems.Count > 1)
-					proj.OtherBuildItems.RemoveAt (proj.OtherBuildItems.Count - 1);
+				while (proj.AndroidJavaSources.Count > 1)
+					proj.AndroidJavaSources.RemoveAt (proj.AndroidJavaSources.Count - 1);
 				proj.SetProperty ("AndroidEnableMultiDex", "False");
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -52,9 +52,9 @@ namespace Xamarin.ProjectTools
 			return File.ReadLines (path).ToList ();
 		}
 
-		public bool IsTargetSkipped (string target) => IsTargetSkipped (Builder.LastBuildOutput, target);
+		public bool IsTargetSkipped (string target, bool defaultIfNotUsed = false) => IsTargetSkipped (Builder.LastBuildOutput, target, defaultIfNotUsed);
 
-		public static bool IsTargetSkipped (IEnumerable<string> output, string target)
+		public static bool IsTargetSkipped (IEnumerable<string> output, string target, bool defaultIfNotUsed = false)
 		{
 			bool found = false;
 			foreach (var line in output) {
@@ -69,7 +69,7 @@ namespace Xamarin.ProjectTools
 					if (found)
 						return true;
 			}
-			return false;
+			return defaultIfNotUsed;
 		}
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -17,10 +17,12 @@ namespace Xamarin.ProjectTools
 
 			Sources = new List<BuildItem> ();
 			OtherBuildItems = new List<BuildItem> ();
+			AndroidJavaSources = new List<BuildItem> ();
 
 			ItemGroupList.Add (References);
 			ItemGroupList.Add (OtherBuildItems);
 			ItemGroupList.Add (Sources);
+			ItemGroupList.Add (AndroidJavaSources);
 
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
@@ -60,6 +62,7 @@ namespace Xamarin.ProjectTools
 
 		public IList<BuildItem> OtherBuildItems { get; private set; }
 		public IList<BuildItem> Sources { get; private set; }
+		public IList<BuildItem> AndroidJavaSources { get; private set; }
 
 		public IList<Property> ActiveConfigurationProperties {
 			get { return IsRelease ? ReleaseProperties : DebugProperties; }

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -632,5 +632,73 @@ namespace Xamarin.Android.Build.Tests
 			var after = File.GetLastWriteTimeUtc (apkset);
 			Assert.AreNotEqual (before, after, $"{apkset} should change!");
 		}
+
+		[Test]
+		public void AppWithAndroidJavaSource ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var itemToDelete = new AndroidItem.AndroidJavaSource ("TestJavaClass2.java") {
+				Encoding = Encoding.ASCII,
+				TextContent = () => @"package com.test.java;
+
+public class TestJavaClass2 {
+
+	public String test(){
+		
+		return ""Java is called"";
+	}
+}",
+				Metadata = {
+					{ "Bind", "True" },
+				},
+			};
+			var proj = new XamarinAndroidApplicationProject {
+				EnableDefaultItems = true,
+				AndroidJavaSources = {
+					new AndroidItem.AndroidJavaSource ("TestJavaClass.java") {
+						Encoding = Encoding.ASCII,
+						TextContent = () => @"package com.test.java;
+
+public class TestJavaClass {
+
+	public String test(){
+		
+		return ""Java is called"";
+	}
+}",
+						Metadata = {
+							{ "Bind", "True" },
+						},
+					},
+					itemToDelete,
+				},
+			};
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				b.AssertHasNoWarnings ();
+				var generatedCode = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"generated", "src", "Com.Test.Java.TestJavaClass.cs");
+				var generatedCode2 = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"generated", "src", "Com.Test.Java.TestJavaClass2.cs");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have been generated.");
+				FileAssert.Exists (generatedCode2, $"'{generatedCode2}' should have been generated.");
+				Assert.IsTrue (b.DesignTimeBuild (proj, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on DTB build!");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on DTB build.");
+				FileAssert.Exists (generatedCode2, $"'{generatedCode2}' should have not be deleted on DTB build.");
+				proj.AndroidJavaSources.Remove (itemToDelete);
+				File.Delete (Path.Combine (Root, b.ProjectDirectory, itemToDelete.Include ()));
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on second build.");
+				FileAssert.DoesNotExist (generatedCode2, $"'{generatedCode2}' should have be deleted on second build.");
+				Assert.IsFalse (b.Output.IsTargetSkipped ("_CompileBindingJava"), $"`_CompileBindingJava` should run on second build!");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings"), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
+				// Call Install directly so Build does not get called automatically
+				Assert.IsTrue (b.RunTarget (proj, "Install", doNotCleanupOnUpdate: true, saveProject: false), "Install build should have succeeded.");
+				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on Install build.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on Install build!");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-android/pull/8706

Fixes: https://github.com/xamarin/xamarin-android/issues/8658
Fixes: https://github.com/xamarin/xamarin-android/issues/8698

Design-time builds don't play nicely with binding project builds:

	% dotnet new androidlib
	% cat > Example.java <<EOF
	package e;

	public class Example {
	    public static void e() {
	    }
	}
	EOF
	% dotnet build -p:DesignTimeBuild=true -v:diag

After this initial Design-Time build, we have the following generated source code for the binding:

	% find obj -iname \*.cs | xargs ls -l
	-rw-r--r--  1 user staff   197 Mar 25 19:22 obj/Debug/net8.0-android/.NETCoreApp,Version=v8.0.AssemblyAttributes.cs
	-rw-r--r--  1 user staff   441 Mar 25 19:22 obj/Debug/net8.0-android/__Microsoft.Android.Resource.Designer.cs
	-rw-r--r--  1 user staff  2975 Mar 25 19:22 obj/Debug/net8.0-android/generated/src/E.Example.cs
	-rw-r--r--  1 user staff  1518 Mar 25 19:22 obj/Debug/net8.0-android/generated/src/Java.Interop.__TypeRegistrations.cs
	-rw-r--r--  1 user staff   696 Mar 25 19:22 obj/Debug/net8.0-android/generated/src/__NamespaceMapping__.cs
	-rw-r--r--  1 user staff  1094 Mar 25 19:22 obj/Debug/net8.0-android/gxa-8706.AssemblyInfo.cs
	-rw-r--r--  1 user staff   407 Mar 25 19:22 obj/Debug/net8.0-android/gxa-8706.GlobalUsings.g.cs

Run a Design-Time build *again*:

	% dotnet build -p:DesignTimeBuild=true -v:diag

…and we're now missing files (?!):

	% find obj -iname \*.cs | xargs ls -l
	-rw-r--r--  1 user staff   197 Mar 25 19:22 obj/Debug/net8.0-android/.NETCoreApp,Version=v8.0.AssemblyAttributes.cs
	-rw-r--r--  1 user staff   441 Mar 25 19:22 obj/Debug/net8.0-android/__Microsoft.Android.Resource.Designer.cs
	-rw-r--r--  1 user staff  1094 Mar 25 19:22 obj/Debug/net8.0-android/gxa-8706.AssemblyInfo.cs
	-rw-r--r--  1 user staff   407 Mar 25 19:22 obj/Debug/net8.0-android/gxa-8706.GlobalUsings.g.cs

In particular, `$(IntermediateOutputPath)generated/*/**.cs` is gone, including `E.Example.cs`!

The result of this is that Design-Time builds and "normal" builds "fight" each other, constantly generating and deleting files, slowing down incremental builds.

The root of the problem is the `_ClearGeneratedManagedBindings` target: It was designed to clean out the `generated` folder in the case where no binding libraries were present.  However, it turns out it was running during a design time build!  During design time builds the binding library item groups are not evaluated, so the `_ClearGeneratedManagedBindings` target would run, deleting everything.

Fix this by ensuring we only run the `_ClearGeneratedManagedBindings` target in in "standard"/*non*-Design-Time builds.