### PR TITLE
[Xamarin.Android.Build.Tasks] Update to newer ILRepack which supports debug files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="ILRepack" Version="2.0.18" />
+    <PackageReference Include="ILRepack" Version="2.0.28" />
     <PackageReference Include="Irony" />
     <PackageReference Include="NuGet.Common" Version="6.7.1" />
     <PackageReference Include="NuGet.Packaging" Version="6.7.1" />


### PR DESCRIPTION
`ILRepack` has a new (Microsoft) maintainer who is working on modernizing it.  This includes updating to a newer version of `Mono.Cecil` which supports `portable` and `embedded` debug symbols:

https://github.com/gluck/il-repack/pull/333

Updating to the latest version should fix our issue about being unable to debug `Xamarin.Android.Build.Tasks` or get full stack traces.