### PR TITLE
Bump to xamarin/monodroid@fefc158ef3

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@77124dc16985a92077e62b0cfeaeb007c4d4fd2a
+xamarin/monodroid:main@fefc158ef36d056249e8775df4e5d409a70119e2


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/77124dc16985a92077e62b0cfeaeb007c4d4fd2a...fefc158ef36d056249e8775df4e5d409a70119e2

  * xamarin/monodroid@fefc158ef: Bump external/android-sdk-installer from `c3daec9` to `852ad3f`
  * xamarin/monodroid@809228010: Bump tools/msbuild/external/androidtools from `863a2cb` to `683b844`
  * xamarin/monodroid@3f9d1b502: Bump external/xamarin-android from `9f548d5` to `378b492`
  * xamarin/monodroid@20cacb191: Bump external/xamarin-android from `4d1fca7` to `9f548d5`
  * xamarin/monodroid@db24ae03d: Bump tools/msbuild/external/androidtools from `7818dc5` to `863a2cb`
  * xamarin/monodroid@98cf75626: Bump external/android-sdk-installer from `438cf89` to `c3daec9`