### PR TITLE
[ci] Use NuGetAuthenticate@1 (#8676)

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -81,7 +81,7 @@ stages:
 
     - template: yaml-templates/use-dot-net.yaml
 
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
       displayName: authenticate with azure artifacts
       inputs:
         forceReinstallCredentialProvider: true

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -67,7 +67,7 @@ stages:
         workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
         displayName: make prepare-external-git-dependencies
 
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
       displayName: authenticate with azure artifacts
       inputs:
         forceReinstallCredentialProvider: true

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -15,7 +15,7 @@ steps:
   parameters:
     remove_dotnet: true
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: authenticate with azure artifacts
   inputs:
     forceReinstallCredentialProvider: true

--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -3,7 +3,7 @@ parameters:
   condition: succeeded()
 
 steps:
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: authenticate with azure artifacts
   inputs:
     forceReinstallCredentialProvider: true


### PR DESCRIPTION
The `NuGetAuthenticate@0` task is deprecated and will soon be removed:

    Task 'NuGet authenticate' version 0 (NuGetAuthenticate@0) is deprecated.
    This task will be removed. From January 31, 2024, onwards it may no longer be available.

Use the updated `NuGetAuthenticate@1` task instead.