### PR TITLE
[release/8.0.2xx] [build] keep $(DotNetAndroidManifestVersionBand) on 8.0.100

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,6 +22,6 @@
     <DotNetMonoManifestVersionBand>8.0.100</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>8.0.100</DotNetEmscriptenManifestVersionBand>
     <!-- NOTE: sometimes we hardcode this when transitioning to new version bands -->
-    <DotNetAndroidManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetAndroidManifestVersionBand>
+    <DotNetAndroidManifestVersionBand>8.0.100</DotNetAndroidManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,11 +17,11 @@
     <!-- Match the first three version numbers and append 00 -->
     <VersionBand Condition=" '$(VersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</VersionBand>
     <VersionSuffixRegex>\-(preview|rc|alpha).\d+</VersionSuffixRegex>
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$(VersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), $(VersionSuffixRegex)))</DotNetPreviewVersionBand>
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">8.0.100</DotNetPreviewVersionBand>
     <DotNetSdkManifestsFolder>$(DotNetPreviewVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMonoManifestVersionBand>8.0.100</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>8.0.100</DotNetEmscriptenManifestVersionBand>
     <!-- NOTE: sometimes we hardcode this when transitioning to new version bands -->
-    <DotNetAndroidManifestVersionBand>8.0.100</DotNetAndroidManifestVersionBand>
+    <DotNetAndroidManifestVersionBand>$(DotNetPreviewVersionBand)</DotNetAndroidManifestVersionBand>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/2ff1a5f67d6da4ebac507a1b248809388f23e7c7/eng/Versions.props#L15

As we moved to the .NET 8.0.200 SDK, we inadvertently changed the version band of the Android workload:

    Microsoft.NET.Sdk.Android.Manifest-8.0.200

This would prevent 8.0.100 .NET SDKs from using the latest Android workload.

Pin `$(DotNetAndroidManifestVersionBand)` to 8.0.100 to fix this.