### PR TITLE
Update THIRD-PARTY-NOTICES.txt generation code

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -13,9 +13,11 @@ The attached notices are provided for information only.
 
 1. android/platform/tools/base (https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE)
 2. bazelbuild/bazel (https://github.com/bazelbuild/bazel/)
-3. force-net/crc32.net (https://github.com/force-net/Crc32.NET)
-4. nunit/nunitlite (https://github.com/nunit/nunitlite/)
-5. tessil/robin-map (https://github.com/Tessil/robin-map)
+3. chys87/constexpr-xxh3 (https://github.com/chys87/constexpr-xxh3/)
+4. Cyan4973/xxHash (https://github.com/Cyan4973/xxHash/)
+5. force-net/crc32.net (https://github.com/force-net/Crc32.NET)
+6. nunit/nunitlite (https://github.com/nunit/nunitlite/)
+7. tessil/robin-map (https://github.com/Tessil/robin-map)
 
 %% android/platform/tools/base NOTICES AND INFORMATION BEGIN HERE
 =================================================================
@@ -433,6 +435,72 @@ END OF android/platform/tools/base NOTICES AND INFORMATION
 ======================================================
 END OF bazelbuild/bazel NOTICES AND INFORMATION
 
+%% chys87/constexpr-xxh3 NOTICES AND INFORMATION BEGIN HERE
+===========================================================
+BSD 2-Clause License
+
+constexpr-xxh3 - C++20 constexpr implementation of the XXH3 64-bit variant of xxHash
+Copyright (c) 2021-2023, chys <admin@chys.info> <chys87@github>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+===========================================================
+END OF chys87/constexpr-xxh3 NOTICES AND INFORMATION
+
+%% Cyan4973/xxHash NOTICES AND INFORMATION BEGIN HERE
+=====================================================
+xxHash Library
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+=====================================================
+END OF Cyan4973/xxHash NOTICES AND INFORMATION
+
 %% force-net/crc32.net NOTICES AND INFORMATION BEGIN HERE
 =========================================================
 The MIT License (MIT)
@@ -516,68 +584,3 @@ SOFTWARE.
 ======================================================
 END OF tessil/robin-map NOTICES AND INFORMATION
 
-%% chys87/constexpr-xxh3 NOTICES AND INFORMATION BEGIN HERE
-===========================================================
-
-BSD 2-Clause License
-
-constexpr-xxh3 - C++20 constexpr implementation of the XXH3 64-bit variant of xxHash
-Copyright (c) 2021-2023, chys <admin@chys.info> <chys87@github>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-======================================================
-END OF chys87/constexpr-xxh3 NOTICES AND INFORMATION
-
-%% Cyan4973/xxHash NOTICES AND INFORMATION BEGIN HERE
-=====================================================
-
-xxHash Library
-Copyright (c) 2012-2021 Yann Collet
-All rights reserved.
-
-BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-%% END OF Cyan4973/xxHash NOTICES AND INFORMATION
-=================================================

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/xxHash.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/xxHash.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	[TPN]
+	class constexpr_xxh3_TPN : ThirdPartyNotice
+	{
+		static readonly Uri url = new Uri ("https://github.com/chys87/constexpr-xxh3/");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.ExternalDir, "constexpr-xxh3", "LICENSE");
+
+		public override string LicenseFile => licenseFile;
+		public override string Name => "chys87/constexpr-xxh3";
+		public override Uri SourceUrl => url;
+		public override string LicenseText => String.Empty;
+
+		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeBuildDeps;
+	}
+
+	[TPN]
+	class xxHash_TPN : ThirdPartyNotice
+	{
+		static readonly Uri url = new Uri ("https://github.com/Cyan4973/xxHash/");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.ExternalDir, "xxHash", "LICENSE");
+
+		public override string LicenseFile => licenseFile;
+		public override string Name => "Cyan4973/xxHash";
+		public override Uri SourceUrl => url;
+		public override string LicenseText => String.Empty;
+
+		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeBuildDeps;
+	}
+}


### PR DESCRIPTION
Context: 0db28d3ff2f9852005eddbfc6ff8c9227f1a5474

0db28d3 added two new submodules and included their licenses directly in the `THIRD-PARTY-NOTICES.txt` file, but it failed to update the relevant `xaprepare` TPN generation code.  In effect, each local build would produce changes to `THIRD-PARTY-NOTICES.txt` file.

Update `xaprepare` to include licenses for the submodules added by 0db28d3