### PR TITLE
Bump to xamarin/monodroid/release/8.0.1xx@d627218f1

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:release/8.0.1xx@7edfb4a9c1daa49216d193db6aa8b986483cf5fa
+xamarin/monodroid:release/8.0.1xx@d627218f1e1d0c1e501e2cc36609deb0b09d30aa
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/7edfb4a9c1daa49216d193db6aa8b986483cf5fa...d627218f1e1d0c1e501e2cc36609deb0b09d30aa

  * xamarin/monodroid@d627218f1: Bump to xamarin/android-sdk-installer/release/8.0.1xx@a6a2702a (xamarin/monodroid#1453)

Update the `InstallAndroidDependencies` target to use the `ANDROID_HOME` environment variable by default, if set:

	% export ANDROID_HOME=path/to/android/sdk
	% dotnet build -t:InstallAndroidDependencies -f:net8.0-android \
	  -p:JavaSdkDirectory="<JavaSdkPath>" \
	  -p:AcceptAndroidSDKLicenses=True
	# provisions the Android SDK at $ANDROID_HOME