### PR TITLE
Bumps LLVM to v18.1.3 and XA utils version to 8.0.0

### DIFF
--- a/build-tools/installers/unix-binutils.projitems
+++ b/build-tools/installers/unix-binutils.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Linux' ">so.18</_LlvmLibExtension>
+    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Linux' ">so.18.1</_LlvmLibExtension>
     <_LlvmLibExtension Condition=" '$(HostOS)' == 'Darwin' ">dylib</_LlvmLibExtension>
   </PropertyGroup>
 

--- a/build-tools/installers/unix-binutils.projitems
+++ b/build-tools/installers/unix-binutils.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Linux' ">so.17</_LlvmLibExtension>
+    <_LlvmLibExtension Condition=" '$(HostOS)' == 'Linux' ">so.18</_LlvmLibExtension>
     <_LlvmLibExtension Condition=" '$(HostOS)' == 'Darwin' ">dylib</_LlvmLibExtension>
   </PropertyGroup>
 
@@ -62,8 +62,10 @@
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMDebugInfoPDB.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMDemangle.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMExtensions.$(_LlvmLibExtension)" />
+    <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMFrontendOffloading.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMFrontendOpenMP.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMGlobalISel.$(_LlvmLibExtension)" />
+    <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMHipStdPar.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMInstCombine.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMInstrumentation.$(_LlvmLibExtension)" />
     <_BinUtilsFilesUnixSign Include="$(MicrosoftAndroidSdkOutDir)$(HostOS)\binutils\lib\libLLVMipo.$(_LlvmLibExtension)" />

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "L_17.0.6-7.2.1";
+		const string BinutilsVersion                = "L_18.1.2-8.0.0";
 
 		const string MicrosoftOpenJDK17Version      = "17.0.8";
 		const string MicrosoftOpenJDK17Release      = "17.0.8.7";

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "L_18.1.2-8.0.0";
+		const string BinutilsVersion                = "L_18.1.3-8.0.0";
 
 		const string MicrosoftOpenJDK17Version      = "17.0.8";
 		const string MicrosoftOpenJDK17Release      = "17.0.8.7";


### PR DESCRIPTION
Bumps LLVM to v18.1.3 and XA utils version to 8.0.0

Changes: https://discourse.llvm.org/t/llvm-18-1-0-released/77448
Changes: https://discourse.llvm.org/t/llvm-18-1-1-released/77540
Changes: https://discourse.llvm.org/t/18-1-2-released/77821
Changes: https://discourse.llvm.org/t/18-1-3-released/78136

Changes interesting for us:

   * AArch64 backend
      * Added support for Cortex-A520, Cortex-A720 and Cortex-X4 CPUs.
      * Assembler/disassembler support has been added for 2023 architecture extensions.
      * Support has been added for Stack Clash Protection. During function frame creation
         and dynamic stack allocations, the compiler will issue memory accesses at regular
         intervals so that a guard area at the top of the stack can’t be skipped over.
   * x86 backend
       * The i128 type now matches GCC and clang’s __int128 type. This mainly benefits external
          projects such as Rust which aim to be binary compatible with C, but also fixes code
          generation where LLVM already assumed that the type matched and called into libgcc
          helper functions.

**Full Changelog**: https://github.com/xamarin/xamarin-android-binutils/compare/L_17.0.6-7.2.1...L_18.1.3-8.0.0