### PR TITLE
[ci] Update dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "external/apksig"
+      - dependency-name: "external/constexpr-xxh3"
       - dependency-name: "external/debugger-libs"
       - dependency-name: "external/lz4"
-      - dependency-name: "external/nrefactory"
-      - dependency-name: "external/opentk"
       - dependency-name: "external/robin-map"
-      - dependency-name: "external/sqlite"
+      - dependency-name: "external/xxHash"


### PR DESCRIPTION
Updates the list of submodules that dependabot ignores when checking for updates.  Repos which are no longer valid have been removed and recently added xxhash repos have been added to this list.